### PR TITLE
Fix qualification tool error parsing cluster tags that are redacted

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -66,7 +66,7 @@ object ToolUtils extends Logging {
         Map.empty
     }
   }
-  
+
   /**
    * Try to get the JobId from the cluster name. Parse the clusterName string which
    * looks like:

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -66,9 +66,7 @@ object ToolUtils extends Logging {
         Map.empty
     }
   }
-
-  //
-
+  
   /**
    * Try to get the JobId from the cluster name. Parse the clusterName string which
    * looks like:

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -81,7 +81,10 @@ object ToolUtils extends Logging {
     val splitArr = clusterNameString.split("-")
     if (splitArr.contains("job")) {
       val jobIdx = splitArr.indexOf("job")
-      jobId = Some(splitArr(jobIdx + 1))
+      // indexes are 0 based so adjust to compare to length
+      if (splitArr.length > jobIdx + 1) {
+        jobId = Some(splitArr(jobIdx + 1))
+      }
     }
     jobId
   }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -62,7 +62,7 @@ object ToolUtils extends Logging {
       clusterTagsMap
     } catch {
       case NonFatal(_) =>
-        logWarning(s"There was an exception parsing cluster tags JSON: $clusterTag, skipping")
+        logWarning(s"There was an exception parsing cluster tags string: $clusterTag, skipping")
         Map.empty
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -333,20 +333,20 @@ class QualificationAppInfo(
       Map.empty[String, String]
     }
 
-    val withClusterId = if (!initialClusterTagsMap.contains(QualOutputWriter.CLUSTER_ID)
+    val tagsMapWithClusterId = if (!initialClusterTagsMap.contains(QualOutputWriter.CLUSTER_ID)
       && clusterTagClusterId.nonEmpty) {
       initialClusterTagsMap + (QualOutputWriter.CLUSTER_ID -> clusterTagClusterId)
     } else {
       initialClusterTagsMap
     }
 
-    if (!withClusterId.contains(QualOutputWriter.JOB_ID)) {
+    if (!tagsMapWithClusterId.contains(QualOutputWriter.JOB_ID) && clusterTagClusterName.nonEmpty) {
       val clusterTagJobId = ToolUtils.parseClusterNameForJobId(clusterTagClusterName)
       clusterTagJobId.map { jobId =>
-        withClusterId + (QualOutputWriter.JOB_ID -> jobId)
-      }.getOrElse(withClusterId)
+        tagsMapWithClusterId + (QualOutputWriter.JOB_ID -> jobId)
+      }.getOrElse(tagsMapWithClusterId)
     } else {
-      withClusterId
+      tagsMapWithClusterId
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationEventProcessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationEventProcessor.scala
@@ -150,6 +150,14 @@ class QualificationEventProcessor(app: QualificationAppInfo, perSqlOnly: Boolean
       app.clusterTags = event.properties.getProperty(
         "spark.databricks.clusterUsageTags.clusterAllTags", "")
     }
+    if (app.clusterTagClusterId.isEmpty) {
+      app.clusterTagClusterId = event.properties.getProperty(
+        "spark.databricks.clusterUsageTags.clusterId", "")
+    }
+    if (app.clusterTagClusterName.isEmpty) {
+      app.clusterTagClusterName = event.properties.getProperty(
+        "spark.databricks.clusterUsageTags.clusterName", "")
+    }
   }
 
   override def doSparkListenerJobEnd(

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationEventProcessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationEventProcessor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,10 @@ class QualificationEventProcessor(app: QualificationAppInfo, perSqlOnly: Boolean
     }
     app.clusterTags = sparkProperties.getOrElse(
       "spark.databricks.clusterUsageTags.clusterAllTags", "")
+    app.clusterTagClusterId = sparkProperties.getOrElse(
+      "spark.databricks.clusterUsageTags.clusterId", "")
+    app.clusterTagClusterName = sparkProperties.getOrElse(
+      "spark.databricks.clusterUsageTags.clusterName", "")
   }
 
   override def doSparkListenerApplicationStart(

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -739,7 +739,6 @@ class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
           val df1 = spark.sparkContext.makeRDD(1 to 1000, 6).toDF
           df1.sample(0.1)
         }
-        // Thread.sleep(120000)
         val expectedClusterId = "0617-131246-dray530"
         val expectedJobId = "215"
 


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids-tools/issues/55

The ClusterTags property can show up as redacted and this ends up causing our code to throw an exception because we expect it to be a Map.  Handle that error and then try to get clusterId and JobId from other properties.

Added unit test and tested on original customer event log this showed up on.

<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
