### PR TITLE
Fix handling of current_databse and ArrayBuffer

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -80,7 +80,7 @@ object SQLPlanParser extends Logging {
     "list",
     // current_database does not cause any CPU fallbacks
     "current_database",
-    // ArrayBuffer is a Scala and may appear in some of the JavaRDDs/UDAFs)
+    // ArrayBuffer is a Scala function and may appear in some of the JavaRDDs/UDAFs)
     "arraybuffer")
 
   /**

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -76,7 +76,12 @@ object SQLPlanParser extends Logging {
 
   val windowFunctionPattern = """(\w+)\(""".r
 
-  val ignoreExpressions = Array("any", "cast", "decimal", "decimaltype", "every", "some", "list")
+  val ignoreExpressions = Array("any", "cast", "decimal", "decimaltype", "every", "some",
+    "list",
+    // current_database does not cause any CPU fallbacks
+    "current_database",
+    // ArrayBuffer is a Scala and may appear in some of the JavaRDDs/UDAFs)
+    "arraybuffer")
 
   /**
    * This function is used to create a set of nodes that should be skipped while parsing the Execs

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -1103,4 +1103,68 @@ class SQLPlanParserSuite extends BaseTestSuite {
     }
   }
 
+  test("current_database is not listed as unsupported: issue-547") {
+    // current_database is a scalar value that does not cause any CPU fallbacks
+    // we should not list it as unsupported expression if it appears in the SQL.
+    TrampolineUtil.withTempDir { parquetoutputLoc =>
+      TrampolineUtil.withTempDir { eventLogDir =>
+        val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
+          "ignoreCurrentDatabase") { spark =>
+          import spark.implicits._
+          val df1 = spark.sparkContext.parallelize(List(10, 20, 30, 40)).toDF
+          df1.write.parquet(s"$parquetoutputLoc/ignore_current_database")
+          val df2 = spark.read.parquet(s"$parquetoutputLoc/ignore_current_database")
+          // Note that the current_database will show up in project only it it is used as a column
+          // name. For example:
+          // > SELECT current_database(), current_database() as my_db;
+          //   +------------------+-------+
+          //   |current_database()|  my_db|
+          //   +------------------+-------+
+          //   |           default|default|
+          //   |           default|default|
+          //   |           default|default|
+          //   |           default|default|
+          //   +------------------+-------+
+          //   == Physical Plan ==
+          //   *(1) Project [default AS current_database()#10, default AS my_db#9]
+          //   +- *(1) ColumnarToRow
+          //      +- FileScan parquet [] Batched: true, DataFilters: [], Format: Parquet, Location:
+          //         InMemoryFileIndex(1 paths)[file:/tmp_folder/T/toolTest..., PartitionFilters: []
+          //         PushedFilters: [], ReadSchema: struct<>
+          df2.selectExpr("current_database()","current_database() as my_db")
+        }
+        val pluginTypeChecker = new PluginTypeChecker()
+        val app = createAppFromEventlog(eventLog)
+        val parsedPlans = app.sqlPlans.map { case (sqlID, plan) =>
+          SQLPlanParser.parseSQLPlan(app.appId, plan, sqlID, "", pluginTypeChecker, app)
+        }
+        // The current_database should be part of the project exec and it is to be ignored.
+        val allExecInfo = getAllExecsFromPlan(parsedPlans.toSeq)
+        val projExecs = allExecInfo.filter(_.exec.contains("Project"))
+        assertSizeAndSupported(1, projExecs)
+      }
+    }
+  }
+
+  test("ArrayBuffer should be ignored in Expand: issue-554") {
+    // ArrayBuffer appears in some SQL queries.
+    // It is a non-Spark expression and it should not be considered as SQL-Function
+    val exprString = "[" +
+      "ArrayBuffer(cast((cast(ds#1241L as double) / 100.0) as bigint), null, null, 0," +
+      "            cast(if ((ret_type#1236 = 2)) 1 else 0 as bigint))," +
+      "ArrayBuffer(cast((cast(ds#1241L as double) / 100.0) as bigint), wuid#1234, null, 1, null)," +
+      "ArrayBuffer(cast((cast(ds#1241L as double) / 100.0) as bigint), null," +
+      "            if ((if ((ret_type#1236 = 2)) 1 else 0 = 1)) wuid#1234 else null, 2, null)," +
+      "[" +
+      "CAST((CAST(supersql_t12.`ds` AS DOUBLE) / 100.0D) AS BIGINT)#1297L," +
+      "supersql_t12.`wuid`#1298," +
+      "(IF(((IF((supersql_t12.`ret_type` = 2), 1, 0)) = 1), supersql_t12.`wuid`," +
+      "CAST(NULL AS STRING)))#1299," +
+      "gid#1296," +
+      "CAST((IF((supersql_t12.`ret_type` = 2), 1, 0)) AS BIGINT)#1300L]]"
+    // Only "IF" should be picked up as a function name
+    val expected = Array("IF")
+    val expressions = SQLPlanParser.parseExpandExpressions(exprString)
+    expressions should ===(expected)
+  }
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -1114,7 +1114,7 @@ class SQLPlanParserSuite extends BaseTestSuite {
           val df1 = spark.sparkContext.parallelize(List(10, 20, 30, 40)).toDF
           df1.write.parquet(s"$parquetoutputLoc/ignore_current_database")
           val df2 = spark.read.parquet(s"$parquetoutputLoc/ignore_current_database")
-          // Note that the current_database will show up in project only it it is used as a column
+          // Note that the current_database will show up in project only if it is used as a column
           // name. For example:
           // > SELECT current_database(), current_database() as my_db;
           //   +------------------+-------+
@@ -1138,7 +1138,7 @@ class SQLPlanParserSuite extends BaseTestSuite {
         val parsedPlans = app.sqlPlans.map { case (sqlID, plan) =>
           SQLPlanParser.parseSQLPlan(app.appId, plan, sqlID, "", pluginTypeChecker, app)
         }
-        // The current_database should be part of the project exec and it is to be ignored.
+        // The current_database should be part of the project-exec and the parser should ignore it.
         val allExecInfo = getAllExecsFromPlan(parsedPlans.toSeq)
         val projExecs = allExecInfo.filter(_.exec.contains("Project"))
         assertSizeAndSupported(1, projExecs)


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #547, Fixes #554

- current_database() is a scala value that does not cause any fallback to CPU. It should be added to the ignored-lists
- ArrayBuffer is not Spark sql function. Add it to to the ignored list
- Create 2 new unit tests
