### PR TITLE
Add platform argument in profiling tool for custom tuning based on the platform

### DIFF
--- a/core/docs/spark-profiling-tool.md
+++ b/core/docs/spark-profiling-tool.md
@@ -626,6 +626,8 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
   -p, --print-plans               Print the SQL plans to a file named
                                   'planDescriptions.log'.
                                   Default is false.
+      --platform  <arg>           Cluster platform where Spark CPU workloads were
+                                  executed. Default is onprem.
   -s, --start-app-time  <arg>     Filter event logs whose application start
                                   occurred within the past specified time
                                   period. Valid time periods are

--- a/core/docs/spark-profiling-tool.md
+++ b/core/docs/spark-profiling-tool.md
@@ -626,8 +626,10 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
   -p, --print-plans               Print the SQL plans to a file named
                                   'planDescriptions.log'.
                                   Default is false.
-      --platform  <arg>           Cluster platform where Spark CPU workloads were
-                                  executed. Default is onprem.
+      --platform  <arg>           Cluster platform where Spark GPU workloads were
+                                  executed. Options include onprem, dataproc, emr,
+                                  databricks.
+                                  Default is onprem.
   -s, --start-app-time  <arg>     Filter event logs whose application start
                                   occurred within the past specified time
                                   period. Valid time periods are

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -988,9 +988,10 @@ object AutoTuner extends Logging {
 
   private def handleException(
       ex: Exception,
-      appInfo: AppSummaryInfoBaseProvider): AutoTuner = {
+      appInfo: AppSummaryInfoBaseProvider,
+      platform: String): AutoTuner = {
     logError("Exception: " + ex.getStackTrace.mkString("Array(", ", ", ")"))
-    val tuning = new AutoTuner(new ClusterProperties(), appInfo)
+    val tuning = new AutoTuner(new ClusterProperties(), appInfo, platform)
     val msg = ex match {
       case cEx: ConstructorException => cEx.getContext
       case _ => if (ex.getCause != null) ex.getCause.toString else ex.toString
@@ -1041,7 +1042,7 @@ object AutoTuner extends Logging {
       new AutoTuner(clusterPropsOpt.getOrElse(new ClusterProperties()), singleAppProvider, platform)
     } catch {
       case e: Exception =>
-        handleException(e, singleAppProvider)
+        handleException(e, singleAppProvider, platform)
     }
   }
 
@@ -1054,7 +1055,7 @@ object AutoTuner extends Logging {
       new AutoTuner(clusterPropsOpt.getOrElse(new ClusterProperties()), singleAppProvider, platform)
     } catch {
       case e: Exception =>
-        handleException(e, singleAppProvider)
+        handleException(e, singleAppProvider, platform)
     }
   }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -328,7 +328,8 @@ class RecommendationEntry(val name: String,
  */
 class AutoTuner(
     val clusterProps: ClusterProperties,
-    val appInfoProvider: AppSummaryInfoBaseProvider)  extends Logging {
+    val appInfoProvider: AppSummaryInfoBaseProvider,
+    val platform: String)  extends Logging {
 
   import AutoTuner._
 
@@ -935,6 +936,7 @@ object AutoTuner extends Logging {
   val DEF_READ_SIZE_THRESHOLD = 100 * 1024L * 1024L * 1024L
   val DEFAULT_WORKER_INFO_PATH = "./worker_info.yaml"
   val SUPPORTED_SIZE_UNITS: Seq[String] = Seq("b", "k", "m", "g", "t", "p")
+  val DEFAULT_PLATFORM = "onprem"
 
   val commentsForMissingProps: Map[String, String] = Map(
     "spark.executor.memory" ->
@@ -1033,10 +1035,11 @@ object AutoTuner extends Logging {
    */
   def buildAutoTunerFromProps(
       clusterProps: String,
-      singleAppProvider: AppSummaryInfoBaseProvider): AutoTuner = {
+      singleAppProvider: AppSummaryInfoBaseProvider,
+      platform: String = DEFAULT_PLATFORM): AutoTuner = {
     try {
       val clusterPropsOpt = loadClusterPropertiesFromContent(clusterProps)
-      new AutoTuner(clusterPropsOpt.getOrElse(new ClusterProperties()), singleAppProvider)
+      new AutoTuner(clusterPropsOpt.getOrElse(new ClusterProperties()), singleAppProvider, platform)
     } catch {
       case e: Exception =>
         handleException(e, singleAppProvider)
@@ -1045,10 +1048,11 @@ object AutoTuner extends Logging {
 
   def buildAutoTuner(
       filePath: String,
-      singleAppProvider: AppSummaryInfoBaseProvider): AutoTuner = {
+      singleAppProvider: AppSummaryInfoBaseProvider,
+      platform: String = DEFAULT_PLATFORM): AutoTuner = {
     try {
       val clusterPropsOpt = loadClusterProps(filePath)
-      new AutoTuner(clusterPropsOpt.getOrElse(new ClusterProperties()), singleAppProvider)
+      new AutoTuner(clusterPropsOpt.getOrElse(new ClusterProperties()), singleAppProvider, platform)
     } catch {
       case e: Exception =>
         handleException(e, singleAppProvider)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -936,7 +936,6 @@ object AutoTuner extends Logging {
   val DEF_READ_SIZE_THRESHOLD = 100 * 1024L * 1024L * 1024L
   val DEFAULT_WORKER_INFO_PATH = "./worker_info.yaml"
   val SUPPORTED_SIZE_UNITS: Seq[String] = Seq("b", "k", "m", "g", "t", "p")
-  val DEFAULT_PLATFORM = "onprem"
 
   val commentsForMissingProps: Map[String, String] = Map(
     "spark.executor.memory" ->
@@ -1036,7 +1035,7 @@ object AutoTuner extends Logging {
   def buildAutoTunerFromProps(
       clusterProps: String,
       singleAppProvider: AppSummaryInfoBaseProvider,
-      platform: String = DEFAULT_PLATFORM): AutoTuner = {
+      platform: String = Profiler.DEFAULT_PLATFORM): AutoTuner = {
     try {
       val clusterPropsOpt = loadClusterPropertiesFromContent(clusterProps)
       new AutoTuner(clusterPropsOpt.getOrElse(new ClusterProperties()), singleAppProvider, platform)
@@ -1049,7 +1048,7 @@ object AutoTuner extends Logging {
   def buildAutoTuner(
       filePath: String,
       singleAppProvider: AppSummaryInfoBaseProvider,
-      platform: String = DEFAULT_PLATFORM): AutoTuner = {
+      platform: String = Profiler.DEFAULT_PLATFORM): AutoTuner = {
     try {
       val clusterPropsOpt = loadClusterProps(filePath)
       new AutoTuner(clusterPropsOpt.getOrElse(new ClusterProperties()), singleAppProvider, platform)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
@@ -65,9 +65,10 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
         " Default is false.")
   val platform: ScallopOption[String] =
     opt[String](required = false,
-      descr = "Cluster platform where Spark CPU workloads were executed." +
+      descr = "Cluster platform where Spark GPU workloads were executed. Options include " +
+        "onprem, dataproc, emr, databricks." +
         " Default is onprem.",
-      default = Some("onprem"))
+      default = Some(Profiler.DEFAULT_PLATFORM))
   val generateTimeline: ScallopOption[Boolean] =
     opt[Boolean](required = false,
       descr = "Write an SVG graph out for the full application timeline.")

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
@@ -63,6 +63,11 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
     opt[Boolean](required = false,
       descr = "Print the SQL plans to a file named 'planDescriptions.log'." +
         " Default is false.")
+  val platform: ScallopOption[String] =
+    opt[String](required = false,
+      descr = "Cluster platform where Spark CPU workloads were executed." +
+        " Default is onprem.",
+      default = Some("onprem"))
   val generateTimeline: ScallopOption[Boolean] =
     opt[Boolean](required = false,
       descr = "Write an SVG graph out for the full application timeline.")

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
@@ -470,8 +470,9 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs) extends Logging 
 
       if (useAutoTuner) {
         val workerInfoPath = appArgs.workerInfo.getOrElse(AutoTuner.DEFAULT_WORKER_INFO_PATH)
+        val platform = appArgs.platform.getOrElse(AutoTuner.DEFAULT_PLATFORM)
         val autoTuner: AutoTuner = AutoTuner.buildAutoTuner(workerInfoPath,
-          new SingleAppSummaryInfoProvider(app))
+          new SingleAppSummaryInfoProvider(app), platform)
         // the autotuner allows skipping some properties
         // e.g. getRecommendedProperties(Some(Seq("spark.executor.instances"))) skips the
         // recommendation related to executor instances.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
@@ -470,7 +470,7 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs) extends Logging 
 
       if (useAutoTuner) {
         val workerInfoPath = appArgs.workerInfo.getOrElse(AutoTuner.DEFAULT_WORKER_INFO_PATH)
-        val platform = appArgs.platform.getOrElse(AutoTuner.DEFAULT_PLATFORM)
+        val platform = appArgs.platform.getOrElse(Profiler.DEFAULT_PLATFORM)
         val autoTuner: AutoTuner = AutoTuner.buildAutoTuner(workerInfoPath,
           new SingleAppSummaryInfoProvider(app), platform)
         // the autotuner allows skipping some properties
@@ -490,6 +490,8 @@ object Profiler {
   val COMPARE_LOG_FILE_NAME_PREFIX = "rapids_4_spark_tools_compare"
   val COMBINED_LOG_FILE_NAME_PREFIX = "rapids_4_spark_tools_combined"
   val SUBDIR = "rapids_4_spark_profile"
+  val DEFAULT_PLATFORM = "onprem"
+
   def getAutoTunerResultsAsString(props: Seq[RecommendedPropertyResult],
       comments: Seq[RecommendedCommentResult]): String = {
     val propStr = if (props.nonEmpty) {

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -869,28 +869,4 @@ class ApplicationInfoSuite extends FunSuite with Logging {
       }
     }
   }
-
-  test("test values for platform argument") {
-    TrampolineUtil.withTempDir { eventLogDir =>
-      val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir, "platform-test") { spark =>
-        import spark.implicits._
-        val testData = Seq((1, 1662519019), (2, 1662519020)).toDF("id", "timestamp")
-        spark.sparkContext.setJobDescription("timestamp functions as potential problems")
-        testData.createOrReplaceTempView("t1")
-        spark.sql("SELECT id, hour(current_timestamp()), second(to_timestamp(timestamp)) FROM t1")
-      }
-
-      TrampolineUtil.withTempDir { outpath =>
-        val appArgs = new ProfileArgs(Array(
-          "--output-directory",
-          outpath.getAbsolutePath,
-          "--platform",
-          "onprem",
-          eventLog))
-
-        val (exit, _) = ProfileMain.mainInternal(appArgs)
-        assert(exit == 0)
-      }
-    }
-  }
 }


### PR DESCRIPTION
Contributes in #190. This PR is similar to #70 (adding platform argument for Qualification tools)

**Changes:**
- Added new argument (`--platform`) to allow a user to pass in platform on which the application was executed.

**Tests added:**
- ApplicationInfoSuite: Unit test that runs profiling tool using the `--platform` option.