### PR TITLE
Adding TakeOrderedAndProject and BroadcastNestedLoopJoin, removing Project from speedup generation

### DIFF
--- a/user_tools/custom_speedup_factors/generate_speedup_factors.py
+++ b/user_tools/custom_speedup_factors/generate_speedup_factors.py
@@ -155,8 +155,6 @@ if 'Scan orc ' in cpu_stage_totals and 'GpuScan orc ' in gpu_stage_totals:
     scores_dict["FileSourceScanExec"] = str(round(cpu_stage_totals['Scan orc '] / gpu_stage_totals['GpuScan orc '], 2))
 
 # Other operators
-if 'Project' in cpu_stage_totals and 'GpuProject' in gpu_stage_totals:
-    scores_dict["ProjectExec"] = str(round(cpu_stage_totals['Project'] / gpu_stage_totals['GpuProject'], 2))
 if 'Expand' in cpu_stage_totals and 'GpuExpand' in gpu_stage_totals:
     scores_dict["ExpandExec"] = str(round(cpu_stage_totals['Expand'] / gpu_stage_totals['GpuExpand'], 2))
 if 'CartesianProduct' in cpu_stage_totals and 'GpuCartesianProduct' in gpu_stage_totals:
@@ -173,6 +171,10 @@ if 'HashAggregate' in cpu_stage_totals and 'GpuHashAggregate' in gpu_stage_total
     scores_dict["HashAggregateExec"] = str(round(cpu_stage_totals['HashAggregate'] / gpu_stage_totals['GpuHashAggregate'], 2))
     scores_dict["ObjectHashAggregateExec"] = str(round(cpu_stage_totals['HashAggregate'] / gpu_stage_totals['GpuHashAggregate'], 2))
     scores_dict["SortAggregateExec"] = str(round(cpu_stage_totals['HashAggregate'] / gpu_stage_totals['GpuHashAggregate'], 2))
+if 'TakeOrderedAndProject' in cpu_stage_totals and 'GpuTopN' in gpu_stage_totals:
+    scores_dict["TakeOrderedAndProjectExec"] = str(round(cpu_stage_totals['TakeOrderedAndProject'] / gpu_stage_totals['GpuTopN'], 2))
+if 'BroadcastNestedLoopJoin' in cpu_stage_totals and 'GpuBroadcastNestedLoopJoin' in gpu_stage_totals:
+    scores_dict["BroadcastNestedLoopJoinExec"] = str(round(cpu_stage_totals['BroadcastNestedLoopJoin'] / gpu_stage_totals['GpuBroadcastNestedLoopJoin'], 2))
 
 # Set minimum to 1.0 for speedup factors
 for key in scores_dict:

--- a/user_tools/custom_speedup_factors/operatorsList.csv
+++ b/user_tools/custom_speedup_factors/operatorsList.csv
@@ -11,7 +11,6 @@ ProjectExec
 RangeExec
 SampleExec
 SortExec
-SubqueryBroadcastExec
 TakeOrderedAndProjectExec
 HashAggregateExec
 ObjectHashAggregateExec
@@ -19,7 +18,6 @@ SortAggregateExec
 DataWritingCommandExec
 ExecutedCommandExec
 BatchScanExec
-BroadcastExchangeExec
 ShuffleExchangeExec
 BroadcastHashJoinExec
 BroadcastNestedLoopJoinExec


### PR DESCRIPTION
Closes #480 

Changes in this PR
- removed ProjectExec from speedup ratio calculation to leave as environment default due to issues with logic found in validation
- added in BroadcastNestedLoopJoin and TakeOrderedAndProject execs with logic
- removed SubqueryBroadcastExec and BroadcastExchangeExec from operator list to default to 1.0 given expected speedup to be minimal

Validated on customer event logs and Dataproc SF3K event logs and improved accuracy overall.  Dataproc went from ~23% error to ~18% error.
