### PR TITLE
Fix negative GPU speedup in core qualification module

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -271,7 +271,7 @@ class PluginTypeChecker(platform: String = "onprem") extends Logging {
   }
 
   def getSpeedupFactor(execOrExpr: String): Double = {
-    supportedOperatorsScore.get(execOrExpr).getOrElse(-1)
+    supportedOperatorsScore.get(execOrExpr).getOrElse(1)
   }
 
   def isExecSupported(exec: String): Boolean = {

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
@@ -108,7 +108,7 @@ class PluginTypeCheckerSuite extends FunSuite with Logging {
       Files.write(csvSupportedFile, supText)
       checker.setOperatorScore(csvSupportedFile.toString)
       assert(checker.getSpeedupFactor("UnionExec") == 3)
-      assert(checker.getSpeedupFactor("ProjectExec") == -1)
+      assert(checker.getSpeedupFactor("ProjectExec") == 1)
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/478.

We change the default speedup factor for non-existing execs or expressions to 1.0, so that there will not be negative GPU duration or speedup in the estimation results.