### PR TITLE
Keeping spark-rapids-tools and spark-rapids tools docs in sync

### DIFF
--- a/core/docs/spark-profiling-tool.md
+++ b/core/docs/spark-profiling-tool.md
@@ -658,7 +658,7 @@ Rapids accelerator.
 Currently, the _Auto-Tuner_ calculates a set of configurations that impact the performance of Apache
 Spark apps executing on GPU. Those calculations can leverage cluster information
 (e.g. memory, cores, Spark default configurations) as well as information processed in the
-application event logs.  Note that the tool also will recommend setting for the application assuming
+application event logs.  Note that the tool also will recommend settings for the application assuming
 that the job will be able to use all the cluster resources (CPU and GPU) when it is running.
 
 The values loaded from the app logs have higher precedence than the default configs.  

--- a/core/docs/spark-qualification-tool.md
+++ b/core/docs/spark-qualification-tool.md
@@ -16,7 +16,9 @@ that could not run on GPU because they are unsupported operators or not SQL/Data
 
 This tool is intended to give the users a starting point and does not guarantee the
 queries or applications with the highest _recommendation_ will actually be accelerated the most. Currently,
-it reports by looking at the amount of time spent in tasks of SQL Dataframe operations.
+it reports by looking at the amount of time spent in tasks of SQL Dataframe operations.  Note that the qualification
+tool estimates assume that the application is run on a dedicated cluster where it can use all of the available
+Spark resources.
 
 The estimations for GPU duration are available for different environments and are based on benchmarks run in the
 applicable environments.  Here are the cluster information for the ETL benchmarks used for the estimates:


### PR DESCRIPTION
Keeping profiling and qualification tools doc the same between spark-rapids-tools and spark-rapids repos to allow us to do simpler maintenance going forward
