### PR TITLE
Fix version format to YY.MM.MICRO

### DIFF
--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -26,7 +26,9 @@ dependencies = [
     "packaging==23.0",
     "certifi==2022.12.7",
     "idna==3.4",
-    "urllib3==1.26.14"
+    "urllib3==1.26.14",
+    "certifi==2022.12.7",
+    "beautifulsoup4==4.11.2"
 ]
 dynamic=["entry-points", "version"]
 [tool.setuptools.dynamic]

--- a/user_tools/src/spark_rapids_dataproc_tools/rapids_models.py
+++ b/user_tools/src/spark_rapids_dataproc_tools/rapids_models.py
@@ -30,6 +30,7 @@ from urllib.request import urlopen
 import certifi
 import pandas as pd
 import yaml
+from packaging.version import Version
 from tabulate import tabulate
 
 from spark_rapids_dataproc_tools.cost_estimator import DataprocCatalogContainer, DataprocPriceProvider, \
@@ -39,6 +40,7 @@ from spark_rapids_dataproc_tools.dataproc_utils import validate_dataproc_sdk, ge
     get_incompatible_criteria
 from spark_rapids_dataproc_tools.utilities import bail, \
     get_log_dict, remove_dir, make_dirs, resource_path, YAMLPropertiesContainer, gen_random_string
+from spark_rapids_pytools.common.sys_storage import FSUtil
 from spark_rapids_pytools.common.utilities import Utils
 
 
@@ -123,18 +125,12 @@ class ToolContext(YAMLPropertiesContainer):
     def get_remote_work_dir(self) -> str:
         return self.get_remote('depFolder')
 
-    def get_default_jar_name(self) -> str:
-        # get the version from the package, instead of the yaml file
-        # jar_version = self.get_value('sparkRapids', 'version')
-        jar_version = Utils.get_base_release()
-        default_jar_name = self.get_value('sparkRapids', 'jarFile')
-        return default_jar_name.format(jar_version)
-
     def get_rapids_jar_url(self) -> str:
         # get the version from the package, instead of the yaml file
         # jar_version = self.get_value('sparkRapids', 'version')
-        jar_version = Utils.get_base_release()
-        rapids_url = self.get_value('sparkRapids', 'repoUrl').format(jar_version, jar_version)
+        mvn_base_url = self.get_value('sparkRapids', 'mvnUrl')
+        jar_version = Utils.get_latest_available_jar_version(mvn_base_url, Utils.get_base_release())
+        rapids_url = self.get_value('sparkRapids', 'repoUrl').format(mvn_base_url, jar_version, jar_version)
         return rapids_url
 
     def get_tool_main_class(self) -> str:
@@ -218,15 +214,22 @@ class RapidsTool(object):
         return arguments_list
 
     def get_wrapper_arguments(self, arg_list: List[str]) -> List[str]:
-        version_num = Utils.get_base_release()
-        arg_definitions = self.ctxt.get_value_silent('sparkRapids',
-                                                     'cli',
-                                                     'tool_options_per_release',
-                                                     version_num)
         res = arg_list
