### PR TITLE
Adding default pageable pool and spill storage to memoryOverhead for bootstrap/profiler

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -500,11 +500,10 @@ class AutoTuner(
     val executorHeap = execHeapCalculator()
     var executorMemOverhead = (executorHeap * DEF_HEAP_OVERHEAD_FRACTION).toLong
     val pageablePool = DEF_PAGEABLE_POOL_MB.toLong
-    val spillStorage = DEF_SPILL_STORAGE_MB.toLong
     // pinned memory uses any unused space up to 4GB
     val pinnedMem = Math.min(MAX_PINNED_MEMORY_MB, containerMemCalculator.apply() -
-      executorHeap - executorMemOverhead - pageablePool - spillStorage).toLong
-    executorMemOverhead += pinnedMem + pageablePool + spillStorage
+      executorHeap - executorMemOverhead - pageablePool).toLong
+    executorMemOverhead += pinnedMem + pageablePool
     (pinnedMem, executorMemOverhead)
   }
 
@@ -898,8 +897,6 @@ object AutoTuner extends Logging {
   val DEF_PINNED_MEMORY_MB: Long = 2 * 1024L
   // Default pageable pool to use per executor in MB
   val DEF_PAGEABLE_POOL_MB: Long = 1 * 1024L
-  // Default spill storage to use per executor in MB
-  val DEF_SPILL_STORAGE_MB: Long = 1 * 1024L
   // value in MB
   val MIN_PARTITION_BYTES_RANGE_MB = 128L
   // value in MB

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -499,10 +499,12 @@ class AutoTuner(
       containerMemCalculator: () => Double): (Long, Long) = {
     val executorHeap = execHeapCalculator()
     var executorMemOverhead = (executorHeap * DEF_HEAP_OVERHEAD_FRACTION).toLong
+    val pageablePool = DEF_PAGEABLE_POOL_MB.toLong
+    val spillStorage = DEF_SPILL_STORAGE_MB.toLong
     // pinned memory uses any unused space up to 4GB
-    val pinnedMem = Math.min(MAX_PINNED_MEMORY_MB,
-      containerMemCalculator.apply() - executorHeap - executorMemOverhead).toLong
-    executorMemOverhead += pinnedMem
+    val pinnedMem = Math.min(MAX_PINNED_MEMORY_MB, containerMemCalculator.apply() -
+      executorHeap - executorMemOverhead - pageablePool - spillStorage).toLong
+    executorMemOverhead += pinnedMem + pageablePool + spillStorage
     (pinnedMem, executorMemOverhead)
   }
 
@@ -894,6 +896,10 @@ object AutoTuner extends Logging {
   val MAX_PINNED_MEMORY_MB: Long = 4 * 1024L
   // Default pinned memory to use per executor in MB
   val DEF_PINNED_MEMORY_MB: Long = 2 * 1024L
+  // Default pageable pool to use per executor in MB
+  val DEF_PAGEABLE_POOL_MB: Long = 1 * 1024L
+  // Default spill storage to use per executor in MB
+  val DEF_SPILL_STORAGE_MB: Long = 1 * 1024L
   // value in MB
   val MIN_PARTITION_BYTES_RANGE_MB = 128L
   // value in MB

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -136,7 +136,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=2
           |--conf spark.executor.memory=32768m
-          |--conf spark.executor.memoryOverhead=7372m
+          |--conf spark.executor.memoryOverhead=9420m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=16
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=16
@@ -276,7 +276,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=2
           |--conf spark.executor.memory=32768m
-          |--conf spark.executor.memoryOverhead=7372m
+          |--conf spark.executor.memoryOverhead=9420m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=16
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=16
@@ -334,7 +334,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |Spark Properties:
           |--conf spark.executor.cores=32
           |--conf spark.executor.memory=65536m
-          |--conf spark.executor.memoryOverhead=10649m
+          |--conf spark.executor.memoryOverhead=12697m
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=32
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=32
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=32
@@ -364,7 +364,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val customProps = mutable.LinkedHashMap(
       "spark.executor.cores" -> "16",
       "spark.executor.memory" -> "32768m",
-      "spark.executor.memoryOverhead" -> "7372m",
+      "spark.executor.memoryOverhead" -> "9420m",
       "spark.rapids.memory.pinnedPool.size" -> "4096m",
       "spark.rapids.shuffle.multiThreaded.reader.threads" -> "16",
       "spark.rapids.shuffle.multiThreaded.writer.threads" -> "16",
@@ -402,7 +402,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val customProps = mutable.LinkedHashMap(
       "spark.executor.cores" -> "16",
       "spark.executor.memory" -> "32768m",
-      "spark.executor.memoryOverhead" -> "7372m",
+      "spark.executor.memoryOverhead" -> "9420m",
       "spark.rapids.memory.pinnedPool.size" -> "4096m",
       "spark.rapids.shuffle.multiThreaded.reader.threads" -> "16",
       "spark.rapids.shuffle.multiThreaded.writer.threads" -> "16",
@@ -437,7 +437,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val customProps = mutable.LinkedHashMap(
       "spark.executor.cores" -> "16",
       "spark.executor.memory" -> "32768m",
-      "spark.executor.memoryOverhead" -> "7372m",
+      "spark.executor.memoryOverhead" -> "9420m",
       "spark.rapids.memory.pinnedPool.size" -> "4096m",
       "spark.rapids.shuffle.multiThreaded.reader.threads" -> "16",
       "spark.rapids.shuffle.multiThreaded.writer.threads" -> "16",
@@ -476,7 +476,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val customProps = mutable.LinkedHashMap(
       "spark.executor.cores" -> "16",
       "spark.executor.memory" -> "32768m",
-      "spark.executor.memoryOverhead" -> "7372m",
+      "spark.executor.memoryOverhead" -> "9420m",
       "spark.rapids.memory.pinnedPool.size" -> "4096m",
       "spark.rapids.shuffle.multiThreaded.reader.threads" -> "16",
       "spark.rapids.shuffle.multiThreaded.writer.threads" -> "16",
@@ -513,7 +513,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val customProps = mutable.LinkedHashMap(
       "spark.executor.cores" -> "16",
       "spark.executor.memory" -> "32768m",
-      "spark.executor.memoryOverhead" -> "7372m",
+      "spark.executor.memoryOverhead" -> "9420m",
       "spark.rapids.memory.pinnedPool.size" -> "4096m",
       "spark.rapids.shuffle.multiThreaded.reader.threads" -> "16",
       "spark.rapids.shuffle.multiThreaded.writer.threads" -> "16",
@@ -551,7 +551,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
       "spark.dynamicAllocation.enabled" -> "false",
       "spark.executor.cores" -> "16",
       "spark.executor.memory" -> "32768m",
-      "spark.executor.memoryOverhead" -> "7372m",
+      "spark.executor.memoryOverhead" -> "9420m",
       "spark.rapids.memory.pinnedPool.size" -> "4096m",
       "spark.rapids.shuffle.multiThreaded.reader.threads" -> "16",
       "spark.rapids.shuffle.multiThreaded.writer.threads" -> "16",
@@ -591,7 +591,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=8
           |--conf spark.executor.memory=32768m
-          |--conf spark.executor.memoryOverhead=7372m
+          |--conf spark.executor.memoryOverhead=9420m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=16
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=16
@@ -673,7 +673,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |--conf spark.executor.cores=8
           |--conf spark.executor.instances=20
           |--conf spark.executor.memory=16384m
-          |--conf spark.executor.memoryOverhead=5734m
+          |--conf spark.executor.memoryOverhead=7782m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
@@ -853,7 +853,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |--conf spark.executor.cores=8
           |--conf spark.executor.instances=20
           |--conf spark.executor.memory=16384m
-          |--conf spark.executor.memoryOverhead=5734m
+          |--conf spark.executor.memoryOverhead=7782m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
@@ -916,7 +916,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |--conf spark.executor.cores=8
           |--conf spark.executor.instances=20
           |--conf spark.executor.memory=16384m
-          |--conf spark.executor.memoryOverhead=5734m
+          |--conf spark.executor.memoryOverhead=7782m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
@@ -974,7 +974,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |--conf spark.executor.cores=8
           |--conf spark.executor.instances=20
           |--conf spark.executor.memory=16384m
-          |--conf spark.executor.memoryOverhead=5734m
+          |--conf spark.executor.memoryOverhead=7782m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
@@ -998,7 +998,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val customProps = mutable.LinkedHashMap(
       "spark.executor.cores" -> "16",
       "spark.executor.memory" -> "32768m",
-      "spark.executor.memoryOverhead" -> "7372m",
+      "spark.executor.memoryOverhead" -> "9420m",
       "spark.rapids.memory.pinnedPool.size" -> "4096m",
       "spark.rapids.shuffle.multiThreaded.reader.threads" -> "16",
       "spark.rapids.shuffle.multiThreaded.writer.threads" -> "16",

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -136,7 +136,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=2
           |--conf spark.executor.memory=32768m
-          |--conf spark.executor.memoryOverhead=9420m
+          |--conf spark.executor.memoryOverhead=8396m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=16
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=16
@@ -276,7 +276,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=2
           |--conf spark.executor.memory=32768m
-          |--conf spark.executor.memoryOverhead=9420m
+          |--conf spark.executor.memoryOverhead=8396m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=16
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=16
@@ -334,7 +334,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |Spark Properties:
           |--conf spark.executor.cores=32
           |--conf spark.executor.memory=65536m
-          |--conf spark.executor.memoryOverhead=12697m
+          |--conf spark.executor.memoryOverhead=11673m
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=32
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=32
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=32
@@ -364,7 +364,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val customProps = mutable.LinkedHashMap(
       "spark.executor.cores" -> "16",
       "spark.executor.memory" -> "32768m",
-      "spark.executor.memoryOverhead" -> "9420m",
+      "spark.executor.memoryOverhead" -> "8396m",
       "spark.rapids.memory.pinnedPool.size" -> "4096m",
       "spark.rapids.shuffle.multiThreaded.reader.threads" -> "16",
       "spark.rapids.shuffle.multiThreaded.writer.threads" -> "16",
@@ -402,7 +402,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val customProps = mutable.LinkedHashMap(
       "spark.executor.cores" -> "16",
       "spark.executor.memory" -> "32768m",
-      "spark.executor.memoryOverhead" -> "9420m",
+      "spark.executor.memoryOverhead" -> "8396m",
       "spark.rapids.memory.pinnedPool.size" -> "4096m",
       "spark.rapids.shuffle.multiThreaded.reader.threads" -> "16",
       "spark.rapids.shuffle.multiThreaded.writer.threads" -> "16",
@@ -437,7 +437,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val customProps = mutable.LinkedHashMap(
       "spark.executor.cores" -> "16",
       "spark.executor.memory" -> "32768m",
-      "spark.executor.memoryOverhead" -> "9420m",
+      "spark.executor.memoryOverhead" -> "8396m",
       "spark.rapids.memory.pinnedPool.size" -> "4096m",
       "spark.rapids.shuffle.multiThreaded.reader.threads" -> "16",
       "spark.rapids.shuffle.multiThreaded.writer.threads" -> "16",
@@ -476,7 +476,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val customProps = mutable.LinkedHashMap(
       "spark.executor.cores" -> "16",
       "spark.executor.memory" -> "32768m",
-      "spark.executor.memoryOverhead" -> "9420m",
+      "spark.executor.memoryOverhead" -> "8396m",
       "spark.rapids.memory.pinnedPool.size" -> "4096m",
       "spark.rapids.shuffle.multiThreaded.reader.threads" -> "16",
       "spark.rapids.shuffle.multiThreaded.writer.threads" -> "16",
@@ -513,7 +513,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val customProps = mutable.LinkedHashMap(
       "spark.executor.cores" -> "16",
       "spark.executor.memory" -> "32768m",
-      "spark.executor.memoryOverhead" -> "9420m",
+      "spark.executor.memoryOverhead" -> "8396m",
       "spark.rapids.memory.pinnedPool.size" -> "4096m",
       "spark.rapids.shuffle.multiThreaded.reader.threads" -> "16",
       "spark.rapids.shuffle.multiThreaded.writer.threads" -> "16",
@@ -551,7 +551,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
       "spark.dynamicAllocation.enabled" -> "false",
       "spark.executor.cores" -> "16",
       "spark.executor.memory" -> "32768m",
-      "spark.executor.memoryOverhead" -> "9420m",
+      "spark.executor.memoryOverhead" -> "8396m",
       "spark.rapids.memory.pinnedPool.size" -> "4096m",
       "spark.rapids.shuffle.multiThreaded.reader.threads" -> "16",
       "spark.rapids.shuffle.multiThreaded.writer.threads" -> "16",
@@ -591,7 +591,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=8
           |--conf spark.executor.memory=32768m
-          |--conf spark.executor.memoryOverhead=9420m
+          |--conf spark.executor.memoryOverhead=8396m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=16
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=16
@@ -673,7 +673,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |--conf spark.executor.cores=8
           |--conf spark.executor.instances=20
           |--conf spark.executor.memory=16384m
-          |--conf spark.executor.memoryOverhead=7782m
+          |--conf spark.executor.memoryOverhead=6758m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
@@ -853,7 +853,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |--conf spark.executor.cores=8
           |--conf spark.executor.instances=20
           |--conf spark.executor.memory=16384m
-          |--conf spark.executor.memoryOverhead=7782m
+          |--conf spark.executor.memoryOverhead=6758m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
@@ -916,7 +916,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |--conf spark.executor.cores=8
           |--conf spark.executor.instances=20
           |--conf spark.executor.memory=16384m
-          |--conf spark.executor.memoryOverhead=7782m
+          |--conf spark.executor.memoryOverhead=6758m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
@@ -974,7 +974,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |--conf spark.executor.cores=8
           |--conf spark.executor.instances=20
           |--conf spark.executor.memory=16384m
-          |--conf spark.executor.memoryOverhead=7782m
+          |--conf spark.executor.memoryOverhead=6758m
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
@@ -998,7 +998,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val customProps = mutable.LinkedHashMap(
       "spark.executor.cores" -> "16",
       "spark.executor.memory" -> "32768m",
-      "spark.executor.memoryOverhead" -> "9420m",
+      "spark.executor.memoryOverhead" -> "8396m",
       "spark.rapids.memory.pinnedPool.size" -> "4096m",
       "spark.rapids.shuffle.multiThreaded.reader.threads" -> "16",
       "spark.rapids.shuffle.multiThreaded.writer.threads" -> "16",

--- a/user_tools/src/spark_rapids_pytools/rapids/bootstrap.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/bootstrap.py
@@ -61,13 +61,12 @@ class Bootstrap(RapidsTool):
         # give up to 2GB of heap to each executor core
         executor_heap = min(max_executor_heap, constants.get('heapPerCoreMB') * num_executor_cores)
         executor_mem_overhead = int(executor_heap * constants.get('heapOverheadFraction'))
-        # use defaults for pageable_pool and spill_storage to add to memory overhead
+        # use default for pageable_pool to add to memory overhead
         pageable_pool = constants.get('defaultPageablePoolMB')
-        spill_storage = constants.get('defaultSpillStorageMB')
         # pinned memory uses any unused space up to 4GB
         pinned_mem = min(constants.get('maxPinnedMemoryMB'),
-                         executor_container_mem - executor_heap - executor_mem_overhead - pageable_pool - spill_storage)
-        executor_mem_overhead += pinned_mem + pageable_pool + spill_storage
+                         executor_container_mem - executor_heap - executor_mem_overhead - pageable_pool)
+        executor_mem_overhead += pinned_mem + pageable_pool
         res = {
             'spark.executor.cores': num_executor_cores,
             'spark.executor.memory': f'{executor_heap}m',

--- a/user_tools/src/spark_rapids_pytools/rapids/bootstrap.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/bootstrap.py
@@ -61,10 +61,13 @@ class Bootstrap(RapidsTool):
         # give up to 2GB of heap to each executor core
         executor_heap = min(max_executor_heap, constants.get('heapPerCoreMB') * num_executor_cores)
         executor_mem_overhead = int(executor_heap * constants.get('heapOverheadFraction'))
+        # use defaults for pageable_pool and spill_storage to add to memory overhead
+        pageable_pool = constants.get('defaultPageablePoolMB')
+        spill_storage = constants.get('defaultSpillStorageMB')
         # pinned memory uses any unused space up to 4GB
         pinned_mem = min(constants.get('maxPinnedMemoryMB'),
-                         executor_container_mem - executor_heap - executor_mem_overhead)
-        executor_mem_overhead += pinned_mem
+                         executor_container_mem - executor_heap - executor_mem_overhead - pageable_pool - spill_storage)
+        executor_mem_overhead += pinned_mem + pageable_pool + spill_storage
         res = {
             'spark.executor.cores': num_executor_cores,
             'spark.executor.memory': f'{executor_heap}m',

--- a/user_tools/src/spark_rapids_pytools/resources/bootstrap-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/bootstrap-conf.yaml
@@ -12,6 +12,10 @@ local:
     constants:
       # Maximum amount of pinned memory to use per executor in megabytes
       maxPinnedMemoryMB: 4096
+      # Default pageable pool size per executor in megabytes
+      defaultPageablePoolMB: 1024
+      # Default spill storage size per executor in megabytes
+      defaultSpillStorageMB: 1024
       # Maximum number of concurrent tasks to run on the GPU
       maxGpuConcurrent: 4
       # Amount of GPU memory to use per concurrent task in megabytes

--- a/user_tools/src/spark_rapids_pytools/resources/bootstrap-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/bootstrap-conf.yaml
@@ -14,8 +14,6 @@ local:
       maxPinnedMemoryMB: 4096
       # Default pageable pool size per executor in megabytes
       defaultPageablePoolMB: 1024
-      # Default spill storage size per executor in megabytes
-      defaultSpillStorageMB: 1024
       # Maximum number of concurrent tasks to run on the GPU
       maxGpuConcurrent: 4
       # Amount of GPU memory to use per concurrent task in megabytes


### PR DESCRIPTION
Closes #321 

Manually verified for bootstrap on Dataproc and local profiler that 1GB is added to memoryOverhead to account for defaults for pageable pool.
