### PR TITLE
[WIP] Generate Status Report of Event Logs and Applications from Qualification Tool

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
@@ -52,7 +52,7 @@ object ProfileMain extends Logging {
       Math.ceil(Runtime.getRuntime.availableProcessors() / 4f).toInt)
 
     // Get the event logs required to process
-    val (eventLogFsFiltered, _) = EventLogPathProcessor.processAllPaths(filterN.toOption,
+    val (eventLogFsFiltered, _, _) = EventLogPathProcessor.processAllPaths(filterN.toOption,
       matchEventLogs.toOption, eventlogPaths, hadoopConf)
 
     val filteredLogs = if (argsContainsAppFilters(appArgs)) {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
@@ -1090,7 +1090,7 @@ object QualOutputWriter {
   private def getDetailedStatusHeaderStringsAndSizes(
       statusInfos: Seq[StatusSummaryInfo]): mutable.LinkedHashMap[String, Int] = {
     val descLengthList = statusInfos.map { statusInfo =>
-      statusInfo.appInfo.map(_.appId).getOrElse("").length + statusInfo.message.length + 1
+      statusInfo.appId.length + statusInfo.message.length + 1
     }
     val detailedHeadersAndFields = mutable.LinkedHashMap[String, Int](
       EVENT_PATH_STR -> getMaxSizeForHeader(statusInfos.map(_.path.length), APP_NAME_STR),
@@ -1108,10 +1108,9 @@ object QualOutputWriter {
       reformatCSV: Boolean = true): Seq[String] = {
     val reformatCSVFunc: String => String =
       if (reformatCSV) str => StringUtils.reformatCSVString(str) else str => stringIfempty(str)
-    val descriptionStr = statusInfo.appInfo match {
-      case Some(app) =>
-        if(statusInfo.message.isEmpty) app.appId else s"${app.appId},${statusInfo.message}"
-      case None => statusInfo.message
+    val descriptionStr = statusInfo.appId match {
+      case "" => statusInfo.message
+      case appId => if (statusInfo.message.isEmpty) appId else s"$appId,${statusInfo.message}"
     }
     val data = ListBuffer[(String, Int)](
       reformatCSVFunc(statusInfo.path) -> headersAndSizes(EVENT_PATH_STR),

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -37,6 +37,7 @@ class Qualification(outputDir: String, numRows: Int, hadoopConf: Configuration,
     reportSqlLevel: Boolean, maxSQLDescLength: Int, mlOpsEnabled:Boolean) extends Logging {
 
   private val allApps = new ConcurrentLinkedQueue[QualificationSummaryInfo]()
+  // Store the status of applications running in multiple threads
   private val appStatuses =
     new ConcurrentHashMap[EventLogInfo, Status[QualificationAppInfo]]()
 
@@ -214,6 +215,13 @@ class Qualification(outputDir: String, numRows: Int, hadoopConf: Configuration,
     s"$outputDir/rapids_4_spark_qualification_output"
   }
 
+  /**
+   * For each event log processed, generate a summary containing appId and message (if any).
+   * If the event log was a valid path, `appStatuses` will contain application level status.
+   * @param eventStatusMap - Map[Path -> Event Log Status]
+   * @param appStatuses - Map[Event Log -> Application Status]
+   * @return Summary - path, status, [appId], [message]
+   */
   private def generateStatusSummary(
       eventStatusMap: Map[String, Status[EventLogInfo]],
       appStatuses: Map[EventLogInfo, Status[QualificationAppInfo]]): Seq[StatusQualSummaryInfo] = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
@@ -87,7 +87,7 @@ object QualificationMain extends Logging {
     }
 
     // Add the status of event logs that were filtered above
-    eventLogFsFiltered.filterNot(filteredLogs.contains).foreach { eventLogInfo =>
+    allEventLogs.filterNot(filteredLogs.contains).foreach { eventLogInfo =>
       statusReporter.reportFiltered(eventLogInfo.eventLog.toString)
     }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
@@ -71,7 +71,7 @@ object QualificationMain extends Logging {
         return (1, Seq[QualificationSummaryInfo]())
     }
 
-    val (eventLogFsFiltered, allEventLogs) = EventLogPathProcessor.processAllPaths(
+    val (eventLogFsFiltered, allEventLogs, eventStatusMap) = EventLogPathProcessor.processAllPaths(
       filterN.toOption, matchEventLogs.toOption, eventlogPaths, hadoopConf)
 
     val filteredLogs = if (argsContainsAppFilters(appArgs)) {
@@ -94,7 +94,8 @@ object QualificationMain extends Logging {
     val qual = new Qualification(outputDirectory, numOutputRows, hadoopConf, timeout,
       nThreads, order, pluginTypeChecker, reportReadSchema, printStdout, uiEnabled,
       enablePB, reportSqlLevel, maxSQLDescLength, mlOpsEnabled)
-    val res = qual.qualifyApps(filteredLogs)
+    val res = qual.qualifyApps(filteredLogs, eventStatusMap)
+
     (0, res)
   }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
@@ -95,7 +95,6 @@ object QualificationMain extends Logging {
       nThreads, order, pluginTypeChecker, reportReadSchema, printStdout, uiEnabled,
       enablePB, reportSqlLevel, maxSQLDescLength, mlOpsEnabled)
     val res = qual.qualifyApps(filteredLogs, eventStatusMap)
-
     (0, res)
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -322,7 +322,7 @@ case class GpuEventLogException(message: String) extends Exception(message)
 sealed trait Status
 case class StatusSuccess(value: String) extends Status
 case class StatusFailure(message: String) extends Status
-case class StatusUnavailable(value: String, message: String) extends Status
+case class StatusUnknown(value: String, message: String) extends Status
 case class StatusFiltered() extends Status
 
 /**
@@ -338,8 +338,8 @@ class StatusReporter {
   def reportFailure(key: String, message: String): Unit = {
     statusReports.put(key, StatusFailure(message))
   }
-  def reportUnavailable(key: String, value: String, message: String): Unit = {
-    statusReports.put(key, StatusUnavailable(value, message))
+  def reportUnknown(key: String, value: String, message: String): Unit = {
+    statusReports.put(key, StatusUnknown(value, message))
   }
   def reportFiltered(key: String): Unit = {
     statusReports.put(key, StatusFiltered())

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -313,3 +313,8 @@ object SupportedMLFuncsName {
 }
 
 case class GpuEventLogException(message: String) extends Exception(message)
+
+trait Status[T]
+case class StatusSuccess[T](value: Option[T]) extends Status[T]
+case class StatusNotAvailable[T](value: Option[T], message: String) extends Status[T]
+case class StatusFailure[T](message: String) extends Status[T]

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -314,6 +314,9 @@ object SupportedMLFuncsName {
 
 case class GpuEventLogException(message: String) extends Exception(message)
 
+/**
+ * Classes for storing event/application level status.
+ */
 trait Status[T]
 case class StatusSuccess[T](value: Option[T]) extends Status[T]
 case class StatusNotAvailable[T](value: Option[T], message: String) extends Status[T]

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -734,7 +734,7 @@ case class StageQualSummaryInfo(
 case class StatusSummaryInfo(
     path: String,
     status: String,
-    appInfo: Option[QualificationAppInfo] = None,
+    appId: String = "",
     message: String = "")
 
 object QualificationAppInfo extends Logging {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -731,6 +731,12 @@ case class StageQualSummaryInfo(
     unsupportedTaskDur: Long,
     estimated: Boolean = false)
 
+case class StatusQualSummaryInfo(
+    path: String,
+    status: String,
+    appInfo: Option[QualificationAppInfo] = None,
+    message: String = "")
+
 object QualificationAppInfo extends Logging {
   // define recommendation constants
   val RECOMMENDED = "Recommended"

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -731,7 +731,7 @@ case class StageQualSummaryInfo(
     unsupportedTaskDur: Long,
     estimated: Boolean = false)
 
-case class StatusQualSummaryInfo(
+case class StatusSummaryInfo(
     path: String,
     status: String,
     appInfo: Option[QualificationAppInfo] = None,

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -71,7 +71,7 @@ class SQLPlanParserSuite extends BaseTestSuite {
 
   private def createAppFromEventlog(eventLog: String): QualificationAppInfo = {
     val hadoopConf = RapidsToolsConfUtil.newHadoopConf()
-    val (_, allEventLogs) = EventLogPathProcessor.processAllPaths(
+    val (_, allEventLogs, _) = EventLogPathProcessor.processAllPaths(
       None, None, List(eventLog), hadoopConf)
     val pluginTypeChecker = new PluginTypeChecker()
     assert(allEventLogs.size == 1)

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -566,7 +566,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
       s"$qualLogDir/dataset_eventlog"
     ))
 
-    val (result, _) = EventLogPathProcessor.processAllPaths(appArgs.filterCriteria.toOption,
+    val (result, _, _) = EventLogPathProcessor.processAllPaths(appArgs.filterCriteria.toOption,
       appArgs.matchEventLogs.toOption, appArgs.eventlog(), hadoopConf)
     assert(result.length == 2)
   }
@@ -595,7 +595,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
         tempFile3.toString
       ))
 
-      val (result, _) = EventLogPathProcessor.processAllPaths(appArgs.filterCriteria.toOption,
+      val (result, _, _) = EventLogPathProcessor.processAllPaths(appArgs.filterCriteria.toOption,
         appArgs.matchEventLogs.toOption, appArgs.eventlog(), hadoopConf)
       assert(result.length == 2)
       // Validate 2 newest files
@@ -639,7 +639,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
         tempFile4.toString
       ))
 
-      val (result, _) = EventLogPathProcessor.processAllPaths(appArgs.filterCriteria.toOption,
+      val (result, _, _) = EventLogPathProcessor.processAllPaths(appArgs.filterCriteria.toOption,
         appArgs.matchEventLogs.toOption, appArgs.eventlog(), hadoopConf)
       assert(result.length == 3)
       // Validate 3 oldest files

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -454,7 +454,7 @@ class QualificationSuite extends BaseTestSuite {
       s"$logDir/udf_func_eventlog"
     ))
 
-    val (eventLogInfo, _) = EventLogPathProcessor.processAllPaths(
+    val (eventLogInfo, _, _) = EventLogPathProcessor.processAllPaths(
       appArgs.filterCriteria.toOption, appArgs.matchEventLogs.toOption, appArgs.eventlog(),
       RapidsToolsConfUtil.newHadoopConf())
 
@@ -475,7 +475,7 @@ class QualificationSuite extends BaseTestSuite {
       s"$logDir/udf_func_eventlog"
     ))
 
-    val (eventLogInfo, _) = EventLogPathProcessor.processAllPaths(
+    val (eventLogInfo, _, _) = EventLogPathProcessor.processAllPaths(
       appArgs.filterCriteria.toOption, appArgs.matchEventLogs.toOption, appArgs.eventlog(),
       RapidsToolsConfUtil.newHadoopConf())
 


### PR DESCRIPTION
### Description:

Fixes #353, this PR introduces changes to collect the status of event logs and applications processed with the qualification tool. It generates a CSV file in the format: `event log path, application status, and description`. 

These changes enable better tracking of processing event logs and applications.

### Proposed Design:

1. Introduce a `Status` class: Create a base `Status` class for `StatusSuccess`, `StatusFailure`, and `StatusNotAvailable`.

2. While processing event log paths and applications, store the status in a class `StatusReporter` that contains a `Map[Path -> Status]`

4. Status is calculated as following:
    - If event logs path do not exist or any exception thrown while parsing the path - FAILURE
    - If event logs get filtered - FILTERED
    - If application can be processed - SUCCESSFUL
    - If application cannot be created or statistics cannot be aggregated - UNAVAILABLE
    - Any exception thrown while processing application - FAILURE

5. Write the generated summary into a CSV file.

### Implementation:
1. Use a thread-safe global HashMap to store the status, since the applications are processed concurrently.
2. Changes in existing methods:
	- `getEventLogInfo()`: Modify the method to update the global variable `statusReporter`
	- `mainInternal()`:
		- Add the status of events logs as FILTERED that were filtered using appFilter.
		- Before checking if there are any logs present after filtering, create an instance of the Qualification class. This ensures that a summary can still be generated even in the case where no application would be processed
3. New methods:
	- `generateStatusSummary()`: Generates a summary for each event log processed using the `statusReporter`, using the logic described in the proposed design. 
	
### Output Format (csv file):
```
Event Log,Status,Description
"file:/path-to-eventlog/test-1","SUCCESS","application_1686676198636_0002"
"file:/path-to-eventlog/test-2","NOT AVAILABLE","No Application found that contain SQL for file:/path-to-eventlog/test-2!"
"file:/path-to-eventlog/test-3","NOT AVAILABLE","No Application found that contain SQL for file:/path-to-eventlog/test-3!"
"/path-to-eventlog/test-4","FAILURE","/path-to-eventlog/test-4 not found, skipping!"
```

<br>

**TODO:**
1. Unit tests for the feature