### PR TITLE
Add ascli as a new simplified tools command

### DIFF
--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "chevron==0.14.0",
     "fastprogress==1.0.3",
     "fastcore==1.5.29",
-    "fire==0.4.0",
+    "fire>=0.5.0",
     "pandas==1.4.3",
     "pyYAML==6.0",
     "tabulate==0.8.10",

--- a/user_tools/setup.cfg
+++ b/user_tools/setup.cfg
@@ -1,5 +1,6 @@
 [options.entry_points]
 console_scripts =
     spark_rapids_user_tools = spark_rapids_pytools.wrapper:main
+    ascli = spark_rapids_pytools.ascli_cli.ascli:main
 [options.package_data]
 * = *.json, *.yaml, *.ms, *.sh

--- a/user_tools/src/spark_rapids_pytools/ascli_cli/__init__.py
+++ b/user_tools/src/spark_rapids_pytools/ascli_cli/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""init file of the ascli package."""

--- a/user_tools/src/spark_rapids_pytools/ascli_cli/ascli.py
+++ b/user_tools/src/spark_rapids_pytools/ascli_cli/ascli.py
@@ -167,7 +167,7 @@ class ASCLIWrapper(object):  # pylint: disable=too-few-public-methods
 
 
 def main():
-    fire.Fire(ASCLIWrapper)
+    fire.Fire(ASCLIWrapper())
 
 
 if __name__ == '__main__':

--- a/user_tools/src/spark_rapids_pytools/ascli_cli/ascli.py
+++ b/user_tools/src/spark_rapids_pytools/ascli_cli/ascli.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI to run tools associated with RAPIDS Accelerator for Apache Spark plugin."""
+
+import fire
+
+from spark_rapids_pytools.cloud_api.sp_types import CloudPlatform, DeployMode
+from spark_rapids_pytools.rapids.qualification import QualGpuClusterReshapeType, QualFilterApp, QualificationAsLocal
+from spark_rapids_pytools.wrappers.onprem_wrapper import CliOnpremLocalMode
+
+
+class ASCLIWrapper(object):
+    """CLI to run tools associated with RAPIDS Accelerator for Apache Spark plugin.
+
+    A wrapper script to run RAPIDS Accelerator tools (Qualification, Profiling, and Bootstrap)
+    locally on the dev machine.
+    """
+
+    def qualification(self,
+                      eventlogs: str = None,
+                      cluster: str = None,
+                      platform: str = CloudPlatform.tostring(CloudPlatform.get_default()),
+                      output_folder: str = None,
+                      target_platform: str = None,
+                      filter_apps: str = QualFilterApp.tostring(QualFilterApp.SAVINGS),
+                      gpu_cluster_recommendation: str = QualGpuClusterReshapeType.tostring(
+                          QualGpuClusterReshapeType.get_default())):
+        """Provides a wrapper to simplify the execution of RAPIDS Qualification tool.
+
+        The Qualification tool analyzes Spark events generated from CPU based Spark applications to
+        help quantify the expected acceleration and costs savings of migrating a Spark application
+        or query to GPU. The wrapper downloads dependencies and executes the analysis on the local
+        dev machine.
+
+        :param eventlogs: Event log filenames or gs storage directories containing event logs
+                (comma separated).
+
+                Skipping this argument requires that the cluster argument points to a valid
+                cluster name on the CSP.
+        :param cluster: Name of cluster or path to cluster-properties. Note that using a "file path"
+                requires the `platform` argument.
+        :param platform: defines one of the following "onprem", "emr", "dataproc", "databricks".
+        :param output_folder: path to store the output
+        :param target_platform: Cost savings and speedup recommendation for comparable cluster in
+                target_platform based on on-premises cluster configuration.
+                Requires cluster.
+        :param gpu_cluster_recommendation: The type of GPU cluster recommendation to generate.
+                Requires "Cluster".
+                It accepts one of the following:
+
+                "MATCH": keep GPU cluster same number of nodes as CPU cluster;
+                "CLUSTER": recommend optimal GPU cluster by cost for entire cluster;
+                "JOB": recommend optimal GPU cluster by cost per job
+        :param filter_apps:  filtering criteria of the applications listed in the final STDOUT table
+                is one of the following (NONE, SPEEDUPS, savings).
+                Requires "Cluster".
+
+                Note that this filter does not affect the CSV report.
+                "NONE" means no filter applied. "SPEEDUPS" lists all the apps that are either
+                'Recommended', or 'Strongly Recommended' based on speedups. "SAVINGS"
+                lists all the apps that have positive estimated GPU savings except for the apps that
+                are "Not Applicable"
+        """
+        runtime_platform = CloudPlatform.fromstring(platform)
+        if runtime_platform == CloudPlatform.ONPREM:
+            # if target_platform is specified, check if it's valid supported platform and filter the
+            # apps based on savings
+            if target_platform is not None:
+                if CliOnpremLocalMode.is_target_platform_supported(target_platform):
+                    if cluster is None:
+                        raise RuntimeError('OnPrem\'s cluster property file required to calculate'
+                                           'savings for ' + target_platform + ' platform')
+                else:
+                    raise RuntimeError(f'The platform [{target_platform}] is currently not supported'
+                                       'to calculate savings from OnPrem cluster')
+            else:
+                # For onPRem runtime, the filter should be reset to speedups when no target_platform
+                # is defined
+                filter_apps = QualFilterApp.tostring(QualFilterApp.SPEEDUPS)
+
+        wrapper_qual_options = {
+            'platformOpts': {
+                'credentialFile': None,
+                'deployMode': DeployMode.LOCAL,
+                'targetPlatform': target_platform
+            },
+            'migrationClustersProps': {
+                'cpuCluster': cluster,
+                'gpuCluster': None
+            },
+            'jobSubmissionProps': {
+                'remoteFolder': None,
+                'platformArgs': {
+                    'jvmMaxHeapSize': 24
+                }
+            },
+            'eventlogs': eventlogs,
+            'filterApps': filter_apps,
+            'toolsJar': None,
+            'gpuClusterRecommendation': gpu_cluster_recommendation,
+            'target_platform': target_platform
+        }
+        tool_obj = QualificationAsLocal(platform_type=runtime_platform,
+                                        output_folder=output_folder,
+                                        wrapper_options=wrapper_qual_options)
+        return tool_obj.launch()
+
+
+def main():
+    fire.Fire(ASCLIWrapper)
+
+
+if __name__ == '__main__':
+    main()

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -123,8 +123,11 @@ class CloudPlatform(EnumeratedType):
     DATAPROC = 'dataproc'
     EMR = 'emr'
     ONPREM = 'onprem'
