### PR TITLE
Fix intermittent failure downloading dependencies in local mode

### DIFF
--- a/user_tools/docs/user-tools-aws-emr.md
+++ b/user_tools/docs/user-tools-aws-emr.md
@@ -40,13 +40,13 @@ the applications running on AWS EMR.
 Before running any command, you can set environment variables to specify configurations.
 - RAPIDS variables have a naming pattern `RAPIDS_USER_TOOLS_*`:
   - `RAPIDS_USER_TOOLS_CACHE_FOLDER`: specifies the location of a local directory that the RAPIDS-cli uses to
-    store and cache the downloaded resources. The default is `/var/tmp/rapids_user_tools_cache`.  Note that
+    store and cache the downloaded resources. The default is `/var/tmp/spark_rapids_user_tools_cache`.  Note that
     caching the resources locally has an impact on the total execution time of the command.
   - `RAPIDS_USER_TOOLS_OUTPUT_DIRECTORY`: specifies the location of a local directory that the RAPIDS-cli uses to
     generate the output. The wrapper CLI arguments override that environment variable
     (`--output_folder` and `local_folder` for Bootstrap and Qualification respectively).
 - For AWS CLI, some environment variables can be set and picked by the RAPIDS-user tools such as:
-  `AWS_PROFILE`, `AWS_DEFAULT_REGION` and `AWS_CONFIG_FILE`. See the full list of variables in
+  `AWS_PROFILE`, `AWS_DEFAULT_REGION`, `AWS_CONFIG_FILE`, `AWS_SHARED_CREDENTIALS_FILE`. See the full list of variables in
   [aws-cli-configure-envvars](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).
 
 ## Qualification command

--- a/user_tools/docs/user-tools-aws-emr.md
+++ b/user_tools/docs/user-tools-aws-emr.md
@@ -40,7 +40,7 @@ the applications running on AWS EMR.
 Before running any command, you can set environment variables to specify configurations.
 - RAPIDS variables have a naming pattern `RAPIDS_USER_TOOLS_*`:
   - `RAPIDS_USER_TOOLS_CACHE_FOLDER`: specifies the location of a local directory that the RAPIDS-cli uses to
-    store and cache the downloaded resources. The default is `/tmp/rapids_user_tools_cache`.  Note that
+    store and cache the downloaded resources. The default is `/var/tmp/rapids_user_tools_cache`.  Note that
     caching the resources locally has an impact on the total execution time of the command.
   - `RAPIDS_USER_TOOLS_OUTPUT_DIRECTORY`: specifies the location of a local directory that the RAPIDS-cli uses to
     generate the output. The wrapper CLI arguments override that environment variable

--- a/user_tools/docs/user-tools-databricks-aws.md
+++ b/user_tools/docs/user-tools-databricks-aws.md
@@ -42,7 +42,7 @@ The tool currently only supports event logs stored on S3 (no DBFS paths). The re
 
 Before running any command, you can set environment variables to specify configurations.
 - RAPIDS variables have a naming pattern `RAPIDS_USER_TOOLS_*`:
