### PR TITLE
Tolerant multiple speedup factors for 'FilterExec' test

### DIFF
--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
@@ -160,7 +160,7 @@ class PluginTypeCheckerSuite extends FunSuite with Logging {
 
   test("supported operator score from dataproc") {
     val checker = new PluginTypeChecker("dataproc")
-    assert(checker.getSpeedupFactor("FilterExec") == 2.8)
+    assert(checker.getSpeedupFactor("FilterExec") >= 2.0)
     assert(checker.getSpeedupFactor("Ceil") == 4)
   }
 


### PR DESCRIPTION
to allow update `operatorsScore-dataproc.csv` by leveraging NDS test result

Signed-off-by: Alex Zhang <alex4zhang@gmail.com>
