### PR TITLE
[FEA] Enhance qualification tool to handle custom speedup factor file as input

### DIFF
--- a/core/docs/spark-qualification-tool.md
+++ b/core/docs/spark-qualification-tool.md
@@ -266,6 +266,10 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
                                      configs:
                                      --spark-property=spark.eventLog.enabled:true
                                      --spark-property=spark.driver.port
+      --speedup-factor-file <arg>    Custom speedup factor file used to get estimated
+                                     GPU speedup that is specific to the user's environment.
+                                     If the file is not provided, it defaults to use the
+                                     speedup factor files included in the jar.
   -s, --start-app-time  <arg>        Filter event logs whose application start
                                      occurred within the past specified time
                                      period. Valid time periods are

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -27,7 +27,8 @@ import org.apache.spark.internal.Logging
  * By default it relies on a csv file included in the jar which is generated
  * by the plugin which lists the formats and types supported.
  */
-class PluginTypeChecker(platform: String = "onprem", speedupFactorFile: String = "") extends Logging {
+class PluginTypeChecker(platform: String = "onprem",
+                        speedupFactorFile: String = "") extends Logging {
 
   private val NS = "NS"
   private val PS = "PS"

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids.tool.qualification
 
 import scala.collection.mutable.{ArrayBuffer,HashMap}
 import scala.io.{BufferedSource, Source}
+import scala.util.control.NonFatal
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -119,7 +120,7 @@ class PluginTypeChecker(platform: String = "onprem",
       }
       readSupportedOperators(source, "score").map(x => (x._1, x._2.toDouble))
     } catch {
-      case e: Exception => speedupFactorFile match {
+      case NonFatal(e) => speedupFactorFile match {
         case Some(file) =>
           logError(s"Exception processing operators scores with $file", e)
         case None =>

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -19,6 +19,9 @@ package com.nvidia.spark.rapids.tool.qualification
 import scala.collection.mutable.{ArrayBuffer,HashMap}
 import scala.io.{BufferedSource, Source}
 
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+
 import org.apache.spark.internal.Logging
 
 /**
@@ -110,7 +113,9 @@ class PluginTypeChecker(platform: String = "onprem",
           Source.fromResource(file)
         case Some(file) =>
           logInfo(s"Reading operators scores from custom speedup factor file: $file")
-          Source.fromFile(file)
+          val path = new Path(file)
+          val fs = FileSystem.get(path.toUri, new Configuration())
+          new BufferedSource(fs.open(path))
       }
       readSupportedOperators(source, "score").map(x => (x._1, x._2.toDouble))
     } catch {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
@@ -152,6 +152,9 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
         "databricks-azure. " +
         "Default is onprem.",
       default = Some("onprem"))
+  val speedupFactorFile: ScallopOption[String] =
+    opt[String](required = false,
+      descr = "Custom speed up factor file")
 
   validate(order) {
     case o if (QualificationArgs.isOrderAsc(o) || QualificationArgs.isOrderDesc(o)) => Right(Unit)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
@@ -154,7 +154,9 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
       default = Some("onprem"))
   val speedupFactorFile: ScallopOption[String] =
     opt[String](required = false,
-      descr = "Custom speed up factor file")
+      descr = "Custom speedup factor file used to get estimated GPU speedup that is specific " +
+        "to the user's environment. If the file is not provided, it defaults to use the " +
+        "speedup files included in the jar.")
 
   validate(order) {
     case o if (QualificationArgs.isOrderAsc(o) || QualificationArgs.isOrderDesc(o)) => Right(Unit)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
@@ -60,11 +60,12 @@ object QualificationMain extends Logging {
     val reportSqlLevel = appArgs.perSql.getOrElse(false)
     val platform = appArgs.platform.getOrElse("onprem")
     val mlOpsEnabled = appArgs.mlFunctions.getOrElse(false)
+    val speedupFactorFile = appArgs.speedupFactorFile.getOrElse("")
 
     val hadoopConf = RapidsToolsConfUtil.newHadoopConf
 
     val pluginTypeChecker = try {
-      new PluginTypeChecker(platform)
+      new PluginTypeChecker(platform, speedupFactorFile)
     } catch {
       case ie: IllegalStateException =>
         logError("Error creating the plugin type checker!", ie)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
@@ -60,12 +60,11 @@ object QualificationMain extends Logging {
     val reportSqlLevel = appArgs.perSql.getOrElse(false)
     val platform = appArgs.platform.getOrElse("onprem")
     val mlOpsEnabled = appArgs.mlFunctions.getOrElse(false)
-    val speedupFactorFile = appArgs.speedupFactorFile.getOrElse("")
 
     val hadoopConf = RapidsToolsConfUtil.newHadoopConf
 
     val pluginTypeChecker = try {
-      new PluginTypeChecker(platform, speedupFactorFile)
+      new PluginTypeChecker(platform, appArgs.speedupFactorFile.toOption)
     } catch {
       case ie: IllegalStateException =>
         logError("Error creating the plugin type checker!", ie)

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids.tool.qualification
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
 
+import com.nvidia.spark.rapids.tool.ToolTestUtils
 import com.nvidia.spark.rapids.tool.planparser.DataWritingCommandExecParser
 import org.scalatest.FunSuite
 
@@ -192,5 +193,12 @@ class PluginTypeCheckerSuite extends FunSuite with Logging {
     val checker = new PluginTypeChecker("emr-a10")
     assert(checker.getSpeedupFactor("UnionExec") == 3.0)
     assert(checker.getSpeedupFactor("Ceil") == 4)
+  }
+
+  test("supported operator score from custom speedup factor file") {
+    val speedupFactorFile = ToolTestUtils.getTestResourcePath("operatorsScore-databricks-azure.csv")
+    val checker = new PluginTypeChecker(speedupFactorFile=Some(speedupFactorFile))
+    assert(checker.getSpeedupFactor("SortExec") == 14.15)
+    assert(checker.getSpeedupFactor("FilterExec") == 3.12)
   }
 }

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -77,6 +77,7 @@ sparkRapids:
       - report-read-schema
       - s
       - spark-property
+      - speedup-factor-file
       - start-app-time
       - t
       - timeout


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/467.

We add support for handling custom speedup factor file as input for the qualification tool.

Our current approach is adding a rapids(core) qualification tool option for java commands called `--speedup-factor-file`, where the user can pass in an absolute path to the speedup factor file they want to use.