### PR TITLE
Adding environment argument in qualification tool to allow for custom speedup factors per environment

### DIFF
--- a/core/docs/spark-qualification-tool.md
+++ b/core/docs/spark-qualification-tool.md
@@ -205,6 +205,9 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
                                      min(minute),h(hours),d(days),w(weeks),m(months).
                                      If a period is not specified it defaults to
                                      days.
+      --spark-env  <arg>...          Spark environment where CPU workloads were
+                                     executed.  Options include onprem, dataproc,
+                                     and emr.  Default is onprem.
   -t, --timeout  <arg>               Maximum time in seconds to wait for the event
                                      logs to be processed. Default is 24 hours
                                      (86400 seconds) and must be greater than 3

--- a/core/docs/spark-qualification-tool.md
+++ b/core/docs/spark-qualification-tool.md
@@ -183,9 +183,9 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
                                      It will overwrite any existing directory with
                                      the same name.
   -p, --per-sql                      Report at the individual SQL query level.
-      --platform  <arg>...           Cluster platform where Spark CPU workloads were
-                                     executed.  Options include onprem, dataproc,
-                                     and emr.  Default is onprem.
+      --platform  <arg>              Cluster platform where Spark CPU workloads were
+                                     executed. Options include onprem, dataproc,
+                                     and emr. Default is onprem.
   -r, --report-read-schema           Whether to output the read formats and
                                      datatypes to the CSV file. This can be very
                                      long. Default is false.

--- a/core/docs/spark-qualification-tool.md
+++ b/core/docs/spark-qualification-tool.md
@@ -183,6 +183,9 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
                                      It will overwrite any existing directory with
                                      the same name.
   -p, --per-sql                      Report at the individual SQL query level.
+      --platform  <arg>...           Cluster platform where Spark CPU workloads were
+                                     executed.  Options include onprem, dataproc,
+                                     and emr.  Default is onprem.
   -r, --report-read-schema           Whether to output the read formats and
                                      datatypes to the CSV file. This can be very
                                      long. Default is false.
@@ -205,9 +208,6 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
                                      min(minute),h(hours),d(days),w(weeks),m(months).
                                      If a period is not specified it defaults to
                                      days.
-      --spark-env  <arg>...          Spark environment where CPU workloads were
-                                     executed.  Options include onprem, dataproc,
-                                     and emr.  Default is onprem.
   -t, --timeout  <arg>               Maximum time in seconds to wait for the event
                                      logs to be processed. Default is 24 hours
                                      (86400 seconds) and must be greater than 3

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -27,7 +27,7 @@ import org.apache.spark.internal.Logging
  * By default it relies on a csv file included in the jar which is generated
  * by the plugin which lists the formats and types supported.
  */
