### PR TITLE
Remove memoryOverhead recommendations for Standalone Spark

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -546,6 +546,7 @@ class AutoTuner(
 
   /**
    * Flow:
+   *   if "spark.master" is standalone => Do Nothing
    *   if "spark.rapids.memory.pinnedPool.size" is set
    *     if yarn -> recommend "spark.executor.memoryOverhead"
    *     if using k8s ->
@@ -553,13 +554,15 @@ class AutoTuner(
    *         else recommend "spark.kubernetes.memoryOverheadFactor" and add comment if missing
    */
   def addRecommendationForMemoryOverhead(recomValue: String): Unit = {
-    val memOverheadLookup = memoryOverheadLabel
-    appendRecommendationForMemoryMB(memOverheadLookup, recomValue)
-    getPropertyValue("spark.rapids.memory.pinnedPool.size").foreach { lookup =>
-      if (lookup != "spark.executor.memoryOverhead") {
-        if (getPropertyValue(memOverheadLookup).isEmpty) {
-          appendComment(s"'$memOverheadLookup' must be set if using " +
-            s"'spark.rapids.memory.pinnedPool.size")
+    if (enableMemoryOverheadRecommendation(getPropertyValue("spark.master"))) {
+      val memOverheadLookup = memoryOverheadLabel
+      appendRecommendationForMemoryMB(memOverheadLookup, recomValue)
+      getPropertyValue("spark.rapids.memory.pinnedPool.size").foreach { lookup =>
+        if (lookup != "spark.executor.memoryOverhead") {
+          if (getPropertyValue(memOverheadLookup).isEmpty) {
+            appendComment(s"'$memOverheadLookup' must be set if using " +
+              s"'spark.rapids.memory.pinnedPool.size")
+          }
         }
       }
     }
@@ -1136,6 +1139,25 @@ object AutoTuner extends Logging {
       f"${sizeNum.toLong}$sizeUnit"
     } else {
       f"$sizeNum%.2f$sizeUnit"
+    }
+  }
+
+  /**
+   * Given the spark property "spark.master", it checks whether memoryOverhead should be
+   * enabled/disabled. For Spark Standalone Mode, memoryOverhead property is skipped.
+   * @param confValue the value of property "spark.master"
+   * @return False if the value is a spark standalone. True if the value is not defined or
+   *         set for yarn/Mesos
+   */
+  def enableMemoryOverheadRecommendation(confValue: Option[String]): Boolean = {
+    confValue match {
+      case Some(sparkMaster) =>
+        if (sparkMaster.startsWith("spark:")) {
+          false
+        } else {
+          true
+        }
+      case _ => true
     }
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -1151,12 +1151,7 @@ object AutoTuner extends Logging {
    */
   def enableMemoryOverheadRecommendation(confValue: Option[String]): Boolean = {
     confValue match {
-      case Some(sparkMaster) =>
-        if (sparkMaster.startsWith("spark:")) {
-          false
-        } else {
-          true
-        }
+      case Some(sparkMaster) if sparkMaster.startsWith("spark:") => false
       case _ => true
     }
   }


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #553

- Add functionality to disable memoryOverhead when spark is standalone
- Add unit-test with standalone enabled

