### PR TITLE
Fix handling of Json parse exceptions on Spark3.40+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ wheels/
 
 # Maven
 dependency-reduced-pom.xml
+
+# Scala classes
+target/

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -511,6 +511,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <!-- parent-pom only executions -->
+                <inherited>false</inherited>
                 <version>3.0.0</version>
                 <executions>
                     <execution>
@@ -567,14 +569,6 @@
                             </target>
                         </configuration>
                     </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <!-- parent-pom only executions -->
-                <inherited>false</inherited>
-                <executions>
                     <execution>
                         <!--
                         This is an alternative implementation of the scalastyle check invocation,

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -216,32 +216,12 @@ abstract class AppBase(
               // Using find as foreach with conditional to exit early if we are done.
               // Do NOT use a while loop as it is much much slower.
               lines.find { line =>
-                val isDone = try {
-                  totalNumEvents += 1
-                  val event = ToolUtils.getEventFromJsonMethod(line)
-                  processEvent(event)
+                totalNumEvents += 1
+                val event = ToolUtils.getEventFromJsonMethod(line)
+                event match {
+                  case Some(e) => processEvent(e)
+                  case _ => false
                 }
-                catch {
-                  case i: java.lang.reflect.InvocationTargetException =>
-                    // swallow any messages about this class since likely using spark version
-                    // before 3.1
-                    if (i.getCause != null && i.getCause.getMessage != null) {
-                      if (!i.getCause.getMessage.contains("SparkListenerResourceProfileAdded")) {
-                        logWarning(s"ClassNotFoundException: ${i.getCause.getMessage}")
-                      }
-                    } else {
-                      logError(s"Unknown exception", i)
-                    }
-                    false
-                  case e: ClassNotFoundException =>
-                    // swallow any messages about this class since likely using spark version
-                    // before 3.1
-                    if (!e.getMessage.contains("SparkListenerResourceProfileAdded")) {
-                      logWarning(s"ClassNotFoundException: ${e.getMessage}")
-                    }
-                    false
-                }
-                isDone
               }
             }
           }


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #282

- extract the JsonParseExceptions from TargetInvocationException
- classNotFoundExceptions were also wrapped inside invocation exception
- fixes the unit test `skip malformed json eventlog` for spark-3.4+
- fixes a bug in the pom.xml where a plugin was duplicate
- fixed gitignore file
