### PR TITLE
[FEA] Include bootstrap recommended configs in qualification output

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/bootstrap.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/bootstrap.py
@@ -16,7 +16,7 @@
 
 from dataclasses import dataclass
 
-from spark_rapids_pytools.cloud_api.sp_types import ClusterBase, NodeHWInfo
+from spark_rapids_pytools.cloud_api.sp_types import ClusterBase
 from spark_rapids_pytools.common.sys_storage import FSUtil
 from spark_rapids_pytools.common.utilities import Utils
 from spark_rapids_pytools.rapids.rapids_tool import RapidsTool
@@ -36,51 +36,6 @@ class Bootstrap(RapidsTool):
     def requires_cluster_connection(self) -> bool:
         return True
 
-    def __calculate_spark_settings(self, worker_info: NodeHWInfo) -> dict:
-        """
-        Calculate the cluster properties that we need to append to the /etc/defaults of the spark
-        if necessary.
-        :param worker_info: the hardware info as extracted from the worker. Note that we assume
-                            that all the workers have the same configurations.
-        :return: dictionary containing 7 spark properties to be set by default on the cluster.
-        """
-        num_gpus = worker_info.gpu_info.num_gpus
-        gpu_mem = worker_info.gpu_info.gpu_mem
-        num_cpus = worker_info.sys_info.num_cpus
-        cpu_mem = worker_info.sys_info.cpu_mem
-
-        constants = self.ctxt.get_value('local', 'clusterConfigs', 'constants')
-        executors_per_node = num_gpus
-        num_executor_cores = max(1, num_cpus // executors_per_node)
-        gpu_concurrent_tasks = min(constants.get('maxGpuConcurrent'), gpu_mem // constants.get('gpuMemPerTaskMB'))
-        # account for system overhead
-        usable_worker_mem = max(0, cpu_mem - constants.get('systemReserveMB'))
-        executor_container_mem = usable_worker_mem // executors_per_node
-        # reserve 10% of heap as memory overhead
-        max_executor_heap = max(0, int(executor_container_mem * (1 - constants.get('heapOverheadFraction'))))
-        # give up to 2GB of heap to each executor core
-        executor_heap = min(max_executor_heap, constants.get('heapPerCoreMB') * num_executor_cores)
-        executor_mem_overhead = int(executor_heap * constants.get('heapOverheadFraction'))
-        # use default for pageable_pool to add to memory overhead
-        pageable_pool = constants.get('defaultPageablePoolMB')
-        # pinned memory uses any unused space up to 4GB
-        pinned_mem = min(constants.get('maxPinnedMemoryMB'),
-                         executor_container_mem - executor_heap - executor_mem_overhead - pageable_pool)
-        executor_mem_overhead += pinned_mem + pageable_pool
-        res = {
-            'spark.executor.cores': num_executor_cores,
-            'spark.executor.memory': f'{executor_heap}m',
-            'spark.executor.memoryOverhead': f'{executor_mem_overhead}m',
-            'spark.rapids.sql.concurrentGpuTasks': gpu_concurrent_tasks,
-            'spark.rapids.memory.pinnedPool.size': f'{pinned_mem}m',
-            'spark.sql.files.maxPartitionBytes': f'{constants.get("maxSqlFilesPartitionsMB")}m',
-            'spark.task.resource.gpu.amount': 1 / num_executor_cores,
-            'spark.rapids.shuffle.multiThreaded.reader.threads': num_executor_cores,
-            'spark.rapids.shuffle.multiThreaded.writer.threads': num_executor_cores,
-            'spark.rapids.sql.multiThreadedRead.numThreads': max(20, num_executor_cores)
-        }
-        return res
-
     def _run_rapids_tool(self):
         """
         Run the bootstrap on the driver node
@@ -91,7 +46,7 @@ class Bootstrap(RapidsTool):
         worker_hw_info = exec_cluster.get_worker_hw_info()
         self.logger.debug('Worker hardware INFO %s', worker_hw_info)
         try:
-            spark_settings = self.__calculate_spark_settings(worker_info=worker_hw_info)
+            spark_settings = super()._calculate_spark_settings(worker_info=worker_hw_info)
             self.ctxt.set_ctxt('bootstrap_results', spark_settings)
             self.logger.debug('%s Tool finished calculating recommended Apache Spark configurations for cluster %s: %s',
                               self.pretty_name(),

--- a/user_tools/src/spark_rapids_pytools/rapids/bootstrap.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/bootstrap.py
@@ -46,7 +46,7 @@ class Bootstrap(RapidsTool):
         worker_hw_info = exec_cluster.get_worker_hw_info()
         self.logger.debug('Worker hardware INFO %s', worker_hw_info)
         try:
-            spark_settings = super()._calculate_spark_settings(worker_info=worker_hw_info)
+            spark_settings = self._calculate_spark_settings(worker_info=worker_hw_info)
             self.ctxt.set_ctxt('bootstrap_results', spark_settings)
             self.logger.debug('%s Tool finished calculating recommended Apache Spark configurations for cluster %s: %s',
                               self.pretty_name(),

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -193,51 +193,6 @@ class Qualification(RapidsJarTool):
     """
     name = 'qualification'
 
-    def __calculate_spark_settings(self, worker_info: NodeHWInfo) -> dict:
-        """
-        Calculate the cluster properties that we need to append to the /etc/defaults of the spark
-        if necessary.
-        :param worker_info: the hardware info as extracted from the worker. Note that we assume
-                            that all the workers have the same configurations.
-        :return: dictionary containing 7 spark properties to be set by default on the cluster.
-        """
-        num_gpus = worker_info.gpu_info.num_gpus
-        gpu_mem = worker_info.gpu_info.gpu_mem
-        num_cpus = worker_info.sys_info.num_cpus
-        cpu_mem = worker_info.sys_info.cpu_mem
-
-        constants = self.ctxt.get_value('local', 'clusterConfigs', 'constants')
-        executors_per_node = num_gpus
-        num_executor_cores = max(1, num_cpus // executors_per_node)
-        gpu_concurrent_tasks = min(constants.get('maxGpuConcurrent'), gpu_mem // constants.get('gpuMemPerTaskMB'))
-        # account for system overhead
-        usable_worker_mem = max(0, cpu_mem - constants.get('systemReserveMB'))
-        executor_container_mem = usable_worker_mem // executors_per_node
-        # reserve 10% of heap as memory overhead
-        max_executor_heap = max(0, int(executor_container_mem * (1 - constants.get('heapOverheadFraction'))))
-        # give up to 2GB of heap to each executor core
-        executor_heap = min(max_executor_heap, constants.get('heapPerCoreMB') * num_executor_cores)
-        executor_mem_overhead = int(executor_heap * constants.get('heapOverheadFraction'))
-        # use default for pageable_pool to add to memory overhead
-        pageable_pool = constants.get('defaultPageablePoolMB')
-        # pinned memory uses any unused space up to 4GB
-        pinned_mem = min(constants.get('maxPinnedMemoryMB'),
-                         executor_container_mem - executor_heap - executor_mem_overhead - pageable_pool)
-        executor_mem_overhead += pinned_mem + pageable_pool
-        res = {
-            'spark.executor.cores': num_executor_cores,
-            'spark.executor.memory': f'{executor_heap}m',
-            'spark.executor.memoryOverhead': f'{executor_mem_overhead}m',
-            'spark.rapids.sql.concurrentGpuTasks': gpu_concurrent_tasks,
-            'spark.rapids.memory.pinnedPool.size': f'{pinned_mem}m',
-            'spark.sql.files.maxPartitionBytes': f'{constants.get("maxSqlFilesPartitionsMB")}m',
-            'spark.task.resource.gpu.amount': 1 / num_executor_cores,
-            'spark.rapids.shuffle.multiThreaded.reader.threads': num_executor_cores,
-            'spark.rapids.shuffle.multiThreaded.writer.threads': num_executor_cores,
-            'spark.rapids.sql.multiThreadedRead.numThreads': max(20, num_executor_cores)
-        }
-        return res
-
     def _process_rapids_args(self):
         """
         Qualification tool processes extra arguments:
@@ -279,7 +234,8 @@ class Qualification(RapidsJarTool):
         _process_gpu_cluster_worker_node()
         worker_node_hw_info = gpu_cluster_obj.get_worker_hw_info()
         if gpu_cluster_obj:
-            self.ctxt.set_ctxt('recommendedConfigs', self.__calculate_spark_settings(worker_node_hw_info))
+            self.ctxt.set_ctxt('recommendedConfigs',
+                               super(RapidsJarTool, self)._calculate_spark_settings(worker_node_hw_info))
 
         return gpu_cluster_obj is not None
 

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -234,8 +234,7 @@ class Qualification(RapidsJarTool):
         _process_gpu_cluster_worker_node()
         worker_node_hw_info = gpu_cluster_obj.get_worker_hw_info()
         if gpu_cluster_obj:
-            self.ctxt.set_ctxt('recommendedConfigs',
-                               super(RapidsJarTool, self)._calculate_spark_settings(worker_node_hw_info))
+            self.ctxt.set_ctxt('recommendedConfigs', self._calculate_spark_settings(worker_node_hw_info))
 
         return gpu_cluster_obj is not None
 

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -432,6 +432,9 @@ class Qualification(RapidsJarTool):
 
     def __generate_recommended_configs_report(self) -> list:
         report_content = []
+        # TODO: add bootstrap configs support for databricks platforms
+        if 'databricks' in self.ctxt.platform.get_platform_name():
+            return report_content
         if self.ctxt.get_ctxt('recommendedConfigs'):
             report_content = [
                 Utils.gen_report_sec_header('Recommended Spark configurations for running on GPUs', hrule=False),

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -434,7 +434,7 @@ class Qualification(RapidsJarTool):
         report_content = []
         if self.ctxt.get_ctxt('recommendedConfigs'):
             report_content = [
-                Utils.gen_report_sec_header('Recommended Spark configurations', hrule=False),
+                Utils.gen_report_sec_header('Recommended Spark configurations for running on GPUs', hrule=False),
             ]
             conversion_items = []
             recommended_configs = self.ctxt.get_ctxt('recommendedConfigs')

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -28,6 +28,7 @@ from typing import Any, Callable, Dict, List
 
 from spark_rapids_pytools.cloud_api.sp_types import CloudPlatform, get_platform, \
     ClusterBase, DeployMode, NodeHWInfo
+from spark_rapids_pytools.common.prop_manager import YAMLPropertiesContainer
 from spark_rapids_pytools.common.sys_storage import FSUtil
 from spark_rapids_pytools.common.utilities import ToolLogging, Utils
 from spark_rapids_pytools.rapids.rapids_job import RapidsJobPropContainer
@@ -330,7 +331,8 @@ class RapidsTool(object):
         num_cpus = worker_info.sys_info.num_cpus
         cpu_mem = worker_info.sys_info.cpu_mem
 
-        constants = self.ctxt.get_value('local', 'clusterConfigs', 'constants')
+        config_path = Utils.resource_path('cluster-configs.yaml')
+        constants = YAMLPropertiesContainer(prop_arg=config_path).get_value('clusterConfigs', 'constants')
         executors_per_node = num_gpus
         num_executor_cores = max(1, num_cpus // executors_per_node)
         gpu_concurrent_tasks = min(constants.get('maxGpuConcurrent'), gpu_mem // constants.get('gpuMemPerTaskMB'))

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -27,7 +27,7 @@ from logging import Logger
 from typing import Any, Callable, Dict, List
 
 from spark_rapids_pytools.cloud_api.sp_types import CloudPlatform, get_platform, \
-    ClusterBase, DeployMode
+    ClusterBase, DeployMode, NodeHWInfo
 from spark_rapids_pytools.common.sys_storage import FSUtil
 from spark_rapids_pytools.common.utilities import ToolLogging, Utils
 from spark_rapids_pytools.rapids.rapids_job import RapidsJobPropContainer
@@ -316,6 +316,51 @@ class RapidsTool(object):
                     rep_lines.extend(self._generate_section_content(curr_sec))
             return rep_lines
         return None
+
+    def _calculate_spark_settings(self, worker_info: NodeHWInfo) -> dict:
+        """
+        Calculate the cluster properties that we need to append to the /etc/defaults of the spark
+        if necessary.
+        :param worker_info: the hardware info as extracted from the worker. Note that we assume
+                            that all the workers have the same configurations.
+        :return: dictionary containing 7 spark properties to be set by default on the cluster.
+        """
+        num_gpus = worker_info.gpu_info.num_gpus
+        gpu_mem = worker_info.gpu_info.gpu_mem
+        num_cpus = worker_info.sys_info.num_cpus
+        cpu_mem = worker_info.sys_info.cpu_mem
+
+        constants = self.ctxt.get_value('local', 'clusterConfigs', 'constants')
+        executors_per_node = num_gpus
+        num_executor_cores = max(1, num_cpus // executors_per_node)
+        gpu_concurrent_tasks = min(constants.get('maxGpuConcurrent'), gpu_mem // constants.get('gpuMemPerTaskMB'))
+        # account for system overhead
+        usable_worker_mem = max(0, cpu_mem - constants.get('systemReserveMB'))
+        executor_container_mem = usable_worker_mem // executors_per_node
+        # reserve 10% of heap as memory overhead
+        max_executor_heap = max(0, int(executor_container_mem * (1 - constants.get('heapOverheadFraction'))))
+        # give up to 2GB of heap to each executor core
+        executor_heap = min(max_executor_heap, constants.get('heapPerCoreMB') * num_executor_cores)
+        executor_mem_overhead = int(executor_heap * constants.get('heapOverheadFraction'))
+        # use default for pageable_pool to add to memory overhead
+        pageable_pool = constants.get('defaultPageablePoolMB')
+        # pinned memory uses any unused space up to 4GB
+        pinned_mem = min(constants.get('maxPinnedMemoryMB'),
+                         executor_container_mem - executor_heap - executor_mem_overhead - pageable_pool)
+        executor_mem_overhead += pinned_mem + pageable_pool
+        res = {
+            'spark.executor.cores': num_executor_cores,
+            'spark.executor.memory': f'{executor_heap}m',
+            'spark.executor.memoryOverhead': f'{executor_mem_overhead}m',
+            'spark.rapids.sql.concurrentGpuTasks': gpu_concurrent_tasks,
+            'spark.rapids.memory.pinnedPool.size': f'{pinned_mem}m',
+            'spark.sql.files.maxPartitionBytes': f'{constants.get("maxSqlFilesPartitionsMB")}m',
+            'spark.task.resource.gpu.amount': 1 / num_executor_cores,
+            'spark.rapids.shuffle.multiThreaded.reader.threads': num_executor_cores,
+            'spark.rapids.shuffle.multiThreaded.writer.threads': num_executor_cores,
+            'spark.rapids.sql.multiThreadedRead.numThreads': max(20, num_executor_cores)
+        }
+        return res
 
 
 @dataclass

--- a/user_tools/src/spark_rapids_pytools/resources/bootstrap-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/bootstrap-conf.yaml
@@ -8,25 +8,3 @@ local:
     cleanUp: true
     # Name of the file where the final result is going to show
     fileName: rapids_4_dataproc_bootstrap_output.log
-  clusterConfigs:
-    constants:
-      # Maximum amount of pinned memory to use per executor in megabytes
-      maxPinnedMemoryMB: 4096
-      # Default pageable pool size per executor in megabytes
-      defaultPageablePoolMB: 1024
-      # Maximum number of concurrent tasks to run on the GPU
-      maxGpuConcurrent: 4
-      # Amount of GPU memory to use per concurrent task in megabytes
-      # Using a bit less than 8GB here since Dataproc clusters advertise
-      # T4s as only having around 14.75 GB and we want to run with
-      # 2 concurrent by default on T4s.
-      gpuMemPerTaskMB: 7500
-      # Ideal amount of JVM heap memory to request per CPU core in megabytes
-      heapPerCoreMB: 2048
-      # Fraction of the executor JVM heap size that should be additionally reserved
-      # for JVM off-heap overhead (thread stacks, native libraries, etc.)
-      heapOverheadFraction: 0.1
-      # Amount of CPU memory to reserve for system overhead (kernel, buffers, etc.) in megabytes
-      systemReserveMB: 2048
-      # By default set the spark.sql.files.maxPartitionBytes to 512m
-      maxSqlFilesPartitionsMB: 512

--- a/user_tools/src/spark_rapids_pytools/resources/cluster-configs.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/cluster-configs.yaml
@@ -1,0 +1,22 @@
+clusterConfigs:
+  constants:
+    # Maximum amount of pinned memory to use per executor in megabytes
+    maxPinnedMemoryMB: 4096
+    # Default pageable pool size per executor in megabytes
+    defaultPageablePoolMB: 1024
+    # Maximum number of concurrent tasks to run on the GPU
+    maxGpuConcurrent: 4
+    # Amount of GPU memory to use per concurrent task in megabytes
+    # Using a bit less than 8GB here since Dataproc clusters advertise
+    # T4s as only having around 14.75 GB and we want to run with
+    # 2 concurrent by default on T4s.
+    gpuMemPerTaskMB: 7500
+    # Ideal amount of JVM heap memory to request per CPU core in megabytes
+    heapPerCoreMB: 2048
+    # Fraction of the executor JVM heap size that should be additionally reserved
+    # for JVM off-heap overhead (thread stacks, native libraries, etc.)
+    heapOverheadFraction: 0.1
+    # Amount of CPU memory to reserve for system overhead (kernel, buffers, etc.) in megabytes
+    systemReserveMB: 2048
+    # By default set the spark.sql.files.maxPartitionBytes to 512m
+    maxSqlFilesPartitionsMB: 512

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -224,14 +224,29 @@
           }
         },
         {
-          "sectionID": "runUserToolsBootstrap",
+          "sectionID": "gpuBootstrapRecommendedConfigs",
           "requiresBoolFlag": "enableSavingsCalculations",
+          "sectionName": "Recommended Spark configurations for running on GPUs",
           "content": {
             "header": [
               "",
-              "Once the cluster is created, run the Bootstrap tool to provide optimized",
-              "RAPIDS Accelerator for Apache Spark configs based on GPU cluster shape.",
-              "Notes:",
+              "For the new GPU-accelerated cluster with RAPIDS Accelerator for Apache Spark,",
+              "  it is recommended to set the following Spark configurations:",
+              ""
+            ]
+          }
+        },
+        {
+          "sectionID": "runUserToolsBootstrap",
+          "requiresBoolFlag": "DISABLED",
+          "sectionName": "Regenerating recommended configurations for an existing GPU-Cluster",
+          "content": {
+            "header": [
+              "",
+              "To generate the recommended configurations on an existing GPU-Cluster,",
+              "  re-run the Bootstrap tool to provide optimized RAPIDS Accelerator",
+              "  for Apache Spark configs based on GPU cluster shape.",
+              "  Notes:",
               "    - Overriding the Apache Spark default configurations on the cluster",
               "      requires SSH access.",
               "    - If SSH access is unavailable, you can still dump the recommended",

--- a/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
@@ -254,14 +254,29 @@
           }
         },
         {
-          "sectionID": "runUserToolsBootstrap",
+          "sectionID": "gpuBootstrapRecommendedConfigs",
           "requiresBoolFlag": "enableSavingsCalculations",
+          "sectionName": "Recommended Spark configurations for running on GPUs",
           "content": {
             "header": [
               "",
-              "Once the cluster is created, run the Bootstrap tool to provide optimized",
-              "RAPIDS Accelerator for Apache Spark configs based on GPU cluster shape.",
-              "Notes:",
+              "For the new GPU-accelerated cluster with RAPIDS Accelerator for Apache Spark,",
+              "  it is recommended to set the following Spark configurations:",
+              ""
+            ]
+          }
+        },
+        {
+          "sectionID": "runUserToolsBootstrap",
+          "requiresBoolFlag": "DISABLED",
+          "sectionName": "Regenerating recommended configurations for an existing GPU-Cluster",
+          "content": {
+            "header": [
+              "",
+              "To generate the recommended configurations on an existing GPU-Cluster,",
+              "  re-run the Bootstrap tool to provide optimized RAPIDS Accelerator",
+              "  for Apache Spark configs based on GPU cluster shape.",
+              "  Notes:",
               "    - Overriding the Apache Spark default configurations on the cluster",
               "      requires SSH access.",
               "    - If SSH access is unavailable, you can still dump the recommended",

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -156,30 +156,7 @@ local:
           - '^(\.+).*'
           - '^(\$+).*'
           - '^.+(_\$folder\$)$'
-  clusterConfigs:
-    constants:
-      # Maximum amount of pinned memory to use per executor in megabytes
-      maxPinnedMemoryMB: 4096
-      # Default pageable pool size per executor in megabytes
-      defaultPageablePoolMB: 1024
-      # Maximum number of concurrent tasks to run on the GPU
-      maxGpuConcurrent: 4
-      # Amount of GPU memory to use per concurrent task in megabytes
-      # Using a bit less than 8GB here since Dataproc clusters advertise
-      # T4s as only having around 14.75 GB and we want to run with
-      # 2 concurrent by default on T4s.
-      gpuMemPerTaskMB: 7500
-      # Ideal amount of JVM heap memory to request per CPU core in megabytes
-      heapPerCoreMB: 2048
-      # Fraction of the executor JVM heap size that should be additionally reserved
-      # for JVM off-heap overhead (thread stacks, native libraries, etc.)
-      heapOverheadFraction: 0.1
-      # Amount of CPU memory to reserve for system overhead (kernel, buffers, etc.) in megabytes
-      systemReserveMB: 2048
-      # By default set the spark.sql.files.maxPartitionBytes to 512m
-      maxSqlFilesPartitionsMB: 512
 platform:
   shortName: 'qual'
   outputDir: qual-tool-output
   cleanUp: true
-

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -1,6 +1,9 @@
 toolOutput:
   completeOutput: true
   subFolder: rapids_4_spark_qualification_output
+  textFormat:
+    summaryLog:
+      fileName: rapids_4_spark_qualification_output.log
   csv:
     summaryReport:
       fileName: rapids_4_spark_qualification_output.csv

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -156,6 +156,28 @@ local:
           - '^(\.+).*'
           - '^(\$+).*'
           - '^.+(_\$folder\$)$'
+  clusterConfigs:
+    constants:
+      # Maximum amount of pinned memory to use per executor in megabytes
+      maxPinnedMemoryMB: 4096
+      # Default pageable pool size per executor in megabytes
+      defaultPageablePoolMB: 1024
+      # Maximum number of concurrent tasks to run on the GPU
+      maxGpuConcurrent: 4
+      # Amount of GPU memory to use per concurrent task in megabytes
+      # Using a bit less than 8GB here since Dataproc clusters advertise
+      # T4s as only having around 14.75 GB and we want to run with
+      # 2 concurrent by default on T4s.
+      gpuMemPerTaskMB: 7500
+      # Ideal amount of JVM heap memory to request per CPU core in megabytes
+      heapPerCoreMB: 2048
+      # Fraction of the executor JVM heap size that should be additionally reserved
+      # for JVM off-heap overhead (thread stacks, native libraries, etc.)
+      heapOverheadFraction: 0.1
+      # Amount of CPU memory to reserve for system overhead (kernel, buffers, etc.) in megabytes
+      systemReserveMB: 2048
+      # By default set the spark.sql.files.maxPartitionBytes to 512m
+      maxSqlFilesPartitionsMB: 512
 platform:
   shortName: 'qual'
   outputDir: qual-tool-output


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/410.

We add the recommended configs that the bootstrap tool would generate to the qualification output, both in the CLI and in the summary log file.

We will generate these recommended configs only when the qualification tool outputs a recommended GPU cluster.

For now, the bootstrap tool is not available for `Databricks-AWS`/`Databricks-Azure` platforms, so we cannot include the bootstrap recommendation output for the `Databricks` platforms.
Follow up issue is tracked here: https://github.com/NVIDIA/spark-rapids-tools/issues/461