### PR TITLE
Regenerate expected Profile tool outputs with no other code changes

### DIFF
--- a/core/src/test/resources/ProfilingExpectations/executors_removed_eventlog_expectation.csv
+++ b/core/src/test/resources/ProfilingExpectations/executors_removed_eventlog_expectation.csv
@@ -1,3 +1,3 @@
-appIndex,executorID,time,reason_first100char
+appIndex,executorId,time,reason
 1,1,1623285426806,Executor Process Lost
 1,2,1623285426654,Executor Process Lost

--- a/core/src/test/resources/ProfilingExpectations/stages_failure_eventlog_expectation.csv
+++ b/core/src/test/resources/ProfilingExpectations/stages_failure_eventlog_expectation.csv
@@ -1,2 +1,2 @@
 appIndex,stageId,attemptId,name,numTasks,failureReason
-1,238,0,show at <console>:33,200,"org.apache.spark.shuffle.FetchFailedException: /hadoop_disks/disk0/local/usercache/username/appcache"
+1,238,0,show at <console>:33,200,org.apache.spark.shuffle.FetchFailedException: /hadoop_disks/disk0/local/usercache/username/appcache


### PR DESCRIPTION
Noticed as part of #358 that the expected outputs did not match to newly regenerated outputs. This is especially true around some header changes. To reduce confusion I split this off. Related too #361 and at least triages the current diff.

There is 1 salient file in this set `core/src/test/resources/ProfilingExpectations/unsupported_sql_eventlog_expectation.csv` which compares a file output to raw tool output in the `HealthCheckSuite`. Raw output includes `,`'s but they are removed in preparation for file writing -- as a result the raw DF vs csv file DF comparison will not match.

I used the following script, which may be useful in the future as it provides a direct mapping of the files. Perhaps it could be integrated into the qualification tool's script for regenerating unit testing output in the future.

```bash
BASECMD="java ${QUALIFICATION_HEAP} -cp target/rapids-4-spark-tools_2.12-23.04.0-SNAPSHOT.jar:${SPARK_HOME}/jars/* com.nvidia.spark.rapids.tool.profiling.ProfileMain --csv "
COREDIR="."
PROFLOGPATH="src/test/resources/spark-events-profiling"
QUALLOGPATH="src/test/resources/spark-events-qualification"
PROFEXPECTPATH="src/test/resources/ProfilingExpectations"

${BASECMD} --combined ${COREDIR}/${PROFLOGPATH}/rapids_join_eventlog.zstd ${COREDIR}/${PROFLOGPATH}/rapids_join_eventlog2.zstd
${BASECMD} ${COREDIR}/${PROFLOGPATH}/rapids_join_eventlog.zstd
${BASECMD} ${COREDIR}/${PROFLOGPATH}/rapids_join_eventlog2.zstd
${BASECMD} ${COREDIR}/${PROFLOGPATH}/dataset_eventlog
${BASECMD} ${COREDIR}/${QUALLOGPATH}/complex_dec_eventlog.zstd
${BASECMD} ${COREDIR}/${PROFLOGPATH}/tasks_executors_fail_compressed_eventlog.zstd

cp ${COREDIR}/rapids_4_spark_profile/application_1603128018386_7846/removed_executors.csv ${COREDIR}/${PROFEXPECTPATH}/executors_removed_eventlog_expectation.csv
cp ${COREDIR}/rapids_4_spark_profile/application_1603128018386_7846/failed_jobs.csv ${COREDIR}/${PROFEXPECTPATH}/jobs_failure_eventlog_expectation.csv
cp ${COREDIR}/rapids_4_spark_profile/local-1626104300434/sql_duration_and_executor_cpu_time_percent.csv ${COREDIR}/${PROFEXPECTPATH}/rapids_duration_and_cpu_expectation.csv
cp ${COREDIR}/rapids_4_spark_profile/local-1622814619968/job_+_stage_level_aggregated_task_metrics.csv ${COREDIR}/${PROFEXPECTPATH}/rapids_join_eventlog_jobandstagemetrics_expectation.csv
cp ${COREDIR}/rapids_4_spark_profile/local-1622821994212/job_+_stage_level_aggregated_task_metrics.csv ${COREDIR}/${PROFEXPECTPATH}/rapids_join_eventlog_jobandstagemetrics2_expectation.csv
cp ${COREDIR}/rapids_4_spark_profile/combined/job_+_stage_level_aggregated_task_metrics.csv ${COREDIR}/${PROFEXPECTPATH}/rapids_join_eventlog_jobandstagemetricsmulti_expectation.csv
cp ${COREDIR}/rapids_4_spark_profile/local-1622814619968/sql_plan_metrics_for_application.csv ${COREDIR}/${PROFEXPECTPATH}/rapids_join_eventlog_sqlmetrics_expectation.csv
cp ${COREDIR}/rapids_4_spark_profile/local-1622814619968/sql_level_aggregated_task_metrics.csv ${COREDIR}/${PROFEXPECTPATH}/rapids_join_eventlog_sqlmetricsagg_expectation.csv
cp ${COREDIR}/rapids_4_spark_profile/local-1622821994212/sql_level_aggregated_task_metrics.csv ${COREDIR}/${PROFEXPECTPATH}/rapids_join_eventlog_sqlmetricsagg2_expectation.csv
cp ${COREDIR}/rapids_4_spark_profile/combined/sql_level_aggregated_task_metrics.csv ${COREDIR}/${PROFEXPECTPATH}/rapids_join_eventlog_sqlmetricsaggmulti_expectation.csv
cp ${COREDIR}/rapids_4_spark_profile/application_1603128018386_7846/removed_blockmanagers.csv ${COREDIR}/${PROFEXPECTPATH}/removed_blockManagers_eventlog_expectation.csv
cp ${COREDIR}/rapids_4_spark_profile/application_1603128018386_7846/failed_stages.csv ${COREDIR}/${PROFEXPECTPATH}/stages_failure_eventlog_expectation.csv
cp ${COREDIR}/rapids_4_spark_profile/application_1603128018386_7846/failed_tasks.csv ${COREDIR}/${PROFEXPECTPATH}/tasks_failure_eventlog_expectation.csv
cp ${COREDIR}/rapids_4_spark_profile/local-1621955976602/unsupported_sql_plan.csv ${COREDIR}/${PROFEXPECTPATH}/unsupported_sql_eventlog_expectation.csv
```

<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
