### PR TITLE
Add stack-trace errors on failure

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -475,9 +475,8 @@ class RapidsJarTool(RapidsTool):
                     futures.add_done_callback(exception_handler)
                     futures_list.append(futures)
                 try:
-                    # TODO: Note that we do not set timeout here to avoid failing when network
-                    #       is slow downloading one of the resources.
-                    for future in concurrent.futures.as_completed(futures_list):
+                    # set the timeout to 30 minutes.
+                    for future in concurrent.futures.as_completed(futures_list, timeout=1800):
                         result = future.result()
                         results.append(result)
                 except Exception as ex:    # pylint: disable=broad-except


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #299

- set download timeout to 30 minutes so that the runtime won't fail when network is slow
- add stack-trace to exceptions when application fails in order to help identify the problems

This PR deals with random failures that occur due to slow network downloading dependencies.
A quick fix is to remove the time limit.

Example error before changes

```
2023-05-08 15:14:54,845 ERROR rapids.tools.qualification: Qualification. Raised an error in phase [Process-Arguments]
Error copying resource on local disk. Resource /jars/rapids-4-spark-tools_2.12-*.jarx does not exist
```

After applying the change:

```
2023-05-08 15:11:41,718 ERROR root: Qualification. Raised an error in phase [Process-Arguments]
Traceback (most recent call last):
  File "/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py", line 104, in wrapper
    func_cb(self, *args, **kwargs)  # pylint: disable=not-callable
  File "/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py", line 148, in _process_arguments
    self._process_rapids_args()
  File "/user_tools/src/spark_rapids_pytools/rapids/qualification.py", line 192, in _process_rapids_args
    super()._process_rapids_args()
  File "/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py", line 503, in _process_rapids_args
    self._process_jar_arg()
  File "/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py", line 330, in _process_jar_arg
    jar_path = self.ctxt.platform.storage.download_resource(tools_jar_url,
  File "/user_tools/src/spark_rapids_pytools/common/sys_storage.py", line 322, in download_resource
    raise store_ex
  File "/user_tools/src/spark_rapids_pytools/common/sys_storage.py", line 319, in download_resource
    return self._download_remote_resource(src, abs_dest)
  File "/user_tools/src/spark_rapids_pytools/cloud_api/gstorage.py", line 84, in _download_remote_resource
    return super()._download_remote_resource(src, dest)
  File "/user_tools/src/spark_rapids_pytools/common/sys_storage.py", line 300, in _download_remote_resource
    return FSUtil.copy_resource(src, dest)
  File "/user_tools/src/spark_rapids_pytools/common/sys_storage.py", line 98, in copy_resource
    raise StorageException('Error copying resource on local disk. '
spark_rapids_pytools.common.exceptions.StorageException: Error copying resource on local disk. Resource jars/rapids-4-spark-tools_2.12-*.jarx does not exist
```