### PR TITLE
Handle ReusedExchange and GenerateBloomFilter in SQLPlanParser

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -109,7 +109,7 @@ object SQLPlanParser extends Logging {
       // This implies that the wholeStageCodeGen is also reused.
       // Note that the following logic can be moved to the WholeStageCodegen parser. Handling the
       // logic here has advantages:
-      //   1- no need to append to append to the final set
+      //   1- no need to append to the final set
       //   2- keep the logic in one place.
       val allStageNodes = planGraph.nodes.filter(
         stageNode => stageNode.name.contains("WholeStageCodegen"))
@@ -161,7 +161,7 @@ object SQLPlanParser extends Logging {
   private val execsToBeRemoved = Set(
     "GenerateBloomFilter",   // Exclusive on AWS. Ignore it as metrics cannot be evaluated.
     "ReusedExchange",        // reusedExchange should not be added to speedups
-    "ColumnarToRow"          // for now as assume everything is columnar
+    "ColumnarToRow"          // for now, assume everything is columnar
   )
 
   def parsePlanNode(

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -32,7 +32,6 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{SparkSession, TrampolineUtil}
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions.{ceil, col, collect_list, count, explode, floor, hex, json_tuple, round, row_number, sum}
-import org.apache.spark.sql.rapids.tool.ToolUtils
 import org.apache.spark.sql.rapids.tool.qualification.QualificationAppInfo
 import org.apache.spark.sql.types.StringType
 
@@ -364,6 +363,27 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
     assertSizeAndSupported(1, subqueryBroadcast.toSeq, expectedDur = Seq(Some(1175)))
     val exchanges = allExecInfo.filter(_.exec == "Exchange")
     assertSizeAndSupported(2, exchanges.toSeq, expectedDur = Seq(Some(15688), Some(8)))
+  }
+
+  test("ReusedExchangeExec") {
+    // The eventlog has a ReusedExchange that causes multiple nodes to be duplicate.
+    // This unit test is to check that we set the duplicate nodes as shouldRemove
+    // to avoid adding them multiple times to the speedups.
+    val eventLog = s"$qualLogDir/nds_q86_test"
+    val pluginTypeChecker = new PluginTypeChecker()
+    val app = createAppFromEventlog(eventLog)
+    val parsedPlans = app.sqlPlans.map { case (sqlID, plan) =>
+      SQLPlanParser.parseSQLPlan(app.appId, plan, sqlID, "", pluginTypeChecker, app)
+    }
+    val allExecInfo = getAllExecsFromPlan(parsedPlans.toSeq)
+    // reusedExchange is added as a supportedExec
+    val reusedExchangeExecs = allExecInfo.filter(_.exec == "ReusedExchange")
+    assertSizeAndSupported(1, reusedExchangeExecs)
+    val nodesWithRemove = allExecInfo.filter(_.shouldRemove)
+    // There are 7 nodes that are duplicated including 1 ReusedExchangeExec node and 1 WholeStageCodegen.
+    assert(1 == nodesWithRemove.count(
+      exec => exec.expr.contains("WholeStageCodegen")))
+    assert(1 == nodesWithRemove.count(exec => exec.exec.equals("ReusedExchange")))
   }
 
   test("CustomShuffleReaderExec") {


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #136

* Special handling for `ReusedExchange` by finding all the ancestors
* Mark duplicate graph nodes (ancestors of `ReusedExchange`) as `shouldRemove`
* Mark all "`GenerateBloomFilter`" nodes as unsupported and `shouldRemove`
* Add a unit test that parses "nds_q86_test" which contains `ReusedExchange` nodes
* For now, no test was added for `GenerateBloomFilter` as it requires an actual eventlog generated on EMR cluster
* Skipped updating the expectation files since the `ReusedExchange` should not appear in the unsupported column; but this does not break the test.

**Other approaches**

In this PR duplicate nodes were added to the Execs, but they were all marked as "`shouldRemove`"

Another way to handle the duplicate nodes is to return an empty sequence of ExecInfo for all duplicate nodes.
This means that the tool output won't include any of those execs.  
This approach is straightforward and could be more efficient as we skip those nodes.
Cons: we will lose the information regarding those missing IDs. At least for the first few iterations, it will be good to have this information to be able to debug and revisit the approach.