### PR TITLE
Improve parsing of aggregate expressions

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -404,25 +404,33 @@ object SQLPlanParser extends Logging {
   // This parser is used for SortAggregateExec, HashAggregateExec and ObjectHashAggregateExec
   def parseAggregateExpressions(exprStr: String): Array[String] = {
     val parsedExpressions = ArrayBuffer[String]()
-    // (key=[num#83], functions=[partial_collect_list(letter#84, 0, 0), partial_count(letter#84)])
-    val pattern = """functions=\[([\w#, +*\\\-\.<>=\`\(\)]+\])""".r
-    val aggregatesString = pattern.findFirstMatchIn(exprStr)
-    // This is to split multiple column names in AggregateExec. Each column will be aggregating
-    // based on the aggregate function. Here "partial_"  and "merge_" is removed and
-    // only function name is preserved. Below regex will first remove the
-    // "functions=" from the string followed by removing "partial_" and "merge_". That string is
-    // split which produces an array containing column names. Finally we remove the parentheses
-    // from the beginning and end to get only the expressions. Result will be as below.
-    // paranRemoved = Array(collect_list(letter#84, 0, 0),, count(letter#84))
-    if (aggregatesString.isDefined) {
-      val paranRemoved = aggregatesString.get.toString.replaceAll("functions=", "").
-          replaceAll("partial_", "").replaceAll("merge_", "").split("(?<=\\),)").map(_.trim).
-          map(_.replaceAll("""^\[+""", "").replaceAll("""\]+$""", ""))
-      paranRemoved.foreach { case expr =>
-        val functionName = getFunctionName(functionPattern, expr)
-        functionName match {
-          case Some(func) => parsedExpressions += func
-          case _ => // NO OP
+    // (keys=[num#83], functions=[partial_collect_list(letter#84, 0, 0), partial_count(letter#84)])
+    // Currently we only parse the functions expressions.
+    // "Keys" parsing is disabled for now because we won't be able to detect the types
+
+    // A map (value -> parseEnabled) between the group and the parsing metadata
+    val patternMap = Map(
+      "functions" -> true,
+      "keys" -> false
+    )
+    // It won't hurt to define a pattern that is neutral to the order of the functions/keys.
+    // This can avoid mismatches when exprStr comes in the fom of (functions=[], keys=[]).
+    val pattern = """^\((keys|functions)=\[(.*)\]\s*,\s*(keys|functions)=\[(.*)\]\s*\)$""".r
+    // Iterate through the matches and exclude disabled clauses
+    pattern.findAllMatchIn(exprStr).foreach { m =>
+      // The matching groups are:
+      // 0 -> entire expression
+      // 1 -> "keys"; 2 -> keys' expression
+      // 3 -> "functions"; 4 -> functions' expression
+      Array(1, 3).foreach { group_ind =>
+        val group_value = m.group(group_ind)
+        if (patternMap.getOrElse(group_value, false)) {
+          val clauseExpr = m.group(group_ind + 1)
+          // Here "partial_"  and "merge_" is removed and only function name is preserved.
+          val processedExpr = clauseExpr.replaceAll("partial_", "").replaceAll("merge_", "")
+          // No need to split the expr any further because we are only interested in function names
+          val used_functions = getAllFunctionNames(functionPrefixPattern, processedExpr)
+          parsedExpressions ++= used_functions
         }
       }
     }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -1022,4 +1022,18 @@ class SQLPlanParserSuite extends BaseTestSuite {
     val expressions = SQLPlanParser.parseFilterExpressions(exprString)
     expressions should ===(expected)
   }
+
+
+  test("Parse aggregate expressions") {
+    val exprString = "(keys=[], functions=[split(split(split(replace(replace(replace(replace(" +
+      "trim(replace(cast(unbase64(content#192) as string),  , ), Some( )), *., ), *, ), " +
+      "https://, ), http://, ), /, -1)[0], :, -1)[0], \\?, -1)[0]#199, " +
+      "CASE WHEN (instr(replace(cast(unbase64(content#192) as string),  , ), *) = 0) " +
+      "THEN concat(replace(cast(unbase64(content#192) as string),  , ), %) " +
+      "ELSE replace(replace(replace(cast(unbase64(content#192) as string),  , ), %, " +
+      "\\%), *, %) END#200])"
+    val expected = Array("replace", "concat", "instr", "split", "trim", "unbase64")
+    val expressions = SQLPlanParser.parseAggregateExpressions(exprString)
+    expressions should ===(expected)
+  }
 }


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #519

- `parseAggregateExpressions` function was very specific on the pattern of the aggregate expression.
- the chnages update the implementation to correctly pull any possible function name from the aggregates
- added 1 unit test with complex expression

