### PR TITLE
Handle deprecation errors in python packaging

### DIFF
--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -39,5 +39,7 @@ ascli = "spark_rapids_pytools.ascli_cli.ascli:main"
 
 [tool.setuptools.dynamic]
 version = {attr = "spark_rapids_pytools.__version__"}
+[tool.setuptools.package-data]
+spark_rapids_pytools = ["*.json", "*.yaml", "*.ms", "*.sh"]
 [tool.poetry]
 repository = "https://github.com/NVIDIA/spark-rapids-tools/tree/main"

--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -37,9 +37,11 @@ dynamic=["entry-points", "version"]
 spark_rapids_user_tools = "spark_rapids_pytools.wrapper:main"
 ascli = "spark_rapids_pytools.ascli_cli.ascli:main"
 
+[tool.setuptools.packages.find]
+where = ["src"]
 [tool.setuptools.dynamic]
 version = {attr = "spark_rapids_pytools.__version__"}
 [tool.setuptools.package-data]
-spark_rapids_pytools = ["*.json", "*.yaml", "*.ms", "*.sh"]
+"*"= ["*.json", "*.yaml", "*.ms", "*.sh"]
 [tool.poetry]
 repository = "https://github.com/NVIDIA/spark-rapids-tools/tree/main"

--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -33,6 +33,10 @@ dependencies = [
     "pygments==2.15.0"
 ]
 dynamic=["entry-points", "version"]
+[project.scripts]
+spark_rapids_user_tools = "spark_rapids_pytools.wrapper:main"
+ascli = "spark_rapids_pytools.ascli_cli.ascli:main"
+
 [tool.setuptools.dynamic]
 version = {attr = "spark_rapids_pytools.__version__"}
 [tool.poetry]

--- a/user_tools/setup.cfg
+++ b/user_tools/setup.cfg
@@ -1,2 +1,0 @@
-[options.package_data]
-* = *.json, *.yaml, *.ms, *.sh

--- a/user_tools/setup.cfg
+++ b/user_tools/setup.cfg
@@ -1,6 +1,2 @@
-[options.entry_points]
-console_scripts =
-    spark_rapids_user_tools = spark_rapids_pytools.wrapper:main
-    ascli = spark_rapids_pytools.ascli_cli.ascli:main
 [options.package_data]
 * = *.json, *.yaml, *.ms, *.sh


### PR DESCRIPTION
Fixes #512 

Move `entry-points` to toml file `project.scripts` as python packaging is deprecating the definition of project entry-points outside toml file