### PR TITLE
Add Progress Bar in Profiling tools

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
@@ -30,7 +30,7 @@ object ProfileMain extends Logging {
    * Entry point from spark-submit running this as the driver.
    */
   def main(args: Array[String]) {
-    val (exitCode, _) = mainInternal(new ProfileArgs(args))
+    val (exitCode, _) = mainInternal(new ProfileArgs(args), enablePB = true)
     if (exitCode != 0) {
       System.exit(exitCode)
     }
@@ -39,7 +39,7 @@ object ProfileMain extends Logging {
   /**
    * Entry point for tests
    */
-  def mainInternal(appArgs: ProfileArgs): (Int, Int) = {
+  def mainInternal(appArgs: ProfileArgs, enablePB: Boolean = false): (Int, Int) = {
 
     // Parsing args
     val eventlogPaths = appArgs.eventlog()
@@ -67,7 +67,7 @@ object ProfileMain extends Logging {
       return (0, filteredLogs.size)
     }
 
-    val profiler = new Profiler(hadoopConf, appArgs)
+    val profiler = new Profiler(hadoopConf, appArgs, enablePB)
     profiler.profile(eventLogFsFiltered)
     (0, filteredLogs.size)
   }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ui/ConsoleProgressBar.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ui/ConsoleProgressBar.scala
@@ -133,20 +133,15 @@ class ConsoleProgressBar(
   }
 
   def reportSuccessfulProcesses(n: Int): Unit = {
-    for(_ <- 1 to n) {
-      reportSuccessfulProcess()
-    }
+    (1 to n).foreach(_ => reportSuccessfulProcess())
   }
 
   def reportFailedProcesses(n: Int): Unit = {
-    for (_ <- 1 to n) {
-      reportFailedProcess()
-    }
+    (1 to n).foreach(_ => reportFailedProcess())
   }
+
   def reportUnknownStatusProcesses(n: Int): Unit = {
-    for (_ <- 1 to n) {
-      reportUnkownStatusProcess()
-    }
+    (1 to n).foreach(_ => reportUnkownStatusProcess())
   }
 
   def metricsToString: String = {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ui/ConsoleProgressBar.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ui/ConsoleProgressBar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,6 +132,23 @@ class ConsoleProgressBar(
     totalCounter.incrementAndGet()
   }
 
+  def reportSuccessfulProcesses(n: Int): Unit = {
+    for(_ <- 1 to n) {
+      reportSuccessfulProcess()
+    }
+  }
+
+  def reportFailedProcesses(n: Int): Unit = {
+    for (_ <- 1 to n) {
+      reportFailedProcess()
+    }
+  }
+  def reportUnknownStatusProcesses(n: Int): Unit = {
+    for (_ <- 1 to n) {
+      reportUnkownStatusProcess()
+    }
+  }
+
   def metricsToString: String = {
     val sb = new mutable.StringBuilder()
     metrics.foreach { case (name, counter) =>
@@ -193,6 +210,8 @@ class ConsoleProgressBar(
 
   /**
    * Mark all processing as finished.
+   * TODO: All processes that have not been finished (totalCount - currentCount)
+   *       should be marked as unknown.
    */
   def finishAll(): Unit = synchronized {
     stop()


### PR DESCRIPTION
This PR fixes #278. 
It introduces the progress bar for Profiling tools based on different modes of operation. 

## Progress Bar Update Design:
Depending on the `mode` parameter, the progress bar will now be updated as follows:

1. **Compare Mode:**
   - Unknown: Each app that cannot be created or if number of created apps are less than 2
   - Failure: Any exception caught.
   - Success: All apps that can be processed successfully.

2. **Combined Mode:**
   - Unknown: Each app that cannot be created.
   - Failure: Any exception caught.
   - Success: All apps that can be processed successfully.

3. **Collection Mode:**
   - Unknown: Each app that cannot be created.
   - Failure: Any exception caught.
   - Success: All apps that can be processed successfully.


## Changes to Current Design:
- Previously, in compare mode and collection mode, the `processApp()` and `writeOutput()` functions were handled by the same try-catch block. 
- However, this structure made it difficult to differentiate if an exception was thrown by `processApp` or `writeOutput`. 
- To address this issue, a new method called `writeSafelyToOutput` is introduced to handle exceptions thrown during the writing process, ensuring that the progress bar excludes failures related to writing operations.