-    LOCAL = 'local'
     NONE = 'NONE'
+
+    @classmethod
+    def get_default(cls):
+        return cls.ONPREM
 
 
 class TargetPlatform(EnumeratedType):

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -207,7 +207,7 @@ class Qualification(RapidsJarTool):
             cpu_cluster_obj = self._create_migration_cluster('CPU', cpu_cluster_arg)
             self.ctxt.set_ctxt('cpuClusterProxy', cpu_cluster_obj)
 
-    def _process_gpu_cluster_args(self, offline_cluster_opts: dict = None):
+    def _process_gpu_cluster_args(self, offline_cluster_opts: dict = None) -> bool:
         gpu_cluster_arg = offline_cluster_opts.get('gpuCluster')
         if gpu_cluster_arg is None:
             self.logger.info('Creating GPU cluster by converting the CPU cluster instances to GPU supported types')
@@ -217,6 +217,7 @@ class Qualification(RapidsJarTool):
         else:
             gpu_cluster_obj = self._create_migration_cluster('GPU', gpu_cluster_arg)
         self.ctxt.set_ctxt('gpuClusterProxy', gpu_cluster_obj)
+        return True
 
     def _process_offline_cluster_args(self):
         offline_cluster_opts = self.wrapper_options.get('migrationClustersProps', {})

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -507,7 +507,7 @@ class RapidsJarTool(RapidsTool):
     def _process_offline_cluster_args(self):
         pass
 
