### PR TITLE
Add `translate` as supported expression in qualification tools

### DIFF
--- a/core/src/main/resources/operatorsScore-databricks-aws.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws.csv
@@ -217,6 +217,7 @@ StringRepeat,2.45
 StringReplace,2.45
 StringSplit,2.45
 StringToMap,2.45
+StringTranslate,2.45
 StringTrim,2.45
 StringTrimLeft,2.45
 StringTrimRight,2.45

--- a/core/src/main/resources/operatorsScore-databricks-azure.csv
+++ b/core/src/main/resources/operatorsScore-databricks-azure.csv
@@ -217,6 +217,7 @@ StringRepeat,2.73
 StringReplace,2.73
 StringSplit,2.73
 StringToMap,2.73
+StringTranslate,2.73
 StringTrim,2.73
 StringTrimLeft,2.73
 StringTrimRight,2.73

--- a/core/src/main/resources/operatorsScore-dataproc-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-l4.csv
@@ -217,6 +217,7 @@ StringRepeat,4.16
 StringReplace,4.16
 StringSplit,4.16
 StringToMap,4.16
+StringTranslate,4.16
 StringTrim,4.16
 StringTrimLeft,4.16
 StringTrimRight,4.16

--- a/core/src/main/resources/operatorsScore-dataproc-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-t4.csv
@@ -217,6 +217,7 @@ StringRepeat,4.88
 StringReplace,4.88
 StringSplit,4.88
 StringToMap,4.88
+StringTranslate,4.88
 StringTrim,4.88
 StringTrimLeft,4.88
 StringTrimRight,4.88

--- a/core/src/main/resources/operatorsScore-emr-a10.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10.csv
@@ -217,6 +217,7 @@ StringRepeat,2.59
 StringReplace,2.59
 StringSplit,2.59
 StringToMap,2.59
+StringTranslate,2.59
 StringTrim,2.59
 StringTrimLeft,2.59
 StringTrimRight,2.59

--- a/core/src/main/resources/operatorsScore-emr-t4.csv
+++ b/core/src/main/resources/operatorsScore-emr-t4.csv
@@ -217,6 +217,7 @@ StringRepeat,2.07
 StringReplace,2.07
 StringSplit,2.07
 StringToMap,2.07
+StringTranslate,2.07
 StringTrim,2.07
 StringTrimLeft,2.07
 StringTrimRight,2.07

--- a/core/src/main/resources/operatorsScore.csv
+++ b/core/src/main/resources/operatorsScore.csv
@@ -222,6 +222,7 @@ StringRepeat,4
 StringReplace,4
 StringSplit,4
 StringToMap,4
+StringTranslate,4
 StringTrim,4
 StringTrimLeft,4
 StringTrimRight,4

--- a/core/src/main/resources/supportedExprs.csv
+++ b/core/src/main/resources/supportedExprs.csv
@@ -501,6 +501,10 @@ StringToMap,S,`str_to_map`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,N
 StringToMap,S,`str_to_map`,None,project,pairDelim,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA
 StringToMap,S,`str_to_map`,None,project,keyValueDelim,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA
 StringToMap,S,`str_to_map`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA
+StringTranslate,S,`translate`,This is not 100% compatible with the Spark version because the GPU implementation supports all unicode code points. In Spark versions < 3.2.0; translate() does not support unicode characters with code point >= U+10000 (See SPARK-34094),project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA
+StringTranslate,S,`translate`,This is not 100% compatible with the Spark version because the GPU implementation supports all unicode code points. In Spark versions < 3.2.0; translate() does not support unicode characters with code point >= U+10000 (See SPARK-34094),project,from,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA,NA,NA,NA
+StringTranslate,S,`translate`,This is not 100% compatible with the Spark version because the GPU implementation supports all unicode code points. In Spark versions < 3.2.0; translate() does not support unicode characters with code point >= U+10000 (See SPARK-34094),project,to,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA,NA,NA,NA
+StringTranslate,S,`translate`,This is not 100% compatible with the Spark version because the GPU implementation supports all unicode code points. In Spark versions < 3.2.0; translate() does not support unicode characters with code point >= U+10000 (See SPARK-34094),project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA
 StringTrim,S,`trim`,None,project,src,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA
 StringTrim,S,`trim`,None,project,trimStr,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA,NA,NA,NA
 StringTrim,S,`trim`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -922,7 +922,6 @@ class SQLPlanParserSuite extends BaseTestSuite {
         val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
           "ProjectExprsSupported") { spark =>
           import spark.implicits._
-          import org.apache.spark.sql.types.StringType
           val df1 = Seq("", "abc", "ABC", "AaBbCc").toDF("value")
           // write df1 to parquet to transform LocalTableScan to ProjectExec
           df1.write.parquet(s"$parquetoutputLoc/testtext")

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -866,9 +866,11 @@ class SQLPlanParserSuite extends BaseTestSuite {
           import spark.implicits._
           val df1 = Seq((9.9, "ABC"), (10.2, "abc"), (11.6, ""), (12.5, "AaBbCc"))
                       .toDF("num", "str")
+          // write df1 to parquet to transform LocalTableScan to ProjectExec
           df1.write.parquet(s"$parquetoutputLoc/testtext")
           val df2 = spark.read.parquet(s"$parquetoutputLoc/testtext")
           df2.select(df2("num").cast(StringType), ceil(df2("num")), df2("num"))
+          // translate should be part of ProjectExec
           df2.select(translate(df2("str"), "ABC", "123"))
         }
         val pluginTypeChecker = new PluginTypeChecker()

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -30,7 +30,7 @@ import org.scalatest.exceptions.TestFailedException
 
 import org.apache.spark.sql.TrampolineUtil
 import org.apache.spark.sql.expressions.Window
-import org.apache.spark.sql.functions.{ceil, col, collect_list, count, explode, floor, hex, json_tuple, round, row_number, sum}
+import org.apache.spark.sql.functions.{ceil, col, collect_list, count, explode, floor, hex, json_tuple, round, row_number, sum, translate}
 import org.apache.spark.sql.rapids.tool.ToolUtils
 import org.apache.spark.sql.rapids.tool.qualification.QualificationAppInfo
 import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
@@ -864,10 +864,12 @@ class SQLPlanParserSuite extends BaseTestSuite {
         val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
           "ProjectExprsSupported") { spark =>
           import spark.implicits._
-          val df1 = Seq(9.9, 10.2, 11.6, 12.5).toDF("value")
+          val df1 = Seq((9.9, "ABC"), (10.2, "abc"), (11.6, ""), (12.5, "AaBbCc"))
+                      .toDF("num", "str")
           df1.write.parquet(s"$parquetoutputLoc/testtext")
           val df2 = spark.read.parquet(s"$parquetoutputLoc/testtext")
-          df2.select(df2("value").cast(StringType), ceil(df2("value")), df2("value"))
+          df2.select(df2("num").cast(StringType), ceil(df2("num")), df2("num"))
+          df2.select(translate(df2("str"), "ABC", "123"))
         }
         val pluginTypeChecker = new PluginTypeChecker()
         val app = createAppFromEventlog(eventLog)


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/499

`translate` function is supported in plug-in. We updated `supportedExprs.csv` and `operatorsScore.csv` to treat it as supported in the tools, and added unit tests to verify that.