### PR TITLE
Autotuner change to return reliable set of confs.

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -51,6 +51,7 @@ trait AppInfoPropertyGetter {
 trait AppInfoSqlTaskAggMetricsVisitor {
   def getJvmGCFractions: Seq[Double]
   def getSpilledMetrics: Seq[Long]
+  def getMaxNumberTasks: Int
 }
 
 trait AppInfoSQLMaxTaskInputSizes {
@@ -71,6 +72,7 @@ class AppSummaryInfoBaseProvider extends AppInfoPropertyGetter
   override def getMaxInput: Double = 0.0
   override def getJvmGCFractions: Seq[Double] = Seq()
   override def getSpilledMetrics: Seq[Long] = Seq()
+  override def getMaxNumberTasks: Int = 0
 }
 
 /**
@@ -120,6 +122,14 @@ class SingleAppSummaryInfoProvider(val app: ApplicationSummaryInfo)
   override def getSpilledMetrics: Seq[Long] = {
     app.sqlTaskAggMetrics.map { task =>
       task.diskBytesSpilledSum + task.memoryBytesSpilledSum
+    }
+  }
+
+  override def getMaxNumberTasks: Int = {
+    if (app.sqlTaskAggMetrics.nonEmpty) {
+      app.sqlStageInfo.maxBy(_.numTasks).numTasks
+    } else {
+      0
     }
   }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
@@ -111,7 +111,8 @@ case class SQLStageInfoProfileResult(
     stageId: Int,
     stageAttemptId: Int,
     duration: Option[Long],
-    nodeNames: Seq[String]) extends ProfileResult {
+    nodeNames: Seq[String],
+    numTasks: Int) extends ProfileResult {
   override val outputHeaders = Seq("appIndex", "sqlID", "jobID", "stageId",
     "stageAttemptId", "Stage Duration", "SQL Nodes(IDs)")
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -349,7 +349,8 @@ class ApplicationInfo(
           }
           validNodes.map(n => s"${n.name}(${n.id.toString})")
         }.getOrElse(null)
-        SQLStageInfoProfileResult(index, j.sqlID.get, jobId, s, sa, info.duration, nodeNames)
+        SQLStageInfoProfileResult(index, j.sqlID.get, jobId, s, sa, info.duration, nodeNames,
+          info.info.numTasks)
       }
     }
     sqlToStages.toSeq

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -729,7 +729,8 @@ object QualificationAppInfo extends Logging {
   // Summarize and estimate based on wall clock times
   def calculateEstimatedInfoSummary(estimatedRatio: Double, sqlDataFrameDuration: Long,
       appDuration: Long, sqlSpeedupFactor: Double, appName: String,
-      appId: String, hasFailures: Boolean, mlSpeedupFactor: Option[MLFuncsSpeedupAndDuration] = None,
+      appId: String, hasFailures: Boolean,
+      mlSpeedupFactor: Option[MLFuncsSpeedupAndDuration] = None,
       unsupportedExecs: String = "", unsupportedExprs: String = "",
       allClusterTagsMap: Map[String, String] = Map.empty[String, String]): EstimatedSummaryInfo = {
     val sqlDataFrameDurationToUse = if (sqlDataFrameDuration > appDuration) {

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -31,12 +31,14 @@ class AppInfoProviderMockTest(val maxInput: Double,
     val spilledMetrics: Seq[Long],
     val jvmGCFractions: Seq[Double],
     val propsFromLog: mutable.Map[String, String],
-    val sparkVersion: Option[String]) extends AppSummaryInfoBaseProvider {
+    val sparkVersion: Option[String],
+    val maxNumTask: Int) extends AppSummaryInfoBaseProvider {
   override def getMaxInput: Double = maxInput
   override def getSpilledMetrics: Seq[Long] = spilledMetrics
   override def getJvmGCFractions: Seq[Double] = jvmGCFractions
   override def getProperty(propKey: String): Option[String] = propsFromLog.get(propKey)
   override def getSparkVersion: Option[String] = sparkVersion
+  override def getMaxNumberTasks: Int = maxNumTask
 }
 
 class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
@@ -101,9 +103,10 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
       spilledMetrics: Seq[Long],
       jvmGCFractions: Seq[Double],
       propsFromLog: mutable.Map[String, String],
-      sparkVersion: Option[String]): AppSummaryInfoBaseProvider = {
+      sparkVersion: Option[String],
+      maxNumTask: Int = 200): AppSummaryInfoBaseProvider = {
     new AppInfoProviderMockTest(maxInput, spilledMetrics, jvmGCFractions, propsFromLog,
-      sparkVersion)
+      sparkVersion, maxNumTask)
   }
 
   test("Load non-existing cluster properties") {
@@ -201,6 +204,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
          |Spark Properties:
          |--conf spark.dynamicAllocation.enabled=true
          |--conf spark.dynamicAllocation.maxExecutors=2
+         |--conf spark.executor.cores=16
          |--conf spark.executor.memory=32768m
          |--conf spark.executor.memoryOverhead=7372m
          |--conf spark.rapids.memory.pinnedPool.size=4096m
@@ -213,6 +217,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
          |Comments:
          |- 'spark.dynamicAllocation.enabled' was not set.
          |- 'spark.dynamicAllocation.maxExecutors' was not set.
+         |- 'spark.executor.cores' was not set.
          |- 'spark.executor.memory' was not set.
          |- 'spark.executor.memoryOverhead' was not set.
          |- 'spark.rapids.memory.pinnedPool.size' was not set.
@@ -247,6 +252,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
       s"""|
           |Spark Properties:
           |--conf spark.dynamicAllocation.maxExecutors=4
+          |--conf spark.executor.cores=32
           |--conf spark.executor.memory=65536m
           |--conf spark.executor.memoryOverhead=10649m
           |--conf spark.shuffle.service.enabled=true
@@ -455,6 +461,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |Spark Properties:
           |--conf spark.dynamicAllocation.enabled=true
           |--conf spark.dynamicAllocation.maxExecutors=8
+          |--conf spark.executor.cores=16
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=7372m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
@@ -467,6 +474,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |Comments:
           |- 'spark.dynamicAllocation.enabled' was not set.
           |- 'spark.dynamicAllocation.maxExecutors' was not set.
+          |- 'spark.executor.cores' was not set.
           |- 'spark.executor.memory' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.memory.pinnedPool.size' was not set.
@@ -521,6 +529,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |Spark Properties:
           |--conf spark.dynamicAllocation.enabled=true
           |--conf spark.dynamicAllocation.maxExecutors=20
+          |--conf spark.executor.cores=8
           |--conf spark.executor.memory=16384m
           |--conf spark.executor.memoryOverhead=5734m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
@@ -616,6 +625,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |Spark Properties:
           |--conf spark.dynamicAllocation.enabled=true
           |--conf spark.dynamicAllocation.maxExecutors=20
+          |--conf spark.executor.cores=8
           |--conf spark.executor.memory=16384m
           |--conf spark.executor.memoryOverhead=5734m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
@@ -674,6 +684,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |Spark Properties:
           |--conf spark.dynamicAllocation.enabled=true
           |--conf spark.dynamicAllocation.maxExecutors=20
+          |--conf spark.executor.cores=8
           |--conf spark.executor.memory=16384m
           |--conf spark.executor.memoryOverhead=5734m
           |--conf spark.rapids.memory.pinnedPool.size=4096m

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -91,8 +91,10 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     rawString.split("\n").drop(1).mkString("\n")
   }
 
-  private def getUnusedProvider: AppSummaryInfoBaseProvider = {
-    new AppSummaryInfoBaseProvider()
+  private def getGpuAppMockInfoProvider(): AppSummaryInfoBaseProvider = {
+    getMockInfoProvider(0, Seq(0), Seq(0.0),
+      mutable.Map("spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin"), Some("3.1.1"))
   }
 
   private def getMockInfoProvider(maxInput: Double,
@@ -105,7 +107,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
   }
 
   test("Load non-existing cluster properties") {
-    val autoTuner = AutoTuner.buildAutoTuner("non-existing.yaml", getUnusedProvider)
+    val autoTuner = AutoTuner.buildAutoTuner("non-existing.yaml", getGpuAppMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -125,7 +127,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
 
   test("Load cluster properties with CPU cores 0") {
     val dataprocWorkerInfo = buildWorkerInfoAsString(None, Some(0))
-    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -147,7 +149,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
 
   test("Load cluster properties with CPU memory missing") {
     val dataprocWorkerInfo = buildWorkerInfoAsString(None, Some(32), None)
-    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -169,7 +171,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
 
   test("Load cluster properties with CPU memory 0") {
     val dataprocWorkerInfo = buildWorkerInfoAsString(None, Some(32), Some("0m"))
-    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -191,7 +193,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
 
   test("Load cluster properties with number of workers 0") {
     val dataprocWorkerInfo = buildWorkerInfoAsString(None, Some(32), Some("122880MiB"), Some(0))
-    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -236,7 +238,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val sparkProps = defaultDataprocProps.++(customProps)
     val dataprocWorkerInfo = buildWorkerInfoAsString(Some(sparkProps), Some(32),
       Some("122880MiB"), Some(4), Some(0))
-    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -268,7 +270,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val sparkProps = defaultDataprocProps.++(customProps)
     val dataprocWorkerInfo =
       buildWorkerInfoAsString(Some(sparkProps), Some(32), Some("122880MiB"), Some(4), Some(2), None)
-    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -296,7 +298,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val sparkProps = defaultDataprocProps.++(customProps)
     val dataprocWorkerInfo = buildWorkerInfoAsString(Some(sparkProps), Some(32),
       Some("122880MiB"), Some(4), Some(2), Some("0M"))
-    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -323,7 +325,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val sparkProps = defaultDataprocProps.++(customProps)
     val dataprocWorkerInfo = buildWorkerInfoAsString(Some(sparkProps), Some(32),
       Some("122880MiB"), Some(4), Some(2), Some("0MiB"), None)
-    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -352,7 +354,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val sparkProps = defaultDataprocProps.++(customProps)
     val dataprocWorkerInfo = buildWorkerInfoAsString(Some(sparkProps), Some(32),
       Some("122880MiB"), Some(4), Some(2), Some("0MiB"), Some("GPU-X"))
-    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -386,7 +388,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |Comments:
           |- 'spark.sql.shuffle.partitions' was not set.
           |""".stripMargin
-    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     assert(expectedResults == autoTunerOutput)
@@ -415,7 +417,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |Comments:
           |- 'spark.sql.shuffle.partitions' was not set.
           |""".stripMargin
-    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     assert(expectedResults == autoTunerOutput)
@@ -448,7 +450,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |- 'spark.sql.shuffle.partitions' was not set.
           |- 'spark.task.resource.gpu.amount' was not set.
           |""".stripMargin
-    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     assert(expectedResults == autoTunerOutput)
@@ -477,6 +479,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
         "spark.task.resource.gpu.amount" -> "0.0625",
         "spark.rapids.memory.pinnedPool.size" -> "5g",
         "spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
         "spark.rapids.sql.concurrentGpuTasks" -> "4")
     val dataprocWorkerInfo = buildWorkerInfoAsString(Some(customProps), Some(32),
       Some("212992MiB"), Some(5), Some(4), Some("15109MiB"), Some("Tesla T4"))
@@ -526,6 +529,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
         "spark.task.resource.gpu.amount" -> "0.0625",
         "spark.rapids.memory.pinnedPool.size" -> "5g",
         "spark.rapids.sql.enabled" -> "false",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
         "spark.rapids.sql.concurrentGpuTasks" -> "4")
     val dataprocWorkerInfo = buildWorkerInfoAsString(Some(customProps), Some(32),
       Some("212992MiB"), Some(5), Some(4), Some("15109MiB"), Some("Tesla T4"))
@@ -566,6 +570,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
         "spark.task.resource.gpu.amount" -> "0.25",
         "spark.rapids.memory.pinnedPool.size" -> "5g",
         "spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
         "spark.rapids.sql.concurrentGpuTasks" -> "1")
     val dataprocWorkerInfo = buildWorkerInfoAsString(Some(customProps), Some(32),
       Some("212992MiB"), Some(5), Some(4), Some("15109MiB"), Some("Tesla T4"))
@@ -619,6 +624,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
         "spark.task.resource.gpu.amount" -> "0.25",
         "spark.rapids.memory.pinnedPool.size" -> "5g",
         "spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
         "spark.rapids.sql.concurrentGpuTasks" -> "1")
     val dataprocWorkerInfo = buildWorkerInfoAsString(Some(customProps), Some(32),
       Some("212992MiB"), Some(5), Some(4), Some("15109MiB"), Some("Tesla T4"))

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -197,31 +197,33 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
-      s"""|
-          |Spark Properties:
-          |--conf spark.executor.cores=16
-          |--conf spark.executor.instances=2
-          |--conf spark.executor.memory=32768m
-          |--conf spark.executor.memoryOverhead=7372m
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
-          |--conf spark.rapids.sql.concurrentGpuTasks=2
-          |--conf spark.sql.files.maxPartitionBytes=512m
-          |--conf spark.sql.shuffle.partitions=200
-          |--conf spark.task.resource.gpu.amount=0.0625
-          |
-          |Comments:
-          |- 'spark.executor.cores' was not set.
-          |- 'spark.executor.instances' was not set.
-          |- 'spark.executor.memory' was not set.
-          |- 'spark.executor.memoryOverhead' was not set.
-          |- 'spark.rapids.memory.pinnedPool.size' was not set.
-          |- 'spark.rapids.sql.concurrentGpuTasks' was not set.
-          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
-          |- 'spark.sql.files.maxPartitionBytes' was not set.
-          |- 'spark.sql.shuffle.partitions' was not set.
-          |- 'spark.task.resource.gpu.amount' was not set.
-          |- Number of workers is missing. Setting default to 1.
-          |""".stripMargin
+      s"""
+         |Spark Properties:
+         |--conf spark.dynamicAllocation.enabled=true
+         |--conf spark.dynamicAllocation.maxExecutors=2
+         |--conf spark.executor.memory=32768m
+         |--conf spark.executor.memoryOverhead=7372m
+         |--conf spark.rapids.memory.pinnedPool.size=4096m
+         |--conf spark.rapids.sql.concurrentGpuTasks=2
+         |--conf spark.shuffle.service.enabled=true
+         |--conf spark.sql.files.maxPartitionBytes=512m
+         |--conf spark.sql.shuffle.partitions=200
+         |--conf spark.task.resource.gpu.amount=0.0625
+         |
+         |Comments:
+         |- 'spark.dynamicAllocation.enabled' was not set.
+         |- 'spark.dynamicAllocation.maxExecutors' was not set.
+         |- 'spark.executor.memory' was not set.
+         |- 'spark.executor.memoryOverhead' was not set.
+         |- 'spark.rapids.memory.pinnedPool.size' was not set.
+         |- 'spark.rapids.sql.concurrentGpuTasks' was not set.
+         |- 'spark.shuffle.service.enabled' was not set.
+         |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+         |- 'spark.sql.files.maxPartitionBytes' was not set.
+         |- 'spark.sql.shuffle.partitions' was not set.
+         |- 'spark.task.resource.gpu.amount' was not set.
+         |- Number of workers is missing. Setting default to 1.
+         |""".stripMargin
     assert(expectedResults == autoTunerOutput)
   }
 
@@ -244,13 +246,16 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.executor.cores=32
+          |--conf spark.dynamicAllocation.maxExecutors=4
           |--conf spark.executor.memory=65536m
           |--conf spark.executor.memoryOverhead=10649m
+          |--conf spark.shuffle.service.enabled=true
           |--conf spark.sql.shuffle.partitions=200
           |--conf spark.task.resource.gpu.amount=0.03125
           |
           |Comments:
+          |- 'spark.dynamicAllocation.maxExecutors' was not set.
+          |- 'spark.shuffle.service.enabled' was not set.
           |- 'spark.sql.shuffle.partitions' was not set.
           |- GPU count is missing. Setting default to 1.
           |""".stripMargin
@@ -276,9 +281,13 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val expectedResults =
       s"""|
           |Spark Properties:
+          |--conf spark.dynamicAllocation.maxExecutors=8
+          |--conf spark.shuffle.service.enabled=true
           |--conf spark.sql.shuffle.partitions=200
           |
           |Comments:
+          |- 'spark.dynamicAllocation.maxExecutors' was not set.
+          |- 'spark.shuffle.service.enabled' was not set.
           |- 'spark.sql.shuffle.partitions' was not set.
           |- GPU memory is missing. Setting default to 15109m.
           |""".stripMargin
@@ -304,9 +313,13 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val expectedResults =
       s"""|
           |Spark Properties:
+          |--conf spark.dynamicAllocation.maxExecutors=8
+          |--conf spark.shuffle.service.enabled=true
           |--conf spark.sql.shuffle.partitions=200
           |
           |Comments:
+          |- 'spark.dynamicAllocation.maxExecutors' was not set.
+          |- 'spark.shuffle.service.enabled' was not set.
           |- 'spark.sql.shuffle.partitions' was not set.
           |- GPU memory is missing. Setting default to 15109m.
           |""".stripMargin
@@ -331,9 +344,13 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val expectedResults =
       s"""|
           |Spark Properties:
+          |--conf spark.dynamicAllocation.maxExecutors=8
+          |--conf spark.shuffle.service.enabled=true
           |--conf spark.sql.shuffle.partitions=200
           |
           |Comments:
+          |- 'spark.dynamicAllocation.maxExecutors' was not set.
+          |- 'spark.shuffle.service.enabled' was not set.
           |- 'spark.sql.shuffle.partitions' was not set.
           |- GPU device is missing. Setting default to T4.
           |- GPU memory is missing. Setting default to 15109m.
@@ -360,9 +377,13 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val expectedResults =
       s"""|
           |Spark Properties:
+          |--conf spark.dynamicAllocation.maxExecutors=8
+          |--conf spark.shuffle.service.enabled=true
           |--conf spark.sql.shuffle.partitions=200
           |
           |Comments:
+          |- 'spark.dynamicAllocation.maxExecutors' was not set.
+          |- 'spark.shuffle.service.enabled' was not set.
           |- 'spark.sql.shuffle.partitions' was not set.
           |- GPU memory is missing. Setting default to 15109m.
           |""".stripMargin
@@ -383,9 +404,13 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val expectedResults =
       s"""|
           |Spark Properties:
+          |--conf spark.dynamicAllocation.maxExecutors=8
+          |--conf spark.shuffle.service.enabled=true
           |--conf spark.sql.shuffle.partitions=200
           |
           |Comments:
+          |- 'spark.dynamicAllocation.maxExecutors' was not set.
+          |- 'spark.shuffle.service.enabled' was not set.
           |- 'spark.sql.shuffle.partitions' was not set.
           |""".stripMargin
     val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider)
@@ -396,7 +421,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
 
   // This mainly to test that the executorInstances will be calculated when the dynamic allocation
   // is missing.
-  test("test T4 dataproc cluster with missing dynamic allocation") {
+  test("test T4 dataproc cluster with dynamic allocation set to false") {
     val customProps = mutable.LinkedHashMap(
       "spark.dynamicAllocation.enabled" -> "false",
       "spark.executor.cores" -> "16",
@@ -428,23 +453,25 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.executor.cores=16
-          |--conf spark.executor.instances=8
+          |--conf spark.dynamicAllocation.enabled=true
+          |--conf spark.dynamicAllocation.maxExecutors=8
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=7372m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.sql.concurrentGpuTasks=2
+          |--conf spark.shuffle.service.enabled=true
           |--conf spark.sql.files.maxPartitionBytes=512m
           |--conf spark.sql.shuffle.partitions=200
           |--conf spark.task.resource.gpu.amount=0.0625
           |
           |Comments:
-          |- 'spark.executor.cores' was not set.
-          |- 'spark.executor.instances' was not set.
+          |- 'spark.dynamicAllocation.enabled' was not set.
+          |- 'spark.dynamicAllocation.maxExecutors' was not set.
           |- 'spark.executor.memory' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.memory.pinnedPool.size' was not set.
           |- 'spark.rapids.sql.concurrentGpuTasks' was not set.
+          |- 'spark.shuffle.service.enabled' was not set.
           |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
           |- 'spark.sql.files.maxPartitionBytes' was not set.
           |- 'spark.sql.shuffle.partitions' was not set.
@@ -492,18 +519,22 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.executor.cores=8
-          |--conf spark.executor.instances=20
+          |--conf spark.dynamicAllocation.enabled=true
+          |--conf spark.dynamicAllocation.maxExecutors=20
           |--conf spark.executor.memory=16384m
           |--conf spark.executor.memoryOverhead=5734m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.sql.concurrentGpuTasks=2
+          |--conf spark.shuffle.service.enabled=true
           |--conf spark.sql.files.maxPartitionBytes=4096m
           |--conf spark.task.resource.gpu.amount=0.125
           |
           |Comments:
+          |- 'spark.dynamicAllocation.enabled' was not set.
+          |- 'spark.dynamicAllocation.maxExecutors' was not set.
           |- 'spark.executor.memoryOverhead' must be set if using 'spark.rapids.memory.pinnedPool.size
           |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.shuffle.service.enabled' was not set.
           |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
           |""".stripMargin
     // scalastyle:on line.size.limit
@@ -583,18 +614,22 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.executor.cores=8
-          |--conf spark.executor.instances=20
+          |--conf spark.dynamicAllocation.enabled=true
+          |--conf spark.dynamicAllocation.maxExecutors=20
           |--conf spark.executor.memory=16384m
           |--conf spark.executor.memoryOverhead=5734m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.sql.concurrentGpuTasks=2
+          |--conf spark.shuffle.service.enabled=true
           |--conf spark.sql.files.maxPartitionBytes=3669m
           |--conf spark.task.resource.gpu.amount=0.125
           |
           |Comments:
+          |- 'spark.dynamicAllocation.enabled' was not set.
+          |- 'spark.dynamicAllocation.maxExecutors' was not set.
           |- 'spark.executor.memoryOverhead' must be set if using 'spark.rapids.memory.pinnedPool.size
           |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.shuffle.service.enabled' was not set.
           |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
           |""".stripMargin
     // scalastyle:on line.size.limit
@@ -637,18 +672,22 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.executor.cores=8
-          |--conf spark.executor.instances=20
+          |--conf spark.dynamicAllocation.enabled=true
+          |--conf spark.dynamicAllocation.maxExecutors=20
           |--conf spark.executor.memory=16384m
           |--conf spark.executor.memoryOverhead=5734m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.sql.concurrentGpuTasks=2
+          |--conf spark.shuffle.service.enabled=true
           |--conf spark.sql.files.maxPartitionBytes=3669m
           |--conf spark.task.resource.gpu.amount=0.125
           |
           |Comments:
+          |- 'spark.dynamicAllocation.enabled' was not set.
+          |- 'spark.dynamicAllocation.maxExecutors' was not set.
           |- 'spark.executor.memoryOverhead' must be set if using 'spark.rapids.memory.pinnedPool.size
           |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.shuffle.service.enabled' was not set.
           |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
           |- Average JVM GC time is very high. Other Garbage Collectors can be used for better performance.
           |""".stripMargin


### PR DESCRIPTION
The following changes were made to recommend configuration to users based on a single eventLog. 

- Calculate the max cores needed by looking at max tasks in Stages
- Enable dynamicAllocation
- Enable dynamic shuffle

<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
