### PR TITLE
Modify wrapper qualification tool `--platform` argument 

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -708,7 +708,7 @@ class Qualification(RapidsJarTool):
 
     def _init_rapids_arg_list(self) -> List[str]:
         # TODO: Make sure we add this argument only for jar versions 23.02+
-        return ['--platform', self.ctxt.get_platform_name().replace("_", "-")]
+        return ['--platform', self.ctxt.get_platform_name().replace('_', '-')]
 
     def _generate_section_content(self, sec_conf: dict) -> List[str]:
         if sec_conf.get('sectionID') == 'initializationScript':

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -708,7 +708,7 @@ class Qualification(RapidsJarTool):
 
     def _init_rapids_arg_list(self) -> List[str]:
         # TODO: Make sure we add this argument only for jar versions 23.02+
-        return ['--platform', self.ctxt.get_platform_name()]
+        return ['--platform', self.ctxt.get_platform_name().replace("_", "-")]
 
     def _generate_section_content(self, sec_conf: dict) -> List[str]:
         if sec_conf.get('sectionID') == 'initializationScript':


### PR DESCRIPTION
For Databricks platforms, we need to modify the way we build the `--platform` argument for the core tools to process the platforms correctly.
For example, in the user tools, the platform name is `databricks_aws` for Databricks AWS, but the core tools takes in `databricks-aws`. We process the `--platform` argument so the wrapper will be able to pass the correct value to the Jar.

Contributes to #77 