### PR TITLE
AutoTuner should make comments based on RAPIDS jar

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -353,3 +353,45 @@ Spur Dashboard V1.1.0
     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
     DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+jsoup License
+
+    The MIT License
+
+    Copyright (c) 2009 - 2023 Jonathan Hedley (https://jsoup.org/)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+    and associated documentation files (the "Software"), to deal in the Software without
+    restriction, including without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+scallop License
+
+    The MIT License
+
+    Copyright (C) 2012 Platon Pronko and Chris Hodapp
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+    and associated documentation files (the "Software"), to deal in the Software without
+    restriction, including without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -12,6 +12,8 @@ Copyright 2014 and onwards The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
+snakeyaml
+
 ---------------------------------------------------------------------
 This product bundles various third-party components under other open source licenses.
 
@@ -37,3 +39,11 @@ Mustache.js V4.10 - The MIT License (MIT)
 Spur Dashboard V1.1.0 - The MIT License (MIT)
     License Text ( https://github.com/HackerThemes/spur-template/blob/master/LICENSE )
     Copyright 2016 - 2019 Alexander Rechsteiner
+
+jsoup - The MIT License (MIT)
+    License Text ( https://jsoup.org/license )
+    Copyright (c) 2009 - 2023 Jonathan Hedley (https://jsoup.org/)
+
+scallop - The MIT License (MIT)
+    License Text ( https://github.com/scallop/scallop/blob/develop/license.txt )
+    Copyright (c) 2012 Platon Pronko and Chris Hodapp

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -429,6 +429,18 @@
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
                                         <exclude>META-INF/*.md</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.apache.maven:maven-artifact</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/LICENSE</exclude>
+                                        <exclude>META-INF/NOTICE</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.jsoup:jsoup</artifact>
+                                    <excludes>
                                         <exclude>META-INF/LICENSE</exclude>
                                         <exclude>META-INF/NOTICE</exclude>
                                         <exclude>META-INF/CHANGES</exclude>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -277,6 +277,9 @@
         <scala.javac.args>-Xlint:all,-serial,-path,-try</scala.javac.args>
         <rapids.shade.package>com.nvidia.shaded.spark</rapids.shade.package>
         <jsoup.version>1.16.1</jsoup.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.sourceEncoding>UTF-8</project.reporting.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>
@@ -426,13 +429,9 @@
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
                                         <exclude>META-INF/*.md</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>org.apache.maven:maven-artifact</artifact>
-                                    <excludes>
                                         <exclude>META-INF/LICENSE</exclude>
                                         <exclude>META-INF/NOTICE</exclude>
+                                        <exclude>META-INF/CHANGES</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -276,6 +276,7 @@
         <maven.artifact.version>3.9.0</maven.artifact.version>
         <scala.javac.args>-Xlint:all,-serial,-path,-try</scala.javac.args>
         <rapids.shade.package>com.nvidia.shaded.spark</rapids.shade.package>
+        <jsoup.version>1.16.1</jsoup.version>
     </properties>
 
     <dependencies>
@@ -316,8 +317,8 @@
             <version>${scalatest.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- Required for processing yaml files in AutoTuner -->
         <dependency>
+            <!-- Required for processing yaml files in AutoTuner -->
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>${snakeyaml.version}</version>
@@ -332,6 +333,12 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
             <version>${maven.artifact.version}</version>
+        </dependency>
+        <dependency>
+            <!-- jsoup HTML parser library @ https://jsoup.org/ -->
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>${jsoup.version}</version>
         </dependency>
     </dependencies>
 
@@ -393,6 +400,7 @@
                                     <include>org.rogach:scallop_${scala.binary.version}</include>
                                     <include>org.yaml:snakeyaml</include>
                                     <include>org.apache.maven:maven-artifact</include>
+                                    <include>org.jsoup:jsoup</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
@@ -404,6 +412,10 @@
                                     <pattern>org.apache.maven.artifact</pattern>
                                     <shadedPattern>${rapids.shade.package}.org.apache.maven.artifact</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>org.jsoup</pattern>
+                                    <shadedPattern>${rapids.shade.package}.org.jsoup</shadedPattern>
+                                </relocation>
                             </relocations>
                             <filters>
                                 <filter>
@@ -413,6 +425,7 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/*.md</exclude>
                                     </excludes>
                                 </filter>
                                 <filter>

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -46,6 +46,7 @@ trait AppInfoPropertyGetter {
   def getRapidsProperty(propKey: String): Option[String]
   def getProperty(propKey: String): Option[String]
   def getSparkVersion: Option[String]
+  def getRapidsJars: Seq[String]
 }
 
 trait AppInfoSqlTaskAggMetricsVisitor {
@@ -71,6 +72,7 @@ class AppSummaryInfoBaseProvider extends AppInfoPropertyGetter
   override def getMaxInput: Double = 0.0
   override def getJvmGCFractions: Seq[Double] = Seq()
   override def getSpilledMetrics: Seq[Long] = Seq()
+  override def getRapidsJars: Seq[String] = Seq()
 }
 
 /**
@@ -129,5 +131,9 @@ class SingleAppSummaryInfoProvider(val app: ApplicationSummaryInfo)
     } else {
       0.0
     }
+  }
+
+  override def getRapidsJars: Seq[String] = {
+    app.rapidsJar.map(_.jar).seq
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -31,6 +31,8 @@ import org.yaml.snakeyaml.constructor.{Constructor, ConstructorException}
 import org.yaml.snakeyaml.representer.Representer
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.rapids.tool.ToolUtils
+import org.apache.spark.sql.rapids.tool.util.WebCrawlerUtil
 
 /**
  * A wrapper class that stores all the GPU properties.
@@ -520,7 +522,7 @@ class AutoTuner(
         } else if (sparkMaster.contains("k8s")) {
           appInfoProvider.getSparkVersion match {
             case Some(version) =>
-              if (compareSparkVersion(version, "3.3.0") > 0) {
+              if (ToolUtils.isSpark331OrLater(version)) {
                 "spark.executor.memoryOverheadFactor"
               } else {
                 "spark.kubernetes.memoryOverheadFactor"
@@ -582,14 +584,12 @@ class AutoTuner(
     val shuffleManagerVersion = appInfoProvider.getSparkVersion.get.toString.filterNot("().".toSet)
     appendRecommendation("spark.shuffle.manager",
       "com.nvidia.spark.rapids.spark" + shuffleManagerVersion + ".RapidsShuffleManager")
-    appendComment("The RAPIDS Shuffle Manager requires the spark.driver.extraClassPath and\n" +
-      "  spark.executor.extraClassPath settings to include the path to the Spark RAPIDS\n" +
-      "  plugin jar.  If the Spark RAPIDS jar is being bundled with your Spark distribution,\n" +
-      "  this step is not needed.")
+    appendComment(classPathComments("rapids.shuffle.jars"))
 
     recommendMaxPartitionBytes()
     recommendShufflePartitions()
     recommendGeneralProperties()
+    recommendClassPathEntries()
   }
 
   /**
@@ -625,7 +625,7 @@ class AutoTuner(
     }
     appInfoProvider.getSparkVersion match {
       case Some(version) =>
-        if (compareSparkVersion(version, "3.2.0") < 0 &&
+        if (!ToolUtils.isSpark320OrLater(version) &&
                 getPropertyValue("spark.sql.adaptive.coalescePartitions.minPartitionNum").isEmpty) {
           appendRecommendation("spark.sql.adaptive.coalescePartitions.minPartitionNum", "1")
         }
@@ -637,6 +637,45 @@ class AutoTuner(
         appendComment("Average JVM GC time is very high. " +
           "Other Garbage Collectors can be used for better performance.")
       }
+    }
+  }
+
+  /**
+   * Check the class path entries with the following rules:
+   * 1- If ".*rapids-4-spark.*jar" is missing then add a comment that the latest jar should be
+   *    included in the classpath unless it is part of the spark
+   * 2- If there are more than 1 entry for ".*rapids-4-spark.*jar", then add a comment that the
+   *    there should be only 1 jar in the class path.
+   * 3- If there are cudf jars, then comment that cudf jars should be removed.
+   * 4- If there is a new release recommend that to the user
+   */
+  private def recommendClassPathEntries(): Unit = {
+    val missingRapidsJarsEntry = classPathComments("rapids.jars.missing")
+    val multipleRapidsJarsEntry = classPathComments("rapids.jars.multiple")
+
+    appInfoProvider.getRapidsJars match {
+      case Seq() =>
+        // No rapids jars
+        appendComment(missingRapidsJarsEntry)
+      case s: Seq[String] =>
+        s.flatMap(e => pluginJarRegEx.findAllMatchIn(e).map(_.group(1))) match {
+          case Seq() => appendComment(missingRapidsJarsEntry)
+          case v: Seq[String] if v.length > 1 =>
+            val comment = s"$multipleRapidsJarsEntry [${v.mkString(", ")}]"
+            appendComment(comment)
+          case Seq(jarVer) =>
+            // compare jarVersion to the latest release
+            val latestPluginVersion = WebCrawlerUtil.getLatestPluginRelease
+            latestPluginVersion match {
+              case Some(ver) =>
+                if (ToolUtils.compareVersions(jarVer, ver) < 0) {
+                  appendComment(
+                    "A newer RAPIDS Accelerator for Apache Spark plugin\n" +
+                      s"  jar is available [$ver].\n" +
+                      s"  Current version is $jarVer.")
+                }
+            }
+        }
     }
   }
 
@@ -846,14 +885,13 @@ object AutoTuner extends Logging {
   val DEF_WORKER_GPU_NAME = "T4"
   // T4 default memory is 16G
   // A100 set default to 40GB
-  val DEF_WORKER_GPU_MEMORY_MB: mutable.LinkedHashMap[String, String] =
-    mutable.LinkedHashMap[String, String]("T4"-> "15109m", "A100" -> "40960m")
+  val DEF_WORKER_GPU_MEMORY_MB = Map("T4"-> "15109m", "A100" -> "40960m")
   // Default Number of Workers 1
   val DEF_NUM_WORKERS = 1
   val DEFAULT_WORKER_INFO_PATH = "./worker_info.yaml"
   val SUPPORTED_SIZE_UNITS: Seq[String] = Seq("b", "k", "m", "g", "t", "p")
 
-  val commentsForMissingProps: mutable.Map[String, String] = mutable.LinkedHashMap[String, String](
+  val commentsForMissingProps = Map(
     "spark.executor.memory" ->
       "'spark.executor.memory' should be set to at least 2GB/core.",
     "spark.executor.instances" ->
@@ -865,7 +903,8 @@ object AutoTuner extends Logging {
     "spark.rapids.memory.pinnedPool.size" ->
       s"'spark.rapids.memory.pinnedPool.size' should be set to ${DEF_PINNED_MEMORY_MB}m.",
     "spark.sql.adaptive.enabled" ->
-      "'spark.sql.adaptive.enabled' should be enabled for better performance.")
+      "'spark.sql.adaptive.enabled' should be enabled for better performance."
+  )
 
   val recommendationsTarget: Seq[String] = Seq[String](
     "spark.executor.instances",
@@ -880,6 +919,26 @@ object AutoTuner extends Logging {
     "spark.executor.memoryOverhead",
     "spark.executor.memoryOverheadFactor",
     "spark.kubernetes.memoryOverheadFactor")
+
+  val classPathComments = Map(
+    "rapids.jars.missing" ->
+      ("RAPIDS Accelerator for Apache Spark plugin jar is missing\n" +
+        "  from the classpath entries.\n" +
+        "  If the Spark RAPIDS jar is being bundled with your\n" +
+        "  Spark distribution, this step is not needed."),
+    "rapids.jars.multiple" ->
+      ("Multiple RAPIDS Accelerator for Apache Spark plugin jar\n" +
+        "  exist on the classpath.\n" +
+        "  Make sure to keep only a single jar "),
+    "rapids.shuffle.jars" ->
+      ("The RAPIDS Shuffle Manager requires spark.driver.extraClassPath\n" +
+        "  and spark.executor.extraClassPath settings to include the\n" +
+        "  path to the Spark RAPIDS plugin jar.\n" +
+        "  If the Spark RAPIDS jar is being bundled with your Spark\n" +
+        "  distribution, this step is not needed.")
+  )
+  // the plugin jar is in the form of rapids-4-spark_scala_binary-(version)-*.jar
+  val pluginJarRegEx = "rapids-4-spark_\\d\\.\\d+-(\\d{2}\\.\\d{2}\\.\\d+).*\\.jar".r
 
   private def handleException(
       ex: Exception,
@@ -1002,14 +1061,5 @@ object AutoTuner extends Logging {
     } else {
       f"$sizeNum%.2f$sizeUnit"
     }
-  }
-
-  /**
-   * Reference - https://stackoverflow.com/a/55246235
-   */
-  def compareSparkVersion(version1: String, version2: String): Int = {
-    val paddedVersions = version1.split("\\.").zipAll(version2.split("\\."), "0", "0")
-    val difference = paddedVersions.find { case (a, b) => a != b }
-    difference.fold(0) { case (a, b) => a.toInt - b.toInt }
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -674,8 +674,9 @@ class AutoTuner(
                   appendComment(
                     "A newer RAPIDS Accelerator for Apache Spark plugin is available:\n" +
                       s"  $jarURL\n" +
-                      s"  Current version is $jarVer.")
+                      s"  Version used in application is $jarVer.")
                 }
+              case None => logError("Could not pull the latest release of plugin jar.")
             }
         }
     }
@@ -931,7 +932,7 @@ object AutoTuner extends Logging {
     "rapids.jars.multiple" ->
       ("Multiple RAPIDS Accelerator for Apache Spark plugin jar\n" +
         "  exist on the classpath.\n" +
-        "  Make sure to keep only a single jar "),
+        "  Make sure to keep only a single jar."),
     "rapids.shuffle.jars" ->
       ("The RAPIDS Shuffle Manager requires spark.driver.extraClassPath\n" +
         "  and spark.executor.extraClassPath settings to include the\n" +

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -37,6 +37,7 @@ object ToolUtils extends Logging {
   private val lookupVersions = Map(
     "311" -> new ComparableVersion("3.1.1"), // default build version
     "320" -> new ComparableVersion("3.2.0"), // introduced reusedExchange
+    "331" -> new ComparableVersion("3.3.1"), // used to check for memoryOverheadFactor
     "340" -> new ComparableVersion("3.4.0")  // introduces jsonProtocolChanges
   )
 
@@ -102,6 +103,19 @@ object ToolUtils extends Logging {
     }
   }
 
+  def compareVersions(verA: String, verB: String): Int = {
+    Try {
+      val verObjA = new ComparableVersion(verA)
+      val verObjB = new ComparableVersion(verB)
+      verObjA.compareTo(verObjB)
+    } match {
+      case Success(compRes) => compRes
+      case Failure(t) =>
+        logError(s"exception comparing two versions [$verA, $verB]", t)
+        0
+    }
+  }
+
   def compareToSparkVersion(currVersion: String, lookupVersion: String): Int = {
     val lookupVersionObj = lookupVersions.get(lookupVersion).get
     val currVersionObj = new ComparableVersion(currVersion)
@@ -110,6 +124,10 @@ object ToolUtils extends Logging {
 
   def isSpark320OrLater(sparkVersion: String = sparkRuntimeVersion): Boolean = {
     compareToSparkVersion(sparkVersion, "320") >= 0
+  }
+
+  def isSpark331OrLater(sparkVersion: String = sparkRuntimeVersion): Boolean = {
+    compareToSparkVersion(sparkVersion, "331") >= 0
   }
 
   def isSpark340OrLater(sparkVersion: String = sparkRuntimeVersion): Boolean = {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/WebCrawlerUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/WebCrawlerUtil.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool.util
+
+import java.io.IOException
+
+import org.jsoup.Jsoup
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+import org.apache.spark.internal.Logging
+
+
+/**
+ * Utility to extract information about RAPIDS packages from mvn URLs.
+ */
+object WebCrawlerUtil extends Logging {
+  private val MAX_CRAWLER_DEPTH = 1
+  private val NV_MVN_BASE_URL = "https://repo1.maven.org/maven2/com/nvidia"
+  // defines the artifacts of the RAPIDS libraries
+  private val NV_ARTIFACTS_LOOKUP = Map(
+    "rapids.plugin" -> "rapids-4-spark_2.12",
+    "rapids.tools" -> "rapids-4-spark-tools_2.12"
+  )
+  // regular expression used to extract the version number from
+  // the mvn repository url
+  private val ARTIFACT_VERSION_REGEX = "\\d{2}\\.\\d{2}\\.\\d+/"
+  // given an artifactID returns the full mvn url that lists all the
+  // releases
+  private def getMVNArtifactURL(artifactID: String) : String = s"$NV_MVN_BASE_URL/$artifactID"
+
+  /**
+   * Given a valid URL, this method recursively picks all the hrefs defined in the HTML doc.
+   * @param webURL a valid URL to the html page to be crawled
+   * @param regEx a valid regular expression as defined by the jsoup library.
+   *              For more details, check https://jsoup.org/cookbook/extracting-data/selector-syntax
+   * @param maxDepth the level of recursion to get the links.
+   * @return a set of all links found recursively in the given url
+   */
+  def getPageLinks(
+      webURL: String,
+      regEx: Option[String],
+      maxDepth: Int = MAX_CRAWLER_DEPTH): mutable.Set[String] = {
+
+    def processPageLinksInternal(currURL: String,
+        cssQuery: String,
+        currDepth: Int,
+        allLinks: mutable.Set[String]): Unit = {
+      if (currDepth < maxDepth && !allLinks.contains(currURL)) {
+        try {
+          val doc = Jsoup.connect(currURL).get
+          val pageURLs = doc.select(cssQuery).asScala.toList
+          val newDepth = currDepth + 1
+          for (page <- pageURLs) {
+            val newLink = page.attr("abs:href")
+            allLinks.add(newLink)
+            processPageLinksInternal(newLink, cssQuery, newDepth, allLinks)
+          }
+        } catch {
+          case x: IOException =>
+            logError(s"Exception while visiting webURL $webURL", x)
+        }
+      }
+    }
+
+    val selectorQuery = regEx match {
+      case Some(value) => s"a[href~=$value]"
+      case None => "a[href]"
+    }
+    val links = mutable.Set[String]()
+    processPageLinksInternal(webURL, selectorQuery, 0, links)
+    links
+  }
+
+  // given an artifactID, returns a list of strings containing all
+  // available releases.
+  def getMvnReleasesForNVPackage(artifactID: String): Seq[String] = {
+    val mvnURL = getMVNArtifactURL(artifactID)
+    val definedLinks = getPageLinks(mvnURL, Some(ARTIFACT_VERSION_REGEX)).toSeq.sorted
+    definedLinks.map(_.split("/").last)
+  }
+
+  // given an artifactID, will return the latest version if any
+  def getLatestMvnReleaseForNVPackage(artifactID: String): Option[String] = {
+    val allVersions = getMvnReleasesForNVPackage(artifactID)
+    allVersions match {
+      case Seq() => None
+      case s: Seq[String] => Some(s.last)
+    }
+  }
+
+  // get the latest version available for rapids plugin
+  def getLatestPluginRelease: Option[String] = {
+    getLatestMvnReleaseForNVPackage(NV_ARTIFACTS_LOOKUP("rapids.plugin"))
+  }
+
+  // get the latest version available for rapids tools
+  def getLatestToolsRelease: Option[String] = {
+    getLatestMvnReleaseForNVPackage(NV_ARTIFACTS_LOOKUP("rapids.tools"))
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/WebCrawlerUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/WebCrawlerUtil.scala
@@ -103,6 +103,15 @@ object WebCrawlerUtil extends Logging {
     }
   }
 
+  // given artifactID and release, returns the full mvn url to download the jar
+  def getMvnDownloadLink(artifactID: String, release: String): String = {
+    s"${getMVNArtifactURL(artifactID)}/$release/$artifactID-$release.jar"
+  }
+
+  def getPluginMvnDownloadLink(release: String): String = {
+    getMvnDownloadLink(NV_ARTIFACTS_LOOKUP("rapids.plugin"), release)
+  }
+
   // get the latest version available for rapids plugin
   def getLatestPluginRelease: Option[String] = {
     getLatestMvnReleaseForNVPackage(NV_ARTIFACTS_LOOKUP("rapids.plugin"))
@@ -112,4 +121,8 @@ object WebCrawlerUtil extends Logging {
   def getLatestToolsRelease: Option[String] = {
     getLatestMvnReleaseForNVPackage(NV_ARTIFACTS_LOOKUP("rapids.tools"))
   }
+
+
+
+
 }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/package.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/package.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool
+
+/**
+ * RAPIDS tools utilities
+ */
+package object util {
+
+}

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -974,7 +974,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |- 'spark.sql.shuffle.partitions' was not set.
           |- A newer RAPIDS Accelerator for Apache Spark plugin is available:
           |  $pluginJarMvnURl
-          |  Current version is $jarVer.
+          |  Version used in application is $jarVer.
           |- ${AutoTuner.classPathComments("rapids.shuffle.jars")}
           |""".stripMargin
     val rapidsJarsArr = Seq(s"rapids-4-spark_2.12-$jarVer.jar")

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.util
+
+import org.scalatest.FunSuite
+import org.scalatest.Matchers.{contain, convertToAnyShouldWrapper}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.rapids.tool.util.WebCrawlerUtil
+
+class ToolUtilsSuite extends FunSuite with Logging {
+  test("get page links of a url") {
+    // Tests that getPageLinks return all the [href] in a page.
+    // This is done manually by checking against a URL that won't likely change
+    // (aka. an old release page should be stable).
+    val baseURL = "https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12"
+    val version = "23.04.0"
+    val filePrefix = s"rapids-4-spark_2.12-$version"
+    val mvnURL = s"$baseURL/$version"
+
+    val webURL = mvnURL
+    val allLinks = WebCrawlerUtil.getPageLinks(webURL, None)
+    val expected = Set[String](
+      s"$baseURL/",
+      s"$mvnURL/$filePrefix-cuda11.jar.asc.sha1",
+      s"$mvnURL/$filePrefix-javadoc.jar.asc.md5",
+      s"$mvnURL/$filePrefix-sources.jar.md5",
+      s"$mvnURL/$filePrefix-cuda11.jar.sha1",
+      s"$mvnURL/$filePrefix-javadoc.jar.asc.sha1",
+      s"$mvnURL/$filePrefix-javadoc.jar.sha1",
+      s"$mvnURL/$filePrefix-sources.jar",
+      s"$mvnURL/$filePrefix.jar.asc",
+      s"$mvnURL/$filePrefix-sources.jar.sha1",
+      s"$mvnURL/$filePrefix.jar.sha1",
+      s"$mvnURL/$filePrefix.pom.asc.md5",
+      s"$mvnURL/$filePrefix-sources.jar.asc.sha1",
+      s"$mvnURL/$filePrefix-javadoc.jar",
+      s"$mvnURL/$filePrefix.jar",
+      s"$mvnURL/$filePrefix.jar.md5",
+      s"$mvnURL/$filePrefix.jar.asc.sha1",
+      s"$mvnURL/$filePrefix.jar.asc.md5",
+      s"$mvnURL/$filePrefix.pom.asc.sha1",
+      s"$mvnURL/$filePrefix.pom.md5",
+      s"$mvnURL/$filePrefix.pom.sha1",
+      s"$mvnURL/$filePrefix-javadoc.jar.asc",
+      s"$mvnURL/$filePrefix-cuda11.jar.asc",
+      s"$mvnURL/$filePrefix-cuda11.jar.asc.md5",
+      s"$mvnURL/$filePrefix-cuda11.jar",
+      s"$mvnURL/$filePrefix-javadoc.jar.md5",
+      s"$mvnURL/$filePrefix-cuda11.jar.md5",
+      s"$mvnURL/$filePrefix-sources.jar.asc",
+      s"$mvnURL/$filePrefix-sources.jar.asc.md5",
+      s"$mvnURL/$filePrefix.pom.asc",
+      s"$mvnURL/$filePrefix.pom")
+    // all links should be matching
+    allLinks shouldBe expected
+  }
+
+  // checks that regex is used correctly to filter the href pulled from a given url
+  test("get page links of a url with regex") {
+    // see the list of available regex in https://jsoup.org/cookbook/extracting-data/selector-syntax
+    val baseURL = "https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12"
+    val version = "23.04.0"
+    val filePrefix = s"rapids-4-spark_2.12-$version"
+    val mvnURL = s"$baseURL/$version"
+
+    val webURL = mvnURL
+    val jarFileRegEx = ".*\\.jar$"
+    val allLinks = WebCrawlerUtil.getPageLinks(webURL, Some(jarFileRegEx))
+    val expected = Set[String](
+      s"$mvnURL/$filePrefix-cuda11.jar",
+      s"$mvnURL/$filePrefix.jar",
+      s"$mvnURL/$filePrefix-javadoc.jar",
+      s"$mvnURL/$filePrefix-sources.jar"
+    )
+    // all links should end with jar files
+    allLinks shouldBe expected
+  }
+
+  //
+  test("list available mvn releases") {
+    // use mvn repo url got testing
+    val artifactID = "rapids-4-spark_2.12"
+    val baseURL = "https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12"
+    val nvReleases = WebCrawlerUtil.getMvnReleasesForNVPackage(artifactID)
+    // get all the links on the page
+    val allLinks = WebCrawlerUtil.getPageLinks(baseURL, None).mkString("\n")
+    val versionPattern = "(\\d{2}\\.\\d{2}\\.\\d+)/".r
+    val actualVersions = versionPattern.findAllMatchIn(allLinks).map(_.group(1)).toSeq
+    nvReleases should contain theSameElementsAs actualVersions
+  }
+
+  test("get latest release") {
+    // use mvn repo url got testing
+    val artifactID = "rapids-4-spark_2.12"
+    val baseURL = "https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12"
+    val latestRelease = WebCrawlerUtil.getLatestMvnReleaseForNVPackage(artifactID) match {
+      case Some(v) => v
+      case None => fail("Could not find pull the latest release successfully")
+    }
+    // get all the links on the page
+    val allLinks = WebCrawlerUtil.getPageLinks(baseURL, None).mkString("\n")
+    val versionPattern = "(\\d{2}\\.\\d{2}\\.\\d+)/".r
+    // get the latest release from the mvn url
+    val actualRelease = versionPattern.findAllMatchIn(allLinks).map(_.group(1)).toSeq.sorted.last
+    latestRelease shouldBe actualRelease
+  }
+}

--- a/user_tools/LICENSE
+++ b/user_tools/LICENSE
@@ -353,3 +353,45 @@ Spur Dashboard V1.1.0
     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
     DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+jsoup License
+
+    The MIT License
+
+    Copyright (c) 2009 - 2023 Jonathan Hedley (https://jsoup.org/)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+    and associated documentation files (the "Software"), to deal in the Software without
+    restriction, including without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+scallop License
+
+    The MIT License
+
+    Copyright (C) 2012 Platon Pronko and Chris Hodapp
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+    and associated documentation files (the "Software"), to deal in the Software without
+    restriction, including without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/user_tools/src/spark_rapids_pytools/rapids/profiling.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/profiling.py
@@ -187,9 +187,11 @@ class Profiling(RapidsJarTool):
             props_list = ['- No recommendations']
         if len(comments_list) == 0:
             comments_list = ['- No comments']
-        # sort the comments and the recommendations so that the two values are aligned
+        # Note that sorting the comments is disabled because it will change the order
+        # of multiline entries
+        # Recommendations can be sorted so that the two values are aligned
+        # comments_list.sort()
         props_list.sort()
-        comments_list.sort()
         return app_name, props_list, comments_list
 
     def _write_summary(self):


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #149, Fixes #266

- AutoTuner recommends upgrading to latest PLUGIN jar
- AutoTuner warns the user when they have multiple RAPIDS jars in the classpath
- Fixed a bug in pytools: multiline comments were not displayed correctly on stdout. This was due to sorting lines.
- The latest release is pulled by crawling the mvn repo url
- Added new utility class `WebCrawlerUtil` to crawl web urls extracting all available references
- A new dependency `jsoup` is added to the fat jar
- Updated the LICENSE and BINARY notices to include the shaded binaries

Note that the `TooUtils` object need to be refactored and split into other objects based on functionality (similar to what is done here with `WebCrawlerUtil`). This can be tracked in #310
