### PR TITLE
Fix initialization scripts in Qualification dataproc output

### DIFF
--- a/user_tools/docs/legacy-user-tools-dataproc.md
+++ b/user_tools/docs/legacy-user-tools-dataproc.md
@@ -218,7 +218,7 @@ For more details, please visit the
       Overall estimated cost savings  57.50%
       ------------------------------  ------
       To launch a GPU-accelerated cluster with RAPIDS Accelerator for Apache Spark, add the following to your cluster creation script:
-              --initialization-actions=gs://goog-dataproc-initialization-actions-us-central1/gpu/install_gpu_driver.sh,gs://goog-dataproc-initialization-actions-us-central1/rapids/rapids.sh \ 
+              --initialization-actions=gs://goog-dataproc-initialization-actions-us-central1/spark-rapids/spark-rapids.sh \ 
               --worker-accelerator type=nvidia-tesla-t4,count=2 \ 
               --metadata gpu-driver-provider="NVIDIA" \ 
               --metadata rapids-runtime=SPARK \ 
@@ -267,7 +267,7 @@ For more details, please visit the
       
       To support acceleration with T4 GPUs, you will need to switch your worker node instance type to n1-highcpu-32
       To launch a GPU-accelerated cluster with RAPIDS Accelerator for Apache Spark, add the following to your cluster creation script:
-              --initialization-actions=gs://goog-dataproc-initialization-actions-us-central1/gpu/install_gpu_driver.sh,gs://goog-dataproc-initialization-actions-us-central1/rapids/rapids.sh \ 
+              --initialization-actions=gs://goog-dataproc-initialization-actions-us-central1/spark-rapids/spark-rapids.sh \ 
               --worker-accelerator type=nvidia-tesla-t4,count=2 \ 
               --metadata gpu-driver-provider="NVIDIA" \ 
               --metadata rapids-runtime=SPARK \ 
@@ -439,7 +439,7 @@ be stored locally or on GCS bucket.
                 Overall estimated cost savings  12.30%
                 ------------------------------  ------
                 To launch a GPU-accelerated cluster with RAPIDS Accelerator for Apache Spark, add the following to your cluster creation script:
-                        --initialization-actions=gs://goog-dataproc-initialization-actions-us-central1/gpu/install_gpu_driver.sh,gs://goog-dataproc-initialization-actions-us-central1/rapids/rapids.sh \ 
+                        --initialization-actions=gs://goog-dataproc-initialization-actions-us-central1/spark-rapids/spark-rapids.sh \ 
                         --worker-accelerator type=nvidia-tesla-t4,count=2 \ 
                         --metadata gpu-driver-provider="NVIDIA" \ 
                         --metadata rapids-runtime=SPARK \ 

--- a/user_tools/docs/user-tools-dataproc.md
+++ b/user_tools/docs/user-tools-dataproc.md
@@ -34,7 +34,7 @@ the applications running on _Google Cloud Dataproc_.
     - from source: `pip install -e .`
 - verify the command is installed correctly by running
   ```bash
-    spark-rapids-user-tools dataproc --help
+    spark_rapids_user_tools dataproc --help
   ```
 
 ## Qualification command
@@ -138,14 +138,21 @@ The command creates a directory with UUID that contains the following:
 - A CSV file that contains the summary of all the applications along with estimated absolute costs
 - Sample directory structure:
     ```
-    .
+    qual_20230314145334_d2CaFA34
     ├── qualification_summary.csv
     └── rapids_4_spark_qualification_output
-        ├── rapids_4_spark_qualification_output.csv
-        ├── rapids_4_spark_qualification_output.log
-        ├── rapids_4_spark_qualification_output_execs.csv
+        ├── ui
+        │   └── html
+        │       ├── sql-recommendation.html
+        │       ├── index.html
+        │       ├── application.html
+        │       └── raw.html
         ├── rapids_4_spark_qualification_output_stages.csv
-        └── ui
+        ├── rapids_4_spark_qualification_output.csv
+        ├── rapids_4_spark_qualification_output_execs.csv
+        └── rapids_4_spark_qualification_output.log
+    3 directories, 9 files
+
     ```
 
 ## Profiling command
