### PR TITLE
Improve AutoTuner plugin recommendation for Fat mode

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -706,7 +706,14 @@ class AutoTuner(
                       s"  $jarURL\n" +
                       s"  Version used in application is $jarVer.")
                 }
-              case None => logError("Could not pull the latest release of plugin jar.")
+              case None =>
+                logError("Could not pull the latest release of RAPIDS-plugin jar.")
+                val pluginRepoUrl = WebCrawlerUtil.getMVNArtifactURL("rapids.plugin")
+                appendComment(
+                  "Failed to validate the latest release of Apache Spark plugin.\n" +
+                    s"  Verify that the version used in application ($jarVer) is the latest on:\n" +
+                    s"  $pluginRepoUrl")
+
             }
         }
     }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/WebCrawlerUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/WebCrawlerUtil.scala
@@ -41,7 +41,10 @@ object WebCrawlerUtil extends Logging {
   private val ARTIFACT_VERSION_REGEX = "\\d{2}\\.\\d{2}\\.\\d+/"
   // given an artifactID returns the full mvn url that lists all the
   // releases
-  private def getMVNArtifactURL(artifactID: String) : String = s"$NV_MVN_BASE_URL/$artifactID"
+  def getMVNArtifactURL(artifactID: String) : String = {
+    val artifactUrlPart = NV_ARTIFACTS_LOOKUP.getOrElse(artifactID, artifactID)
+    s"$NV_MVN_BASE_URL/$artifactUrlPart"
+  }
 
   /**
    * Given a valid URL, this method recursively picks all the hrefs defined in the HTML doc.
@@ -72,7 +75,7 @@ object WebCrawlerUtil extends Logging {
           }
         } catch {
           case x: IOException =>
-            logError(s"Exception while visiting webURL $webURL", x)
+            logWarning(s"Exception while visiting webURL $webURL: ${x.toString}")
         }
       }
     }


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #536

- when the AutoTuner fails to read the latest plugin version, it shows a warning message
- the autotuner adds a comment instructing the user to validate that the current version is the latest on the mvn URL

**Implementation**

The description in the original bug filing was long-term solution.

- The autoTuner actually works fine but it throws a long stacktrace.
- A simple fix is to:
  - make a warning message instead of the stackTrace
  - Append a comment suggesting that the user should verify the latest plugin release.

Example of new comment:

```
- Failed to validate the latest release of Apache Spark plugin. 
  Verify that the version used in application (22.12.0) is the latest on:
  https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12
```
example of the tsdout of the core:

```
Profile Tool Progress 100% [====================================================] (73 succeeded + 0 failed + 0 N/A) / 73
23/09/06 15:19:07 WARN WebCrawlerUtil: Exception while visiting webURL https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12: java.net.UnknownHostException: repo1.maven.org
23/09/06 15:19:07 ERROR AutoTuner: Could not pull the latest release of RAPIDS-plugin jar.
```

