### PR TITLE
Add Profiling unit-tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,30 @@ There are two branches in this repository:
 
 ## Code contributions
 
+### Code style guide
+
+Please follow the style of the existing codebase.
+
+* Run `pylint` over your code using `.pylintrc` file in each module.
+  * line width: 120 characters
+* Some pylint warnings could be incorrect. For incorrect ones, suppress those warnings by setting a line-level comment.
+
+### Testing your changes
+
+* Add appropriate unit-tests that covers the new changes.
+* Run `tox` on the entire project. For example, to test changes committed to `user_tools`:
+  ```bash
+  $ cd user_tools
+  $ # install tox
+  $ pip install tox
+  $ # run tox
+  $ tox  
+  ```
+
 ### Sign your work
 
-We require that all contributors sign-off on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
+We require that all contributors sign-off on their commits. This certifies that the contribution is
+your original work, or you have rights to submit it under the same license, or a compatible license.
 
 Any contribution which contains commits that are not signed off will not be accepted.
 
@@ -48,7 +69,11 @@ This will append the following to your commit message:
 Signed-off-by: Your Name <your@email.com>
 ```
 
-The sign-off is a simple line at the end of the explanation for the patch. Your signature certifies that you wrote the patch or otherwise have the right to pass it on as an open-source patch. Use your real name, no pseudonyms or anonymous contributions.  If you set your `user.name` and `user.email` git configs, you can sign your commit automatically with `git commit -s`.
+The sign-off is a simple line at the end of the explanation for the patch. Your signature certifies
+that you wrote the patch or otherwise have the right to pass it on as an open-source patch.  
+Use your real name, no pseudonyms or anonymous contributions.  
+If you set your `user.name` and `user.email` git configs, you can sign your commit automatically with
+`git commit -s`.
 
 
 The signoff means you certify the below (from [developercertificate.org](https://developercertificate.org)):

--- a/user_tools/src/spark_rapids_dataproc_tools/rapids_models.py
+++ b/user_tools/src/spark_rapids_dataproc_tools/rapids_models.py
@@ -665,14 +665,14 @@ class Profiling(RapidsTool):
                                                              '--worker-info',
                                                              f'{worker_info_path}'])
         submit_cmd_args = (
-            f'dataproc jobs submit spark --cluster={self.cluster}'
+            f'--cluster={self.cluster}'
             f' --region={self.region}'
             f' --jars={jars_path}'
             f' --class={self.ctxt.get_tool_main_class()}'
             f' --'
             f' {tool_arguments}'
         )
-        self.ctxt.logdebug(f'Going to submit job <submit spark{submit_cmd_args}>')
+        self.ctxt.logdebug(f'Going to submit job <submit spark {submit_cmd_args}>')
         self.ctxt.cli.gcloud_submit_as_spark(submit_cmd_args, err_msg='Failed Submitting Spark job')
 
 
@@ -1106,16 +1106,16 @@ class Qualification(RapidsTool):
         # set the arguments
         jars_path = os.path.join(self.ctxt.get_remote_work_dir(), self.ctxt.get_remote('jarFileName'))
         tool_arguments = self.generate_final_tool_arguments([])
-        submit_cmd = (
-            f'dataproc jobs submit spark --cluster={self.cluster}'
+        submit_cmd_args = (
+            f'--cluster={self.cluster}'
             f' --region={self.region}'
             f' --jars={jars_path}'
             f' --class={self.ctxt.get_tool_main_class()}'
             f' --'
             f' {tool_arguments}'
         )
-        self.ctxt.logdebug(f'Going to submit job {submit_cmd}')
-        self.ctxt.cli.gcloud(submit_cmd, msg_fail='Failed Submitting Spark job')
+        self.ctxt.logdebug(f'Going to submit job <submit spark {submit_cmd_args}>')
+        self.ctxt.cli.gcloud_submit_as_spark(submit_cmd_args, err_msg='Failed Submitting Spark job')
 
 
 @dataclass

--- a/user_tools/tests/conftest.py
+++ b/user_tools/tests/conftest.py
@@ -11,15 +11,72 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Add common helpers and utilities"""
 
+import os
+import re
+from typing import Optional
+from unittest.mock import patch, call
+
+import pytest  # pylint: disable=import-error
 import yaml
+from cli_test_helpers import ArgvContext  # pylint: disable=import-error
+
+from spark_rapids_dataproc_tools import dataproc_wrapper
+from spark_rapids_dataproc_tools.dataproc_utils import CMDRunner
 
 
 def mock_cluster_props(cluster: str, **unused_kwargs):
     with open(f'tests/resources/{cluster}.yaml', 'r', encoding='utf-8') as yaml_file:
         static_properties = yaml.safe_load(yaml_file)
         return yaml.dump(static_properties)
+
+
+def mock_success_pull_cluster_props(*argvs, **unused_kwargs):
+    if len(argvs) >= 2:
+        # first argument is cluster_name
+        # second argument is region_name
+        with open(f'tests/resources/{argvs[0]}.yaml', 'r', encoding='utf-8') as yaml_file:
+            static_properties = yaml.safe_load(yaml_file)
+            return yaml.dump(static_properties)
+    return ''
+
+
+def mock_pull_gpu_mem_non_running_cluster():
+    simulate_gcloud_pull_gpu_mem_err('non-running')
+
+
+def mock_pull_gpu_mem_no_gpu_driver(*unused_argv):
+    simulate_gcloud_pull_gpu_mem_err('nvidia-smi-not-found')
+
+
+def simulate_gcloud_pull_gpu_mem_err(scenario: str):
+    msg_lookup = {
+        'non-running': (
+            'Failure Running Rapids Tool (Bootstrap).'
+            '\n\tCould not ssh to cluster or Cluster does not support GPU. '
+            'Make sure the cluster is running and NVIDIA drivers are installed.'
+            '\n\tRun Terminated with error.'
+            'Error invoking CMD <gcloud compute ssh dataproc-test-gpu-cluster '
+            "--zone=us-central1-a --command='nvidia-smi --query-gpu=memory.total --format=csv,noheader'>: "
+            '\n\t| ERROR: (gcloud.compute.ssh) [/usr/bin/ssh] exited with return code [255].'),
+        'nvidia-smi-not-found': (
+            'Failure Running Rapids Tool (Bootstrap).'
+            '\n\tCould not ssh to cluster or Cluster does not support GPU. '
+            'Make sure the cluster is running and NVIDIA drivers are installed.'
+            '\n\tRun Terminated with error.'
+            'Error invoking CMD <gcloud compute ssh dataproc-test-gpu-cluster '
+            "--zone=us-central1-a --command='nvidia-smi --query-gpu=memory.total --format=csv,noheader'>: "
+            '\n\t| bash: nvidia-smi: command not found')
+    }
+    err_msg = msg_lookup.get(scenario)
+    raise RuntimeError(f'{err_msg}')
+
+
+def assert_patterns_in_output(reg_expressions, captured_out, msg: Optional[str] = None):
+    for stdout_reg in reg_expressions:
+        assert re.search(stdout_reg, captured_out), f'Could not match {stdout_reg} in output. {msg}'
 
 
 def get_wrapper_work_dir(tool_name, root_dir):
@@ -31,3 +88,140 @@ def get_wrapper_work_dir(tool_name, root_dir):
     """
     # TODO: load constants from the configuration files src/resources/*.yaml.
     return f'{root_dir}/wrapper-output/rapids_user_tools_{tool_name}'
+
+
+def dir_exists(dir_path):
+    return os.path.exists(dir_path)
+
+
+class RapidsToolTestBasic:
+    """Basic class that encapsulates common methods and setup."""
+    tool_ctxt = {}
+
+    def _init_tool_ctx(self, autofilled_ctx: dict):
+        self.tool_ctxt.update(autofilled_ctx)
+
+    def get_tool_name(self):
+        return self.tool_ctxt['tool_name']
+
+    def get_work_dir_postfix(self):
+        return self.tool_ctxt['work_dir_postfix']
+
+    def get_capsys(self):
+        return self.tool_ctxt['capsys']
+
+    def get_work_dir(self, ut_dir):
+        return f'{ut_dir}/{self.get_work_dir_postfix()}'
+
+    def get_wrapper_out_dir(self, ut_dir):
+        work_dir = f'{self.get_work_dir(ut_dir)}'
+        tool_out_dir = f'{work_dir}/{self.tool_ctxt["wrapper_out_dirname"]}'
+        return tool_out_dir
+
+    @pytest.fixture(autouse=True)
+    def init_tool(self, capsys):
+        """Capsys hook into this class"""
+        self.tool_ctxt['capsys'] = capsys
+        self._init_tool_ctx(autofilled_ctx={})
+
+    @pytest.fixture(name='ut_dir')
+    def ut_dir(self, tmp_path):
+        return tmp_path
+
+    def print_to_console(self, msg):
+        """Print strOut to console (even within a pyTest execution)"""
+        with self.get_capsys().disabled():
+            print(msg)
+
+    def get_default_args(self, cluster_name, ut_dir):
+        return [
+            'spark_rapids_dataproc',
+            f'{self.get_tool_name()}',
+            '--cluster', f'{cluster_name}',
+            '--region', 'us-central1',
+            '--output_folder', f'{ut_dir}']
+
+    def capture_wrapper_output(self) -> (str, str):
+        captured_out = self.get_capsys().readouterr()
+        return captured_out.out, captured_out.err
+
+    def run_successful_wrapper(self, cluster_name, ut_dir, extra_wrapper_args=None):
+        wrapper_args = self.get_default_args(cluster_name, ut_dir)
+        if extra_wrapper_args is not None:
+            wrapper_args.extend(extra_wrapper_args)
+        with ArgvContext(*wrapper_args):
+            dataproc_wrapper.main()
+
+    def run_fail_wrapper(self, cluster_name, ut_dir, extra_wrapper_args=None):
+        wrapper_args = self.get_default_args(cluster_name, ut_dir)
+        if extra_wrapper_args is not None:
+            wrapper_args.extend(extra_wrapper_args)
+        with pytest.raises(SystemExit):
+            with ArgvContext(*wrapper_args):
+                dataproc_wrapper.main()
+
+    def assert_work_dir_exists(self, ut_root_dir):
+        work_dir = self.get_work_dir(ut_root_dir)
+        assert dir_exists(work_dir), f'Working directory {work_dir} exists!!'
+
+    def assert_work_dir_not_exists(self, ut_root_dir):
+        work_dir = self.get_work_dir(ut_root_dir)
+        assert not dir_exists(work_dir), f'Working directory {work_dir} exists!! '
+
+    def assert_output_as_expected(self,
+                                  std_regs,
+                                  log_regs=None,
+                                  std_msg: Optional[str] = 'Stdout has no match.',
+                                  log_msg: Optional[str] = 'Log-output has no match.'):
+        cap_out, cap_err = self.capture_wrapper_output()
+        if std_regs is not None:
+            assert_patterns_in_output(std_regs, cap_out, std_msg)
+        if log_regs is not None:
+            assert_patterns_in_output(log_regs, cap_err, log_msg)
+
+    def _run_tool_on_spark2(self, tool_name,
+                            ut_root_dir,
+                            submission_cluster='dataproc-test-spark2-cluster'):
+        """Qualification/Profiling Tools cannot run on Spark2.x clusters."""
+        # 2022-12-07 11:14:12,582 WARNING qualification: The cluster image 1.5.75-debian10 is not supported. \
+        # To support the RAPIDS user tools, you will need to use an image that runs Spark3.x.
+        # Failure Running Rapids Tool (Profiling).
+        #         Tool cannot execute on the execution cluster.
+        #         Run Terminated with error.
+        #         The cluster image 1.5.75-debian10 is not supported. To support the RAPIDS user tools, \
+        #         you will need to use an image that runs Spark3.x.
+        std_reg_expressions = [
+            rf'Failure Running Rapids Tool \({tool_name.capitalize()}\)\.',
+            r'Tool cannot execute on the execution cluster\.'
+        ]
+        log_reg_expressions = [
+            rf'WARNING {tool_name}: The cluster image 1\.5\.75-debian10 is not supported',
+            r'To support the RAPIDS user tools, you will need to use an image that runs Spark3\.x\.'
+        ]
+        with patch.object(CMDRunner, 'gcloud_describe_cluster',
+                          side_effect=mock_success_pull_cluster_props) as pull_cluster_props:
+            self.run_fail_wrapper(submission_cluster, ut_root_dir)
+        self.assert_output_as_expected(std_reg_expressions, log_reg_expressions)
+        pull_cluster_props.assert_called_once()
+        expected_pull_cluster_args = [
+            call(f'{submission_cluster}',
+                 'us-central1',
+                 f'Could not pull Cluster description region:us-central1, {submission_cluster}')]
+        assert pull_cluster_props.call_args_list == expected_pull_cluster_args
+        self.assert_work_dir_not_exists(ut_root_dir)
+
+    def _run_tool_on_non_running_gpu_cluster(self,
+                                             ut_root_dir,
+                                             std_reg_expressions,
+                                             log_reg_expressions=None,
+                                             submission_cluster='dataproc-test-gpu-cluster'):
+        expected_pull_cluster_args = [
+            call(f'{submission_cluster}',
+                 'us-central1',
+                 f'Could not pull Cluster description region:us-central1, {submission_cluster}')]
+        with patch.object(CMDRunner, 'gcloud_describe_cluster',
+                          side_effect=mock_success_pull_cluster_props) as pull_cluster_props:
+            self.run_fail_wrapper(submission_cluster, ut_root_dir)
+        self.assert_output_as_expected(std_reg_expressions, log_regs=log_reg_expressions)
+        self.assert_work_dir_not_exists(ut_root_dir)
+        assert pull_cluster_props.call_args_list == expected_pull_cluster_args

--- a/user_tools/tests/conftest.py
+++ b/user_tools/tests/conftest.py
@@ -27,12 +27,6 @@ from spark_rapids_dataproc_tools import dataproc_wrapper
 from spark_rapids_dataproc_tools.dataproc_utils import CMDRunner
 
 
-def mock_cluster_props(cluster: str, **unused_kwargs):
-    with open(f'tests/resources/{cluster}.yaml', 'r', encoding='utf-8') as yaml_file:
-        static_properties = yaml.safe_load(yaml_file)
-        return yaml.dump(static_properties)
-
-
 def mock_success_pull_cluster_props(*argvs, **unused_kwargs):
     if len(argvs) >= 2:
         # first argument is cluster_name
@@ -90,8 +84,8 @@ def get_wrapper_work_dir(tool_name, root_dir):
     return f'{root_dir}/wrapper-output/rapids_user_tools_{tool_name}'
 
 
-def dir_exists(dir_path):
-    return os.path.exists(dir_path)
+def os_path_exists(filesys_path):
+    return os.path.exists(filesys_path)
 
 
 class RapidsToolTestBasic:
@@ -115,7 +109,8 @@ class RapidsToolTestBasic:
 
     def get_wrapper_out_dir(self, ut_dir):
         work_dir = f'{self.get_work_dir(ut_dir)}'
-        tool_out_dir = f'{work_dir}/{self.tool_ctxt["wrapper_out_dirname"]}'
+        out_dir_name = self.tool_ctxt['wrapper_out_dirname']
+        tool_out_dir = os.path.join(work_dir, out_dir_name)
         return tool_out_dir
 
     @pytest.fixture(autouse=True)
@@ -162,11 +157,19 @@ class RapidsToolTestBasic:
 
     def assert_work_dir_exists(self, ut_root_dir):
         work_dir = self.get_work_dir(ut_root_dir)
-        assert dir_exists(work_dir), f'Working directory {work_dir} exists!!'
+        assert os_path_exists(work_dir), f'Working directory {work_dir} exists!!'
 
     def assert_work_dir_not_exists(self, ut_root_dir):
         work_dir = self.get_work_dir(ut_root_dir)
-        assert not dir_exists(work_dir), f'Working directory {work_dir} exists!! '
+        assert not os_path_exists(work_dir), f'Working directory {work_dir} exists!!'
+
+    def assert_wrapper_out_dir_not_exists(self, ut_root_dir):
+        out_dir = self.get_wrapper_out_dir(ut_root_dir)
+        assert not os_path_exists(out_dir), f'Wrapper output directory {out_dir} exists!!'
+
+    def assert_wrapper_out_dir_exists(self, ut_root_dir):
+        out_dir = self.get_wrapper_out_dir(ut_root_dir)
+        assert os_path_exists(out_dir), f'Wrapper output directory {out_dir} does not exist!!'
 
     def assert_output_as_expected(self,
                                   std_regs,

--- a/user_tools/tests/test_profiling.py
+++ b/user_tools/tests/test_profiling.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test Profiling functions."""
+
+import pytest  # pylint: disable=import-error
+
+from conftest import RapidsToolTestBasic
+
+
+class TestProfiling(RapidsToolTestBasic):
+    """Test Profiling features."""
+
+    def _init_tool_ctx(self, autofilled_ctx: dict):
+        tool_name = 'profiling'
+        prof_ctxt = {
+            'tool_name': tool_name,
+            'work_dir_postfix': f'wrapper-output/rapids_user_tools_{tool_name}'
+        }
+        autofilled_ctx.update(prof_ctxt)
+        super()._init_tool_ctx(autofilled_ctx)
+
+    def test_fail_on_spark2(self, ut_dir):
+        """
+        Tools cannot run on Spark2.x clusters.
+        The wrapper should fail and show meaningful output to the user.
+        """
+        self._run_tool_on_spark2(self.get_tool_name(), ut_dir)
+
+    @pytest.mark.parametrize('submission_cluster', ['dataproc-test-gpu-cluster', 'dataproc-test-nongpu-cluster'])
+    def test_fail_non_running_cluster(self, ut_dir, submission_cluster):
+        """Test Profiling failure with non-running cluster."""
+
+        # Failure Running Rapids Tool (Profiling).
+        # Could not ssh to cluster or Cluster does not support GPU. Make sure the cluster is running and \
+        # NVIDIA drivers are installed.
+        # Run Terminated with error.
+        #         Error invoking CMD <gcloud compute ssh dataproc-cluster-gpu-w-0 -\
+        #         -zone=us-central1-a --command='nvidia-smi --query-gpu=memory.total --format=csv,noheader'>:
+        #         | External IP address was not found; defaulting to using IAP tunneling.
+        #         | ERROR: (gcloud.compute.start-iap-tunnel) Error while connecting [4033: 'not authorized'].
+        #         | kex_exchange_identification: Connection closed by remote host
+        #         | Connection closed by UNKNOWN port 65535
+        #         |
+        #         | Recommendation: To check for possible causes of SSH connectivity issues and get
+        #         | recommendations, rerun the ssh command with the --troubleshoot option.
+        #         |
+        #         | gcloud compute ssh dataproc-cluster-gpu-w-0 --project=rapids-spark --zone=us-central1-a \
+        #         --troubleshoot
+        #         |
+        #         | Or, to investigate an IAP tunneling issue:
+        #         |
+        #         | gcloud compute ssh dataproc-cluster-gpu-w-0-w-0 --project=project-id --zone=us-central1-a \
+        #         --troubleshoot --tunnel-through-iap
+        #         |
+        #         | ERROR: (gcloud.compute.ssh) [/usr/bin/ssh] exited with return code [255].
+
+        std_reg_expressions = [
+            rf'Failure Running Rapids Tool \({self.get_tool_name().capitalize()}\)\.',
+            r'Could not ssh to cluster',
+            r'ERROR: \(gcloud\.compute\.ssh\)'
+        ]
+        self._run_tool_on_non_running_gpu_cluster(ut_dir, std_reg_expressions, submission_cluster=submission_cluster)

--- a/user_tools/tests/test_profiling.py
+++ b/user_tools/tests/test_profiling.py
@@ -26,7 +26,8 @@ class TestProfiling(RapidsToolTestBasic):
         tool_name = 'profiling'
         prof_ctxt = {
             'tool_name': tool_name,
-            'work_dir_postfix': f'wrapper-output/rapids_user_tools_{tool_name}'
+            'work_dir_postfix': f'wrapper-output/rapids_user_tools_{tool_name}',
+            'wrapper_out_dirname': 'profiling-tool-output'
         }
         autofilled_ctx.update(prof_ctxt)
         super()._init_tool_ctx(autofilled_ctx)
@@ -61,7 +62,7 @@ class TestProfiling(RapidsToolTestBasic):
         #         |
         #         | Or, to investigate an IAP tunneling issue:
         #         |
-        #         | gcloud compute ssh dataproc-cluster-gpu-w-0-w-0 --project=project-id --zone=us-central1-a \
+        #         | gcloud compute ssh dataproc-cluster-gpu-w-0 --project=project-id --zone=us-central1-a \
         #         --troubleshoot --tunnel-through-iap
         #         |
         #         | ERROR: (gcloud.compute.ssh) [/usr/bin/ssh] exited with return code [255].

--- a/user_tools/tests/test_qualification.py
+++ b/user_tools/tests/test_qualification.py
@@ -14,17 +14,12 @@
 
 """Test Qualification functions."""
 
-import os
-import re
-import subprocess
 import tarfile
-from unittest.mock import patch, call
+from unittest.mock import patch
 
 import pytest  # pylint: disable=import-error
-from cli_test_helpers import ArgvContext  # pylint: disable=import-error
 
-from conftest import mock_cluster_props, get_wrapper_work_dir
-from spark_rapids_dataproc_tools import dataproc_wrapper
+from conftest import mock_cluster_props, get_wrapper_work_dir, RapidsToolTestBasic, dir_exists
 from spark_rapids_dataproc_tools.dataproc_utils import CMDRunner
 from spark_rapids_dataproc_tools.rapids_models import Qualification
 
@@ -41,41 +36,6 @@ def fixture_qual_output_dir(tmp_path):
 
 def qual_result_dir(root_out_directory):
     return get_wrapper_work_dir('qualification', root_out_directory)
-
-
-def test_qual_failure_non_existing_cluster(capfd, qual_output_dir):
-    """Test Qualification with non-existing cluster."""
-
-    # Expected output running on invalid cluster
-    # Failure Running Rapids Tool (Quallification).
-    # \tCould not pull Cluster description region:us-central1, dataproc-test-cluster
-    # \tRun Terminated with error.
-    # \tError invoking CMD <gcloud dataproc clusters describe dataproc-test-cluster --region=us-central1>:
-    # \t| ERROR: (gcloud.dataproc.clusters.describe) NOT_FOUND: Not found: \
-    # Cluster projects/rapids-spark/regions/us-central1/clusters/dataproc-test-cluster
-    def check_failure_content(actual_captured: str) -> bool:
-        main_key_stmts = [
-            'Failure Running Rapids Tool (Qualification).',
-            'Could not pull Cluster description',
-            'ERROR: (gcloud.dataproc.clusters.describe) NOT_FOUND: Not found:'
-        ]
-        return all(actual_captured.find(stmt) != -1 for stmt in main_key_stmts)
-
-    cluster_name = 'dataproc-test-non-existing-cluster'
-    # Run the actual test
-    qual_args = [
-        '--region=us-central1',
-        f'--cluster={cluster_name}',
-        f'--output_folder={qual_output_dir}'
-    ]
-    wrapper_args = ' '.join(qual_args)
-    # pylint: disable=subprocess-run-check
-    c = subprocess.run(f'spark_rapids_dataproc qualification {wrapper_args}', shell=True, text=True)
-    # pylint: enable=subprocess-run-check
-    captured_output = capfd.readouterr().out
-    assert check_failure_content(captured_output)
-    assert c.returncode != 0
-    assert not os.path.exists(f'{qual_result_dir(qual_output_dir)}')
 
 
 def mock_passive_copy(*unused_argv, **unused_kwargs):
@@ -108,207 +68,160 @@ def mock_successful_run_as_spark(*unused_argv, **unused_kwargs):
     return ''
 
 
-def test_qual_failure_on_spark2(capsys, caplog, qual_output_dir):
-    """
-    Tools cannot run on Spark2.x clusters.
-    The wrapper should fail and show meaningful output to the user.
-    """
-    # 2022-12-07 11:14:12,582 WARNING qualification: The cluster image 1.5.75-debian10 is not supported. \
-    # To support the RAPIDS user tools, you will need to use an image that runs Spark3.x.
-    # Failure Running Rapids Tool (Qualification).
-    #         Tool cannot execute on the execution cluster.
-    #         Run Terminated with error.
-    #         The cluster image 1.5.75-debian10 is not supported. To support the RAPIDS user tools, \
-    #         you will need to use an image that runs Spark3.x.
-    cluster_name = 'dataproc-test-spark2-cluster'
+class TestQualification(RapidsToolTestBasic):
+    """Test Qualification features."""
+    def _init_tool_ctx(self, autofilled_ctx: dict):
+        tool_name = 'qualification'
+        prof_ctxt = {
+            'tool_name': tool_name,
+            'work_dir_postfix': f'wrapper-output/rapids_user_tools_{tool_name}',
+            'wrapper_out_dirname': 'qual-tool-output'
+        }
+        autofilled_ctx.update(prof_ctxt)
+        super()._init_tool_ctx(autofilled_ctx)
 
-    log_key_stmts = [
-        'To support the RAPIDS user tools, you will need to use an image that runs Spark3.x.'
-    ]
-    stdout_key_stmts = [
-        'Failure Running Rapids Tool (Qualification).',
-        'Tool cannot execute on the execution cluster.'
-    ]
-    stdout_key_stmts.extend(log_key_stmts)
+    def test_fail_on_spark2(self, ut_dir):
+        """qualification tool does not run on spark2.x"""
+        self._run_tool_on_spark2(self.get_tool_name(), ut_dir)
 
-    with patch.object(CMDRunner, 'gcloud_describe_cluster',
-                      side_effect=[mock_cluster_props(f'{cluster_name}')]) as pull_cluster_props:
-        with pytest.raises(SystemExit):
-            with ArgvContext('spark_rapids_dataproc',
-                             'qualification',
-                             '--cluster', f'{cluster_name}',
-                             '--region', 'us-central1',
-                             '--output_folder', f'{qual_output_dir}'):
-                dataproc_wrapper.main()
-    captured_output = capsys.readouterr().out
-    captured_log = caplog.text
-    # assert the output message
-    assert (captured_log.find(log_msg) != -1 for log_msg in log_key_stmts)
-    assert (captured_output.find(stdout_msg) != -1 for stdout_msg in stdout_key_stmts)
-    pull_cluster_props.assert_called_once()
-    expected_pull_cluster_args = [
-        call(f'{cluster_name}',
-             'us-central1',
-             f'Could not pull Cluster description region:us-central1, {cluster_name}')]
-    assert pull_cluster_props.call_args_list == expected_pull_cluster_args
-    assert not os.path.exists(f'{qual_result_dir(qual_output_dir)}')
+    @pytest.mark.parametrize('submission_cluster', ['dataproc-test-gpu-cluster', 'dataproc-test-nongpu-cluster'])
+    def test_fail_non_running_cluster(self, ut_dir, submission_cluster):
+        """
+        Qualification runs on non GPU cluster as well as GPU cluster.
+        This unit test verifies the error due to run qualification tool for an existing cluster; but it is not
+        started at the time of submission.
+        Note that we need to pass the first command of gcloud_cp that copies the dependencies from local
+        disk to the remote storage.
+        """
+        # pylint: disable=line-too-long
 
+        # spark_rapids_dataproc qualification --region=us-central1 --cluster=CLUSTER_NAME \
+        # --output_folder={qual_output_dir}
+        # 2022-12-07 12:43:12,442 INFO qualification: The original CPU cluster is the same as the \
+        # submission cluster on which the tool runs. To update the configuration of the CPU cluster, \
+        # make sure to pass the properties file to the CLI arguments.
+        # 2022-12-07 12:43:12,443 INFO qualification: The GPU cluster is the same as the submission \
+        # cluster on which the RAPIDS tool is running [ahussein-dp-spark3]. To update the configuration \
+        # of the GPU cluster, make sure to pass the properties file to the CLI arguments.
+        # 2022-12-07 12:43:14,079 INFO qualification: Preparing remote work env
+        # 2022-12-07 12:43:15,847 INFO qualification: Upload dependencies to remote cluster
+        # 2022-12-07 12:43:17,878 INFO qualification: Executing the tool
+        # 2022-12-07 12:43:17,878 INFO qualification: Running the tool as a spark job on dataproc
+        # Failure Running Rapids Tool (Qualification).
+        #         Failed Submitting Spark job
+        #         Run Terminated with error.
+        #         Error invoking CMD <gcloud dataproc jobs submit spark --cluster=CLUSTER_NAME \
+        #         --region=us-central1 \
+        #         --jars=gs:///rapids-4-spark-tools_2.12-22.10.0.jar \
+        #         --class=com.nvidia.spark.rapids.tool.qualification.QualificationMain --  \
+        #         --output-directory  gs:///qual-tool-output:
+        #         | ERROR: (gcloud.dataproc.jobs.submit.spark) FAILED_PRECONDITION: Unable to submit job,
+        #         cluster 'CLUSTER_NAME' is in state STOPPED and cannot accept jobs.
 
-@pytest.mark.parametrize('submission_cluster', ['dataproc-test-gpu-cluster', 'dataproc-test-nongpu-cluster'])
-def test_qual_failure_non_running_cluster(capsys, qual_output_dir, submission_cluster):
-    """
-    Qualification runs on non GPU cluster as well as GPU cluster.
-    This unit test verifies the error due to run qualification tool for an existing cluster; but it is not
-    started at the time of submission.
-    """
-    # pylint: disable=line-too-long
+        # pylint: enable=line-too-long
 
-    # spark_rapids_dataproc qualification --region=us-central1 --cluster=CLUSTER_NAME \
-    # --output_folder={qual_output_dir}
-    # 2022-12-07 12:43:12,442 INFO qualification: The original CPU cluster is the same as the submission cluster on \
-    # which the tool runs. To update the configuration of the CPU cluster, make sure to pass the properties file to \
-    # the CLI arguments.
-    # 2022-12-07 12:43:12,443 INFO qualification: The GPU cluster is the same as the submission cluster on which the \
-    # RAPIDS tool is running [ahussein-dp-spark3]. To update the configuration of the GPU cluster, \
-    # make sure to pass the properties file to the CLI arguments.
-    # 2022-12-07 12:43:14,079 INFO qualification: Preparing remote work env
-    # 2022-12-07 12:43:15,847 INFO qualification: Upload dependencies to remote cluster
-    # 2022-12-07 12:43:17,878 INFO qualification: Executing the tool
-    # 2022-12-07 12:43:17,878 INFO qualification: Running the tool as a spark job on dataproc
-    # Failure Running Rapids Tool (Qualification).
-    #         Failed Submitting Spark job
-    #         Run Terminated with error.
-    #         Error invoking CMD <gcloud dataproc jobs submit spark --cluster=CLUSTER_NAME \
-    #         --region=us-central1 \
-    #         --jars=gs:///rapids-4-spark-tools_2.12-22.10.0.jar \
-    #         --class=com.nvidia.spark.rapids.tool.qualification.QualificationMain --  \
-    #         --output-directory  gs:///qual-tool-output:
-    #         | ERROR: (gcloud.dataproc.jobs.submit.spark) FAILED_PRECONDITION: Unable to submit job,
-    #         cluster 'CLUSTER_NAME' is in state STOPPED and cannot accept jobs.
+        cluster_name = submission_cluster
 
-    # pylint: enable=line-too-long
-
-    cluster_name = submission_cluster
-
-    log_reg_expressions = [
-        (r'INFO qualification: The original CPU cluster is the same as the submission cluster on which the tool runs\. '
-         r'To update the configuration of the CPU cluster, make sure to pass the properties file to the CLI arguments'),
-        (r'INFO qualification: The GPU cluster is the same as the submission cluster on which the RAPIDS tool is '
-         rf'running \[{cluster_name}\]\. To update the configuration of the GPU cluster, make sure to pass the '
-         r'properties file to the CLI arguments\.'),
-    ]
-    std_reg_expressions = [
-        r'Failure Running Rapids Tool \(Qualification\)\.',
-        r'Failed Submitting Spark job',
-        r'Run Terminated with error\.',
-        r'ERROR: \(gcloud\.dataproc\.jobs\.submit\.spark\) ',
-    ]
-    expected_pull_cluster_args = [
-        call(f'{cluster_name}',
-             'us-central1',
-             f'Could not pull Cluster description region:us-central1, {cluster_name}')]
-    with patch.object(CMDRunner, 'gcloud_describe_cluster',
-                      side_effect=[mock_cluster_props(f'{cluster_name}')]) as pull_cluster_props, \
-            patch.object(CMDRunner, 'gcloud_cp',
-                         side_effect=mock_passive_copy):
-        with pytest.raises(SystemExit):
-            with ArgvContext('spark_rapids_dataproc',
-                             'qualification',
-                             '--cluster', f'{cluster_name}',
-                             '--region', 'us-central1',
-                             '--output_folder', f'{qual_output_dir}'):
-                dataproc_wrapper.main()
-    captured_output = capsys.readouterr()
-    assert pull_cluster_props.call_args_list == expected_pull_cluster_args
-    for stdout_reg in std_reg_expressions:
-        assert re.search(stdout_reg, captured_output.out), f'Could not match {stdout_reg} in tool output'
-    for log_reg in log_reg_expressions:
-        assert re.search(log_reg, captured_output.err), f'Could not match {log_reg} in tool log'
-    assert not os.path.exists(f'{qual_result_dir(qual_output_dir)}')
-
-
-@pytest.mark.parametrize('submission_cluster', ['dataproc-test-gpu-cluster', 'dataproc-test-nongpu-cluster'])
-@pytest.mark.parametrize('events_scenario',
-                         [{'label': 'with_events', 'mockFunc': mock_remote_download},
-                          {'label': 'no_events', 'mockFunc': mock_passive_copy}])
-def test_qual_success(capsys, qual_output_dir, submission_cluster, events_scenario):
-    """
-    This is a successful run achieved by capturing cloud_copy command. It is executed with two different scenarios:
-    1- with empty eventlogs, and 2- with mocked eventlogs loaded from resources folder.
-    For more details on the sample see resources/output_samples/generation.md
-    :param capsys: captures the stdout of the execution.
-    :param qual_output_dir: the temp folder passed as an argument to the wrapper command.
-    :param submission_cluster: the name of the cluster used to submit the tool.
-    :param events_scenario: the method to be used as side effect for cloud copy command.
-    """
-
-    # If the Qualification tool generates no output, it is expected to get the following output
-    # Configuration Incompatibilities:
-    # --------------- --------------------------------------------------------------------------------------------------
-    # workerLocalSSDs - Worker nodes have no local SSDs. Local SSD is recommended for Spark scratch space to improve IO.
-    # --------------- --------------------------------------------------------------------------------------------------
-    # The Qualification tool did not generate any output. Nothing to display.
-
-    cluster_name = submission_cluster
-    scenario_id = events_scenario.get('label')
-    wrapper_output_folder = f'{qual_result_dir(qual_output_dir)}/qual-tool-output'
-    wrapper_summary_file = f'{wrapper_output_folder}/rapids_4_dataproc_qualification_output.csv'
-    rapids_qual_folder = f'{wrapper_output_folder}/rapids_4_spark_qualification_output'
-    log_reg_expressions = [
-        (r'INFO qualification: The original CPU cluster is the same as the submission cluster on which the tool runs\. '
-         r'To update the configuration of the CPU cluster, make sure to pass the properties file to the CLI arguments'),
-        (r'INFO qualification: The GPU cluster is the same as the submission cluster on which the RAPIDS tool is '
-         rf'running \[{cluster_name}\]\. To update the configuration of the GPU cluster, make sure to pass the '
-         r'properties file to the CLI arguments\.'),
-    ]
-    std_reg_expressions = {
-        'no_events': [
-            r'Configuration Incompatibilities:',
-            (r'workerLocalSSDs  '
-             r'- Worker nodes have no local SSDs\. Local SSD is recommended for Spark scratch space to improve IO\.'),
-            r'The Qualification tool did not generate any output\. Nothing to display\.'
-        ],
-        'with_events': [
-            rf'Qualification tool output is saved to local disk {rapids_qual_folder}',
-            rf'Full savings and speedups CSV report: {wrapper_summary_file}',
-            r'Report Summary:',
-            r'(Total applications)\s+(\d+)',
-            r'(RAPIDS candidates)\s+(\d+)',
-            r'(Overall estimated speedup)\s+([1-9]+\.[0-9]+)',  # Estimated speedup cannot be LT 1.00
-            r'(Overall estimated cost savings)\s+([+-]?[0-9]+\.[0-9]+)%',
-            r'Worker nodes have no local SSDs\. Local SSD is recommended for Spark scratch space to improve IO',
-            r'Cost estimation is based on 1 local SSD per worker',
-            r'To launch a GPU-accelerated cluster with RAPIDS Accelerator for Apache Spark',
-            r'--initialization-actions=gs://',
-            r'--cuda-version=([1-9]+\.[0-9]+)'
+        log_reg_expressions = [
+            (r'INFO qualification: The original CPU cluster is the same as the submission cluster on '
+             r'which the tool runs\. To update the configuration of the CPU cluster, make sure to pass '
+             r'the properties file to the CLI arguments'),
+            (r'INFO qualification: The GPU cluster is the same as the submission cluster on which the RAPIDS tool is '
+             rf'running \[{cluster_name}\]\. To update the configuration of the GPU cluster, make sure to pass the '
+             r'properties file to the CLI arguments\.'),
         ]
-    }
-    with patch.object(CMDRunner, 'gcloud_describe_cluster',
-                      side_effect=[mock_cluster_props(f'{cluster_name}')]) as pull_cluster_props, \
-            patch.object(CMDRunner, 'gcloud_cp',
-                         side_effect=events_scenario.get('mockFunc')) as mock_remote_copy, \
-            patch.object(Qualification, '_run_tool_as_spark',
-                         side_effect=mock_successful_run_as_spark) as mock_submit_as_spark:
-        with ArgvContext('spark_rapids_dataproc',
-                         'qualification',
-                         '--cluster', f'{cluster_name}',
-                         '--region', 'us-central1',
-                         '--output_folder', f'{qual_output_dir}'):
-            dataproc_wrapper.main()
-    # check the output on local disk
-    if scenario_id == 'no_events':
-        assert not os.path.exists(f'{wrapper_output_folder}')
-    else:
-        assert os.path.exists(f'{wrapper_summary_file}'), 'Summary report was not generated!'
-    # check the stdout and log output
-    captured_output = capsys.readouterr()
-    for stdout_reg in std_reg_expressions.get(scenario_id):
-        assert re.search(stdout_reg, captured_output.out), \
-            f'Could not match {stdout_reg} in tool output in {scenario_id} scenario'
-    for log_reg in log_reg_expressions:
-        assert re.search(log_reg, captured_output.err), \
-            f'Could not match {log_reg} in tool log in {scenario_id} scenario'
+        std_reg_expressions = [
+            r'Failure Running Rapids Tool \(Qualification\)\.',
+            r'Failed Submitting Spark job',
+            r'Run Terminated with error\.',
+            r'ERROR: \(gcloud\.dataproc\.jobs\.submit\.spark\) ',
+        ]
+        # Note that we need to pass the phase in which the wrapper upload dependencies to the remote storage.
+        # This is mainly because storage can still be accessible even when the cluster is offline.
+        with patch.object(CMDRunner, 'gcloud_cp', side_effect=mock_passive_copy):
+            self._run_tool_on_non_running_gpu_cluster(ut_dir,
+                                                      std_reg_expressions,
+                                                      log_reg_expressions,
+                                                      submission_cluster=submission_cluster)
 
-    pull_cluster_props.assert_called_once()
-    mock_submit_as_spark.assert_called_once()
-    assert mock_remote_copy.call_count == 2
+    @pytest.mark.parametrize('events_scenario',
+                             [{'label': 'with_events', 'mockFunc': mock_remote_download},
+                              {'label': 'no_events', 'mockFunc': mock_passive_copy}],
+                             ids=('with tool output', 'No tool output'))
+    @pytest.mark.parametrize('submission_cluster',
+                             ['dataproc-test-gpu-cluster', 'dataproc-test-nongpu-cluster'])
+    def test_qual_success(self, ut_dir, submission_cluster, events_scenario):
+        """
+        This is a successful run achieved by capturing cloud_copy command. It is executed with two different scenarios:
+        1- with empty eventlogs, and 2- with mocked eventlogs loaded from resources folder.
+        For more details on the sample see resources/output_samples/generation.md
+        :param capsys: captures the stdout of the execution.
+        :param qual_output_dir: the temp folder passed as an argument to the wrapper command.
+        :param submission_cluster: the name of the cluster used to submit the tool.
+        :param events_scenario: the method to be used as side effect for cloud copy command.
+        """
+
+        # pylint: disable=line-too-long
+
+        # If the Qualification tool generates no output, it is expected to get the following output
+        # Configuration Incompatibilities:
+        # --------------- --------------------------------------------------------------------------------------------------
+        # workerLocalSSDs - Worker nodes have no local SSDs. Local SSD is recommended for Spark scratch space to improve IO.
+        # --------------- --------------------------------------------------------------------------------------------------
+        # The Qualification tool did not generate any output. Nothing to display.
+
+        # pylint: enable=line-too-long
+
+        scenario_id = events_scenario.get('label')
+        wrapper_output_folder = self.get_wrapper_out_dir(ut_dir)
+        wrapper_summary_file = f'{wrapper_output_folder}/rapids_4_dataproc_qualification_output.csv'
+        rapids_qual_folder = f'{wrapper_output_folder}/rapids_4_spark_qualification_output'
+        log_reg_expressions = [
+            (r'INFO qualification: The original CPU cluster is the same as the submission cluster on which the tool '
+             r'runs\. To update the configuration of the CPU cluster, make sure to pass the properties file to '
+             r'the CLI arguments'),
+            (r'INFO qualification: The GPU cluster is the same as the submission cluster on which the RAPIDS tool is '
+             rf'running \[{submission_cluster}\]\. To update the configuration of the GPU cluster, '
+             r'make sure to pass the properties file to the CLI arguments\.'),
+        ]
+        std_reg_expressions = {
+            'no_events': [
+                r'Configuration Incompatibilities:',
+                (r'workerLocalSSDs  '
+                 r'- Worker nodes have no local SSDs\. Local SSD is recommended for Spark scratch '
+                 r'space to improve IO\.'),
+                r'The Qualification tool did not generate any output\. Nothing to display\.'
+            ],
+            'with_events': [
+                rf'Qualification tool output is saved to local disk {rapids_qual_folder}',
+                rf'Full savings and speedups CSV report: {wrapper_summary_file}',
+                r'Report Summary:',
+                r'(Total applications)\s+(\d+)',
+                r'(RAPIDS candidates)\s+(\d+)',
+                r'(Overall estimated speedup)\s+([1-9]+\.[0-9]+)',  # Estimated speedup cannot be LT 1.00
+                r'(Overall estimated cost savings)\s+([+-]?[0-9]+\.[0-9]+)%',
+                r'Worker nodes have no local SSDs\. Local SSD is recommended for Spark scratch space to improve IO',
+                r'Cost estimation is based on 1 local SSD per worker',
+                r'To launch a GPU-accelerated cluster with RAPIDS Accelerator for Apache Spark',
+                r'--initialization-actions=gs://',
+                r'--cuda-version=([1-9]+\.[0-9]+)'
+            ]
+        }
+        with patch.object(CMDRunner, 'gcloud_describe_cluster',
+                          side_effect=[mock_cluster_props(f'{submission_cluster}')]) as pull_cluster_props, \
+                patch.object(CMDRunner, 'gcloud_cp',
+                             side_effect=events_scenario.get('mockFunc')) as mock_remote_copy, \
+                patch.object(Qualification, '_run_tool_as_spark',
+                             side_effect=mock_successful_run_as_spark) as mock_submit_as_spark:
+            self.run_successful_wrapper(submission_cluster, ut_dir)
+        # check the output on local disk
+        if scenario_id == 'no_events':
+            assert not dir_exists(f'{wrapper_output_folder}')
+        else:
+            assert dir_exists(f'{wrapper_summary_file}'), 'Summary report was not generated!'
+        # check the stdout and log output
+        self.assert_output_as_expected(std_reg_expressions.get(scenario_id),
+                                       log_reg_expressions)
+        pull_cluster_props.assert_called_once()
+        mock_submit_as_spark.assert_called_once()
+        assert mock_remote_copy.call_count == 2


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Partially contribute to #37 by adding the following unit tests:
- avoid redundancy of code by adding classes
- [x] failure_non_existing_cluster
- [x] failure_on_spark2
- [x] failure_non_running_cluster