@@ -280,6 +287,7 @@ This case is relevant to the following plans:
 2. Users who have no access to the properties of the cluster.
 
 The CLI is triggered by providing the location where the yaml file is stored `--worker_info $WORKER_INFO_PATH`
+
     ```
     # First, create a yaml file as described in previous section
     $> export WORKER_INFO_PATH=worker-info.yaml
@@ -340,7 +348,6 @@ The steps to run the command:
     ```bash
     spark_rapids_user_tools dataproc bootstrap \
       --cluster my-cluster-name \
-      --key_pair_path my-file-path \
       --nodry_run
     ```
 

--- a/user_tools/src/spark_rapids_dataproc_tools/rapids_models.py
+++ b/user_tools/src/spark_rapids_dataproc_tools/rapids_models.py
@@ -943,7 +943,7 @@ class Qualification(RapidsTool):
     def __generate_qualification_configs(self) -> str:
         initialization_actions = self.ctxt.get_value('sparkRapids',
                                                      'gpu',
-                                                     'initializationScripts').format(self.region, self.region)
+                                                     'initializationScripts').format(self.region)
         instructions_str = (
             f'To launch a GPU-accelerated cluster with RAPIDS Accelerator for Apache Spark, add the '
             f'following to your cluster creation script:\n\t'

--- a/user_tools/src/spark_rapids_dataproc_tools/resources/profiling-conf.yaml
+++ b/user_tools/src/spark_rapids_dataproc_tools/resources/profiling-conf.yaml
@@ -15,7 +15,7 @@ sparkRapids:
     device: 't4'
     workersPerNode: 2
     cudaVersion: '11.5'
-    initializationScripts: 'gs://goog-dataproc-initialization-actions-{}/gpu/install_gpu_driver.sh,gs://goog-dataproc-initialization-actions-{}/rapids/rapids.sh'
+    initializationScripts: 'gs://goog-dataproc-initialization-actions-{}/spark-rapids/spark-rapids.sh'
   cli:
     tool_options:
       - csv

--- a/user_tools/src/spark_rapids_dataproc_tools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_dataproc_tools/resources/qualification-conf.yaml
@@ -30,7 +30,7 @@ sparkRapids:
     device: 't4'
     workersPerNode: 2
     cudaVersion: '11.5'
-    initializationScripts: 'gs://goog-dataproc-initialization-actions-{}/gpu/install_gpu_driver.sh,gs://goog-dataproc-initialization-actions-{}/rapids/rapids.sh'
+    initializationScripts: 'gs://goog-dataproc-initialization-actions-{}/spark-rapids/spark-rapids.sh'
   cli:
     defaults:
       filters:

--- a/user_tools/src/spark_rapids_pytools/common/utilities.py
+++ b/user_tools/src/spark_rapids_pytools/common/utilities.py
@@ -163,8 +163,7 @@ class Utils:
         if hrule:
             dash = ruler * line_width
             return cls.gen_multiline_str(f'{title}:', dash)
-        else:
-            return f'{title}:'
+        return f'{title}:'
 
     @classmethod
     def gen_joined_str(cls, join_elem: str, items) -> str:

--- a/user_tools/src/spark_rapids_pytools/common/utilities.py
+++ b/user_tools/src/spark_rapids_pytools/common/utilities.py
@@ -154,6 +154,19 @@ class Utils:
         return cls.gen_multiline_str(dash, f'{title:^{line_width}}', dash)
 
     @classmethod
+    def gen_report_sec_header(cls,
+                              title: str,
+                              ruler='-',
+                              title_width: int = 20,
+                              hrule: bool = True) -> str:
+        line_width = max(title_width, len(title) + 1)
+        if hrule:
+            dash = ruler * line_width
+            return cls.gen_multiline_str(f'{title}:', dash)
+        else:
+            return f'{title}:'
+
+    @classmethod
     def gen_joined_str(cls, join_elem: str, items) -> str:
         """
         Given a variable length of String arguments (or list), returns a single string

--- a/user_tools/src/spark_rapids_pytools/rapids/profiling.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/profiling.py
@@ -232,7 +232,7 @@ class Profiling(RapidsJarTool):
             wrapper_summary.write(log_file_lines_str)
         self.logger.info('Generating Full STDOUT summary report')
         # wrapper STDOUT report contains both tabular and plain text format of recommendations
-        wrapper_content = [Utils.gen_str_header('Recommendations'),
+        wrapper_content = [Utils.gen_report_sec_header('Recommendations'),
                            log_file_lines_str,
                            '### Recommendations Table Summary ###',
                            tabulate(recommendations_table, headers, tablefmt='grid')]

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -489,8 +489,8 @@ class Qualification(RapidsJarTool):
                 else:
                     res.append(l_str)
             return res
-        else:
-            return super()._generate_section_content(sec_conf)
+        return super()._generate_section_content(sec_conf)
+
 
 @dataclass
 class QualificationAsLocal(Qualification):

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -246,6 +246,23 @@ class RapidsTool(object):
     def _report_results_are_empty(self):
         return [f'The {self.pretty_name()} tool did not generate any output. Nothing to display.']
 
+    def _generate_section_content(self, sec_conf: dict) -> List[str]:
+        rep_lines = [Utils.gen_report_sec_header(sec_conf.get('sectionName'), line_width=20)]
+        for sec_line in sec_conf['content'].get('lines'):
+            rep_lines.append(sec_line)
+        return rep_lines
+
+    def _generate_platform_report_sections(self) -> List[str]:
+        section_arr = self.ctxt.platform.configs.get_value_silent('wrapperReporting',
+                                                                  self.name,
+                                                                  'sections')
+        if section_arr:
+            rep_lines = []
+            for curr_sec in section_arr:
+                rep_lines.extend(self._generate_section_content(curr_sec))
+            return rep_lines
+        return None
+
 
 @dataclass
 class RapidsJarTool(RapidsTool):
@@ -530,7 +547,7 @@ class RapidsJarTool(RapidsTool):
         if not self._rapids_jar_tool_has_output():
             return None
         out_folder_path = self.ctxt.get_rapids_output_folder()
-        res_arr = [Utils.gen_str_header('Output'),
+        res_arr = [Utils.gen_report_sec_header('Output'),
                    f'{self.pretty_name()} tool output: {out_folder_path}']
         out_tree_list = self._gen_output_tree()
         return Utils.gen_multiline_str(res_arr, out_tree_list)

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -247,7 +247,7 @@ class RapidsTool(object):
         return [f'The {self.pretty_name()} tool did not generate any output. Nothing to display.']
 
     def _generate_section_content(self, sec_conf: dict) -> List[str]:
-        rep_lines = [Utils.gen_report_sec_header(sec_conf.get('sectionName'), line_width=20)]
+        rep_lines = [Utils.gen_report_sec_header(sec_conf.get('sectionName'), title_width=20)]
         for sec_line in sec_conf['content'].get('lines'):
             rep_lines.append(sec_line)
         return rep_lines

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -173,5 +173,27 @@
         }
       }
     }
+  },
+  "wrapperReporting": {
+    "qualification": {
+      "sections": [
+        {
+          "sectionID": "initializationScript",
+          "sectionName": "Initialization Scripts",
+          "content": {
+            "lines": [
+              "To launch a GPU-accelerated cluster with RAPIDS Accelerator for Apache Spark, add the",
+              "following to your cluster creation script:",
+              "\t--initialization-actions=gs://goog-dataproc-initialization-actions-{}/spark-rapids/spark-rapids.sh \\",
+              "\t--worker-accelerator type=nvidia-tesla-{},count={} \\",
+              "\t--metadata gpu-driver-provider=\"NVIDIA\" \\",
+              "\t--metadata rapids-runtime=SPARK \\",
+              "\t--cuda-version=11.5"
+            ]
+          }
+        }
+      ]
+
+    }
   }
 }

--- a/user_tools/tests/resources/dataproc-test-gpu-cluster.yaml
+++ b/user_tools/tests/resources/dataproc-test-gpu-cluster.yaml
@@ -33,7 +33,7 @@ config:
   initializationActions:
   - executableFile: gs://goog-dataproc-initialization-actions-us-central1/gpu/install_gpu_driver.sh
     executionTimeout: 600s
-  - executableFile: gs://goog-dataproc-initialization-actions-us-central1/rapids/rapids.sh
+  - executableFile: gs://goog-dataproc-initialization-actions-us-central1/spark-rapids/spark-rapids.sh
     executionTimeout: 600s
   masterConfig:
     diskConfig:

--- a/user_tools/tests/resources/dataproc-test-gpu-cluster.yaml
+++ b/user_tools/tests/resources/dataproc-test-gpu-cluster.yaml
@@ -31,8 +31,6 @@ config:
     subnetworkUri: https://www.googleapis.com/compute/v1/projects/dataproc-project-id/regions/us-central1/subnetworks/default
     zoneUri: https://www.googleapis.com/compute/v1/projects/dataproc-project-id/zones/us-central1-a
   initializationActions:
-  - executableFile: gs://goog-dataproc-initialization-actions-us-central1/gpu/install_gpu_driver.sh
-    executionTimeout: 600s
   - executableFile: gs://goog-dataproc-initialization-actions-us-central1/spark-rapids/spark-rapids.sh
     executionTimeout: 600s
   masterConfig:


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #137

- Updated all references to initialization actions
- Add the initial configuration to Dataproc qual output since it was missing
- Fixed a couple of typos in the dataproc documentation


The new output of Dataproc Qualification local-mode:

```
____________________________________________________________________________________________________
                                        QUALIFICATION Report                                        
