### PR TITLE
Bump default build to use Spark-333

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        spark-version: ['311', '320', '330', '341']
+        spark-version: ['311', '320', '333', '341']
     steps:
     - uses: actions/checkout@v3
 

--- a/core/README.md
+++ b/core/README.md
@@ -20,14 +20,14 @@ mvn clean package
 ```
 
 After a successful build, the jar of 'rapids-4-spark-tools_2.12-*-SNAPSHOT.jar' will be in 'target/' directory.  
-This will build the plugin for a single version of Spark. By default, this is Apache Spark 3.1.1.
+This will build the plugin for a single version of Spark. By default, this is Apache Spark 3.3.3.
 
 For development purpose, you may need to run the tests against different spark versions.
 To run the tests against a specific Spark version, you can use the `-Dbuildver=XXX` command line option.  
-For instance to build Spark 3.3.0 you would use:
+For instance to build Spark 3.4.1 you would use:
 
 ```shell script
-mvn -Dbuildver=330 clean package
+mvn -Dbuildver=341 clean package
 ```
 
 Run `mvn help:all-profiles` to list supported Spark versions.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -73,7 +73,6 @@
         <profile>
             <id>release311</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
                 <property>
                     <name>buildver</name>
                     <value>311</value>
@@ -83,7 +82,7 @@
                 <buildver>311</buildver>
                 <spark.version>${spark311.version}</spark.version>
                 <delta.core.version>${delta10x.version}</delta.core.version>
-                <hadoop.version>3.2.0</hadoop.version>
+                <hadoop.version>3.3.6</hadoop.version>
             </properties>
         </profile>
         <profile>
@@ -98,7 +97,7 @@
                 <buildver>312</buildver>
                 <spark.version>${spark312.version}</spark.version>
                 <delta.core.version>${delta10x.version}</delta.core.version>
-                <hadoop.version>3.2.0</hadoop.version>
+                <hadoop.version>3.3.6</hadoop.version>
             </properties>
         </profile>
         <profile>
@@ -113,7 +112,22 @@
                 <buildver>313</buildver>
                 <spark.version>${spark313.version}</spark.version>
                 <delta.core.version>${delta10x.version}</delta.core.version>
-                <hadoop.version>3.2.0</hadoop.version>
+                <hadoop.version>3.3.6</hadoop.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>release314</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>314</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>314</buildver>
+                <spark.version>${spark314.version}</spark.version>
+                <delta.core.version>${delta10x.version}</delta.core.version>
+                <hadoop.version>3.3.6</hadoop.version>
             </properties>
         </profile>
         <profile>
@@ -128,7 +142,7 @@
                 <buildver>320</buildver>
                 <spark.version>${spark320.version}</spark.version>
                 <delta.core.version>${delta20x.version}</delta.core.version>
-                <hadoop.version>3.3.1</hadoop.version>
+                <hadoop.version>3.3.6</hadoop.version>
             </properties>
         </profile>
         <profile>
@@ -143,7 +157,7 @@
                 <buildver>321</buildver>
                 <spark.version>${spark321.version}</spark.version>
                 <delta.core.version>${delta20x.version}</delta.core.version>
-                <hadoop.version>3.3.1</hadoop.version>
+                <hadoop.version>3.3.6</hadoop.version>
             </properties>
         </profile>
         <profile>
@@ -158,7 +172,7 @@
                 <buildver>322</buildver>
                 <spark.version>${spark322.version}</spark.version>
                 <delta.core.version>${delta20x.version}</delta.core.version>
-                <hadoop.version>3.3.1</hadoop.version>
+                <hadoop.version>3.3.6</hadoop.version>
             </properties>
         </profile>
         <profile>
@@ -173,7 +187,7 @@
                 <buildver>323</buildver>
                 <spark.version>${spark323.version}</spark.version>
                 <delta.core.version>${delta20x.version}</delta.core.version>
-                <hadoop.version>3.3.1</hadoop.version>
+                <hadoop.version>3.3.6</hadoop.version>
             </properties>
         </profile>
         <profile>
@@ -188,7 +202,7 @@
                 <buildver>324</buildver>
                 <spark.version>${spark324.version}</spark.version>
                 <delta.core.version>${delta20x.version}</delta.core.version>
-                <hadoop.version>3.3.1</hadoop.version>
+                <hadoop.version>3.3.6</hadoop.version>
             </properties>
         </profile>
         <profile>
@@ -203,7 +217,7 @@
                 <buildver>325</buildver>
                 <spark.version>${spark325.version}</spark.version>
                 <delta.core.version>${delta20x.version}</delta.core.version>
-                <hadoop.version>3.3.5</hadoop.version>
+                <hadoop.version>3.3.6</hadoop.version>
             </properties>
         </profile>
         <profile>
@@ -218,7 +232,7 @@
                 <buildver>330</buildver>
                 <spark.version>${spark330.version}</spark.version>
                 <delta.core.version>${delta23x.version}</delta.core.version>
-                <hadoop.version>3.3.2</hadoop.version>
+                <hadoop.version>3.3.6</hadoop.version>
             </properties>
         </profile>
         <profile>
@@ -233,7 +247,7 @@
                 <buildver>331</buildver>
                 <spark.version>${spark331.version}</spark.version>
                 <delta.core.version>${delta23x.version}</delta.core.version>
-                <hadoop.version>3.3.2</hadoop.version>
+                <hadoop.version>3.3.6</hadoop.version>
             </properties>
         </profile>
         <profile>
@@ -248,12 +262,13 @@
                 <buildver>332</buildver>
                 <spark.version>${spark332.version}</spark.version>
                 <delta.core.version>${delta23x.version}</delta.core.version>
-                <hadoop.version>3.3.2</hadoop.version>
+                <hadoop.version>3.3.6</hadoop.version>
             </properties>
         </profile>
         <profile>
             <id>release333</id>
             <activation>
+                <activeByDefault>true</activeByDefault>
                 <property>
                     <name>buildver</name>
                     <value>333</value>
@@ -263,7 +278,22 @@
                 <buildver>333</buildver>
                 <spark.version>${spark333.version}</spark.version>
                 <delta.core.version>${delta23x.version}</delta.core.version>
-                <hadoop.version>3.3.4</hadoop.version>
+                <hadoop.version>3.3.6</hadoop.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>release334</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>334</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>334</buildver>
+                <spark.version>${spark334.version}</spark.version>
+                <delta.core.version>${delta23x.version}</delta.core.version>
+                <hadoop.version>3.3.6</hadoop.version>
             </properties>
         </profile>
         <profile>
@@ -278,7 +308,7 @@
                 <buildver>340</buildver>
                 <spark.version>${spark340.version}</spark.version>
                 <delta.core.version>${delta24x.version}</delta.core.version>
-                <hadoop.version>3.3.4</hadoop.version>
+                <hadoop.version>3.3.6</hadoop.version>
             </properties>
         </profile>
         <profile>
@@ -293,7 +323,22 @@
                 <buildver>341</buildver>
                 <spark.version>${spark341.version}</spark.version>
                 <delta.core.version>${delta24x.version}</delta.core.version>
-                <hadoop.version>3.3.4</hadoop.version>
+                <hadoop.version>3.3.6</hadoop.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>release342</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>342</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>342</buildver>
+                <spark.version>${spark342.version}</spark.version>
+                <delta.core.version>${delta24x.version}</delta.core.version>
+                <hadoop.version>3.3.6</hadoop.version>
             </properties>
         </profile>
         <profile>
@@ -308,7 +353,37 @@
                 <buildver>350</buildver>
                 <spark.version>${spark350.version}</spark.version>
                 <delta.core.version>${delta24x.version}</delta.core.version>
-                <hadoop.version>3.3.5</hadoop.version>
+                <hadoop.version>3.3.6</hadoop.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>release351</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>351</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>351</buildver>
+                <spark.version>${spark351.version}</spark.version>
+                <delta.core.version>${delta24x.version}</delta.core.version>
+                <hadoop.version>3.3.6</hadoop.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>release400</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>400</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>400</buildver>
+                <spark.version>${spark400.version}</spark.version>
+                <delta.core.version>${delta24x.version}</delta.core.version>
+                <hadoop.version>3.3.6</hadoop.version>
             </properties>
         </profile>
     </profiles>
@@ -316,6 +391,7 @@
         <spark311.version>3.1.1</spark311.version>
         <spark312.version>3.1.2</spark312.version>
         <spark313.version>3.1.3</spark313.version>
+        <spark314.version>3.1.4-SNAPSHOT</spark314.version>
         <spark320.version>3.2.0</spark320.version>
         <spark321.version>3.2.1</spark321.version>
         <spark322.version>3.2.2</spark322.version>
@@ -325,16 +401,20 @@
         <spark330.version>3.3.0</spark330.version>
         <spark331.version>3.3.1</spark331.version>
         <spark332.version>3.3.2</spark332.version>
-        <spark333.version>3.3.3-SNAPSHOT</spark333.version>
+        <spark333.version>3.3.3</spark333.version>
+        <spark334.version>3.3.4-SNAPSHOT</spark334.version>
         <spark340.version>3.4.0</spark340.version>
         <spark341.version>3.4.1</spark341.version>
+        <spark342.version>3.4.2-SNAPSHOT</spark342.version>
         <spark350.version>3.5.0-SNAPSHOT</spark350.version>
+        <spark351.version>3.5.1-SNAPSHOT</spark351.version>
+        <spark400.version>4.0.0-SNAPSHOT</spark400.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.plugin.version>4.3.0</scala.plugin.version>
         <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>
         <maven.clean.plugin.version>3.2.0</maven.clean.plugin.version>
         <scala.version>2.12.15</scala.version>
-        <spark.test.version>${spark311.version}</spark.test.version>
+        <spark.test.version>${spark333.version}</spark.test.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <scallop.version>3.5.1</scallop.version>
         <scalatest.version>3.0.5</scalatest.version>

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
@@ -3,15 +3,15 @@
       "deployMode": {
         "LOCAL": [
           {
-            "name":  "Apache Spark",
-            "uri": "https://archive.apache.org/dist/spark/spark-3.3.1/spark-3.3.1-bin-hadoop3.tgz",
+            "name": "Apache Spark",
+            "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
             "type": "archive",
             "relativePath": "jars/*",
-            "sha512": "769db39a560a95fd88b58ed3e9e7d1e92fb68ee406689fb4d30c033cb5911e05c1942dcc70e5ec4585df84e80aabbc272b9386a208debda89522efff1335c8ff",
-            "size": 299350810
+            "sha512": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9",
+            "size": 299426263
           },
           {
-            "name":  "Hadoop AWS",
+            "name": "Hadoop AWS",
             "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
             "type": "jar",
             "md5": "59907e790ce713441955015d79f670bc",
@@ -19,7 +19,7 @@
             "size": 962685
           },
           {
-            "name":  "AWS Java SDK Bundled",
+            "name": "AWS Java SDK Bundled",
             "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
             "type": "jar",
             "md5": "8a22f2d30b7e8eee9ea44f04fb13b35a",

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_azure-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_azure-configs.json
@@ -3,15 +3,15 @@
       "deployMode": {
         "LOCAL": [
           {
-            "name":  "Apache Spark",
-            "uri": "https://archive.apache.org/dist/spark/spark-3.3.1/spark-3.3.1-bin-hadoop3.tgz",
+            "name": "Apache Spark",
+            "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
             "type": "archive",
             "relativePath": "jars/*",
-            "sha512": "769db39a560a95fd88b58ed3e9e7d1e92fb68ee406689fb4d30c033cb5911e05c1942dcc70e5ec4585df84e80aabbc272b9386a208debda89522efff1335c8ff",
-            "size": 299350810
+            "sha512": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9",
+            "size": 299426263
           },
           {
-            "name":  "Hadoop Azure",
+            "name": "Hadoop Azure",
             "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/3.3.4/hadoop-azure-3.3.4.jar",
             "type": "jar",
             "md5": "1ec4cbd59548412010fe1515070eef73",

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -4,19 +4,19 @@
       "LOCAL": [
         {
           "name": "Apache Spark",
-          "uri": "https://archive.apache.org/dist/spark/spark-3.3.1/spark-3.3.1-bin-hadoop3.tgz",
+          "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
           "type": "archive",
           "relativePath": "jars/*",
-          "sha512": "769db39a560a95fd88b58ed3e9e7d1e92fb68ee406689fb4d30c033cb5911e05c1942dcc70e5ec4585df84e80aabbc272b9386a208debda89522efff1335c8ff",
-          "size": 299350810
+          "sha512": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9",
+          "size": 299426263
         },
         {
           "name": "GCS Connector Hadoop3",
-          "uri": "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.11/gcs-connector-hadoop3-2.2.11-shaded.jar",
+          "uri": "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.17/gcs-connector-hadoop3-2.2.17-shaded.jar",
           "type": "jar",
-          "md5": "7639d38fff9f88fe80d7e4d9d47fb946",
-          "sha1": "519e60640b7ffdbb00dbed20b852c2a406ddaff9",
-          "size": 36497606
+          "md5": "41aea3add826dfbf3384a2c638148709",
+          "sha1": "06438f562692ff8fae5e8555eba2b9f95cb74f66",
+          "size": 38413466
         }
       ]
     }

--- a/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
@@ -3,15 +3,15 @@
     "deployMode": {
       "LOCAL": [
         {
-          "name":  "Apache Spark",
-          "uri": "https://archive.apache.org/dist/spark/spark-3.3.1/spark-3.3.1-bin-hadoop3.tgz",
+          "name": "Apache Spark",
+          "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
           "type": "archive",
           "relativePath": "jars/*",
-          "sha512": "769db39a560a95fd88b58ed3e9e7d1e92fb68ee406689fb4d30c033cb5911e05c1942dcc70e5ec4585df84e80aabbc272b9386a208debda89522efff1335c8ff",
-          "size": 299350810
+          "sha512": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9",
+          "size": 299426263
         },
         {
-          "name":  "Hadoop AWS",
+          "name": "Hadoop AWS",
           "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
           "type": "jar",
           "md5": "59907e790ce713441955015d79f670bc",
@@ -19,7 +19,7 @@
           "size": 962685
         },
         {
-          "name":  "AWS Java SDK Bundled",
+          "name": "AWS Java SDK Bundled",
           "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
           "type": "jar",
           "md5": "8a22f2d30b7e8eee9ea44f04fb13b35a",

--- a/user_tools/src/spark_rapids_pytools/resources/onprem-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/onprem-configs.json
@@ -4,11 +4,11 @@
       "LOCAL": [
         {
           "name": "Apache Spark",
-          "uri": "https://archive.apache.org/dist/spark/spark-3.3.1/spark-3.3.1-bin-hadoop3.tgz",
+          "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
           "type": "archive",
           "relativePath": "jars/*",
-          "sha512": "769db39a560a95fd88b58ed3e9e7d1e92fb68ee406689fb4d30c033cb5911e05c1942dcc70e5ec4585df84e80aabbc272b9386a208debda89522efff1335c8ff",
-          "size": 299350810
+          "sha512": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9",
+          "size": 299426263
         }
       ]
     }


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #515

- update pom file to use spark-333
- upgrade hadoop client versions
- update snapshots and releases
- update the dependencies in the user-tools
