### PR TITLE
Improve logging messages in Qualification Tools

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -726,6 +726,22 @@ object QualificationAppInfo extends Logging {
   val LOWER_BOUND_RECOMMENDED = 1.3
   val LOWER_BOUND_STRONGLY_RECOMMENDED = 2.5
 
+  private def handleException(e: Exception, path: EventLogInfo): Unit = {
+    val message: String = e match {
+      case gpuLog: GpuEventLogException =>
+        gpuLog.message
+      case _: com.fasterxml.jackson.core.JsonParseException =>
+        s"Error parsing JSON: ${path.eventLog.toString}"
+      case _: IllegalArgumentException =>
+        s"Error parsing file: ${path.eventLog.toString}"
+      case _: Exception =>
+        // catch all exceptions and skip that file
+        s"Got unexpected exception processing file: ${path.eventLog.toString}"
+    }
+
+    logWarning(s"${e.getClass.getSimpleName}: $message")
+  }
+
   def getRecommendation(totalSpeedup: Double,
       hasFailures: Boolean): String = {
     if (hasFailures) {
@@ -802,18 +818,8 @@ object QualificationAppInfo extends Logging {
         logInfo(s"${path.eventLog.toString} has App: ${app.appId}")
         Some(app)
       } catch {
-        case gpuLog: GpuEventLogException =>
-          logWarning(gpuLog.message)
-          None
-        case json: com.fasterxml.jackson.core.JsonParseException =>
-          logWarning(s"Error parsing JSON: ${path.eventLog.toString}")
-          None
-        case il: IllegalArgumentException =>
-          logWarning(s"Error parsing file: ${path.eventLog.toString}", il)
-          None
         case e: Exception =>
-          // catch all exceptions and skip that file
-          logWarning(s"Got unexpected exception processing file: ${path.eventLog.toString}", e)
+          handleException(e, path)
           None
       }
     app

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationEventProcessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationEventProcessor.scala
@@ -38,7 +38,7 @@ class QualificationEventProcessor(app: QualificationAppInfo, perSqlOnly: Boolean
     logDebug("Processing event: " + event.getClass)
     val sparkProperties = event.environmentDetails("Spark Properties").toMap
     if (ToolUtils.isPluginEnabled(sparkProperties)) {
-      throw GpuEventLogException(s"Eventlog is from GPU run. Skipping ...")
+      throw GpuEventLogException(s"Cannot parse event logs from GPU run")
     }
     app.clusterTags = sparkProperties.getOrElse(
       "spark.databricks.clusterUsageTags.clusterAllTags", "")


### PR DESCRIPTION


As a part of #353, this PR adds a handler for exceptions in QualificationAppInfo.
- Prints the exception type followed by the message in the console output.

#### Before this change

```
23/06/22 WARN QualificationAppInfo: Eventlog is from GPU run. Skipping ...
23/06/22 WARN Qualification: No Application found that contain SQL for file:/Users/psarthi/Work/event-logs/psarthi-emr-gpu-multiapps-results/application_1687388217362_0001!
```

#### After this change

```
23/06/22 WARN QualificationAppInfo: GpuEventLogException: Cannot parse event logs from GPU run
23/06/22 WARN Qualification: No Application found that contain SQL for file:/Users/psarthi/Work/event-logs/psarthi-emr-gpu-multiapps-results/application_1687388217362_0002!
```
