### PR TITLE
Improve node collection in parallel for diagnostic command

### DIFF
--- a/user_tools/docs/user-tools-aws-emr.md
+++ b/user_tools/docs/user-tools-aws-emr.md
@@ -324,7 +324,7 @@ spark_rapids_user_tools emr diagnostic [options]
 spark_rapids_user_tools emr diagnostic --help
 ```
 
-Run diagnostic command to collects information from Dataproc cluster, such as OS version, # of worker
+Run diagnostic command to collects information from EMR cluster, such as OS version, # of worker
 nodes, Yarn configuration, Spark version and error logs etc. The cluster has to be running and the
 user must have SSH access.
 
@@ -336,6 +336,7 @@ user must have SSH access.
 | **profile**       | A named AWS profile that you can specify to get the settings/credentials of the AWS account.                                                                                                                                | "default" if the the env-variable `AWS_PROFILE` is not set                                  |     N    |
 | **output_folder** | Path to local directory where the final recommendations is logged                                                                                                                                                           | env variable `RAPIDS_USER_TOOLS_OUTPUT_DIRECTORY` if any; or the current working directory. |     N    |
 | **key_pair_path** | A '.pem' file path that enables to connect to EC2 instances using SSH. For more details on creating key pairs, visit [aws-create-key-pair-guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html) | env variable '`RAPIDS_USER_TOOLS_KEY_PAIR_PATH`' if any                                     |     N    |
+| **thread_num**    | Number of threads to access remote cluster nodes in parallel                                                                                                                                                                | 3                                                                                           |     N    |
 | **verbose**       | True or False to enable verbosity to the wrapper script                                                                                                                                                                     | False if `RAPIDS_USER_TOOLS_LOG_DEBUG` is not set                                           |     N    |
 
 ### Info collection

--- a/user_tools/docs/user-tools-dataproc.md
+++ b/user_tools/docs/user-tools-dataproc.md
@@ -407,6 +407,7 @@ user must have SSH access.
 |-------------------|---------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|:--------:|
 | **cluster**       | Name of the Dataproc cluster running an accelerated computing instance    | N/A                                                                                         |     Y    |
 | **output_folder** | Path to local directory where the final recommendations is logged         | env variable `RAPIDS_USER_TOOLS_OUTPUT_DIRECTORY` if any; or the current working directory. |     N    |
+| **thread_num**    | Number of threads to access remote cluster nodes in parallel              | 3                                                                                           |     N    |
 | **verbose**       | True or False to enable verbosity to the wrapper script                   | False if `RAPIDS_USER_TOOLS_LOG_DEBUG` is not set                                           |     N    |
 
 ### Info collection

--- a/user_tools/src/spark_rapids_pytools/rapids/diagnostic.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/diagnostic.py
@@ -14,6 +14,7 @@
 
 """Implementation class representing wrapper around diagnostic tool."""
 
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 
 from spark_rapids_pytools.cloud_api.sp_types import ClusterBase, SparkNodeType
@@ -30,6 +31,15 @@ class Diagnostic(RapidsTool):
     name = 'diagnostic'
     exec_cluster: ClusterBase = None
     all_nodes: list = None
+    thread_num: int = 3
+
+    def _process_custom_args(self):
+        thread_num = self.wrapper_options.get('threadNum', 3)
+        if thread_num < 1 or thread_num > 10:
+            raise RuntimeError(f'Invalid thread number: {thread_num} (Valid value: 1~10)')
+
+        self.thread_num = thread_num
+        self.logger.debug('Set thread number as: %d', self.thread_num)
 
     def requires_cluster_connection(self) -> bool:
         return True
@@ -48,20 +58,37 @@ class Diagnostic(RapidsTool):
         folder_name = FSUtil.get_resource_name(output_path)
         self.ctxt.set_remote('outputFolder', folder_name)
 
-    def _upload_scripts(self):
+    def _upload_scripts(self, node):
         """
-        Upload scripts to both driver & worker nodes
+        Upload scripts to specified node
         :return:
         """
         script = Utils.resource_path('collect.sh')
 
         try:
-            for node in self.all_nodes:
-                self.logger.info('Uploading script to node: %s', node.get_name())
-                self.exec_cluster.scp_to_node(node, str(script), '/tmp/')
+            self.logger.info('Uploading script to node: %s', node.get_name())
+            self.exec_cluster.scp_to_node(node, str(script), '/tmp/')
 
         except Exception as e:
-            self.logger.error('Error while uploading script to remote node')
+            self.logger.error('Error while uploading script to node: %s', node.get_name())
+            raise e
+
+    def _collect_info(self, node):
+        """
+        Run task to collect info from specified node
+        :return:
+        """
+        self._upload_scripts(node)
+
+        remote_output_folder = self.ctxt.get_remote('outputFolder')
+        ssh_cmd = f'"PREFIX={remote_output_folder} /tmp/collect.sh"'
+
+        try:
+            self.logger.info('Collecting info on node: %s', node.get_name())
+            self.exec_cluster.run_cmd_node(node, ssh_cmd)
+
+        except Exception as e:
+            self.logger.error('Error while collecting info from node: %s', node.get_name())
             raise e
 
     def _run_rapids_tool(self):
@@ -69,21 +96,11 @@ class Diagnostic(RapidsTool):
         Run diagnostic tool from both driver & worker nodes to collect info
         :return:
         """
-        self.logger.info('Uploading script to remote cluster nodes:')
-        self._upload_scripts()
-
-        self.logger.info('Collecting info on remote cluster nodes:')
-        remote_output_folder = self.ctxt.get_remote('outputFolder')
-        ssh_cmd = f'"PREFIX={remote_output_folder} /tmp/collect.sh"'
-
-        try:
-            for node in self.all_nodes:
-                self.logger.info('Collecting info on node: %s', node.get_name())
-                self.exec_cluster.run_cmd_node(node, ssh_cmd)
-
-        except Exception as e:
-            self.logger.error('Error while collecting info from remote node')
-            raise e
+        with ThreadPoolExecutor(max_workers=self.thread_num) as executor:
+            for e in executor.map(self._collect_info, self.all_nodes):
+                # Raise exception if any error occurred
+                if e:
+                    raise e
 
     def _download_output(self):
         self.logger.info('Downloading results from remote nodes:')
@@ -92,17 +109,23 @@ class Diagnostic(RapidsTool):
         remote_output_folder = self.ctxt.get_remote('outputFolder')
         remote_output_result = f'/tmp/{remote_output_folder}*.tgz'
 
-        try:
-            for node in self.all_nodes:
+        def _download_result(node):
+            try:
                 node_output_path = FSUtil.build_path(output_path, node.get_name())
                 FSUtil.make_dirs(node_output_path, exist_ok=True)
 
                 self.logger.info('Downloading results from node: %s', node.get_name())
                 self.exec_cluster.scp_from_node(node, remote_output_result, node_output_path)
 
-        except Exception as e:
-            self.logger.error('Error while downloading collected info from remote node')
-            raise e
+            except Exception as e:
+                self.logger.error('Error while downloading collected info from node: %s', node.get_name())
+                raise e
+
+        with ThreadPoolExecutor(max_workers=self.thread_num) as executor:
+            for e in executor.map(_download_result, self.all_nodes):
+                # Raise exception if any error occurred
+                if e:
+                    raise e
 
     def _process_output(self):
         self.logger.info('Processing the collected results.')

--- a/user_tools/src/spark_rapids_pytools/wrappers/dataproc_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/dataproc_wrapper.py
@@ -240,6 +240,7 @@ class CliDataprocLocalMode:  # pylint: disable=too-few-public-methods
     @staticmethod
     def diagnostic(cluster: str,
                    output_folder: str = None,
+                   thread_num: int = 3,
                    verbose: bool = False) -> None:
         """
         Diagnostic tool to collects information from Dataproc cluster, such as OS version, # of worker nodes,
@@ -249,6 +250,8 @@ class CliDataprocLocalMode:  # pylint: disable=too-few-public-methods
                Note that this argument only accepts local filesystem. If the argument is NONE,
                the default value is the env variable "RAPIDS_USER_TOOLS_OUTPUT_DIRECTORY" if any;
                or the current working directory
+        :param thread_num: Number of threads to access remote cluster nodes in parallel. The valid value
+               is 1~10. The default value is 3.
         :param verbose: True or False to enable verbosity to the wrapper script.
         """
         if verbose:
@@ -256,6 +259,7 @@ class CliDataprocLocalMode:  # pylint: disable=too-few-public-methods
             ToolLogging.enable_debug_mode()
         wrapper_diag_options = {
             'platformOpts': {},
+            'threadNum': thread_num,
         }
         diag_tool = Diagnostic(platform_type=CloudPlatform.DATAPROC,
                                cluster=cluster,

--- a/user_tools/src/spark_rapids_pytools/wrappers/emr_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/emr_wrapper.py
@@ -164,9 +164,10 @@ class CliEmrLocalMode:  # pylint: disable=too-few-public-methods
                    profile: str = None,
                    output_folder: str = None,
                    key_pair_path: str = None,
+                   thread_num: int = 3,
                    verbose: bool = False) -> None:
         """
-        Diagnostic tool to collects information from Dataproc cluster, such as OS version, # of worker nodes,
+        Diagnostic tool to collects information from EMR cluster, such as OS version, # of worker nodes,
         Yarn configuration, Spark version and error logs etc.
         :param cluster: Name of the EMR cluster running an accelerated computing instance class g4dn.*
         :param profile: A named AWS profile to get the settings/credentials of the AWS account.
@@ -178,6 +179,8 @@ class CliEmrLocalMode:  # pylint: disable=too-few-public-methods
                If missing, the wrapper reads the env variable 'RAPIDS_USER_TOOLS_KEY_PAIR_PATH' if any.
                For more details on creating key pairs,
                visit https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html.
+        :param thread_num: Number of threads to access remote cluster nodes in parallel. The valid value
+               is 1~10. The default value is 3.
         :param verbose: True or False to enable verbosity to the wrapper script.
         """
         if verbose:
@@ -188,6 +191,7 @@ class CliEmrLocalMode:  # pylint: disable=too-few-public-methods
                 'profile': profile,
                 'keyPairPath': key_pair_path,
             },
+            'threadNum': thread_num,
         }
         diag_tool = Diagnostic(platform_type=CloudPlatform.EMR,
                                cluster=cluster,

--- a/user_tools/tests/test_diagnostic.py
+++ b/user_tools/tests/test_diagnostic.py
@@ -137,10 +137,10 @@ class TestInfoCollect:
         self.run_tool(cloud, ['--thread_num', '1', '--verbose'], expected_exception=SystemExit)
 
         if cloud == 'dataproc':
-            assert len(build_mock.call_args_list) == 8
+            assert len(build_mock.call_args_list) >= 8
 
         elif cloud == 'emr':
-            assert len(build_mock.call_args_list) == 7
+            assert len(build_mock.call_args_list) >= 7
 
         _, stderr = capsys.readouterr()
 

--- a/user_tools/tests/test_diagnostic.py
+++ b/user_tools/tests/test_diagnostic.py
@@ -134,13 +134,13 @@ class TestInfoCollect:
         mock.exec = mock_exec
         build_mock.return_value = mock
 
-        self.run_tool(cloud, expected_exception=SystemExit)
+        self.run_tool(cloud, ['--thread_num', '1', '--verbose'], expected_exception=SystemExit)
 
         if cloud == 'dataproc':
-            assert len(build_mock.call_args_list) == 9
+            assert len(build_mock.call_args_list) == 8
 
         elif cloud == 'emr':
-            assert len(build_mock.call_args_list) == 8
+            assert len(build_mock.call_args_list) == 7
 
         _, stderr = capsys.readouterr()
 
@@ -166,7 +166,7 @@ class TestInfoCollect:
         mock.exec = mock_exec
         build_mock.return_value = mock
 
-        self.run_tool(cloud, expected_exception=SystemExit)
+        self.run_tool(cloud, ['--thread_num', '1', '--verbose'], expected_exception=SystemExit)
 
         if cloud == 'dataproc':
             assert len(build_mock.call_args_list) == 13

--- a/user_tools/tests/test_diagnostic.py
+++ b/user_tools/tests/test_diagnostic.py
@@ -137,10 +137,10 @@ class TestInfoCollect:
         self.run_tool(cloud, expected_exception=SystemExit)
 
         if cloud == 'dataproc':
-            assert len(build_mock.call_args_list) == 8
+            assert len(build_mock.call_args_list) == 9
 
         elif cloud == 'emr':
-            assert len(build_mock.call_args_list) == 7
+            assert len(build_mock.call_args_list) == 8
 
         _, stderr = capsys.readouterr()
 

--- a/user_tools/tests/test_diagnostic.py
+++ b/user_tools/tests/test_diagnostic.py
@@ -25,37 +25,156 @@ from mock_cluster import mock_live_cluster
 from spark_rapids_pytools import wrapper
 
 
-@patch('spark_rapids_pytools.common.utilities.SysCmd.build')
 @pytest.mark.parametrize('cloud', ['dataproc', 'emr'])
-def test_info_collect(build_mock, cloud, capsys):
-    """Test diagnostic function about info collection."""
-    return_values = mock_live_cluster[cloud]
+class TestInfoCollect:
+    """Test info collect functions."""
 
-    # Mock return values for info collection
-    return_values += ['done'] * 6
+    def run_tool(self, cloud, args=['--verbose'], expected_exception=None):  # pylint: disable=dangerous-default-value
+        with tempfile.TemporaryDirectory() as tmpdir:
+            key_file = os.path.join(tmpdir, 'test.pem')
 
-    mock = Mock()
-    mock.exec = Mock(side_effect=return_values)
-    build_mock.return_value = mock
+            if cloud == 'emr':
+                # create empty ssh key file for EMR test
+                with open(key_file, 'a', encoding='utf8') as file:
+                    file.close()
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        key_file = os.path.join(tmpdir, 'test.pem')
+            with EnvironContext(RAPIDS_USER_TOOLS_KEY_PAIR_PATH=key_file):
+                with ArgvContext('spark_rapids_user_tools', cloud, 'diagnostic', 'test-cluster',
+                                 '--output_folder', tmpdir, *args):
+                    if expected_exception:
+                        with pytest.raises(expected_exception):
+                            wrapper.main()
+                    else:
+                        wrapper.main()
 
-        if cloud == 'emr':
-            # create empty ssh key file for EMR test
-            with open(key_file, 'a', encoding='utf8') as file:
-                file.close()
+    @patch('spark_rapids_pytools.common.utilities.SysCmd.build')
+    def test_info_collect(self, build_mock, cloud, capsys):
+        return_values = mock_live_cluster[cloud].copy()
 
-        with EnvironContext(RAPIDS_USER_TOOLS_KEY_PAIR_PATH=key_file):
-            with ArgvContext('spark_rapids_user_tools', cloud, 'diagnostic', 'test-cluster',
-                             '--output_folder', tmpdir, '--verbose'):
-                wrapper.main()
+        # Mock return values for info collection
+        return_values += ['done'] * 6
 
-    if cloud == 'dataproc':
-        assert len(build_mock.call_args_list) == 13
+        mock = Mock()
+        mock.exec = Mock(side_effect=return_values)
+        build_mock.return_value = mock
 
-    elif cloud == 'emr':
-        assert len(build_mock.call_args_list) == 12
+        self.run_tool(cloud)
 
-    _, stderr = capsys.readouterr()
-    assert re.match(r".*Archive '/tmp/.*/diag_.*\.tar' is successfully created\..*", stderr, re.DOTALL)
+        if cloud == 'dataproc':
+            assert len(build_mock.call_args_list) == 13
+
+        elif cloud == 'emr':
+            assert len(build_mock.call_args_list) == 12
+
+        _, stderr = capsys.readouterr()
+        assert re.match(r".*Archive '/tmp/.*/diag_.*\.tar' is successfully created\..*", stderr, re.DOTALL)
+
+    @patch('spark_rapids_pytools.common.utilities.SysCmd.build')
+    def test_thread_num(self, build_mock, cloud, capsys):
+        return_values = mock_live_cluster[cloud].copy()
+
+        # Mock return values for info collection
+        return_values += ['done'] * 6
+
+        mock = Mock()
+        mock.exec = Mock(side_effect=return_values)
+        build_mock.return_value = mock
+
+        self.run_tool(cloud, ['--thread_num', '7', '--verbose'])
+
+        if cloud == 'dataproc':
+            assert len(build_mock.call_args_list) == 13
+
+        elif cloud == 'emr':
+            assert len(build_mock.call_args_list) == 12
+
+        _, stderr = capsys.readouterr()
+
+        assert 'Set thread number as: 7' in stderr
+        assert re.match(r".*Archive '/tmp/.*/diag_.*\.tar' is successfully created\..*", stderr, re.DOTALL)
+
+    @patch('spark_rapids_pytools.common.utilities.SysCmd.build')
+    @pytest.mark.parametrize('thread_num', ['0', '11', '123'])
+    def test_invalid_thread_num(self, build_mock, cloud, thread_num, capsys):
+        return_values = mock_live_cluster[cloud].copy()
+
+        # Mock return values for info collection
+        return_values += ['done'] * 6
+
+        mock = Mock()
+        mock.exec = Mock(side_effect=return_values)
+        build_mock.return_value = mock
+
+        self.run_tool(cloud, ['--thread_num', thread_num, '--verbose'], SystemExit)
+
+        if cloud == 'dataproc':
+            assert len(build_mock.call_args_list) == 7
+
+        elif cloud == 'emr':
+            assert len(build_mock.call_args_list) == 6
+
+        _, stderr = capsys.readouterr()
+
+        assert 'Invalid thread number' in stderr
+        assert 'Raised an error in phase [Process-Arguments]' in stderr
+
+    @patch('spark_rapids_pytools.common.utilities.SysCmd.build')
+    def test_upload_failed(self, build_mock, cloud, capsys):
+        return_values = mock_live_cluster[cloud].copy()
+        return_values.reverse()
+
+        # Mock failure for upload
+        def mock_exec():
+            if return_values:
+                return return_values.pop()
+
+            raise RuntimeError('mock test_upload_failed')
+
+        mock = Mock()
+        mock.exec = mock_exec
+        build_mock.return_value = mock
+
+        self.run_tool(cloud, expected_exception=SystemExit)
+
+        if cloud == 'dataproc':
+            assert len(build_mock.call_args_list) == 8
+
+        elif cloud == 'emr':
+            assert len(build_mock.call_args_list) == 7
+
+        _, stderr = capsys.readouterr()
+
+        assert 'Error while uploading script to node' in stderr
+        assert 'Raised an error in phase [Execution]' in stderr
+
+    @patch('spark_rapids_pytools.common.utilities.SysCmd.build')
+    def test_download_failed(self, build_mock, cloud, capsys):
+        return_values = mock_live_cluster[cloud].copy()
+
+        # Mock return values for info collection
+        return_values += ['done'] * 4
+        return_values.reverse()
+
+        # Mock return values for info collection
+        def mock_exec():
+            if return_values:
+                return return_values.pop()
+
+            raise RuntimeError('mock test_download_failed')
+
+        mock = Mock()
+        mock.exec = mock_exec
+        build_mock.return_value = mock
+
+        self.run_tool(cloud, expected_exception=SystemExit)
+
+        if cloud == 'dataproc':
+            assert len(build_mock.call_args_list) == 13
+
+        elif cloud == 'emr':
+            assert len(build_mock.call_args_list) == 12
+
+        _, stderr = capsys.readouterr()
+
+        assert 'Error while downloading collected info from node' in stderr
+        assert 'Raised an error in phase [Collecting-Results]' in stderr


### PR DESCRIPTION
as https://github.com/NVIDIA/spark-rapids-tools/issues/376 described create multiple (configurable) threads to access remote nodes for info collection.

note, this PR is on top of https://github.com/NVIDIA/spark-rapids-tools/pull/359. Only last 3 commits should be reviewed. Thanks!

Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/376