### PR TITLE
Add profiles to build jars against spark versions

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -22,7 +22,8 @@ mvn clean package
 After a successful build, the jar of 'rapids-4-spark-tools_2.12-*-SNAPSHOT.jar' will be in 'target/' directory.  
 This will build the plugin for a single version of Spark. By default, this is Apache Spark 3.1.1.
 
-To build against other versions of Spark you use the `-Dbuildver=XXX` command line option to Maven.  
+For development purpose, you may need to run the tests against different spark versions.
+To run the tests against a specific Spark version, you can use the `-Dbuildver=XXX` command line option.  
 For instance to build Spark 3.3.0 you would use:
 
 ```shell script

--- a/core/README.md
+++ b/core/README.md
@@ -19,4 +19,14 @@ We use [Maven](https://maven.apache.org) for the build. Simply run as below comm
 mvn clean package
 ```
 
-After a successful build, the jar of 'rapids-4-spark-tools_2.12-*-SNAPSHOT.jar' will be in 'target/' directory.
+After a successful build, the jar of 'rapids-4-spark-tools_2.12-*-SNAPSHOT.jar' will be in 'target/' directory.  
+This will build the plugin for a single version of Spark. By default, this is Apache Spark 3.1.1.
+
+To build against other versions of Spark you use the `-Dbuildver=XXX` command line option to Maven.  
+For instance to build Spark 3.3.0 you would use:
+
+```shell script
+mvn -Dbuildver=330 clean package
+```
+
+Run `mvn help:all-profiles` to list supported Spark versions.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -202,6 +202,19 @@
             </properties>
         </profile>
         <profile>
+            <id>release333</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>333</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>333</buildver>
+                <spark.version>${spark333.version}</spark.version>
+            </properties>
+        </profile>
+        <profile>
             <id>release340</id>
             <activation>
                 <property>
@@ -226,6 +239,7 @@
         <spark330.version>3.3.0</spark330.version>
         <spark331.version>3.3.1</spark331.version>
         <spark332.version>3.3.2</spark332.version>
+        <spark333.version>3.3.3-SNAPSHOT</spark333.version>
         <spark340.version>3.4.0-SNAPSHOT</spark340.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.plugin.version>4.3.0</scala.plugin.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -69,22 +69,176 @@
             <timezone>-6</timezone>
         </developer>
     </developers>
-
+    <profiles>
+        <profile>
+            <id>release311</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>buildver</name>
+                    <value>311</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>311</buildver>
+                <spark.version>${spark311.version}</spark.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>release312</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>312</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>312</buildver>
+                <spark.version>${spark312.version}</spark.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>release313</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>313</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>313</buildver>
+                <spark.version>${spark313.version}</spark.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>release320</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>320</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>320</buildver>
+                <spark.version>${spark320.version}</spark.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>release321</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>321</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>321</buildver>
+                <spark.version>${spark321.version}</spark.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>release322</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>322</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>322</buildver>
+                <spark.version>${spark322.version}</spark.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>release323</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>323</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>323</buildver>
+                <spark.version>${spark323.version}</spark.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>release330</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>330</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>330</buildver>
+                <spark.version>${spark330.version}</spark.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>release331</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>331</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>331</buildver>
+                <spark.version>${spark331.version}</spark.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>release332</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>332</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>332</buildver>
+                <spark.version>${spark332.version}</spark.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>release340</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>340</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>340</buildver>
+                <spark.version>${spark340.version}</spark.version>
+            </properties>
+        </profile>
+    </profiles>
     <properties>
         <spark311.version>3.1.1</spark311.version>
+        <spark312.version>3.1.2</spark312.version>
+        <spark313.version>3.1.3</spark313.version>
+        <spark320.version>3.2.0</spark320.version>
+        <spark321.version>3.2.1</spark321.version>
+        <spark322.version>3.2.2</spark322.version>
+        <spark323.version>3.2.3</spark323.version>
+        <spark330.version>3.3.0</spark330.version>
+        <spark331.version>3.3.1</spark331.version>
+        <spark332.version>3.3.2</spark332.version>
+        <spark340.version>3.4.0-SNAPSHOT</spark340.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.plugin.version>4.3.0</scala.plugin.version>
         <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
         <scala.version>2.12.15</scala.version>
         <hadoop.version>3.3.4</hadoop.version>
-        <spark.version>${spark311.version}</spark.version>
         <spark.test.version>${spark311.version}</spark.test.version>
         <snakeyaml.version>1.33</snakeyaml.version>
         <scallop.version>3.5.1</scallop.version>
         <scalatest.version>3.0.5</scalatest.version>
-        <spark.version.classifier>spark311</spark.version.classifier>
-        <target.classifier>spark311</target.classifier>
+        <spark.version.classifier>spark${buildver}</spark.version.classifier>
+        <target.classifier>${spark.version.classifier}</target.classifier>
         <ui.cache.dir>${project.build.directory}/ui-dependencies-cache</ui.cache.dir>
         <ui.resources.relative>src/main/resources/ui</ui.resources.relative>
         <ui.resources.dir>${project.basedir}/${ui.resources.relative}</ui.resources.dir>
@@ -465,4 +619,16 @@
             </plugin>
         </plugins>
     </build>
+    <repositories>
+        <repository>
+            <id>apache-snapshots-repo</id>
+            <url>https://repository.apache.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
Fixes #174 

- Adds profiles to build the tools jar with different spark versions
- Used same properties and profiles IDs in rapids-plugin. For example, `mvn -Dbuildver=330 clean package`
- Updated the README file accordingly
- This change is required is needed to continue working on #135 