### PR TITLE
Updating speedup generation for more execs from NDS + validation script

### DIFF
--- a/user_tools/custom_speedup_factors/README.md
+++ b/user_tools/custom_speedup_factors/README.md
@@ -37,3 +37,19 @@ Now that you have a custom *operatorsScore.csv* file, you can run the Spark RAPI
 ```
 spark_rapids_user_tools onprem qualification --speedup-factor-file newScores.csv --eventlogs <CPU-event-logs>
 ```
+
+## Validating Custom Speedup Factors
+
+There is a utility script in the directory to allow for validation of custom speedup factors given CPU and GPU event logs for a corresponding job or set of jobs.  By default, the script will generate custom speedup factors, run the qualification tool with the generated custom speed up factors, and then generate validation metrics for the estimations against the actuals.
+
+Example execution of the script:
+```
+python validate_speedup_factors.py --cpu_log CPU-nds-eventlog --gpu_log GPU-nds-eventlog --output test-speedup
+```
+
+The script also allows you to pass in a custom speedup factor file if you have previously generated them.  Example:
+```
+python validate_speedup_factors.py --cpu_log CPU-nds-eventlog --gpu_log GPU-nds-eventlog --output test-speedup --speedups test-scores.csv
+```
+
+Other options include passing in the CPU and/or GPU profiler output if that has already been done via the `cpu_profile` and `gpu_profile` arguments.  Additionally, you can pass in a custom tools jar via `--jar` if that is needed.

--- a/user_tools/custom_speedup_factors/defaultScores.csv
+++ b/user_tools/custom_speedup_factors/defaultScores.csv
@@ -2,6 +2,7 @@ CPUOperator,Score
 AggregateInPandasExec,1.2
 ArrowEvalPythonExec,1.2
 FlatMapGroupsInPandasExec,1.2
+FlatMapCoGroupsInPandasExec,1.2
 MapInPandasExec,1.2
 WindowInPandasExec,1.2
 KMeans-pyspark,8.86

--- a/user_tools/custom_speedup_factors/generate_speedup_factors.py
+++ b/user_tools/custom_speedup_factors/generate_speedup_factors.py
@@ -1,22 +1,18 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-#
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# -----
+
 """Spark RAPIDS speedup factor generation script"""
 
 import argparse

--- a/user_tools/custom_speedup_factors/operatorsList.csv
+++ b/user_tools/custom_speedup_factors/operatorsList.csv
@@ -13,12 +13,9 @@ SampleExec
 SortExec
 SubqueryBroadcastExec
 TakeOrderedAndProjectExec
-UnionExec
-CustomShuffleReaderExec
 HashAggregateExec
 ObjectHashAggregateExec
 SortAggregateExec
-InMemoryTableScanExec
 DataWritingCommandExec
 ExecutedCommandExec
 BatchScanExec
@@ -29,9 +26,7 @@ BroadcastNestedLoopJoinExec
 CartesianProductExec
 ShuffledHashJoinExec
 SortMergeJoinExec
-FlatMapCoGroupsInPandasExec
 WindowExec
-HiveTableScanExec
 Abs
 Acos
 Acosh

