### PR TITLE
Fix handling of Json parse exceptions on Spark340

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ wheels/
 
 # Maven
 dependency-reduced-pom.xml
+# Scala classes
+target/

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -512,6 +512,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>3.0.0</version>
+                <!-- parent-pom only executions -->
+                <inherited>false</inherited>
                 <executions>
                     <execution>
                         <id>download-ui-dependencies</id>
@@ -567,14 +569,6 @@
                             </target>
                         </configuration>
                     </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <!-- parent-pom only executions -->
-                <inherited>false</inherited>
-                <executions>
                     <execution>
                         <!--
                         This is an alternative implementation of the scalastyle check invocation,
@@ -604,7 +598,7 @@
                                 <java classname="org.scalastyle.Main" failonerror="true">
                                     <arg line="--verbose false"/>
                                     <arg line="--warnings false"/>
-				    <arg line="--config ${project.basedir}/scalastyle-config.xml"/>
+                                    <arg line="--config ${project.basedir}/scalastyle-config.xml"/>
                                     <arg line="--xmlOutput ${project.basedir}/target/scalastyle-output.xml"/>
                                     <arg line="--inputEncoding UTF-8"/>
                                     <arg line="--xmlEncoding UTF-8"/>

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -216,32 +216,11 @@ abstract class AppBase(
               // Using find as foreach with conditional to exit early if we are done.
               // Do NOT use a while loop as it is much much slower.
               lines.find { line =>
-                val isDone = try {
-                  totalNumEvents += 1
-                  val event = ToolUtils.getEventFromJsonMethod(line)
-                  processEvent(event)
+                totalNumEvents += 1
+                ToolUtils.getEventFromJsonMethod(line) match {
+                  case Some(e) => processEvent(e)
+                  case None => false
                 }
-                catch {
-                  case i: java.lang.reflect.InvocationTargetException =>
-                    // swallow any messages about this class since likely using spark version
-                    // before 3.1
-                    if (i.getCause != null && i.getCause.getMessage != null) {
-                      if (!i.getCause.getMessage.contains("SparkListenerResourceProfileAdded")) {
-                        logWarning(s"ClassNotFoundException: ${i.getCause.getMessage}")
-                      }
-                    } else {
-                      logError(s"Unknown exception", i)
-                    }
-                    false
-                  case e: ClassNotFoundException =>
-                    // swallow any messages about this class since likely using spark version
-                    // before 3.1
-                    if (!e.getMessage.contains("SparkListenerResourceProfileAdded")) {
-                      logWarning(s"ClassNotFoundException: ${e.getMessage}")
-                    }
-                    false
-                }
-                isDone
               }
             }
           }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -16,6 +16,9 @@
 
 package org.apache.spark.sql.rapids.tool
 
+import java.lang.reflect.InvocationTargetException
+
+import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
 import com.nvidia.spark.rapids.tool.profiling.ProfileUtils.replaceDelimiter
@@ -32,9 +35,9 @@ object ToolUtils extends Logging {
   // Add more entries to this lookup table as necessary.
   // There is no need to list all supported versions.
   private val lookupVersions = Map(
-    "311" -> new ComparableVersion("3.1.1"),
-    "320" -> new ComparableVersion("3.2.0"),
-    "340" -> new ComparableVersion("3.4.0")
+    "311" -> new ComparableVersion("3.1.1"), // default build version
+    "320" -> new ComparableVersion("3.2.0"), // introduced reusedExchange
+    "340" -> new ComparableVersion("3.4.0")  // introduces jsonProtocolChanges
   )
 
   // Property to check the spark runtime version. We need this outside of test module as we
@@ -43,18 +46,59 @@ object ToolUtils extends Logging {
     org.apache.spark.SPARK_VERSION
   }
 
-  lazy val getEventFromJsonMethod: (String) => org.apache.spark.scheduler.SparkListenerEvent = {
+  lazy val getEventFromJsonMethod:
+    (String) => Option[org.apache.spark.scheduler.SparkListenerEvent] = {
     // Spark 3.4 and Databricks changed the signature on sparkEventFromJson
+    // Note that it is preferred we use reflection rather than checking Spark-runtime
+    // because some vendors may back-port features.
     val c = Class.forName("org.apache.spark.util.JsonProtocol")
-    // Explicitly check against the spark version.
-    if (isSpark340OrLater()) {
-      val m = c.getDeclaredMethod("sparkEventFromJson", classOf[String])
-      (line: String) =>
-        m.invoke(null, line).asInstanceOf[org.apache.spark.scheduler.SparkListenerEvent]
-    } else {
-      val m = c.getDeclaredMethod("sparkEventFromJson", classOf[org.json4s.JValue])
-      (line: String) =>
-        m.invoke(null, parse(line)).asInstanceOf[org.apache.spark.scheduler.SparkListenerEvent]
+    val m = Try {
+      // versions prior to spark3.4
+      c.getDeclaredMethod("sparkEventFromJson", classOf[org.json4s.JValue])
+    } match {
+      case Success(a) =>
+        (line: String) =>
+          a.invoke(null, parse(line)).asInstanceOf[org.apache.spark.scheduler.SparkListenerEvent]
+      case Failure(_) =>
+        // Spark3.4+ and databricks
+        val b = c.getDeclaredMethod("sparkEventFromJson", classOf[String])
+        (line: String) =>
+          b.invoke(null, line).asInstanceOf[org.apache.spark.scheduler.SparkListenerEvent]
+    }
+    // At this point, the method is already defined.
+    // Note that the Exception handling is moved within the method to make it easier
+    // to isolate the exception reason.
+    (line: String) => Try {
+      m.apply(line)
+    } match {
+      case Success(i) => Some(i)
+      case Failure(e) =>
+
+        e match {
+          case i: InvocationTargetException =>
+            val targetEx = i.getTargetException
+            if (targetEx != null) {
+              targetEx match {
+                case j: com.fasterxml.jackson.core.JsonParseException =>
+                  // this is a parser error thrown by spark-3.4+ which indicates the log is
+                  // malformed
+                  throw j
+                case z: ClassNotFoundException if z.getMessage != null =>
+                  logWarning(s"ClassNotFoundException while parsing an event: ${z.getMessage}")
+                case t: Throwable =>
+                  // We do not want to swallow unknown exceptions so that we can handle later
+                  logError(s"Unknown exception while parsing an event", t)
+              }
+            } else {
+              // Normally it should not happen that invocation target is null.
+              logError(s"Unknown exception while parsing an event", i)
+            }
+          case j: com.fasterxml.jackson.core.JsonParseException =>
+            // this is a parser error thrown by version prior to spark-3.4+ which indicates the
+            // log is malformed
+            throw j
+        }
+        None
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #282

- the json parse exceptions were not cacthed properly on spark3.4.0+ because they were wrapped in target invocation exceptions
- this change fixes the problem by checking the target of the thrown exceptions
- fixes the unit test `skip malformed json eventlog` for spark-3.4+
- removed the upper level of ClassNotFoundException because it should be wrapped in invocation exception
- removed check of `SparkListenerResourceProfileAdded` because spark releases prior to spark-311 are not supported anyway.
- tested the new changes on eventlogs generated on EMR/Dataproc
- fixed a bug in the pom file (duplicate plugin definition)
- added target folder to gitignore file

In this PR, I moved the exception handling inside`getEventFromJsonMethod`. The motivation is to have a dedicated handling block for exceptions thrown by the  `sparkEventFromJson()`