### PR TITLE
[FEA] Add support to TIMESTAMP functions

### DIFF
--- a/core/src/main/resources/operatorsScore-databricks-aws.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws.csv
@@ -155,6 +155,8 @@ MapKeys,2.45
 MapValues,2.45
 Max,2.45
 Md5,2.45
+MicrosToTimestamp,2.45
+MillisToTimestamp,2.45
 Min,2.45
 Minute,2.45
 MonotonicallyIncreasingID,2.45
@@ -193,6 +195,7 @@ RowNumber,2.45
 ScalaUDF,2.45
 ScalarSubquery,2.45
 Second,2.45
+SecondsToTimestamp,2.45
 Sequence,2.45
 ShiftLeft,2.45
 ShiftRight,2.45

--- a/core/src/main/resources/operatorsScore-databricks-azure.csv
+++ b/core/src/main/resources/operatorsScore-databricks-azure.csv
@@ -155,6 +155,8 @@ MapKeys,2.73
 MapValues,2.73
 Max,2.73
 Md5,2.73
+MicrosToTimestamp,2.73
+MillisToTimestamp,2.73
 Min,2.73
 Minute,2.73
 MonotonicallyIncreasingID,2.73
@@ -193,6 +195,7 @@ RowNumber,2.73
 ScalaUDF,2.73
 ScalarSubquery,2.73
 Second,2.73
+SecondsToTimestamp,2.73
 Sequence,2.73
 ShiftLeft,2.73
 ShiftRight,2.73

--- a/core/src/main/resources/operatorsScore-dataproc-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-l4.csv
@@ -155,6 +155,8 @@ MapKeys,4.16
 MapValues,4.16
 Max,4.16
 Md5,4.16
+MicrosToTimestamp,4.16
+MillisToTimestamp,4.16
 Min,4.16
 Minute,4.16
 MonotonicallyIncreasingID,4.16
@@ -193,6 +195,7 @@ RowNumber,4.16
 ScalaUDF,4.16
 ScalarSubquery,4.16
 Second,4.16
+SecondsToTimestamp,4.16
 Sequence,4.16
 ShiftLeft,4.16
 ShiftRight,4.16

--- a/core/src/main/resources/operatorsScore-dataproc-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-t4.csv
@@ -155,6 +155,8 @@ MapKeys,4.88
 MapValues,4.88
 Max,4.88
 Md5,4.88
+MicrosToTimestamp,4.88
+MillisToTimestamp,4.88
 Min,4.88
 Minute,4.88
 MonotonicallyIncreasingID,4.88
@@ -193,6 +195,7 @@ RowNumber,4.88
 ScalaUDF,4.88
 ScalarSubquery,4.88
 Second,4.88
+SecondsToTimestamp,4.88
 Sequence,4.88
 ShiftLeft,4.88
 ShiftRight,4.88

--- a/core/src/main/resources/operatorsScore-emr-a10.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10.csv
@@ -155,6 +155,8 @@ MapKeys,2.59
 MapValues,2.59
 Max,2.59
 Md5,2.59
+MicrosToTimestamp,2.59
+MillisToTimestamp,2.59
 Min,2.59
 Minute,2.59
 MonotonicallyIncreasingID,2.59
@@ -193,6 +195,7 @@ RowNumber,2.59
 ScalaUDF,2.59
 ScalarSubquery,2.59
 Second,2.59
+SecondsToTimestamp,2.59
 Sequence,2.59
 ShiftLeft,2.59
 ShiftRight,2.59

--- a/core/src/main/resources/operatorsScore-emr-t4.csv
+++ b/core/src/main/resources/operatorsScore-emr-t4.csv
@@ -155,6 +155,8 @@ MapKeys,2.07
 MapValues,2.07
 Max,2.07
 Md5,2.07
+MicrosToTimestamp,2.07
+MillisToTimestamp,2.07
 Min,2.07
 Minute,2.07
 MonotonicallyIncreasingID,2.07
@@ -193,6 +195,7 @@ RowNumber,2.07
 ScalaUDF,2.07
 ScalarSubquery,2.07
 Second,2.07
+SecondsToTimestamp,2.07
 Sequence,2.07
 ShiftLeft,2.07
 ShiftRight,2.07

--- a/core/src/main/resources/operatorsScore.csv
+++ b/core/src/main/resources/operatorsScore.csv
@@ -160,6 +160,8 @@ MapKeys,4
 MapValues,4
 Max,4
 Md5,4
+MicrosToTimestamp,4
+MillisToTimestamp,4
 Min,4
 Minute,4
 MonotonicallyIncreasingID,4
@@ -198,6 +200,7 @@ RowNumber,4
 ScalaUDF,4
 ScalarSubquery,4
 Second,4
