### PR TITLE
Filter parser should check ignored-functions

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -697,7 +697,7 @@ object SQLPlanParser extends Logging {
     // Step-2: Extract function names from the expression
     val functionMatches = functionsRegEx.findAllMatchIn(processedExpr)
     parsedExpressions ++=
-      functionMatches.map(_.group(1)).filter(_.toLowerCase() != "cast")
+      functionMatches.map(_.group(1)).filterNot(ignoreExpression(_))
     // remove all function calls. No need to keep them in the expression
     processedExpr = functionsRegEx.replaceAllIn(processedExpr, " ")
 


### PR DESCRIPTION
Fixes #518 

- Modified `parseConditionalExpressions` to remove all the functions in the Ignored list.
- Added unit-tests