--- a/user_tools/custom_speedup_factors/validate_qualification_estimates.py
+++ b/user_tools/custom_speedup_factors/validate_qualification_estimates.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# -----
+"""Spark RAPIDS speedup factor validation script"""
+
+import argparse
+import os
+import glob
+import subprocess
+
+import pandas as pd
+from tabulate import tabulate
+
+parser = argparse.ArgumentParser(description="Speedup Factor Validation")
+parser.add_argument("--cpu_log", type=str, help="Directory of CPU event log(s)", required=True)
+parser.add_argument("--gpu_log", type=str, help="Directory of GPU event log(s)", required=True)
+parser.add_argument("--output", type=str, help="Output folder for storing logs", required=True)
+parser.add_argument("--speedups", type=str, help="Custom speedup factor file")
+parser.add_argument("--cpu_profile", type=str, help="Directory of CPU profiler log(s)")
+parser.add_argument("--gpu_profile", type=str, help="Directory of GPU profiler log(s)")
+parser.add_argument("--jar", type=str, help="Custom tools jar")
+parser.add_argument("--verbose", action="store_true", help="flag to generate full verbose output for logging raw node results")
+args = parser.parse_args()
+
+cpu_log = args.cpu_log
+gpu_log = args.gpu_log
+cpu_profile = args.cpu_profile
+gpu_profile = args.gpu_profile
+output = args.output
+speedups = args.speedups
+jar = args.jar
+verbose = args.verbose
+
+print(f"Output folder = {output}")
+print(f"CPU event log = {cpu_log}")
+print(f"GPU event log = {gpu_log}")
+
+subprocess.run(f"rm -rf {output}", shell=True)
+
+speedups_arg = ""
+if speedups is not None:
+    speedups_arg = f"--speedup-factor-file {speedups}"
+else:
+    speedups_arg = f"--speedup-factor-file {output}/generatedScores.csv"
+
+jar_arg = ""
+if jar is not None:
+    jar_arg = f"--tools_jar {jar}"
+
+# Generate speedup factors
+
+### run GPU profiler if needed
+gpu_profile_dir = ""
+if gpu_profile is not None:
+    gpu_profile_dir = gpu_profile
+else:
+    gpu_profile_dir = f"{output}/gpu_profile"
+    subprocess.run(f"spark_rapids_user_tools onprem profiling --csv --local_folder {gpu_profile_dir} --eventlogs {gpu_log}", shell=True)
+
+if speedups is None:
+    ### run CPU profiler if needed
+    cpu_profile_dir = ""
+    if cpu_profile is not None:
+        cpu_profile_dir = cpu_profile
+    else:
+        cpu_profile_dir = f"{output}/cpu_profile"
+        subprocess.run(f"spark_rapids_user_tools onprem profiling --csv --local_folder {cpu_profile_dir} --eventlogs {cpu_log}", shell=True)
+
+    ### run speedup factor generation
+    subprocess.run(f"python generate_speedup_factors.py --cpu {cpu_profile_dir}/*/rapids_4_spark_profile --gpu {gpu_profile_dir}/*/rapids_4_spark_profile --output {output}/generatedScores.csv", shell=True)
+
+# Run qualification
+
+### set speedup factors to input or generated
+speedups_arg = ""
+if speedups is not None:
+    speedups_arg = f"--speedup-factor-file {speedups}"
+else:
+    speedups_arg = f"--speedup-factor-file {output}/generatedScores.csv"
+
+### run CPU qualification
+cpu_tmp_dir = f"{output}/cpu"
+subprocess.run(f"spark_rapids_user_tools onprem qualification {speedups_arg} {jar_arg} --local_folder {cpu_tmp_dir} --eventlogs {cpu_log}", shell=True)
+
+# Parse and validate results
+
+### CPU log parsing
+cpu_app_info = pd.read_csv(glob.glob(f"{cpu_tmp_dir}/*/rapids_4_spark_qualification_output/rapids_4_spark_qualification_output.csv")[0])
+cpu_query_info = cpu_app_info[["App Name", "App Duration", "Estimated GPU Duration", "Estimated GPU Speedup"]]
+
+### GPU log parsing
+gpu_query_info = pd.DataFrame(columns = ['App Name', 'GPU Duration'])
+counter = 0
+
+for app in glob.glob(f"{gpu_profile_dir}/*/rapids_4_spark_profile/*/application_information.csv"):
+    app_info = pd.read_csv(app)
+    new_row = pd.DataFrame({'App Name': app_info.loc[0]["appName"], 'GPU Duration': app_info.loc[0]["duration"]}, index=[counter])
+    gpu_query_info = pd.concat([gpu_query_info, new_row])
+    counter = counter+1
+
+merged_info = cpu_query_info.merge(gpu_query_info, left_on='App Name', right_on='App Name')
+merged_info["Duration Error (sec)"] = (merged_info["Estimated GPU Duration"] - merged_info["GPU Duration"])/1000.0
+merged_info["Duration Error (pct)"] = (100.0*(merged_info["Estimated GPU Duration"] - merged_info["GPU Duration"])/merged_info["Estimated GPU Duration"]).apply(lambda x: round(x,2))
+merged_info["GPU Speedup"] = (merged_info["App Duration"]/merged_info["GPU Duration"]).apply(lambda x: round(x,2))
+merged_info["Speedup Error (abs)"] = merged_info["Estimated GPU Speedup"] - merged_info["GPU Speedup"]
+merged_info["Speedup Error (pct)"] = (100.0*(merged_info["Estimated GPU Speedup"] - merged_info["GPU Speedup"])/merged_info["Estimated GPU Speedup"]).apply(lambda x: round(x,2))
+
+print("==================================================")
+print("              Application Details")
+print("==================================================")
+print(tabulate(merged_info, headers='keys', tablefmt='psql'))
+
+print("==================================================")
+print("            Duration Error Metrics ")
+print("==================================================")
+print("Average duration error (seconds)  = " + str(round(merged_info["Duration Error (sec)"].mean(),2)))
+print("Median duration error (seconds)   = " + str(round(merged_info["Duration Error (sec)"].median(),2)))
+print("Min duration error (seconds)      = " + str(round(merged_info["Duration Error (sec)"].min(),2)))
+print("Max duration error (seconds)      = " + str(round(merged_info["Duration Error (sec)"].max(),2)))
+print("Average duration error (diff pct) = " + str(round(merged_info["Duration Error (pct)"].mean(),2)))
+print("Median duration error (diff pct)  = " + str(round(merged_info["Duration Error (pct)"].median(),2)))
+print("Max duration error (diff pct)     = " + str(round(merged_info["Duration Error (pct)"].max(),2)))
+print("Average duration error (diff sec) = " + str(round(merged_info["Duration Error (sec)"].abs().mean(),2)))
+print("Median duration error (diff sec)  = " + str(round(merged_info["Duration Error (sec)"].abs().median(),2)))
+print("Max duration error (diff sec)     = " + str(round(merged_info["Duration Error (sec)"].abs().max(),2)))
+print("Average duration error (abs pct)  = " + str(round(merged_info["Duration Error (pct)"].abs().mean(),2)))
+print("Median duration error (abs pct)   = " + str(round(merged_info["Duration Error (pct)"].abs().median(),2)))
+print("Max duration error (abs pct)      = " + str(round(merged_info["Duration Error (pct)"].abs().max(),2)))
+print("==================================================")
+print("            Speedup Error Metrics ")
+print("==================================================")
+print("Average speedup error (diff)      = " + str(round(merged_info["Speedup Error (abs)"].mean(),2)))
+print("Median speedup error (diff)       = " + str(round(merged_info["Speedup Error (abs)"].median(),2)))
+print("Min speedup error (diff)          = " + str(round(merged_info["Speedup Error (abs)"].min(),2)))
+print("Max speedup error (diff)          = " + str(round(merged_info["Speedup Error (abs)"].max(),2)))
+print("Average speedup error (diff pct)  = " + str(round(merged_info["Speedup Error (pct)"].mean(),2)))
+print("Median speedup error (diff pct    = " + str(round(merged_info["Speedup Error (pct)"].median(),2)))
+print("Max speedup error (diff pct)      = " + str(round(merged_info["Speedup Error (pct)"].max(),2)))
+print("Average speedup error (abs diff)  = " + str(round(merged_info["Speedup Error (abs)"].abs().mean(),2)))
+print("Median speedup error (abs diff)   = " + str(round(merged_info["Speedup Error (abs)"].abs().median(),2)))
+print("Max speedup error (abs diff)      = " + str(round(merged_info["Speedup Error (abs)"].abs().max(),2)))
+print("Average speedup error (abs pct)   = " + str(round(merged_info["Speedup Error (pct)"].abs().mean(),2)))
+print("Median speedup error (abs pct)    = " + str(round(merged_info["Speedup Error (pct)"].abs().median(),2)))
+print("Max speedup error (abs pct)         = " + str(round(merged_info["Speedup Error (pct)"].abs().max(),2)))

--- a/user_tools/custom_speedup_factors/validate_qualification_estimates.py
+++ b/user_tools/custom_speedup_factors/validate_qualification_estimates.py
@@ -1,22 +1,18 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-#
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# -----
+
 """Spark RAPIDS speedup factor validation script"""
 
 import argparse


### PR DESCRIPTION
Contributes to #480 

Includes
- More exec supported from NDS with updated logic
- Removed of execs from operator list that aren't applicable (should have speedup 1.0)
- Changed default speedup calculation to use overall app duration instead of aggregate stage times
- Fix to CPU WholeStageCodegen parsing to accurately remove stages from operator list
- Setting min speedup to 1.0 for execs and default
- Added new validation script to work E2E given CPU and GPU event logs
