### PR TITLE
Add project basedir prefix for 'scalastyle-config.xml'

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -403,7 +403,7 @@
                                 <java classname="org.scalastyle.Main" failonerror="true">
                                     <arg line="--verbose false"/>
                                     <arg line="--warnings false"/>
-                                    <arg line="--config scalastyle-config.xml"/>
+				    <arg line="--config ${project.basedir}/scalastyle-config.xml"/>
                                     <arg line="--xmlOutput ${project.basedir}/target/scalastyle-output.xml"/>
                                     <arg line="--inputEncoding UTF-8"/>
                                     <arg line="--xmlEncoding UTF-8"/>

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -728,8 +728,8 @@ object QualificationAppInfo extends Logging {
 
   // Summarize and estimate based on wall clock times
   def calculateEstimatedInfoSummary(estimatedRatio: Double, sqlDataFrameDuration: Long,
-      appDuration: Long, sqlSpeedupFactor: Double, appName: String,
-      appId: String, hasFailures: Boolean, mlSpeedupFactor: Option[MLFuncsSpeedupAndDuration] = None,
+      appDuration: Long, sqlSpeedupFactor: Double, appName: String, appId: String,
+      hasFailures: Boolean, mlSpeedupFactor: Option[MLFuncsSpeedupAndDuration] = None,
       unsupportedExecs: String = "", unsupportedExprs: String = "",
       allClusterTagsMap: Map[String, String] = Map.empty[String, String]): EstimatedSummaryInfo = {
     val sqlDataFrameDurationToUse = if (sqlDataFrameDuration > appDuration) {


### PR DESCRIPTION
to support "mvn -f core/..." option, that is used by internal CI jobs
