### PR TITLE
Add Github workflow to automate changelog and release pages

### DIFF
--- a/.github/workflows/configuration.json
+++ b/.github/workflows/configuration.json
@@ -1,0 +1,21 @@
+{
+  "categories": [
+    {
+      "title": "### User Tools",
+      "labels": ["user_tools"]
+    },
+    {
+      "title": "### Core",
+      "labels": ["tools"]
+    },
+    {
+      "title": "### Miscellaneous",
+      "labels": []
+    }
+  ],
+  "sort": {
+    "order": "DESC",
+    "on_property": "mergedAt"
+  },
+  "pr_template": "- ${{TITLE}} ([#${{NUMBER}}](${{URL}}))"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release
+
+on:
+  workflow_dispatch: # Allow manual triggering
+  push:
+    tags:
+      - 'v*' # Trigger only on tags starting with 'v'
+
+env:
+  MAVEN_URL: "https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark-tools_2.12"
+  PYPI_URL: "https://pypi.org/project/spark-rapids-user-tools"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build Changelog
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configuration: ".github/workflows/configuration.json" # Configuration file for the changelog builder (optional)z
+          outputFile: "CHANGELOG_BODY.md"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit and Push Changelog
+        if: steps.build_changelog.outputs.changes > 0
+        run: |
+          CURRENT_DATE=$(date +'%Y-%m-%d')
+          BRANCH_URL=https://github.com/$GITHUB_REPOSITORY/tree/${{ github.ref_name }}
+          echo -e "\n<br/>\n" > CURRENT_CHANGELOG.md
+          echo "## Release [${{ github.ref_name }}]($BRANCH_URL)" >> CURRENT_CHANGELOG.md
+          echo "Generated on $CURRENT_DATE" >> CURRENT_CHANGELOG.md
+          cat CURRENT_CHANGELOG.md CHANGELOG_BODY.md >> TEMP_CHANGELOG.md
+          cat TEMP_CHANGELOG.md CHANGELOG.md > NEW_CHANGELOG.md
+
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+          git fetch origin main
+          git checkout main
+          mv NEW_CHANGELOG.md CHANGELOG.md
+          git add CHANGELOG.md
+          git commit -m "Update changelogs"
+          git push origin main
+
+      - name: Set Version Number
+        id: set_version
+        run: |
+          VERSION=${{ github.ref_name }}
+          VERSION=${VERSION#v}  # Remove 'v' prefix
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }} # Use the version number from the tag
+          release_name: ${{ github.ref }} # Use the version number as the release name
+          body: |
+            ## Packages
+            
+            - Maven Release: ${{ env.MAVEN_URL }}/${{ env.VERSION }}/
+            - PyPI Package: ${{ env.PYPI_URL }}/${{ env.VERSION }}/
+            
+            ## Changes
+            ${{ steps.build_changelog.outputs.changelog }}
+          draft: false

--- a/user_tools/README.md
+++ b/user_tools/README.md
@@ -14,7 +14,7 @@ The wrapper improves end-user experience within the following dimensions:
    make sure the cluster is healthy and ready for Spark jobs.
 
 
-## Getting Started
+## Getting started
 
 Set up a Python environment with a version between 3.8 and 3.10
 
@@ -43,10 +43,11 @@ Set up a Python environment with a version between 3.8 and 3.10
       ```
 3. Make sure to install CSP SDK if you plan to run the tool wrapper.
 
-## Usage and Supported Platforms
+## Usage and supported platforms
 
 Please refer to [spark-rapids-user-tools guide](https://github.com/NVIDIA/spark-rapids-tools/blob/main/user_tools/docs/index.md) for details on how to use the tools
 and the platform.
 
-## What's New
+## What's new
+
 Please refer to [CHANGELOG.md](https://github.com/NVIDIA/spark-rapids-tools/blob/main/CHANGELOG.md) for our latest changes.

--- a/user_tools/README.md
+++ b/user_tools/README.md
@@ -3,20 +3,20 @@
 User tools to help with the adoption, installation, execution, and tuning of RAPIDS Accelerator for Apache Spark.
 
 The wrapper improves end-user experience within the following dimensions:
-1. Qualification: Educate the CPU customer on the cost savings and acceleration potential of RAPIDS Accelerator for
+1. **Qualification**: Educate the CPU customer on the cost savings and acceleration potential of RAPIDS Accelerator for
    Apache Spark. The output shows a list of apps recommended for RAPIDS Accelerator for Apache Spark with estimated savings
    and speed-up.
-2. Bootstrap: Provide optimized RAPIDS Accelerator for Apache Spark configs based on GPU cluster shape. The output
+2. **Bootstrap**: Provide optimized RAPIDS Accelerator for Apache Spark configs based on GPU cluster shape. The output
    shows updated Spark config settings on driver node.
-3. Tuning: Tune RAPIDS Accelerator for Apache Spark configs based on initial job run leveraging Spark event logs. The output
+3. **Tuning**: Tune RAPIDS Accelerator for Apache Spark configs based on initial job run leveraging Spark event logs. The output
    shows recommended per-app RAPIDS Accelerator for Apache Spark config settings.
-4. Diagnostics: Run diagnostic functions to validate the Dataproc with RAPIDS Accelerator for Apache Spark environment to
+4. **Diagnostics**: Run diagnostic functions to validate the Dataproc with RAPIDS Accelerator for Apache Spark environment to
    make sure the cluster is healthy and ready for Spark jobs.
 
 
-## Getting started
+## Getting Started
 
-set python environment to version [3.8, 3.10]
+Set up a Python environment with a version between 3.8 and 3.10
 
 1. Run the project in a virtual environment.
     ```sh
@@ -43,8 +43,10 @@ set python environment to version [3.8, 3.10]
       ```
 3. Make sure to install CSP SDK if you plan to run the tool wrapper.
 
-## Usage and supported platforms
+## Usage and Supported Platforms
 
 Please refer to [spark-rapids-user-tools guide](https://github.com/NVIDIA/spark-rapids-tools/blob/main/user_tools/docs/index.md) for details on how to use the tools
 and the platform.
 
+## What's New
+Please refer to [CHANGELOG.md](https://github.com/NVIDIA/spark-rapids-tools/blob/main/CHANGELOG.md) for our latest changes.


### PR DESCRIPTION
Fixes #369

The release process within GitHub is automated using a GitHub Actions workflow script. 

### GitHub Release Workflow:
**File** - `.github/workflow/release.yml`

This workflow is triggered when a branch prefixed with 'v*' is pushed. The following steps are executed:

1. **Checkout Code**
2. **Create Change Log** using a third-party library.
3. **Prepend Current Change Log** to `CHANGELOG.md` in the `main` branch.
    - Commit and push changes to the `main` branch.
4. **Create a Release** using the output obtained from step 2.

**File** - `.github/workflow/configuration.json`

A configuration file to customize the output of change logs.

**Library Used** - https://github.com/marketplace/actions/release-changelog-builder
