### PR TITLE
Update Join parser to include special character

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -68,7 +68,7 @@ case class PlanInfo(
 
 object SQLPlanParser extends Logging {
 
-  val equiJoinRegexPattern = """\[([\w#, +*\\\-\.<>=\`\(\)]+\])""".r
+  val equiJoinRegexPattern = """\[([\w#, +*\\\-\.<>=$\`\(\)]+\])""".r
 
   val functionPattern = """(\w+)\(.*\)""".r
 


### PR DESCRIPTION
This fixes a minor  bug if there are special symbols in column names in Join Execs

Example: 
If SortMergeJoinExec had this string - `[vid#26, sid#27, pv_id_temp#16L, get_json_object(item_info#27, $.itemId)], [vid#3173, sid#3174, pv_id_temp#3106L, prodid#3038], LeftOuter`

It couldn't parse $.itemId correctly and would classify SortMergeJoin as unsupported Exec, With this fix, it parses the string correctly.

<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
