### PR TITLE
Adjust floating roundup to prevent zero values in cost calculations

### DIFF
--- a/user_tools/src/spark_rapids_pytools/pricing/price_provider.py
+++ b/user_tools/src/spark_rapids_pytools/pricing/price_provider.py
@@ -15,7 +15,6 @@
 """Abstract class of providing absolute costs of resources in CSP"""
 
 import datetime
-import math
 import os
 from dataclasses import dataclass, field
 from logging import Logger
@@ -156,7 +155,4 @@ class SavingsEstimator:
             return 0.0, 0.0, 0.0
         gpu_cost = self.target_cost * estimated_gpu_duration_ms / (60.0 * 60 * 1000)
         estimated_savings = 100.0 - ((100.0 * gpu_cost) / cpu_cost)
-        cpu_cost_res = math.ceil(cpu_cost * 100) / 100
-        gpu_cost_res = math.ceil(gpu_cost * 100) / 100
-        estimated_savings_res = math.ceil(estimated_savings * 100) / 100
-        return cpu_cost_res, gpu_cost_res, estimated_savings_res
+        return cpu_cost, gpu_cost, estimated_savings

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -609,7 +609,8 @@ class Qualification(RapidsJarTool):
 
         if not apps_working_set.empty:
             self.logger.info('Generating GPU Estimated Speedup and Savings as %s', csv_out)
-            apps_working_set.to_csv(csv_out)
+            # we can use the general format as well but this will transform numbers to E+. So, stick with %f
+            apps_working_set.to_csv(csv_out, float_format='%.3f')
 
         # if the gpu_reshape_type is set to JOB then, then we should ignore recommended apps
         speedups_irrelevant_flag = self.__recommendation_is_non_standard()

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -610,7 +610,7 @@ class Qualification(RapidsJarTool):
         if not apps_working_set.empty:
             self.logger.info('Generating GPU Estimated Speedup and Savings as %s', csv_out)
             # we can use the general format as well but this will transform numbers to E+. So, stick with %f
-            apps_working_set.to_csv(csv_out, float_format='%.3f')
+            apps_working_set.to_csv(csv_out, float_format='%.2f')
 
         # if the gpu_reshape_type is set to JOB then, then we should ignore recommended apps
         speedups_irrelevant_flag = self.__recommendation_is_non_standard()


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #208

- Remove rounding-up from the price-provider
- Add floating_format to CSV Summary output
- Tested on Dataproc, EMR, and Databricks
