### PR TITLE
Removing static speedup factor validation

### DIFF
--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -63,11 +63,10 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
     }
   }
 
-  private def assertSizeAndSupported(size: Int, execs: Seq[ExecInfo], speedUpFactor: Double = 3.0,
-      expectedDur: Seq[Option[Long]] = Seq.empty, extraText: String = ""): Unit = {
+  private def assertSizeAndSupported(size: Int, execs: Seq[ExecInfo],
+    expectedDur: Seq[Option[Long]] = Seq.empty, extraText: String = ""): Unit = {
     for (t <- Seq(execs)) {
       assert(t.size == size, s"$extraText $t")
-      assert(t.forall(_.speedupFactor == speedUpFactor), s"$extraText $t")
       assert(t.forall(_.isSupported == true), s"$extraText $t")
       assert(t.forall(_.children.isEmpty), s"$extraText $t")
       if (expectedDur.nonEmpty) {
@@ -184,13 +183,13 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
         val allChildren = wholeStages.flatMap(_.children).flatten
         assert(allChildren.size == 10)
         val filters = allChildren.filter(_.exec == "Filter")
-        assertSizeAndSupported(2, filters, 2.8)
+        assertSizeAndSupported(2, filters)
         val projects = allChildren.filter(_.exec == "Project")
         assertSizeAndSupported(2, projects)
         val sorts = allChildren.filter(_.exec == "Sort")
-        assertSizeAndSupported(3, sorts, 8.0)
+        assertSizeAndSupported(3, sorts)
         val smj = allChildren.filter(_.exec == "SortMergeJoin")
-        assertSizeAndSupported(1, smj, 22.7)
+        assertSizeAndSupported(1, smj)
       }
     }
   }
@@ -216,7 +215,7 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
         assert(wholeStages.forall(_.duration.nonEmpty))
         val allChildren = wholeStages.flatMap(_.children).flatten
         val hashAggregate = allChildren.filter(_.exec == "HashAggregate")
-        assertSizeAndSupported(2, hashAggregate, 4.5)
+        assertSizeAndSupported(2, hashAggregate)
       }
     }
   }
@@ -366,7 +365,7 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val subqueryBroadcast = allExecInfo.filter(_.exec == "SubqueryBroadcast")
     assertSizeAndSupported(1, subqueryBroadcast.toSeq, expectedDur = Seq(Some(1175)))
     val exchanges = allExecInfo.filter(_.exec == "Exchange")
-    assertSizeAndSupported(2, exchanges.toSeq, 4.2, expectedDur = Seq(Some(15688), Some(8)))
+    assertSizeAndSupported(2, exchanges.toSeq, expectedDur = Seq(Some(15688), Some(8)))
   }
 
   test("CustomShuffleReaderExec") {
@@ -488,7 +487,7 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
       }
       val allExecInfo = getAllExecsFromPlan(parsedPlans.toSeq)
       val bhj = allExecInfo.filter(_.exec == "BroadcastHashJoin")
-      assertSizeAndSupported(1, bhj, 5.1)
+      assertSizeAndSupported(1, bhj)
       val broadcastNestedJoin = allExecInfo.filter(_.exec == "BroadcastNestedLoopJoin")
       assertSizeAndSupported(1, broadcastNestedJoin)
       val shj = allExecInfo.filter(_.exec == "ShuffledHashJoin")
@@ -635,14 +634,14 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
     }
     val allExecInfo = getAllExecsFromPlan(parsedPlans.toSeq)
     val flatMapGroups = allExecInfo.filter(_.exec == "FlatMapGroupsInPandas")
-    assertSizeAndSupported(1, flatMapGroups, speedUpFactor = 1.2)
+    assertSizeAndSupported(1, flatMapGroups)
     val aggregateInPandas = allExecInfo.filter(_.exec == "AggregateInPandas")
-    assertSizeAndSupported(1, aggregateInPandas, speedUpFactor = 1.2)
+    assertSizeAndSupported(1, aggregateInPandas)
     // this event log had UDF for ArrowEvalPath so shows up as not supported
     val arrowEvalPython = allExecInfo.filter(_.exec == "ArrowEvalPython")