-        if arg_definitions is not None:
-            for arg_name in arg_definitions:
-                res.extend([f'--{arg_name}', arg_definitions.get(arg_name)])
+        version_num = Utils.get_base_release()
+        defined_version = Version(version_num)
+        opts_per_release = self.ctxt.get_value_silent('sparkRapids',
+                                                      'cli',
+                                                      'toolOptionsPerRelease')
+        # TODO: we should add the arguments based on the jar being passed to the CLI
+        if opts_per_release:
+            for release_key in opts_per_release:
+                release_version = Version(release_key)
+                if release_version <= defined_version:
+                    arg_definitions = opts_per_release.get(release_key)
+                    if arg_definitions:
+                        for arg_name in arg_definitions:
+                            res.extend([f'--{arg_name}', arg_definitions.get(arg_name)])
+
         res.extend([
             ' --output-directory',
             f' {self.ctxt.get_remote_output_dir()}',
@@ -304,12 +307,14 @@ class RapidsTool(object):
     def _process_jar_arg(self):
         if self.tools_jar is None:
             # we should download the jar file
-            local_jar_path = os.path.join(self.ctxt.get_local_work_dir(), self.ctxt.get_default_jar_name())
-            wget_cmd = f'wget -O "{local_jar_path}" "{self.ctxt.get_rapids_jar_url()}"'
-            self.ctxt.logdebug(f'Downloading tools jar from {self.ctxt.get_rapids_jar_url()} to {local_jar_path}')
+            jar_url = self.ctxt.get_rapids_jar_url()
+            jar_file_name = FSUtil.get_resource_name(jar_url)
+            local_jar_path = os.path.join(self.ctxt.get_local_work_dir(), jar_file_name)
+            self.ctxt.logdebug(f'Downloading tools jar from {jar_url} to {local_jar_path}')
+            wget_cmd = f'wget -O "{local_jar_path}" "{jar_url}"'
             self.ctxt.cli.run(wget_cmd,
                               msg_fail='Failed downloading tools jar url')
-            jar_file_name = self.ctxt.get_default_jar_name()
+            jar_file_name = FSUtil.get_resource_name(local_jar_path)
         else:
             # copy the tools_jar to the dependency folder
             if self.tools_jar.startswith('gs://'):

--- a/user_tools/src/spark_rapids_dataproc_tools/resources/profiling-conf.yaml
+++ b/user_tools/src/spark_rapids_dataproc_tools/resources/profiling-conf.yaml
@@ -7,8 +7,8 @@ toolOutput:
       sparkProperties: 'Spark Properties:'
       comments: 'Comments:'
 sparkRapids:
-  jarFile: 'rapids-4-spark-tools_2.12-{}.jar'
-  repoUrl: 'https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark-tools_2.12/{}/rapids-4-spark-tools_2.12-{}.jar'
+  mvnUrl: 'https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark-tools_2.12'
+  repoUrl: '{}/{}/rapids-4-spark-tools_2.12-{}.jar'
   mainClass: 'com.nvidia.spark.rapids.tool.profiling.ProfileMain'
   outputDocURL: 'https://nvidia.github.io/spark-rapids/docs/spark-profiling-tool.html#understanding-profiling-tool-detailed-output-and-examples'
   gpu:

--- a/user_tools/src/spark_rapids_dataproc_tools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_dataproc_tools/resources/qualification-conf.yaml
@@ -22,8 +22,8 @@ toolOutput:
       compactWidth: true
       timeUnits: 's'
 sparkRapids:
-  repoUrl: 'https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark-tools_2.12/{}/rapids-4-spark-tools_2.12-{}.jar'
-  jarFile: 'rapids-4-spark-tools_2.12-{}.jar'
+  mvnUrl: 'https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark-tools_2.12'
+  repoUrl: '{}/{}/rapids-4-spark-tools_2.12-{}.jar'
   mainClass: 'com.nvidia.spark.rapids.tool.qualification.QualificationMain'
   outputDocURL: 'https://nvidia.github.io/spark-rapids/docs/spark-qualification-tool.html#understanding-the-qualification-tool-output'
   gpu:
@@ -67,7 +67,7 @@ sparkRapids:
       - timeout
       - u
       - user-name
-    tool_options_per_release:
+    toolOptionsPerRelease:
       23.02.0:
         platform: dataproc
 local:

--- a/user_tools/src/spark_rapids_pytools/common/utilities.py
+++ b/user_tools/src/spark_rapids_pytools/common/utilities.py
@@ -78,7 +78,9 @@ class Utils:
         # make sure that we replace micro version with 0
         version_comp = list(version_tuple)
         version_comp[2] = 0
-        res = '.'.join(str(v_comp) for v_comp in version_comp[:3])
+        # For now, tools jar is under url YY.MM.0 where MM is 02, 04, 06, 08, 10, and 12
+        # res = '.'.join(f'{v_comp:02}' for v_comp in version_comp[:3])
+        res = f'{version_comp[0]}.{version_comp[1]:02}.0'
         return res
 
     @classmethod

--- a/user_tools/src/spark_rapids_pytools/common/utilities.py
+++ b/user_tools/src/spark_rapids_pytools/common/utilities.py
@@ -17,15 +17,20 @@
 import datetime
 import logging.config
 import os
+import re
 import secrets
+import ssl
 import string
 import subprocess
 import sys
+import urllib
 from dataclasses import dataclass, field
 from logging import Logger
 from shutil import which
 from typing import Callable, Any
 
+import certifi
+from bs4 import BeautifulSoup
 from packaging.version import Version
 
 from spark_rapids_pytools import get_version
@@ -65,6 +70,47 @@ class Utils:
         return pkg / 'resources' / resource_name
 
     @classmethod
+    def reformat_release_version(cls, defined_version: Version) -> str:
+        # get the release from version
+        version_tuple = defined_version.release
+        version_comp = list(version_tuple)
+        # release format is under url YY.MM.MICRO where MM is 02, 04, 06, 08, 10, and 12
+        res = f'{version_comp[0]}.{version_comp[1]:02}.{version_comp[2]}'
+        return res
+
+    @classmethod
+    def get_latest_available_jar_version(cls, url_base: str, loaded_version: str) -> str:
+        """
+        Given the defined version in the python tools build, we want to be able to get the highest
+        version number of the jar available for download from the mvn repo.
+        The returned version is guaranteed to be LEQ to the defined version. For example, it is not
+        allowed to use jar version higher than the python tool itself.
+        :param url_base: the base url from which the jar file is downloaded. It can be mvn repo.
+        :param loaded_version: the version from the python tools in string format
+        :return: the string value of the jar that should be downloaded.
+        """
+        context = ssl.create_default_context(cafile=certifi.where())
+        defined_version = Version(loaded_version)
+        jar_version = Version(loaded_version)
+        version_regex = r'\d{2}\.\d{2}\.\d+'
+        version_pattern = re.compile(version_regex)
+        with urllib.request.urlopen(url_base, context=context) as resp:
+            html_content = resp.read()
+            # Parse the HTML content using BeautifulSoup
+            soup = BeautifulSoup(html_content, 'html.parser')
+            # Find all the links with title in the format of "xx.xx.xx"
+            links = soup.find_all('a', {'title': version_pattern})
+            # Get the link with the highest value
+            for link in links:
+                curr_title = re.search(version_regex, link.get('title'))
+                if curr_title:
+                    curr_version = Version(curr_title.group())
+                    if curr_version <= defined_version:
+                        jar_version = curr_version
+        # get formatted string
+        return cls.reformat_release_version(jar_version)
+
+    @classmethod
     def get_base_release(cls) -> str:
         """
         For now the tools_jar is always with major.minor.0.
@@ -74,14 +120,7 @@ class Utils:
         """
         defined_version = Version(get_version(main=None))
         # get the release from version
-        version_tuple = defined_version.release
-        # make sure that we replace micro version with 0
-        version_comp = list(version_tuple)
-        version_comp[2] = 0
-        # For now, tools jar is under url YY.MM.0 where MM is 02, 04, 06, 08, 10, and 12
-        # res = '.'.join(f'{v_comp:02}' for v_comp in version_comp[:3])
-        res = f'{version_comp[0]}.{version_comp[1]:02}.0'
-        return res
+        return cls.reformat_release_version(defined_version)
 
     @classmethod
     def is_system_tool(cls, tool_name: str) -> bool:

--- a/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
@@ -125,18 +125,12 @@ class ToolContext(YAMLPropertiesContainer):
     def get_local_work_dir(self) -> str:
         return self.get_local('depFolder')
 
-    def get_default_jar_name(self) -> str:
-        # we can get the version using get_version(main=None) but this will add a suffix
-        # we want only the major version to get the jar
-        jar_version = Utils.get_base_release()
-        default_jar_name = self.get_value('sparkRapids', 'jarFile')
-        return default_jar_name.format(jar_version)
-
     def get_rapids_jar_url(self) -> str:
-        # we can get the version using get_version(main=None) but this will add a suffix
-        # we want only the major version to get the jar
-        jar_version = Utils.get_base_release()
-        rapids_url = self.get_value('sparkRapids', 'repoUrl').format(jar_version, jar_version)
+        # get the version from the package, instead of the yaml file
+        # jar_version = self.get_value('sparkRapids', 'version')
+        mvn_base_url = self.get_value('sparkRapids', 'mvnUrl')
+        jar_version = Utils.get_latest_available_jar_version(mvn_base_url, Utils.get_base_release())
+        rapids_url = self.get_value('sparkRapids', 'repoUrl').format(mvn_base_url, jar_version, jar_version)
         return rapids_url
 
     def get_tool_main_class(self) -> str:

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -29,8 +29,8 @@ toolOutput:
       compactWidth: true
       timeUnits: 's'
 sparkRapids:
-  repoUrl: 'https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark-tools_2.12/{}/rapids-4-spark-tools_2.12-{}.jar'
-  jarFile: 'rapids-4-spark-tools_2.12-{}.jar'
+  mvnUrl: 'https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark-tools_2.12'
+  repoUrl: '{}/{}/rapids-4-spark-tools_2.12-{}.jar'
   mainClass: 'com.nvidia.spark.rapids.tool.qualification.QualificationMain'
   outputDocURL: 'https://nvidia.github.io/spark-rapids/docs/spark-qualification-tool.html#understanding-the-qualification-tool-output'
   gpu:


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #118

Minor fix to the string format that build the default URL

**Update:**

- uses the MICRO number as well to load the dependencies. MICRO number does not force double digit format 0, 1, 2, 9, 10, 11..etc
- If the release has no equivalent JAR available on MVN repo, the wrapper will pull the highest version number that is LTE the defined release. For example 23.02.1 will download 23.02.0-jar if any, or 22.12.0.jar and so on.
