### PR TITLE
Include '*.sh' as python data package to include 'collect.sh' for diagnostic tool

### DIFF
--- a/user_tools/setup.cfg
+++ b/user_tools/setup.cfg
@@ -3,4 +3,4 @@ console_scripts =
     spark_rapids_dataproc = spark_rapids_dataproc_tools.dataproc_wrapper:main
     spark_rapids_user_tools = spark_rapids_pytools.wrapper:main
 [options.package_data]
-* = *.json, *.yaml, *.ms
+* = *.json, *.yaml, *.ms, *.sh


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/403

passed manual testing after build new python package