### PR TITLE
Handle CPU cluster that has zero worker nodes

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -372,21 +372,22 @@ class DataprocCluster(ClusterBase):
     def _init_nodes(self):
         # assume that only one master node
         master_nodes_from_conf = self.props.get_value('config', 'masterConfig', 'instanceNames')
-        worker_nodes_from_conf = self.props.get_value('config', 'workerConfig', 'instanceNames')
-        # create workers array
+        raw_worker_prop = self.props.get_value_silent('config', 'workerConfig')
         worker_nodes: list = []
-        raw_worker_prop = self.props.get_value('config', 'workerConfig')
-        for worker_node in worker_nodes_from_conf:
-            worker_props = {
-                'name': worker_node,
-                'props': JSONPropertiesContainer(prop_arg=raw_worker_prop, file_load=False),
-                # set the node zone based on the wrapper defined zone
-                'zone': self.zone
-            }
-            worker = DataprocNode.create_worker_node().set_fields_from_dict(worker_props)
-            # TODO for optimization, we should set HW props for 1 worker
-            worker.fetch_and_set_hw_info(self.cli)
-            worker_nodes.append(worker)
+        if raw_worker_prop:
+            worker_nodes_from_conf = self.props.get_value('config', 'workerConfig', 'instanceNames')
+            # create workers array
+            for worker_node in worker_nodes_from_conf:
+                worker_props = {
+                    'name': worker_node,
+                    'props': JSONPropertiesContainer(prop_arg=raw_worker_prop, file_load=False),
+                    # set the node zone based on the wrapper defined zone
+                    'zone': self.zone
+                }
+                worker = DataprocNode.create_worker_node().set_fields_from_dict(worker_props)
+                # TODO for optimization, we should set HW props for 1 worker
+                worker.fetch_and_set_hw_info(self.cli)
+                worker_nodes.append(worker)
         raw_master_props = self.props.get_value('config', 'masterConfig')
         master_props = {
             'name': master_nodes_from_conf[0],

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -852,7 +852,7 @@ class ClusterBase(ClusterGetAccessor):
     logger: Logger = field(default=ToolLogging.get_and_setup_logger('rapids.tools.cluster'), init=False)
 
     @staticmethod
-    def _verify_workers_configurations(has_no_workers_cb: Callable[[], bool]):
+    def _verify_workers_exist(has_no_workers_cb: Callable[[], bool]):
         """
         Specifies how to handle cluster definitions that have no workers
         :param has_no_workers_cb: A callback that returns True if the cluster does not have any
@@ -916,7 +916,7 @@ class ClusterBase(ClusterGetAccessor):
         self.set_fields_from_dict(pre_init_args)
         self._init_nodes()
         # Verify that the cluster has defined workers
-        self._verify_workers_configurations(lambda: not self.nodes.get(SparkNodeType.WORKER))
+        self._verify_workers_exist(lambda: not self.nodes.get(SparkNodeType.WORKER))
         return self
 
     def is_cluster_running(self) -> bool:


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #161

- Added a verification that the workers are defines for a given cluster
- `execution_cluster` can have 0 workers
- The scope of the PR is limited to CLI `spark_rapids_user_tools`
- Changes should affect Dataproc, EMR, and Databricks

**Sample error message with zero-workers cluster:**

```
2023-04-10 14:28:49,788 ERROR rapids.tools.qualification: Qualification. Raised an error in phase [Process-Arguments]
Invalid cluster: The cluster has no worker nodes.
        It is recommended to define a with (1 master, N workers).
```