____________________________________________________________________________________________________
Output:
--------------------
Qualification tool output: /scratch_folder/pr-151/output_folder/qual_20230314143111_CfF8DF4C/rapids_4_spark_qualification_output
    qual_20230314143111_CfF8DF4C
    ├── qualification_summary.csv
    └── rapids_4_spark_qualification_output
        ├── ui
        │   └── html
        │       ├── sql-recommendation.html
        │       ├── index.html
        │       ├── application.html
        │       └── raw.html
        ├── rapids_4_spark_qualification_output_stages.csv
        ├── rapids_4_spark_qualification_output_persql.log
        ├── rapids_4_spark_qualification_output_persql.csv
        ├── rapids_4_spark_qualification_output.csv
        ├── rapids_4_spark_qualification_output_execs.csv
        └── rapids_4_spark_qualification_output.log
    3 directories, 11 files
    - To learn more about the output details, visit https://nvidia.github.io/spark-rapids/docs/spark-qualification-tool.html#understanding-the-qualification-tool-output
    - Full savings and speedups CSV report: /scratch_folder/pr-151/output_folder/qual_20230314143111_CfF8DF4C/qualification_summary.csv
+----+-------------------------+---------------------+----------------------+------------------+-----------------+-----------------+---------------+-----------------+
|    | App ID                  | App Name            | Speedup Based        | Savings Based    |   Estimated GPU |   Estimated GPU |           App |   Estimated GPU |
|    |                         |                     | Recommendation       | Recommendation   |         Speedup |     Duration(s) |   Duration(s) |      Savings(%) |
|----+-------------------------+---------------------+----------------------+------------------+-----------------+-----------------+---------------+-----------------|
|  0 | app-20200423035604-0002 | spark_data_utils.py | Strongly Recommended | Recommended      |            3.68 |          647.89 |       2384.32 |            8.35 |
+----+-------------------------+---------------------+----------------------+------------------+-----------------+-----------------+---------------+-----------------+
Report Summary:
------------------------------  ------
Total applications                   4
RAPIDS candidates                    4
Overall estimated speedup         3.13
Overall estimated cost savings  -6.52%
------------------------------  ------
Initialization Scripts:
-----------------------
To launch a GPU-accelerated cluster with RAPIDS Accelerator for Apache Spark, add the
following to your cluster creation script:
        --initialization-actions=gs://goog-dataproc-initialization-actions-us-central1/spark-rapids/spark-rapids.sh \
        --worker-accelerator type=nvidia-tesla-t4,count=1 \
        --metadata gpu-driver-provider="NVIDIA" \
        --metadata rapids-runtime=SPARK \
        --cuda-version=11.5

```