-  - `RAPIDS_USER_TOOLS_CACHE_FOLDER`: specifies the location of a local directory that the RAPIDS-cli uses to store and cache the downloaded resources. The default is `/var/tmp/rapids_user_tools_cache`.  Note that caching the resources locally has an impact on the total execution time of the command.
+  - `RAPIDS_USER_TOOLS_CACHE_FOLDER`: specifies the location of a local directory that the RAPIDS-cli uses to store and cache the downloaded resources. The default is `/var/tmp/spark_rapids_user_tools_cache`.  Note that caching the resources locally has an impact on the total execution time of the command.
   - `RAPIDS_USER_TOOLS_OUTPUT_DIRECTORY`: specifies the location of a local directory that the RAPIDS-cli uses to generate the output. The wrapper CLI arguments override that environment variable (`--local_folder` for Qualification).
 - For Databricks CLI, some environment variables can be set and picked by the RAPIDS-user tools such as: `DATABRICKS_CONFIG_FILE`, `DATABRICKS_HOST` and `DATABRICKS_TOKEN`. See the description of the variables in [Environment variables](https://docs.databricks.com/dev-tools/auth.html#environment-variables).
 - For AWS CLI, some environment variables can be set and picked by the RAPIDS-user tools such as: `AWS_SHARED_CREDENTIALS_FILE`, `AWS_CONFIG_FILE`, `AWS_REGION`, `AWS_DEFAULT_REGION`, `AWS_PROFILE` and `AWS_DEFAULT_OUTPUT`. See the full list of variables in [aws-cli-configure-envvars](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).

--- a/user_tools/docs/user-tools-databricks-aws.md
+++ b/user_tools/docs/user-tools-databricks-aws.md
@@ -42,7 +42,7 @@ The tool currently only supports event logs stored on S3 (no DBFS paths). The re
 
 Before running any command, you can set environment variables to specify configurations.
 - RAPIDS variables have a naming pattern `RAPIDS_USER_TOOLS_*`:
-  - `RAPIDS_USER_TOOLS_CACHE_FOLDER`: specifies the location of a local directory that the RAPIDS-cli uses to store and cache the downloaded resources. The default is `/tmp/rapids_user_tools_cache`.  Note that caching the resources locally has an impact on the total execution time of the command.
+  - `RAPIDS_USER_TOOLS_CACHE_FOLDER`: specifies the location of a local directory that the RAPIDS-cli uses to store and cache the downloaded resources. The default is `/var/tmp/rapids_user_tools_cache`.  Note that caching the resources locally has an impact on the total execution time of the command.
   - `RAPIDS_USER_TOOLS_OUTPUT_DIRECTORY`: specifies the location of a local directory that the RAPIDS-cli uses to generate the output. The wrapper CLI arguments override that environment variable (`--local_folder` for Qualification).
 - For Databricks CLI, some environment variables can be set and picked by the RAPIDS-user tools such as: `DATABRICKS_CONFIG_FILE`, `DATABRICKS_HOST` and `DATABRICKS_TOKEN`. See the description of the variables in [Environment variables](https://docs.databricks.com/dev-tools/auth.html#environment-variables).
 - For AWS CLI, some environment variables can be set and picked by the RAPIDS-user tools such as: `AWS_SHARED_CREDENTIALS_FILE`, `AWS_CONFIG_FILE`, `AWS_REGION`, `AWS_DEFAULT_REGION`, `AWS_PROFILE` and `AWS_DEFAULT_OUTPUT`. See the full list of variables in [aws-cli-configure-envvars](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).

--- a/user_tools/docs/user-tools-dataproc.md
+++ b/user_tools/docs/user-tools-dataproc.md
@@ -37,6 +37,17 @@ the applications running on _Google Cloud Dataproc_.
     spark_rapids_user_tools dataproc --help
   ```
 
+### 4.Environment variables
+
+Before running any command, you can set environment variables to specify configurations.
+RAPIDS variables have a naming pattern `RAPIDS_USER_TOOLS_*`:
+  - `RAPIDS_USER_TOOLS_CACHE_FOLDER`: specifies the location of a local directory that the RAPIDS-cli uses to
+    store and cache the downloaded resources. The default is `/var/tmp/spark_rapids_user_tools_cache`.  
+    Note that caching the resources locally has an impact on the total execution time of the command.
+  - `RAPIDS_USER_TOOLS_OUTPUT_DIRECTORY`: specifies the location of a local directory that the RAPIDS-cli uses to
+    generate the output. The wrapper CLI arguments override that environment variable
+    (`--output_folder` and `local_folder` for Bootstrap and Qualification respectively).
+  
 ## Qualification command
 
 ### Local deployment

--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -17,6 +17,8 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    "fastprogress==1.0.3",
+    "fastcore==1.5.29",
     "fire==0.4.0",
     "pandas==1.4.3",
     "pyYAML==6.0",

--- a/user_tools/src/spark_rapids_pytools/pricing/price_provider.py
+++ b/user_tools/src/spark_rapids_pytools/pricing/price_provider.py
@@ -50,8 +50,11 @@ class PriceProvider:
 
     def _generate_cache_files(self):
         # resource_urls and cache_files should have the same keys
+        cache_checks = {'cacheExpirationSecs': self.cache_expiration_secs}
         for file_key, resource_url in self.resource_urls.items():
-            files_updated = FSUtil.cache_from_url(resource_url, self.cache_files[file_key])
+            files_updated = FSUtil.cache_from_url(resource_url,
+                                                  self.cache_files[file_key],
+                                                  file_checks=cache_checks)
             self.logger.info('The catalog file %s is %s',
                              self.cache_files[file_key],
                              'updated' if files_updated else 'not modified, using the cached content')

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -422,7 +422,8 @@ class RapidsJarTool(RapidsTool):
             dest_folder = self.ctxt.get_cache_folder()
             resource_file_name = FSUtil.get_resource_name(dep['uri'])
             resource_file = FSUtil.build_path(dest_folder, resource_file_name)
-            is_created = FSUtil.cache_from_url(dep['uri'], resource_file)
+            file_check_dict = {'size': dep['size']}
+            is_created = FSUtil.cache_from_url(dep['uri'], resource_file, file_checks=file_check_dict)
             if is_created:
                 self.logger.info('The dependency %s has been downloaded into %s', dep['uri'],
                                  resource_file)

--- a/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
@@ -45,7 +45,7 @@ class ToolContext(YAMLPropertiesContainer):
 
     def __create_and_set_cache_folder(self):
         # get the cache folder from environment variables or set it to default
-        cache_folder = Utils.get_rapids_tools_env('CACHE_FOLDER', '/var/tmp/rapids_user_tools_cache')
+        cache_folder = Utils.get_rapids_tools_env('CACHE_FOLDER', '/var/tmp/spark_rapids_user_tools_cache')
         # make sure the environment is set
         Utils.set_rapids_tools_env('CACHE_FOLDER', cache_folder)
         FSUtil.make_dirs(cache_folder)

--- a/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
@@ -45,7 +45,7 @@ class ToolContext(YAMLPropertiesContainer):
 
     def __create_and_set_cache_folder(self):
         # get the cache folder from environment variables or set it to default
-        cache_folder = Utils.get_rapids_tools_env('CACHE_FOLDER', '/tmp/rapids_user_tools_cache')
+        cache_folder = Utils.get_rapids_tools_env('CACHE_FOLDER', '/var/tmp/rapids_user_tools_cache')
         # make sure the environment is set
         Utils.set_rapids_tools_env('CACHE_FOLDER', cache_folder)
         FSUtil.make_dirs(cache_folder)

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
@@ -7,21 +7,24 @@
             "uri": "https://archive.apache.org/dist/spark/spark-3.3.1/spark-3.3.1-bin-hadoop3.tgz",
             "type": "archive",
             "relativePath": "jars/*",
-            "sha512": "769db39a560a95fd88b58ed3e9e7d1e92fb68ee406689fb4d30c033cb5911e05c1942dcc70e5ec4585df84e80aabbc272b9386a208debda89522efff1335c8ff"
+            "sha512": "769db39a560a95fd88b58ed3e9e7d1e92fb68ee406689fb4d30c033cb5911e05c1942dcc70e5ec4585df84e80aabbc272b9386a208debda89522efff1335c8ff",
+            "size": 299350810
           },
           {
             "name":  "Hadoop AWS",
             "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
             "type": "jar",
             "md5": "59907e790ce713441955015d79f670bc",
-            "sha1": "a65839fbf1869f81a1632e09f415e586922e4f80"
+            "sha1": "a65839fbf1869f81a1632e09f415e586922e4f80",
+            "size": 962685
           },
           {
             "name":  "AWS Java SDK Bundled",
             "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
             "type": "jar",
             "md5": "8a22f2d30b7e8eee9ea44f04fb13b35a",
-            "sha1": "02deec3a0ad83d13d032b1812421b23d7a961eea"
+            "sha1": "02deec3a0ad83d13d032b1812421b23d7a961eea",
+            "size": 280645251
           }
         ]
       }

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -7,14 +7,16 @@
           "uri": "https://archive.apache.org/dist/spark/spark-3.3.1/spark-3.3.1-bin-hadoop3.tgz",
           "type": "archive",
           "relativePath": "jars/*",
-          "sha512": "769db39a560a95fd88b58ed3e9e7d1e92fb68ee406689fb4d30c033cb5911e05c1942dcc70e5ec4585df84e80aabbc272b9386a208debda89522efff1335c8ff"
+          "sha512": "769db39a560a95fd88b58ed3e9e7d1e92fb68ee406689fb4d30c033cb5911e05c1942dcc70e5ec4585df84e80aabbc272b9386a208debda89522efff1335c8ff",
+          "size": 299350810
         },
         {
           "name": "GCS Connector Hadoop3",
           "uri": "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.11/gcs-connector-hadoop3-2.2.11-shaded.jar",
           "type": "jar",
           "md5": "7639d38fff9f88fe80d7e4d9d47fb946",
-          "sha1": "519e60640b7ffdbb00dbed20b852c2a406ddaff9"
+          "sha1": "519e60640b7ffdbb00dbed20b852c2a406ddaff9",
+          "size": 36497606
         }
       ]
     }

--- a/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
@@ -7,21 +7,24 @@
           "uri": "https://archive.apache.org/dist/spark/spark-3.3.1/spark-3.3.1-bin-hadoop3.tgz",
           "type": "archive",
           "relativePath": "jars/*",
-          "sha512": "769db39a560a95fd88b58ed3e9e7d1e92fb68ee406689fb4d30c033cb5911e05c1942dcc70e5ec4585df84e80aabbc272b9386a208debda89522efff1335c8ff"
+          "sha512": "769db39a560a95fd88b58ed3e9e7d1e92fb68ee406689fb4d30c033cb5911e05c1942dcc70e5ec4585df84e80aabbc272b9386a208debda89522efff1335c8ff",
+          "size": 299350810
         },
         {
           "name":  "Hadoop AWS",
           "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
           "type": "jar",
           "md5": "59907e790ce713441955015d79f670bc",
-          "sha1": "a65839fbf1869f81a1632e09f415e586922e4f80"
+          "sha1": "a65839fbf1869f81a1632e09f415e586922e4f80",
+          "size": 962685
         },
         {
           "name":  "AWS Java SDK Bundled",
           "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
           "type": "jar",
           "md5": "8a22f2d30b7e8eee9ea44f04fb13b35a",
-          "sha1": "02deec3a0ad83d13d032b1812421b23d7a961eea"
+          "sha1": "02deec3a0ad83d13d032b1812421b23d7a961eea",
+          "size": 280645251
         }
       ]
     }


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #201

- change default CACHE_FOLDER to `/var/tmp/rapids_user_tools_cache`
  - `/tmp` is cleared on every reboot or every few days while `/var/tmp` is more stable
- use "size" to verify the cached file and redownload if size does not match
  - there was a problem in original implementation. A broken file will be skipped and the user will have to clear the folder manually. 
- add a progress bar to improve user experience while waiting for large files to be downloaded
