### PR TITLE
Fix mvn warning message for formatting string

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
@@ -914,8 +914,8 @@ object QualOutputWriter {
           reformatCSVFunc(appId) -> headersAndSizes(APP_ID_STR),
           reformatCSVFunc("Exec") -> headersAndSizes(UNSUPPORTED_TYPE),
           reformatCSVFunc(exec) -> headersAndSizes(DETAILS),
-          reformatCSVFunc("$exec Exec is not supported as expressions are " +
-            "not supported -  `${exprs}`") -> headersAndSizes(NOTES)
+          reformatCSVFunc(s"$exec Exec is not supported as expressions are " +
+            s"not supported -  `$exprs`") -> headersAndSizes(NOTES)
         )
         constructOutputRow(data, delimiter, prettyPrint)
       }.toArray


### PR DESCRIPTION
This PR closes #445.

Changes:
1. Missing `s` prefix while string formatting