-    assertSizeAndSupported(1, arrowEvalPython, speedUpFactor = 1.2)
+    assertSizeAndSupported(1, arrowEvalPython)
     val mapInPandas = allExecInfo.filter(_.exec == "MapInPandas")
-    assertSizeAndSupported(1, mapInPandas, speedUpFactor = 1.2)
+    assertSizeAndSupported(1, mapInPandas)
     // WindowInPandas configured off by default
     val windowInPandas = allExecInfo.filter(_.exec == "WindowInPandas")
     assertSizeAndNotSupported(1, windowInPandas)
@@ -807,7 +806,7 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
         val allExecInfo = getAllExecsFromPlan(parsedPlans.toSeq)
         val sortExec = allExecInfo.filter(_.exec.contains("Sort"))
         assert(sortExec.size == 3)
-        assertSizeAndSupported(3, sortExec, 8.0)
+        assertSizeAndSupported(3, sortExec)
       }
     }
   }
@@ -889,7 +888,7 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
       }
       val execInfo = getAllExecsFromPlan(parsedPlans.toSeq)
       val hashAggregate = execInfo.filter(_.exec == "HashAggregate")
-      assertSizeAndSupported(2, hashAggregate, 4.5)
+      assertSizeAndSupported(2, hashAggregate)
     }
   }
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
@@ -102,18 +102,18 @@ class PluginTypeCheckerSuite extends FunSuite with Logging {
     val checker = new PluginTypeChecker
     TrampolineUtil.withTempDir { outpath =>
       val header = "CPUOperator,Score\n"
-      val supText = (header + "FilterExec,3\n").getBytes(StandardCharsets.UTF_8)
+      val supText = (header + "UnionExec,3\n").getBytes(StandardCharsets.UTF_8)
       val csvSupportedFile = Paths.get(outpath.getAbsolutePath, "testScore.txt")
       Files.write(csvSupportedFile, supText)
       checker.setOperatorScore(csvSupportedFile.toString)
-      assert(checker.getSpeedupFactor("FilterExec") == 3)
+      assert(checker.getSpeedupFactor("UnionExec") == 3)
       assert(checker.getSpeedupFactor("ProjectExec") == -1)
     }
   }
 
   test("supported operator score from default file") {
     val checker = new PluginTypeChecker
-    assert(checker.getSpeedupFactor("FilterExec") == 2.8)
+    assert(checker.getSpeedupFactor("UnionExec") == 3.0)
     assert(checker.getSpeedupFactor("Ceil") == 4)
   }
 
@@ -154,19 +154,19 @@ class PluginTypeCheckerSuite extends FunSuite with Logging {
 
   test("supported operator score from onprem") {
     val checker = new PluginTypeChecker("onprem")
-    assert(checker.getSpeedupFactor("FilterExec") == 2.8)
+    assert(checker.getSpeedupFactor("UnionExec") == 3.0)
     assert(checker.getSpeedupFactor("Ceil") == 4)
   }
 
   test("supported operator score from dataproc") {
     val checker = new PluginTypeChecker("dataproc")
-    assert(checker.getSpeedupFactor("FilterExec") >= 2.0)
+    assert(checker.getSpeedupFactor("UnionExec") == 3.0)
     assert(checker.getSpeedupFactor("Ceil") == 4)
   }
 
   test("supported operator score from emr") {
     val checker = new PluginTypeChecker("emr")
-    assert(checker.getSpeedupFactor("FilterExec") == 2.7)
+    assert(checker.getSpeedupFactor("UnionExec") == 3.0)
     assert(checker.getSpeedupFactor("Ceil") == 4)
   }
 }


### PR DESCRIPTION
Signed-off-by: mattahrens <matthewahrens@gmail.com>

Removing static validation of speedup factors in support of auto-generated PRs (e.g. https://github.com/NVIDIA/spark-rapids-tools/pull/80).  Follow-on work to add more general validation for speedup factors will be done in this issue: https://github.com/NVIDIA/spark-rapids-tools/issues/86.
<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