+SecondsToTimestamp,4
 Sequence,4
 ShiftLeft,4
 ShiftRight,4

--- a/core/src/main/resources/supportedExprs.csv
+++ b/core/src/main/resources/supportedExprs.csv
@@ -330,6 +330,10 @@ MapValues,S,`map_values`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 MapValues,S,`map_values`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA
 Md5,S,`md5`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA
 Md5,S,`md5`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA
+MicrosToTimestamp,S,`timestamp_micros`,None,project,input,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+MicrosToTimestamp,S,`timestamp_micros`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA,NA,NA,NA,NA
+MillisToTimestamp,S,`timestamp_millis`,None,project,input,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+MillisToTimestamp,S,`timestamp_millis`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Minute,S,`minute`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Minute,S,`minute`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 MonotonicallyIncreasingID,S,`monotonically_increasing_id`,None,project,result,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
@@ -430,6 +434,8 @@ ScalaUDF,S, ,None,project,param,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,NS
 ScalaUDF,S, ,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,NS
 Second,S,`second`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Second,S,`second`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+SecondsToTimestamp,S,`timestamp_seconds`,None,project,input,NA,S,S,S,S,S,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA
+SecondsToTimestamp,S,`timestamp_seconds`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Sequence,S,`sequence`,None,project,start,NA,S,S,S,S,NA,NA,NS,NS,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Sequence,S,`sequence`,None,project,stop,NA,S,S,S,S,NA,NA,NS,NS,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Sequence,S,`sequence`,None,project,step,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NS,NA,NA,NA,NA

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ProjectExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ProjectExecParser.scala
@@ -32,7 +32,11 @@ case class ProjectExecParser(
     val duration = None
     val exprString = node.desc.replaceFirst("Project ", "")
     val expressions = SQLPlanParser.parseProjectExpressions(exprString)
+    System.err.println("expressions =")
+    expressions.map(e => System.err.println(e))
     val notSupportedExprs = expressions.filterNot(expr => checker.isExprSupported(expr))
+    System.err.println("unsupported expressions =")
+    notSupportedExprs.map(e => System.err.println(e))
     val (speedupFactor, isSupported) = if (checker.isExecSupported(fullExecName) &&
         notSupportedExprs.isEmpty) {
       (checker.getSpeedupFactor(fullExecName), true)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ProjectExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ProjectExecParser.scala
@@ -32,11 +32,7 @@ case class ProjectExecParser(
     val duration = None
     val exprString = node.desc.replaceFirst("Project ", "")
     val expressions = SQLPlanParser.parseProjectExpressions(exprString)
-    System.err.println("expressions =")
-    expressions.map(e => System.err.println(e))
     val notSupportedExprs = expressions.filterNot(expr => checker.isExprSupported(expr))
-    System.err.println("unsupported expressions =")
-    notSupportedExprs.map(e => System.err.println(e))
     val (speedupFactor, isSupported) = if (checker.isExecSupported(fullExecName) &&
         notSupportedExprs.isEmpty) {
       (checker.getSpeedupFactor(fullExecName), true)

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -922,12 +922,12 @@ class SQLPlanParserSuite extends BaseTestSuite {
         val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
           "ProjectExprsSupported") { spark =>
           import spark.implicits._
-          val df1 = Seq((1230219000123123L, 1230219000123L, 1230219000)).toDF("micro", "millis", "seconds")
+          val init_df = Seq((1230219000123123L, 1230219000123L, 1230219000.123))
+          val df1 = init_df.toDF("micro", "millis", "seconds")
           df1.write.parquet(s"$parquetoutputLoc/testtext")
           val df2 = spark.read.parquet(s"$parquetoutputLoc/testtext")
-          df2.selectExpr("timestamp_micros(micro)")
-          df2.selectExpr("timestamp_millis(millis)")
-          df2.selectExpr("timestamp_seconds(seconds)")
+          df2.selectExpr("timestamp_micros(micro)", "timestamp_millis(millis)",
+                         "timestamp_seconds(seconds)")
         }
         val pluginTypeChecker = new PluginTypeChecker()
         val app = createAppFromEventlog(eventLog)

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -857,34 +857,6 @@ class SQLPlanParserSuite extends BaseTestSuite {
     }
   }
 
-  // test("Expressions supported in ProjectExec") {
-  //   TrampolineUtil.withTempDir { parquetoutputLoc =>
-  //     TrampolineUtil.withTempDir { eventLogDir =>
-  //       val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
-  //         "ProjectExprsSupported") { spark =>
-  //         import spark.implicits._
-  //         val df1 = Seq(9.9, 10.2, 11.6, 12.5).toDF("value")
-  //         df1.write.parquet(s"$parquetoutputLoc/testtext")
-  //         val df2 = spark.read.parquet(s"$parquetoutputLoc/testtext")
-  //         df2.select(df2("value").cast(StringType), ceil(df2("value")), df2("value"))
-  //       }
-  //       val pluginTypeChecker = new PluginTypeChecker()
-  //       val app = createAppFromEventlog(eventLog)
-  //       assert(app.sqlPlans.size == 2)
-  //       val parsedPlans = app.sqlPlans.map { case (sqlID, plan) =>
-  //         SQLPlanParser.parseSQLPlan(app.appId, plan, sqlID, "", pluginTypeChecker, app)
-  //       }
-  //       val allExecInfo = getAllExecsFromPlan(parsedPlans.toSeq)
-  //       val wholeStages = allExecInfo.filter(_.exec.contains("WholeStageCodegen"))
-  //       assert(wholeStages.size == 1)
-  //       assert(wholeStages.forall(_.duration.nonEmpty))
-  //       val allChildren = wholeStages.flatMap(_.children).flatten
-  //       val projects = allChildren.filter(_.exec == "Project")
-  //       assertSizeAndSupported(1, projects)
-  //     }
-  //   }
-  // }
-
   test("Expressions supported in ProjectExec") {
     TrampolineUtil.withTempDir { parquetoutputLoc =>
       TrampolineUtil.withTempDir { eventLogDir =>
@@ -896,14 +868,10 @@ class SQLPlanParserSuite extends BaseTestSuite {
           df1.write.parquet(s"$parquetoutputLoc/testtext")
           val df2 = spark.read.parquet(s"$parquetoutputLoc/testtext")
           df2.select(df2("value").cast(StringType), ceil(df2("value")), df2("value"))
-          val df3 = Seq((1230219000123123L, 1230219000123L, 1230219000)).toDF("micro", "milli", "sec")
-          df3.write.parquet(s"$parquetoutputLoc/testtext1")
-          val df4 = spark.read.parquet(s"$parquetoutputLoc/testtext1")
-          df4.selectExpr("timestamp_micros(micro)")
         }
         val pluginTypeChecker = new PluginTypeChecker()
         val app = createAppFromEventlog(eventLog)
-        assert(app.sqlPlans.size == 3)
+        assert(app.sqlPlans.size == 2)
         val parsedPlans = app.sqlPlans.map { case (sqlID, plan) =>
           SQLPlanParser.parseSQLPlan(app.appId, plan, sqlID, "", pluginTypeChecker, app)
         }
@@ -944,6 +912,36 @@ class SQLPlanParserSuite extends BaseTestSuite {
         val allChildren = wholeStages.flatMap(_.children).flatten
         val projects = allChildren.filter(_.exec == "Project")
         assertSizeAndNotSupported(1, projects)
+      }
+    }
+  }
+
+  test("Timestamp functions supported in ProjectExec") {
+    TrampolineUtil.withTempDir { parquetoutputLoc =>
+      TrampolineUtil.withTempDir { eventLogDir =>
+        val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
+          "ProjectExprsSupported") { spark =>
+          import spark.implicits._
+          val df1 = Seq((1230219000123123L, 1230219000123L, 1230219000)).toDF("micro", "millis", "seconds")
+          df1.write.parquet(s"$parquetoutputLoc/testtext")
+          val df2 = spark.read.parquet(s"$parquetoutputLoc/testtext")
+          df2.selectExpr("timestamp_micros(micro)")
+          df2.selectExpr("timestamp_millis(millis)")
+          df2.selectExpr("timestamp_seconds(seconds)")
+        }
+        val pluginTypeChecker = new PluginTypeChecker()
+        val app = createAppFromEventlog(eventLog)
+        assert(app.sqlPlans.size == 2)
+        val parsedPlans = app.sqlPlans.map { case (sqlID, plan) =>
+          SQLPlanParser.parseSQLPlan(app.appId, plan, sqlID, "", pluginTypeChecker, app)
+        }
+        val allExecInfo = getAllExecsFromPlan(parsedPlans.toSeq)
+        val wholeStages = allExecInfo.filter(_.exec.contains("WholeStageCodegen"))
+        assert(wholeStages.size == 1)
+        assert(wholeStages.forall(_.duration.nonEmpty))
+        val allChildren = wholeStages.flatMap(_.children).flatten
+        val projects = allChildren.filter(_.exec == "Project")
+        assertSizeAndSupported(1, projects)
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/415

Plugin adds GPU support for `timestamp_micros`, `timestamp_millis`, and `timestamp_seconds`.

We updated speedup factor files for these functions in tools, and added unit tests to verify that.