### PR TITLE
Load HadoopConf using SparkHadoopUtil

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/ToolTextFileWriter.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/ToolTextFileWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.apache.hadoop.fs.{FileSystem, FSDataOutputStream, Path}
 import org.apache.hadoop.fs.permission.FsPermission
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
 
 /**
  * Class for writing local files, allows writing to distributed file systems.
@@ -36,7 +37,7 @@ class ToolTextFileWriter(
   val LOG_FILE_PERMISSIONS = new FsPermission(Integer.parseInt("660", 8).toShort)
   val LOG_FOLDER_PERMISSIONS = new FsPermission(Integer.parseInt("770", 8).toShort)
   private val textOutputPath = new Path(s"$finalOutputDir/$logFileName")
-  private val hadoopConfToUse = hadoopConf.getOrElse(new Configuration())
+  private val hadoopConfToUse = hadoopConf.getOrElse(RapidsToolsConfUtil.newHadoopConf)
 
   private val defaultFs = FileSystem.getDefaultUri(hadoopConfToUse).getScheme
   private val isDefaultLocal = defaultFs == null || defaultFs == "file"

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@
 package com.nvidia.spark.rapids.tool.profiling
 
 import com.nvidia.spark.rapids.tool.EventLogPathProcessor
-import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.rapids.tool.AppFilterImpl
+import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
 
 /**
  * A profiling tool to parse Spark Event Log
@@ -45,7 +45,7 @@ object ProfileMain extends Logging {
     val eventlogPaths = appArgs.eventlog()
     val filterN = appArgs.filterCriteria
     val matchEventLogs = appArgs.matchEventLogs
-    val hadoopConf = new Configuration()
+    val hadoopConf = RapidsToolsConfUtil.newHadoopConf
     val numOutputRows = appArgs.numOutputRows.getOrElse(1000)
     val timeout = appArgs.timeout.toOption
     val nThreads = appArgs.numThreads.getOrElse(

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
@@ -17,11 +17,11 @@
 package com.nvidia.spark.rapids.tool.qualification
 
 import com.nvidia.spark.rapids.tool.EventLogPathProcessor
-import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.rapids.tool.AppFilterImpl
 import org.apache.spark.sql.rapids.tool.qualification.QualificationSummaryInfo
+import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
 
 /**
  * A tool to analyze Spark event logs and determine if 
@@ -61,7 +61,7 @@ object QualificationMain extends Logging {
     val platform = appArgs.platform.getOrElse("onprem")
     val mlOpsEnabled = appArgs.mlFunctions.getOrElse(false)
 
-    val hadoopConf = new Configuration()
+    val hadoopConf = RapidsToolsConfUtil.newHadoopConf
 
     val pluginTypeChecker = try {
       new PluginTypeChecker(platform)

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -34,6 +34,7 @@ import org.apache.spark.scheduler.{SparkListenerEvent, StageInfo}
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.execution.ui.{SparkPlanGraph, SparkPlanGraphNode}
 import org.apache.spark.sql.rapids.tool.qualification.MLFunctions
+import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
 import org.apache.spark.util.Utils
 
 abstract class AppBase(
@@ -198,7 +199,7 @@ abstract class AppBase(
         logInfo("Parsing Event Log: " + eventLogPath.toString)
 
         // at this point all paths should be valid event logs or event log dirs
-        val hconf = hadoopConf.getOrElse(new Configuration())
+        val hconf = hadoopConf.getOrElse(RapidsToolsConfUtil.newHadoopConf)
         val fs = eventLogPath.getFileSystem(hconf)
         var totalNumEvents = 0
         val readerOpt = eventLog match {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ui/QualificationReportGenerator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ui/QualificationReportGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,13 @@ import java.nio.file.{Files, FileSystems, Paths}
 
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, FSDataOutputStream, Path}
 import org.json4s.DefaultFormats
 import org.json4s.jackson.Serialization
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.rapids.tool.qualification.QualificationSummaryInfo
+import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
 import org.apache.spark.util.Utils
 
 class QualificationReportGenerator(outputDir: String,
@@ -37,7 +37,7 @@ class QualificationReportGenerator(outputDir: String,
   implicit val formats = DefaultFormats
 
   val outputWorkPath = new Path(outputDir)
-  val fs = Some(FileSystem.get(outputWorkPath.toUri, new Configuration()))
+  val fs = Some(FileSystem.get(outputWorkPath.toUri, RapidsToolsConfUtil.newHadoopConf))
 
   def launch(): Unit = {
     val uiRootPath = getPathForResource(RAPIDS_UI_ASSETS_DIR)

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/RapidsToolsConfUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/RapidsToolsConfUtil.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool.util
+
+import org.apache.hadoop.conf.Configuration
+
+import org.apache.spark.SparkConf
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+
+/**
+ * Contains util methods to interact with Spark/Hadoop configurations.
+ */
+class RapidsToolsConfUtil extends Logging {
+  val hadoopConf: Configuration = newHadoopConf
+
+  def newHadoopConf: Configuration = {
+    val hConf = SparkHadoopUtil.get.conf
+    RapidsToolsConfUtil.appendRapidsToolsHadoopConfigs(hConf)
+    hConf
+  }
+}
+
+
+object RapidsToolsConfUtil extends Logging {
+  val hadoopConfPrefix = s"${RAPIDS_TOOLS_SYS_PROP_PREFIX}hadoop."
+  val sparkConfPrefix = s"${RAPIDS_TOOLS_SYS_PROP_PREFIX}spark."
+
+  private lazy val configMap = loadConfFromSystemProperties
+  private lazy val instance = new RapidsToolsConfUtil
+
+  def get: RapidsToolsConfUtil = instance
+
+  /**
+   * Creates a sparkConfiguration object from the existing sparkSession if any.
+   * Then it will call [[RapidsToolsConfUtil.newHadoopConf(SparkConf)]]
+   * @return a hadoop configuration object
+   */
+  def newHadoopConf(): Configuration = {
+    val sparkConf = SparkSession.getActiveSession match {
+      case Some(spark) => spark.sparkContext.getConf
+      case None => new SparkConf()
+    }
+    newHadoopConf(sparkConf)
+  }
+
+  /**
+   * Returns a Configuration object with Spark configuration applied on top.
+   * It also applies system properties with prefix "rapids.tools.hadoop" on top of all.
+   *
+   * @param conf a spark configuration instance
+   * @return a hadoop configuration object
+   */
+  def newHadoopConf(conf: SparkConf): Configuration = {
+    appendRapidsToolsSparkConfigs(conf)
+    val hadoopConf = SparkHadoopUtil.newConfiguration(conf)
+    appendRapidsToolsHadoopConfigs(hadoopConf)
+    hadoopConf
+  }
+
+  private def appendRapidsToolsHadoopConfigs(hadoopConf: Configuration): Unit = {
+    // Copy any "rapids.tools.hadoop.prop=val" system properties into hadoopConf as "prop=val"
+    for ((key, value) <- configMap if key.startsWith(hadoopConfPrefix)) {
+      val keyVal = key.substring(hadoopConfPrefix.length)
+      hadoopConf.set(keyVal, value,
+        s"Set by Rapids Tools from keys starting with '$hadoopConfPrefix'")
+    }
+  }
+
+  private def appendRapidsToolsSparkConfigs(sparkConf: SparkConf): Unit = {
+    // Copy any "rapids.tools.spark.prop=val" system properties into sparkConf as "spark.prop=val"
+    for ((key, value) <- configMap if key.startsWith(sparkConfPrefix)) {
+      val keyVal = key.substring(RAPIDS_TOOLS_SYS_PROP_PREFIX.length)
+      sparkConf.set(keyVal, value)
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/package.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/package.scala
@@ -16,9 +16,19 @@
 
 package org.apache.spark.sql.rapids.tool
 
+import scala.collection.JavaConverters._
+
 /**
- * RAPIDS tools utilities
+ * RAPIDS tools utilities.
  */
 package object util {
+  val RAPIDS_TOOLS_SYS_PROP_PREFIX = "rapids.tools."
+  def getSystemProperties: Map[String, String] = {
+    System.getProperties.stringPropertyNames().asScala
+      .map(key => (key, System.getProperty(key))).toMap
+  }
 
+  def loadConfFromSystemProperties: Map[String, String] = {
+    getSystemProperties.filter(_._1.startsWith(RAPIDS_TOOLS_SYS_PROP_PREFIX))
+  }
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -25,7 +25,6 @@ import scala.util.control.NonFatal
 
 import com.nvidia.spark.rapids.tool.{EventLogPathProcessor, ToolTestUtils}
 import com.nvidia.spark.rapids.tool.qualification._
-import org.apache.hadoop.conf.Configuration
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 import org.scalatest.exceptions.TestFailedException
 
@@ -35,6 +34,7 @@ import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions.{ceil, col, collect_list, count, explode, floor, hex, json_tuple, round, row_number, sum}
 import org.apache.spark.sql.rapids.tool.ToolUtils
 import org.apache.spark.sql.rapids.tool.qualification.QualificationAppInfo
+import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
 import org.apache.spark.sql.types.StringType
 
 
@@ -83,7 +83,7 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
   }
 
   private def createAppFromEventlog(eventLog: String): QualificationAppInfo = {
-    val hadoopConf = new Configuration()
+    val hadoopConf = RapidsToolsConfUtil.newHadoopConf()
     val (_, allEventLogs) = EventLogPathProcessor.processAllPaths(
       None, None, List(eventLog), hadoopConf)
     val pluginTypeChecker = new PluginTypeChecker()

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/CompareSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/CompareSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,14 +20,14 @@ package com.nvidia.spark.rapids.tool.profiling
 import scala.collection.mutable.ArrayBuffer
 
 import com.nvidia.spark.rapids.tool.{EventLogPathProcessor, ToolTestUtils}
-import org.apache.hadoop.conf.Configuration
 import org.scalatest.FunSuite
 
 import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
+import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
 
 class CompareSuite extends FunSuite {
 
-  val hadoopConf = new Configuration()
+  val hadoopConf = RapidsToolsConfUtil.newHadoopConf()
   private val logDir = ToolTestUtils.getTestResourcePath("spark-events-profiling")
 
   test("test spark2 and spark3 event logs compare") {

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
@@ -20,7 +20,9 @@ import org.scalatest.FunSuite
 import org.scalatest.Matchers.{contain, convertToAnyShouldWrapper}
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.rapids.tool.util.WebCrawlerUtil
+import org.apache.spark.sql.TrampolineUtil
+import org.apache.spark.sql.rapids.tool.util.{RapidsToolsConfUtil, WebCrawlerUtil}
+
 
 class ToolUtilsSuite extends FunSuite with Logging {
   test("get page links of a url") {
@@ -118,5 +120,15 @@ class ToolUtilsSuite extends FunSuite with Logging {
     // get the latest release from the mvn url
     val actualRelease = versionPattern.findAllMatchIn(allLinks).map(_.group(1)).toSeq.sorted.last
     latestRelease shouldBe actualRelease
+  }
+
+  test("Hadoop Configuration should load system properties") {
+    // Tests that Hadoop configurations can load the system property passed to the
+    // command line. i.e., "-Dspark.hadoop.property.key=value"
+    TrampolineUtil.cleanupAnyExistingSession()
+    // sets a hadoop property through Spark Prefix
+    System.setProperty("spark.hadoop.property.key1", "value1")
+    val hadoopConf = RapidsToolsConfUtil.newHadoopConf()
+    hadoopConf.get("property.key1") shouldBe "value1"
   }
 }


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #329

Piggyback on SparkHadoopUtil to create a Hadoop Configuration object.
Adds ability to load configurations specific to `rapids.tools.*` Tested on spark 3.x.x