-class PluginTypeChecker(sparkEnv: String = "onprem") extends Logging {
+class PluginTypeChecker(platform: String = "onprem") extends Logging {
 
   private val NS = "NS"
   private val PS = "PS"
@@ -86,7 +86,7 @@ class PluginTypeChecker(sparkEnv: String = "onprem") extends Logging {
 
   private def readOperatorsScore: Map[String, Double] = {
     var file: String = null
-    sparkEnv match {
+    platform match {
       case "dataproc" => file = OPERATORS_SCORE_FILE_DATAPROC
       case "emr" => file = OPERATORS_SCORE_FILE_EMR
       case _ => file = OPERATORS_SCORE_FILE_ONPREM

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -27,7 +27,7 @@ import org.apache.spark.internal.Logging
  * By default it relies on a csv file included in the jar which is generated
  * by the plugin which lists the formats and types supported.
  */
-class PluginTypeChecker extends Logging {
+class PluginTypeChecker(sparkEnv: String = "onprem") extends Logging {
 
   private val NS = "NS"
   private val PS = "PS"
@@ -38,7 +38,9 @@ class PluginTypeChecker extends Logging {
   private val NA = "NA"
 
   private val DEFAULT_DS_FILE = "supportedDataSource.csv"
-  private val OPERATORS_SCORE_FILE = "operatorsScore.csv"
+  private val OPERATORS_SCORE_FILE_ONPREM = "operatorsScore.csv"
+  private val OPERATORS_SCORE_FILE_DATAPROC = "operatorsScore-dataproc.csv"
+  private val OPERATORS_SCORE_FILE_EMR = "operatorsScore-emr.csv"
   private val SUPPORTED_EXECS_FILE = "supportedExecs.csv"
   private val SUPPORTED_EXPRS_FILE = "supportedExprs.csv"
 
@@ -83,7 +85,13 @@ class PluginTypeChecker extends Logging {
   def getSupportedExprs: Map[String, String] = supportedExprs
 
   private def readOperatorsScore: Map[String, Double] = {
-    val source = Source.fromResource(OPERATORS_SCORE_FILE)
+    var file: String = null
+    sparkEnv match {
+      case "dataproc" => file = OPERATORS_SCORE_FILE_DATAPROC
+      case "emr" => file = OPERATORS_SCORE_FILE_EMR
+      case _ => file = OPERATORS_SCORE_FILE_ONPREM
+    }
+    val source = Source.fromResource(file)
     readSupportedOperators(source, "score").map(x => (x._1, x._2.toDouble))
   }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,12 +85,12 @@ class PluginTypeChecker(platform: String = "onprem") extends Logging {
   def getSupportedExprs: Map[String, String] = supportedExprs
 
   private def readOperatorsScore: Map[String, Double] = {
-    var file: String = null
-    platform match {
-      case "dataproc" => file = OPERATORS_SCORE_FILE_DATAPROC
-      case "emr" => file = OPERATORS_SCORE_FILE_EMR
-      case _ => file = OPERATORS_SCORE_FILE_ONPREM
+    val file = platform match {
+      case "dataproc" => OPERATORS_SCORE_FILE_DATAPROC
+      case "emr" => OPERATORS_SCORE_FILE_EMR
+      case _ => OPERATORS_SCORE_FILE_ONPREM
     }
+    logInfo(s"Reading operators scores with platform: $platform")
     val source = Source.fromResource(file)
     readSupportedOperators(source, "score").map(x => (x._1, x._2.toDouble))
   }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
@@ -140,9 +140,9 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
       descr = "Maximum length of the SQL description string output with the " +
         "per sql output. Default is 100.",
       default = Some(100))
-  val sparkEnv: ScallopOption[String] =
+  val platform: ScallopOption[String] =
     opt[String](required = false,
-      descr = "Spark environment where CPU workloads were executed.  Options include " +
+      descr = "Cluster platform where Spark CPU workloads were executed.  Options include " +
         "onprem, dataproc, and emr.  Default is onprem.",
       default = Some("onprem"))
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
@@ -140,6 +140,11 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
       descr = "Maximum length of the SQL description string output with the " +
         "per sql output. Default is 100.",
       default = Some(100))
+  val sparkEnv: ScallopOption[String] =
+    opt[String](required = false,
+      descr = "Spark environment where CPU workloads were executed.  Options include " +
+        "onprem, dataproc, and emr.  Default is onprem.",
+      default = Some("onprem"))
 
   validate(order) {
     case o if (QualificationArgs.isOrderAsc(o) || QualificationArgs.isOrderDesc(o)) => Right(Unit)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,8 +142,8 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
       default = Some(100))
   val platform: ScallopOption[String] =
     opt[String](required = false,
-      descr = "Cluster platform where Spark CPU workloads were executed.  Options include " +
-        "onprem, dataproc, and emr.  Default is onprem.",
+      descr = "Cluster platform where Spark CPU workloads were executed. Options include " +
+        "onprem, dataproc, and emr. Default is onprem.",
       default = Some("onprem"))
 
   validate(order) {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
@@ -58,12 +58,12 @@ object QualificationMain extends Logging {
     val order = appArgs.order.getOrElse("desc")
     val uiEnabled = appArgs.htmlReport.getOrElse(false)
     val reportSqlLevel = appArgs.perSql.getOrElse(false)
-    val sparkEnv = appArgs.sparkEnv.getOrElse("onprem")
+    val platform = appArgs.platform.getOrElse("onprem")
 
     val hadoopConf = new Configuration()
 
     val pluginTypeChecker = try {
-      new PluginTypeChecker(sparkEnv)
+      new PluginTypeChecker(platform)
     } catch {
       case ie: IllegalStateException =>
         logError("Error creating the plugin type checker!", ie)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
@@ -58,11 +58,12 @@ object QualificationMain extends Logging {
     val order = appArgs.order.getOrElse("desc")
     val uiEnabled = appArgs.htmlReport.getOrElse(false)
     val reportSqlLevel = appArgs.perSql.getOrElse(false)
+    val sparkEnv = appArgs.sparkEnv.getOrElse("onprem")
 
     val hadoopConf = new Configuration()
 
     val pluginTypeChecker = try {
-      new PluginTypeChecker()
+      new PluginTypeChecker(sparkEnv)
     } catch {
       case ie: IllegalStateException =>
         logError("Error creating the plugin type checker!", ie)

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
@@ -151,4 +151,22 @@ class PluginTypeCheckerSuite extends FunSuite with Logging {
     assert(result(1) == "ORC")
     assert(result(2) == "ORC")
   }
+
+  test("supported operator score from onprem") {
+    val checker = new PluginTypeChecker("onprem")
+    assert(checker.getSpeedupFactor("FilterExec") == 2.8)
+    assert(checker.getSpeedupFactor("Ceil") == 4)
+  }
+
+  test("supported operator score from dataproc") {
+    val checker = new PluginTypeChecker("dataproc")
+    assert(checker.getSpeedupFactor("FilterExec") == 2.8)
+    assert(checker.getSpeedupFactor("Ceil") == 4)
+  }
+
+  test("supported operator score from emr") {
+    val checker = new PluginTypeChecker("emr")
+    assert(checker.getSpeedupFactor("FilterExec") == 2.7)
+    assert(checker.getSpeedupFactor("Ceil") == 4)
+  }
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -1113,7 +1113,7 @@ class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
     }
   }
 
-  test("test different values for spark-env argument") {
+  test("test different values for platform argument") {
     TrampolineUtil.withTempDir { eventLogDir =>
       val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir, "timezone") { spark =>
         import spark.implicits._
@@ -1128,7 +1128,7 @@ class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
         val appArgs = new QualificationArgs(Array(
           "--output-directory",
           outpath.getAbsolutePath,
-          "--spark-env",
+          "--platform",
           "onprem",
           eventLog))
 
@@ -1152,7 +1152,7 @@ class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
         val appArgs = new QualificationArgs(Array(
           "--output-directory",
           outpath.getAbsolutePath,
-          "--spark-env",
+          "--platform",
           "emr",
           eventLog))
 
@@ -1176,7 +1176,7 @@ class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
         val appArgs = new QualificationArgs(Array(
           "--output-directory",
           outpath.getAbsolutePath,
-          "--spark-env",
+          "--platform",
           "dataproc",
           eventLog))
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -1112,6 +1112,90 @@ class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
       }
     }
   }
+
+  test("test different values for spark-env argument") {
+    TrampolineUtil.withTempDir { eventLogDir =>
+      val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir, "timezone") { spark =>
+        import spark.implicits._
+        val testData = Seq((1, 1662519019), (2, 1662519020)).toDF("id", "timestamp")
+        spark.sparkContext.setJobDescription("timestamp functions as potential problems")
+        testData.createOrReplaceTempView("t1")
+        spark.sql("SELECT id, hour(current_timestamp()), second(to_timestamp(timestamp)) FROM t1")
+      }
+
+      // run the qualification tool for onprem
+      TrampolineUtil.withTempDir { outpath =>
+        val appArgs = new QualificationArgs(Array(
+          "--output-directory",
+          outpath.getAbsolutePath,
+          "--spark-env",
+          "onprem",
+          eventLog))
+
+        val (exit, sumInfo) =
+          QualificationMain.mainInternal(appArgs)
+        assert(exit == 0)
+  
+        // the code above that runs the Spark query stops the Sparksession
+        // so create a new one to read in the csv file
+        createSparkSession()
+
+        // validate that the SQL description in the csv file escapes commas properly
+        val outputResults = s"$outpath/rapids_4_spark_qualification_output/" +
+          s"rapids_4_spark_qualification_output.csv"
+        val outputActual = readExpectedFile(new File(outputResults))
+        assert(outputActual.collect().size == 1)
+      }
+
+      // run the qualification tool for emr
+      TrampolineUtil.withTempDir { outpath =>
+        val appArgs = new QualificationArgs(Array(
+          "--output-directory",
+          outpath.getAbsolutePath,
+          "--spark-env",
+          "emr",
+          eventLog))
+
+        val (exit, sumInfo) =
+          QualificationMain.mainInternal(appArgs)
+        assert(exit == 0)
+  
+        // the code above that runs the Spark query stops the Sparksession
+        // so create a new one to read in the csv file
+        createSparkSession()
+
+        // validate that the SQL description in the csv file escapes commas properly
+        val outputResults = s"$outpath/rapids_4_spark_qualification_output/" +
+          s"rapids_4_spark_qualification_output.csv"
+        val outputActual = readExpectedFile(new File(outputResults))
+        assert(outputActual.collect().size == 1)
+      }
+
+      // run the qualification tool for dataproc
+      TrampolineUtil.withTempDir { outpath =>
+        val appArgs = new QualificationArgs(Array(
+          "--output-directory",
+          outpath.getAbsolutePath,
+          "--spark-env",
+          "dataproc",
+          eventLog))
+
+        val (exit, sumInfo) =
+          QualificationMain.mainInternal(appArgs)
+        assert(exit == 0)
+  
+        // the code above that runs the Spark query stops the Sparksession
+        // so create a new one to read in the csv file
+        createSparkSession()
+
+        // validate that the SQL description in the csv file escapes commas properly
+        val outputResults = s"$outpath/rapids_4_spark_qualification_output/" +
+          s"rapids_4_spark_qualification_output.csv"
+        val outputActual = readExpectedFile(new File(outputResults))
+        assert(outputActual.collect().size == 1)
+      }
+    }
+  }
 }
 
 class ToolTestListener extends SparkListener {


### PR DESCRIPTION
Signed-off-by: Matt Ahrens <matthewahrens@gmail.com>

Closed #67 

Changes
- Added new argument (sparkEnv / --spark-env) to allow a user to pass in environment to leverage different speedup factors file (operatorsScore.csv)
- Supports onprem, dataproc, and emr values

Tests added
- QualificationSuite: unit test that runs qualification tool using --spark-env options (onprem, dataproc, emr) for functional positive test
- PluginTypeCheckerSuite: unit tests for each of the 3 environment options to validate an operator score is loaded properly (FilterExec)
- 
<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
