### PR TITLE
Fix excessive numberFormatException in profiling tool

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool.util
+
+import scala.util.control.NonFatal
+
+import com.nvidia.spark.rapids.tool.profiling.TaskStageAccumCase
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.scheduler.AccumulableInfo
+
+/**
+ * Utility containing the implementation of helpers used for parsing data from event.
+ */
+object EventUtils extends Logging {
+
+  /**
+   * Used to parse (value/update) fields of the AccumulableInfo object. If the data is not
+   * a valid long, it tries to parse it as a duration in the format of "hour:mm:ss.SSS".
+   *
+   * @param data value stored in the (value/update) of the AccumulableInfo
+   * @return valid parsed long of the content or the duration
+   * @throws java.lang.NullPointerException if the argument is `null`
+   */
+  def parseAccumFieldToLong(data: Any): Option[Long] = {
+    val strData = data.toString
+    try {
+      Some(strData.toLong)
+    } catch {
+      case _ : NumberFormatException =>
+        StringUtils.parseFromDurationToLongOption(strData)
+      case NonFatal(_) =>
+        None
+    }
+  }
+
+  /**
+   * Given AccumulableInfo object, this method tries to parse value/update fields into long.
+   * It is common to have one of those two fields set to None. That's why, we are not skipping the
+   * entire accumulable if one of those fields fail to parse.
+   *
+   * @param accuInfo object of AccumulableInfo to be processed
+   * @param stageId the tageId to which the metric belongs
+   * @param attemptId the ID of the current execution
+   * @param taskId the task-id to which the metric belongs , if any.
+   * @return option(TaskStageAccumCase) if art least one of the two fields can be parsed to Long.
+   */
+  def buildTaskStageAccumFromAccumInfo(accuInfo: AccumulableInfo,
+      stageId: Int, attemptId: Int, taskId: Option[Long] = None): Option[TaskStageAccumCase] = {
+    val value = accuInfo.value.flatMap(parseAccumFieldToLong)
+    val update = accuInfo.update.flatMap(parseAccumFieldToLong)
+    if (!(value.isDefined || update.isDefined)) {
+      // we could not get any valid number from both value/update
+      if (log.isDebugEnabled()) {
+        if ((accuInfo.value.isDefined && value.isEmpty) ||
+          (accuInfo.update.isDefined && update.isEmpty)) {
+          // in this case we failed to parse
+          logDebug(s"Failed to parse accumulable for stageId=$stageId, taskId=$taskId." +
+            s"The problematic accumulable is: $accuInfo")
+        }
+      }
+      // No need to return a new object to save memory consumption
+      None
+    } else {
+      Some(TaskStageAccumCase(
+        stageId, attemptId,
+        taskId, accuInfo.id, accuInfo.name, value, update, accuInfo.internal))
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/StringUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/StringUtils.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool.util
+
+import scala.concurrent.duration.{DurationDouble, DurationLong}
+
+/**
+ * Utility containing the implementation of helpers used for parsing and/or formatting
+ * strings.
+ */
+object StringUtils {
+  // Regular expression for duration-format 'H+:MM:SS.FFF'
+  // Note: this is not time-of-day. Hours can be larger than 12.
+  private val regExDurationFormat = "^(\\d+):([0-5]\\d):([0-5]\\d\\.\\d+)$"
+
+  /**
+   * Checks if the strData is of pattern 'HH:MM:SS.FFF' and return the time as long if applicable.
+   * If the string is not in the expected format, the result is None.
+   * Note that the hours part can be larger than 23.
+   *
+   * @param stData the data to be evaluated
+   * @return long value of the duration
+   */
+  def parseFromDurationToLongOption(strData: String): Option[Long] = {
+    // String operation is usually faster than regular expression match/find. That's why we check
+    // using string instead of `regEx.findFirstMatchIn()`
+    if (strData.matches(regExDurationFormat)) {
+      val tokens = strData.split(":")
+      Some(tokens(0).toLong.hours.toMillis +
+        tokens(1).toLong.minutes.toMillis +
+        tokens(2).toDouble.seconds.toMillis)
+    } else {
+      None
+    }
+  }
+}

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
@@ -16,12 +16,17 @@
 
 package com.nvidia.spark.rapids.tool.util
 
+import java.text.SimpleDateFormat
+import java.util.Calendar
+
 import org.scalatest.FunSuite
-import org.scalatest.Matchers.{contain, convertToAnyShouldWrapper}
+import org.scalatest.Matchers.{contain, convertToAnyShouldWrapper, not}
+import scala.concurrent.duration._
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.scheduler.AccumulableInfo
 import org.apache.spark.sql.TrampolineUtil
-import org.apache.spark.sql.rapids.tool.util.{RapidsToolsConfUtil, WebCrawlerUtil}
+import org.apache.spark.sql.rapids.tool.util.{EventUtils, RapidsToolsConfUtil, StringUtils, WebCrawlerUtil}
 
 
 class ToolUtilsSuite extends FunSuite with Logging {
@@ -130,5 +135,60 @@ class ToolUtilsSuite extends FunSuite with Logging {
     System.setProperty("spark.hadoop.property.key1", "value1")
     lazy val hadoopConf = RapidsToolsConfUtil.newHadoopConf()
     hadoopConf.get("property.key1") shouldBe "value1"
+  }
+
+  test("parse timeFormat 'HH:MM:SS.FFF' to Long") {
+    val currCalendar = Calendar.getInstance()
+    val acceptedTimeFormat = new SimpleDateFormat("HH:mm:ss.SSS")
+
+    val hour = currCalendar.get(Calendar.HOUR_OF_DAY)
+    val minute = currCalendar.get(Calendar.MINUTE)
+    val seconds = currCalendar.get(Calendar.SECOND)
+    val millis = currCalendar.get(Calendar.MILLISECOND)
+    val currTimeAsStr = acceptedTimeFormat.format(currCalendar.getTime)
+    val duration =
+      hour.hours.toMillis + minute.minutes.toMillis + seconds.seconds.toMillis + millis
+    // test successful parsing
+    StringUtils.parseFromDurationToLongOption(currTimeAsStr).get shouldBe duration
+    // test non-successful with milliseconds is not 3 digits
+    val timeNoMillisAsStr = f"$hour:$minute%02d:$seconds%02d.1"
+    StringUtils.parseFromDurationToLongOption(timeNoMillisAsStr).get shouldBe {
+      duration - millis + 100
+    }
+    // test successful with high number of hours
+    StringUtils.parseFromDurationToLongOption("50:30:30.000").get shouldBe {
+      50.hours.toMillis + 30.minutes.toMillis + 30.seconds.toMillis
+    }
+    // test incorrect format with overflowing minutes
+    val timeBrokenMinutesAsString = f"$hour:${minute + 60}%02d:$seconds%02d.$millis%03d"
+    StringUtils.parseFromDurationToLongOption(timeBrokenMinutesAsString) should not be 'defined
+    // test random string won't cause any exceptions
+    StringUtils.parseFromDurationToLongOption("Hello Worlds") should not be 'defined
+  }
+
+  test("parse Accumulable fields") {
+    val problematicAccum =
+      AccumulableInfo(100, Some("problematicAccum"), Some(Array()), Some(None), true, true, None)
+    EventUtils.buildTaskStageAccumFromAccumInfo(
+      problematicAccum, 1, 1, None) should not be 'defined
+    // test successful value field
+    val accumWithValue =
+      AccumulableInfo(100, Some("successAccum"), Some(None), Some(1000), true, true, None)
+    EventUtils.buildTaskStageAccumFromAccumInfo(
+      accumWithValue, 1, 1, None).get.value.get shouldBe 1000
+    // test successful update field
+    val accumWithUpdate =
+      AccumulableInfo(100, Some("successAccum"), Some(1000), Some(None), true, true, None)
+    EventUtils.buildTaskStageAccumFromAccumInfo(
+      accumWithUpdate, 1, 1, None).get.update.get shouldBe 1000
+    // test successful parse of durations
+    val updateField = "0:00:00.100"
+    val valueField = "0:00:59.200"
+    val accumWithDuration =
+      AccumulableInfo(100, Some("successAccum"),
+        Some(updateField), Some(valueField), true, true, None)
+    val result = EventUtils.buildTaskStageAccumFromAccumInfo(accumWithDuration, 1, 1, None).get
+    result.update.get shouldBe 100
+    result.value.get shouldBe (59 * 1000 + 200)
   }
 }

--- a/user_tools/src/spark_rapids_pytools/common/utilities.py
+++ b/user_tools/src/spark_rapids_pytools/common/utilities.py
@@ -323,7 +323,7 @@ class SysCmd:
                                stderr=stderr)
         self.res = c.returncode
         # pylint: enable=subprocess-run-check
-        self.err_std = c.stderr if isinstance(c.stderr, str) else c.stderr.decode('utf-8')
+        self.err_std = c.stderr if isinstance(c.stderr, str) else c.stderr.decode('utf-8', errors='ignore')
         if self.has_failed():
             std_error_lines = [f'\t| {line}' for line in self.err_std.splitlines()]
             stderr_str = ''
@@ -333,7 +333,7 @@ class SysCmd:
             cmd_err_msg = f'Error invoking CMD <{Utils.gen_joined_str(" ", cmd_args)}>: {stderr_str}'
             raise RuntimeError(f'{cmd_err_msg}')
 
-        self.out_std = c.stdout if isinstance(c.stdout, str) else c.stdout.decode('utf-8')
+        self.out_std = c.stdout if isinstance(c.stdout, str) else c.stdout.decode('utf-8', errors='ignore')
         if self.process_streams_cb is not None:
             self.process_streams_cb(self.out_std, self.err_std)
         if self.out_std:


### PR DESCRIPTION
Fixes #345, Fixes #352

Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

- The parsing error were due to specific databricks metrics.
```
The problematic accumulable is: name=Some(internal.metrics.usage.events),value=Some([]),update=Some([])
```
- One option to fix the issue was to skip the metric if its name of a specific pattern. However, this will be overwhelming to maintain.
- Instead, I opted to avoid throwing the error, and dump the exception when the log-debug is enabled.
- Added unit tests to cover parsing of AccumulableInfo
- Refactored the code by created object Utils so that the code can be re-used later on.
- Put an ignore-flag to avoid failing while processing the output of the profiling/qualification tool