### PR TITLE
Fix latest pylint (2.16) reported issues

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -75,6 +75,7 @@ disable=
         #wrong-import-order,
         #       W0107: Used when a "pass" statement that can be avoided is encountered.
         #unnecessary-pass,
+        broad-exception-raised,
 
 
 # Set max of arguments for function / method the line below if "too-many-arguments" is allowed. Default: 5
@@ -280,6 +281,6 @@ valid-metaclass-classmethod-first-arg=mcs
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=StandardError,
-                       Exception,
-                       BaseException
+overgeneral-exceptions=builtins.StandardError,
+                       builtins.Exception,
+                       builtins.BaseException

--- a/user_tools/src/spark_rapids_dataproc_tools/rapids_models.py
+++ b/user_tools/src/spark_rapids_dataproc_tools/rapids_models.py
@@ -974,8 +974,8 @@ class Qualification(RapidsTool):
             """
             selected_cols = self.ctxt.get_value('local', 'output', 'summaryColumns')
             # check if any filters apply
-            filter_recom_enabled = (self.filter_apps == 'recommended')
-            filter_pos_enabled = (self.filter_apps == 'savings')
+            filter_recom_enabled = self.filter_apps == 'recommended'
+            filter_pos_enabled = self.filter_apps == 'savings'
             # filter by recommendations if enabled
             if filter_recom_enabled:
                 df_row = get_recommended_apps(raw_df, selected_cols)


### PR DESCRIPTION
like following:
```
pylint: Command line or configuration file:1: UserWarning: Specifying exception names in the overgeneral-exceptions option without module name is deprecated and support for it will be removed in pylint 3.0. Use fully qualified name (maybe 'builtins.StandardError' ?) instead.
src/spark_rapids_dataproc_tools/dataproc_wrapper.py:271:12: W0719: Raising too general exception: Exception (broad-exception-raised)
src/spark_rapids_dataproc_tools/rapids_models.py:977:0: C0325: Unnecessary parens after '=' keyword (superfluous-parens)
...
```
more details please refer to https://github.com/NVIDIA/spark-rapids-tools/actions/runs/4065300168/jobs/6999816443

Signed-off-by: Alex Zhang <alex4zhang@gmail.com>