-    def _process_gpu_cluster_args(self, offline_cluster_opts: dict = None):
+    def _process_gpu_cluster_args(self, offline_cluster_opts: dict = None) -> bool:
         pass
 
     def _copy_dependencies_to_remote(self):

--- a/user_tools/src/spark_rapids_pytools/resources/profiling-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/profiling-conf.yaml
@@ -2,6 +2,7 @@ toolOutput:
   subFolder: rapids_4_spark_profile
   recommendations:
     fileName: profile.log
+    disabledInfoMsgTemplate: 'info_recommendations_disabled.ms'
     headers:
       section: '### D. Recommended Configuration ###'
       sparkProperties: 'Spark Properties:'

--- a/user_tools/src/spark_rapids_pytools/resources/templates/info_recommendations_disabled.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/info_recommendations_disabled.ms
@@ -1,7 +1,7 @@
 Recommendations cannot be generated.
     Reason: The cluster information was not set.
     To enable recommendation, the cluster properties must be defined.
-    Please, make sure to set the arguments properly by either:
+    Please make sure to set the arguments properly by either:
         1. Setting <{{ CLUSTER_ARG }}> argument and optional set <eventlogs> if
             the path is not defined by the cluster properties; or
         2. Setting both <{{ CLUSTER_ARG }}> and <eventlogs>

--- a/user_tools/src/spark_rapids_pytools/resources/templates/info_recommendations_disabled.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/info_recommendations_disabled.ms
@@ -1,0 +1,7 @@
+Recommendations cannot be generated.
+    Reason: The cluster information was not set.
+    To enable recommendation, the cluster properties must be defined.
+    Please, make sure to set the arguments properly by either:
+        1. Setting <{{ CLUSTER_ARG }}> argument and optional set <eventlogs> if
+            the path is not defined by the cluster properties; or
+        2. Setting both <{{ CLUSTER_ARG }}> and <eventlogs>

