### PR TITLE
Add reshaped cluster to savingEstimator

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -977,7 +977,7 @@ class ClusterBase(ClusterGetAccessor):
 
 
 @dataclass
-class ClusterReShape(ClusterGetAccessor):
+class ClusterReshape(ClusterGetAccessor):
     """
     A class that handles reshaping of the given cluster.
     It takes argument a cluster object and callable methods that defines

--- a/user_tools/src/spark_rapids_pytools/pricing/price_provider.py
+++ b/user_tools/src/spark_rapids_pytools/pricing/price_provider.py
@@ -20,7 +20,7 @@ import os
 from dataclasses import dataclass, field
 from logging import Logger
 
-from spark_rapids_pytools.cloud_api.sp_types import ClusterBase
+from spark_rapids_pytools.cloud_api.sp_types import ClusterGetAccessor
 from spark_rapids_pytools.common.sys_storage import FSUtil
 from spark_rapids_pytools.common.utilities import ToolLogging, Utils
 
@@ -123,8 +123,8 @@ class SavingsEstimator:
     Implementation of model to get an estimate of cost savings.
     """
     price_provider: PriceProvider
-    target_cluster: ClusterBase
-    source_cluster: ClusterBase
+    source_cluster: ClusterGetAccessor
+    reshaped_cluster: ClusterGetAccessor
     target_cost: float = field(default=None, init=False)
     source_cost: float = field(default=None, init=False)
     comments: list = field(default_factory=lambda: [], init=False)

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -20,7 +20,7 @@ from typing import Any, List
 import pandas as pd
 from tabulate import tabulate
 
-from spark_rapids_pytools.cloud_api.sp_types import EnumeratedType
+from spark_rapids_pytools.cloud_api.sp_types import EnumeratedType, ClusterReShape
 from spark_rapids_pytools.common.sys_storage import FSUtil
 from spark_rapids_pytools.common.utilities import Utils
 from spark_rapids_pytools.pricing.price_provider import SavingsEstimator
@@ -353,9 +353,9 @@ class Qualification(RapidsJarTool):
             return pd.Series([savings_recommendations, est_cpu_cost, est_gpu_cost, est_savings])
 
         # initialize the savings estimator
-        savings_estimator = self.ctxt.platform.create_saving_estimator(
-            self.ctxt.get_ctxt('cpuClusterProxy'),
-            self.ctxt.get_ctxt('gpuClusterProxy'))
+        reshaped_gpu_cluster = ClusterReShape(self.ctxt.get_ctxt('gpuClusterProxy'))
+        savings_estimator = self.ctxt.platform.create_saving_estimator(self.ctxt.get_ctxt('cpuClusterProxy'),
+                                                                       reshaped_gpu_cluster)
         extra_comments = savings_estimator.comments
         conversion_comments = self.__generate_mc_types_conversion_report()
         extra_comments.extend(conversion_comments)

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -20,7 +20,7 @@ from typing import Any, List
 import pandas as pd
 from tabulate import tabulate
 
-from spark_rapids_pytools.cloud_api.sp_types import EnumeratedType, ClusterReShape
+from spark_rapids_pytools.cloud_api.sp_types import EnumeratedType, ClusterReshape
 from spark_rapids_pytools.common.sys_storage import FSUtil
 from spark_rapids_pytools.common.utilities import Utils
 from spark_rapids_pytools.pricing.price_provider import SavingsEstimator
@@ -353,7 +353,7 @@ class Qualification(RapidsJarTool):
             return pd.Series([savings_recommendations, est_cpu_cost, est_gpu_cost, est_savings])
 
         # initialize the savings estimator
-        reshaped_gpu_cluster = ClusterReShape(self.ctxt.get_ctxt('gpuClusterProxy'))
+        reshaped_gpu_cluster = ClusterReshape(self.ctxt.get_ctxt('gpuClusterProxy'))
         savings_estimator = self.ctxt.platform.create_saving_estimator(self.ctxt.get_ctxt('cpuClusterProxy'),
                                                                        reshaped_gpu_cluster)
         extra_comments = savings_estimator.comments


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #154

* Created new class `ClusterReShape` to control cluster properties
* Modified the SavingEstimator to access the new class instead of the cluster

**Usage**

A cluster can be reshaped by creating the ClusterReShape and setting any of the following fields
    - reshape_workers_mc_type: Callable[[str], str]
    - reshape_workers_cnt: Callable[[int], int]
    - reshape_workers_cpus: Callable[[int], int]
    - reshape_workers_mem: Callable[[int], int]
    - reshape_workers_gpu_cnt: Callable[[int], int]
    - reshape_workers_gpu_device: Callable[[str], str]
By default, all those fields are set to return the cluster's actual value. 

Example changing instanceType to 'n1-standard-4'

```
reshaped_cluster = ClusterReShape(self.ctxt.get_ctxt('gpuClusterProxy'),
                                reshape_workers_mc_type=lambda x: 'n1-standard-4')
```

Example changing the workers count to 3

```
reshaped_cluster = ClusterReShape(self.ctxt.get_ctxt('gpuClusterProxy'),
                                 reshape_workers_cnt=lambda x: 3)
```