--- a/user_tools/src/spark_rapids_pytools/wrappers/onprem_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/onprem_wrapper.py
@@ -147,10 +147,6 @@ class CliOnpremLocalMode:  # pylint: disable=too-few-public-methods
         https://nvidia.github.io/spark-rapids/docs/spark-profiling-tool.html#profiling-tool-options
         """
 
-        if worker_info is None:
-            raise RuntimeError('worker_info.yaml file containing the system information of '
-                               'a worker node is required to run profiling tool on OnPrem '
-                               'cluster')
         if verbose:
             # when debug is set to true set it in the environment.
             ToolLogging.enable_debug_mode()


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #425, Fixes #436 

- adds a new `ascli qualification` cmd
- platform default value is onPrem
- the platform is not yet detected from the eventlogs path
- adds a new `ascli profiling` cmd
- platform default value is onPrem
- todo: for profiling detect whether cluster is a CSP properties or worker's info
  custome file

The documentation will be created when the new CLI is fully implemented because we will need to restructure the documentation so that we highlight that there is still option to use the `spark_rapids_user_tools` which allows more flexibility in passing the jar file, and the arguments passed to the rapids tool.

## examples usage

### run ascli help

```
$> ascli - --help

NAME
    ascli - CLI to run tools associated with RAPIDS Accelerator for Apache Spark plugin.

SYNOPSIS
    ascli - COMMAND

DESCRIPTION
    A wrapper script to run RAPIDS Accelerator tools (Qualification, Profiling, and Bootstrap)
    locally on the dev machine.

COMMANDS
    COMMAND is one of the following:

     profiling
       Provides a wrapper to simplify the execution of RAPIDS Profiling tool.

     qualification
       Provides a wrapper to simplify the execution of RAPIDS Qualification tool.

```

### run dataproc qualification

```
ascli qualification --platform dataproc \
   --cluster $CPU_CLUSTER_PROPS \
   --output_folder $LOCAL_OUTPUT_DIR \
   --eventlogs $REMOTE_EVENT_LOGS
```

### qualification help cmd
```
$> ascli qualification --help

NAME
  ascli qualification - Provides a wrapper to simplify the execution of
  RAPIDS Qualification tool.

SYNOPSIS
  ascli qualification <flags>

DESCRIPTION
  The Qualification tool analyzes Spark events generated from CPU based Spark
  applications to help quantify the expected acceleration and costs savings
  of migrating a Spark application or query to GPU.
  The wrapper downloads dependencies and executes the analysis on the local
  dev machine.

FLAGS
  --eventlogs=EVENTLOGS
    Type: Optional[str]
    Default: None
    Event log filenames or gs storage directories containing event logs
    (comma separated).

    Skipping this argument requires that the cluster argument points to a valid
    cluster name on the CSP.
  --cluster=CLUSTER
    Type: Optional[str]
    Default: None
    Name of cluster or path to cluster-properties. Note that using a "file path"
    requires the `platform` argument.
  --platform=PLATFORM
    Type: str
    Default: 'ONPREM'
    defines one of the following "onprem", "emr", "dataproc", "databricks".
  --output_folder=OUTPUT_FOLDER
    Type: Optional[str]
    Default: None
    path to store the output
  --target_platform=TARGET_PLATFORM
    Type: Optional[str]
    Default: None
    Cost savings and speedup recommendation for comparable cluster in `target_platform`
    based on on-premises cluster configuration. Requires cluster.
  --filter_apps=FILTER_APPS
    Type: str
    Default: 'SAVINGS'
    filtering criteria of the applications listed in the final STDOUT table is one of
    the following (NONE, SPEEDUPS, savings). Requires "Cluster".

    Note that this filter does not affect the CSV report. "NONE" means no filter applied.
    "SPEEDUPS" lists all the apps that are either 'Recommended', or 'Strongly Recommended'
    based on speedups. "SAVINGS" lists all the apps that have positive estimated GPU savings
    except for the apps that are "Not Applicable"
  --gpu_cluster_recommendation=GPU_CLUSTER_RECOMMENDATION
    Type: str
    Default: 'MATCH'
    The type of GPU cluster recommendation to generate. Requires "Cluster".
    It accepts one of the following:

    "MATCH": keep GPU cluster same number of nodes as CPU cluster;
    "CLUSTER": recommend optimal GPU cluster by cost for entire cluster;
    "JOB": recommend optimal GPU cluster by cost per job

```


### run dataproc profiling

```
ascli profiling --platform dataproc \
   --cluster $CPU_CLUSTER_PROPS \
   --output_folder $LOCAL_OUTPUT_DIR \
   --eventlogs $REMOTE_EVENT_LOGS
```

### run profiling help

```
NAME
  ascli profiling - Provides a wrapper to simplify the execution of
  RAPIDS Profiling tool.

SYNOPSIS
  ascli profiling <flags>

DESCRIPTION
  The Profiling tool analyzes GPU event logs and generates information
  which can be used for debugging and profiling Apache Spark applications.

FLAGS
  --eventlogs=EVENTLOGS
    Type: Optional[str]
    Default: None
    Event log filenames or CSP storage directories containing event logs
    (comma separated).

    Skipping this argument requires that the cluster argument points to a
    valid cluster name on the CSP.
  --cluster=CLUSTER
    Type: Optional[str]
    Default: None
    The cluster on which the Apache Spark applications were executed. It can
    either be a CSP-cluster name or a path to the cluster/worker's info
    properties file (json format).
  --platform=PLATFORM
    Type: str
    Default: 'ONPREM'
    defines one of the following "onprem", "emr", "dataproc", "databricks-aws",
    and "databricks-azure".
  --output_folder=OUTPUT_FOLDER
    Type: Optional[str]
    Default: None
    path to store the output
```