### PR TITLE
[FEA] Add user qualification tool options for specifying pricing discounts for CPU or GPU cluster, or both

### DIFF
--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "azure-storage-blob==12.17.0",
     "adlfs==2023.4.0"
 ]
-dynamic=["entry-points", "version"]
+dynamic=["version"]
 
 [project.scripts]
 spark_rapids_user_tools = "spark_rapids_pytools.wrapper:main"

--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "azure-storage-blob==12.17.0",
     "adlfs==2023.4.0"
 ]
-dynamic=["version"]
+dynamic=["entry-points", "version"]
 
 [project.scripts]
 spark_rapids_user_tools = "spark_rapids_pytools.wrapper:main"

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -295,18 +295,18 @@ class Qualification(RapidsJarTool):
         raw_cpu_discount = self.wrapper_options.get('cpuDiscount')
         raw_gpu_discount = self.wrapper_options.get('gpuDiscount')
         raw_global_discount = self.wrapper_options.get('globalDiscount')
-        if raw_global_discount != None and (raw_cpu_discount != None or raw_gpu_discount != None):
+        if raw_global_discount is not None and (raw_cpu_discount is not None or raw_gpu_discount is not None):
             self.logger.error('Setting both global_discount and either cpu_discount or '
                               'gpu_discount is inconsistent.')
             raise RuntimeError('Invalid arguments. If global_discount is specified, no additional '
                                'discount arguments (cpu_discount or gpu_discount) should be set.')
         try:
-            cpu_discount = int(raw_cpu_discount) if raw_cpu_discount != None else 0
-            gpu_discount = int(raw_gpu_discount) if raw_gpu_discount != None else 0
-            global_discount = int(raw_global_discount) if raw_global_discount != None else 0
+            cpu_discount = int(raw_cpu_discount) if raw_cpu_discount is not None else 0
+            gpu_discount = int(raw_gpu_discount) if raw_gpu_discount is not None else 0
+            global_discount = int(raw_global_discount) if raw_global_discount is not None else 0
         except Exception as ex:
             self.logger.error('Discount arguments have incorrect type.')
-            raise RuntimeError('Invalid arguments. Discount arguments cannot be converted to integer.')
+            raise RuntimeError('Invalid arguments. Discount arguments cannot be converted to integer.') from ex
 
         if cpu_discount < 0 or cpu_discount > 100:
             self.logger.error('cpu_discount is out of range [0, 100]')

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -292,6 +292,12 @@ class Qualification(RapidsJarTool):
         self.ctxt.set_ctxt('filterApps', selected_filter)
 
     def _process_price_discount_args(self):
+        def check_discount_percentage(discount_type: str, discount_value: int):
+            if discount_value < 0 or discount_value > 100:
+                self.logger.error('%s is out of range [0, 100]', discount_type)
+                raise RuntimeError(f'Invalid arguments. {discount_type} = {discount_value} is an invalid '
+                                   'percentage.')
+
         raw_cpu_discount = self.wrapper_options.get('cpuDiscount')
         raw_gpu_discount = self.wrapper_options.get('gpuDiscount')
         raw_global_discount = self.wrapper_options.get('globalDiscount')
@@ -308,18 +314,9 @@ class Qualification(RapidsJarTool):
             self.logger.error('Discount arguments have incorrect type.')
             raise RuntimeError('Invalid arguments. Discount arguments cannot be converted to integer.') from ex
 
-        if cpu_discount < 0 or cpu_discount > 100:
-            self.logger.error('cpu_discount is out of range [0, 100]')
-            raise RuntimeError(f'Invalid arguments. cpu_discount = {cpu_discount} is an invalid '
-                               'percentage.')
-        if gpu_discount < 0 or gpu_discount > 100:
-            self.logger.error('gpu_discount is out of range [0, 100]')
-            raise RuntimeError(f'Invalid arguments. gpu_discount = {gpu_discount} is an invalid '
-                               'percentage.')
-        if global_discount < 0 or global_discount > 100:
-            self.logger.error('global_discount is out of range [0, 100]')
-            raise RuntimeError(f'Invalid arguments. global_discount = {global_discount} is an invalid '
-                               'percentage.')
+        check_discount_percentage('cpu_discount', cpu_discount)
+        check_discount_percentage('gpu_discount', gpu_discount)
+        check_discount_percentage('global_discount', global_discount)
 
         if global_discount != 0:
             self.ctxt.set_ctxt('cpu_discount', global_discount)

--- a/user_tools/src/spark_rapids_pytools/wrappers/databricks_aws_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/databricks_aws_wrapper.py
@@ -41,6 +41,9 @@ class CliDBAWSLocalMode:  # pylint: disable=too-few-public-methods
                           QualGpuClusterReshapeType.get_default()),
                       jvm_heap_size: int = 24,
                       verbose: bool = False,
+                      cpu_discount: int = None,
+                      gpu_discount: int = None,
+                      global_discount: int = None,
                       **rapids_options) -> None:
         """
         The Qualification tool analyzes Spark events generated from CPU based Spark applications to
@@ -86,9 +89,15 @@ class CliDBAWSLocalMode:  # pylint: disable=too-few-public-methods
                It accepts one of the following ("CLUSTER", "JOB" and the default value "MATCH").
                 "MATCH": keep GPU cluster same number of nodes as CPU cluster;
                 "CLUSTER": recommend optimal GPU cluster by cost for entire cluster;
-                "JOB": recommend optimal GPU cluster by cost per job
-        :param verbose: True or False to enable verbosity to the wrapper script.
+                "JOB": recommend optimal GPU cluster by cost per job.
         :param jvm_heap_size: The maximum heap size of the JVM in gigabytes.
+        :param verbose: True or False to enable verbosity to the wrapper script.
+        :param cpu_discount: A percent discount for the cpu cluster cost in the form of an integer value
+                (e.g. 30 for 30% discount).
+        :param gpu_discount: A percent discount for the gpu cluster cost in the form of an integer value
+                (e.g. 30 for 30% discount).
+        :param global_discount: A percent discount for both the cpu and gpu cluster costs in the form of an
+                integer value (e.g. 30 for 30% discount).
         :param rapids_options: A list of valid Qualification tool options.
                 Note that the wrapper ignores ["output-directory", "platform"] flags, and it does not support
                 multiple "spark-property" arguments.
@@ -119,7 +128,10 @@ class CliDBAWSLocalMode:  # pylint: disable=too-few-public-methods
             'eventlogs': eventlogs,
             'filterApps': filter_apps,
             'toolsJar': tools_jar,
-            'gpuClusterRecommendation': gpu_cluster_recommendation
+            'gpuClusterRecommendation': gpu_cluster_recommendation,
+            'cpuDiscount': cpu_discount,
+            'gpuDiscount': gpu_discount,
+            'globalDiscount': global_discount
         }
         QualificationAsLocal(platform_type=CspEnv.DATABRICKS_AWS,
                              cluster=None,

--- a/user_tools/src/spark_rapids_pytools/wrappers/databricks_azure_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/databricks_azure_wrapper.py
@@ -40,6 +40,9 @@ class CliDBAzureLocalMode:  # pylint: disable=too-few-public-methods
                           QualGpuClusterReshapeType.get_default()),
                       jvm_heap_size: int = 24,
                       verbose: bool = False,
+                      cpu_discount: int = None,
+                      gpu_discount: int = None,
+                      global_discount: int = None,
                       **rapids_options) -> None:
         """
         The Qualification tool analyzes Spark events generated from CPU based Spark applications to
@@ -84,9 +87,15 @@ class CliDBAzureLocalMode:  # pylint: disable=too-few-public-methods
                It accepts one of the following ("CLUSTER", "JOB" and the default value "MATCH").
                 "MATCH": keep GPU cluster same number of nodes as CPU cluster;
                 "CLUSTER": recommend optimal GPU cluster by cost for entire cluster;
-                "JOB": recommend optimal GPU cluster by cost per job
-        :param verbose: True or False to enable verbosity to the wrapper script.
+                "JOB": recommend optimal GPU cluster by cost per job.
         :param jvm_heap_size: The maximum heap size of the JVM in gigabytes.
+        :param verbose: True or False to enable verbosity to the wrapper script.
+        :param cpu_discount: A percent discount for the cpu cluster cost in the form of an integer value
+                (e.g. 30 for 30% discount).
+        :param gpu_discount: A percent discount for the gpu cluster cost in the form of an integer value
+                (e.g. 30 for 30% discount).
+        :param global_discount: A percent discount for both the cpu and gpu cluster costs in the form of an
+                integer value (e.g. 30 for 30% discount).
         :param rapids_options: A list of valid Qualification tool options.
                 Note that the wrapper ignores ["output-directory", "platform"] flags, and it does not support
                 multiple "spark-property" arguments.
@@ -116,7 +125,10 @@ class CliDBAzureLocalMode:  # pylint: disable=too-few-public-methods
             'eventlogs': eventlogs,
             'filterApps': filter_apps,
             'toolsJar': tools_jar,
-            'gpuClusterRecommendation': gpu_cluster_recommendation
+            'gpuClusterRecommendation': gpu_cluster_recommendation,
+            'cpuDiscount': cpu_discount,
+            'gpuDiscount': gpu_discount,
+            'globalDiscount': global_discount
         }
         QualificationAsLocal(platform_type=CspEnv.DATABRICKS_AZURE,
                              cluster=None,

--- a/user_tools/src/spark_rapids_pytools/wrappers/dataproc_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/dataproc_wrapper.py
@@ -41,6 +41,9 @@ class CliDataprocLocalMode:  # pylint: disable=too-few-public-methods
                           QualGpuClusterReshapeType.get_default()),
                       jvm_heap_size: int = 24,
                       verbose: bool = False,
+                      cpu_discount: int = None,
+                      gpu_discount: int = None,
+                      global_discount: int = None,
                       **rapids_options) -> None:
         """
         The Qualification tool analyzes Spark events generated from CPU based Spark applications to
@@ -87,6 +90,12 @@ class CliDataprocLocalMode:  # pylint: disable=too-few-public-methods
                 "JOB": recommend optimal GPU cluster by cost per job
         :param jvm_heap_size: The maximum heap size of the JVM in gigabytes
         :param verbose: True or False to enable verbosity to the wrapper script
+        :param cpu_discount: A percent discount for the cpu cluster cost in the form of an integer value
+                (e.g. 30 for 30% discount).
+        :param gpu_discount: A percent discount for the gpu cluster cost in the form of an integer value
+                (e.g. 30 for 30% discount).
+        :param global_discount: A percent discount for both the cpu and gpu cluster costs in the form of an
+                integer value (e.g. 30 for 30% discount).
         :param rapids_options: A list of valid Qualification tool options.
                 Note that the wrapper ignores ["output-directory", "platform"] flags, and it does not support
                 multiple "spark-property" arguments.
@@ -114,7 +123,10 @@ class CliDataprocLocalMode:  # pylint: disable=too-few-public-methods
             'eventlogs': eventlogs,
             'filterApps': filter_apps,
             'toolsJar': tools_jar,
-            'gpuClusterRecommendation': gpu_cluster_recommendation
+            'gpuClusterRecommendation': gpu_cluster_recommendation,
+            'cpuDiscount': cpu_discount,
+            'gpuDiscount': gpu_discount,
+            'globalDiscount': global_discount
         }
 
         tool_obj = QualificationAsLocal(platform_type=CspEnv.DATAPROC,

--- a/user_tools/src/spark_rapids_pytools/wrappers/emr_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/emr_wrapper.py
@@ -42,6 +42,9 @@ class CliEmrLocalMode:  # pylint: disable=too-few-public-methods
                           QualGpuClusterReshapeType.get_default()),
                       jvm_heap_size: int = 24,
                       verbose: bool = False,
+                      cpu_discount: int = None,
+                      gpu_discount: int = None,
+                      global_discount: int = None,
                       **rapids_options) -> None:
         """
         The Qualification tool analyzes Spark events generated from CPU based Spark applications to
@@ -85,6 +88,12 @@ class CliEmrLocalMode:  # pylint: disable=too-few-public-methods
                 "JOB": recommend optimal GPU cluster by cost per job
         :param jvm_heap_size: The maximum heap size of the JVM in gigabytes
         :param verbose: True or False to enable verbosity to the wrapper script
+        :param cpu_discount: A percent discount for the cpu cluster cost in the form of an integer value
+                (e.g. 30 for 30% discount).
+        :param gpu_discount: A percent discount for the gpu cluster cost in the form of an integer value
+                (e.g. 30 for 30% discount).
+        :param global_discount: A percent discount for both the cpu and gpu cluster costs in the form of an
+                integer value (e.g. 30 for 30% discount).
         :param rapids_options: A list of valid Qualification tool options.
                 Note that the wrapper ignores ["output-directory", "platform"] flags, and it does not support
                 multiple "spark-property" arguments.
@@ -112,7 +121,10 @@ class CliEmrLocalMode:  # pylint: disable=too-few-public-methods
             'eventlogs': eventlogs,
             'filterApps': filter_apps,
             'toolsJar': tools_jar,
-            'gpuClusterRecommendation': gpu_cluster_recommendation
+            'gpuClusterRecommendation': gpu_cluster_recommendation,
+            'cpuDiscount': cpu_discount,
+            'gpuDiscount': gpu_discount,
+            'globalDiscount': global_discount
         }
         QualificationAsLocal(platform_type=CspEnv.EMR,
                              cluster=None,

--- a/user_tools/src/spark_rapids_pytools/wrappers/onprem_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/onprem_wrapper.py
@@ -38,6 +38,9 @@ class CliOnpremLocalMode:  # pylint: disable=too-few-public-methods
                           QualGpuClusterReshapeType.get_default()),
                       jvm_heap_size: int = 24,
                       verbose: bool = False,
+                      cpu_discount: int = None,
+                      gpu_discount: int = None,
+                      global_discount: int = None,
                       **rapids_options) -> None:
         """
         The Qualification tool analyzes Spark events generated from CPU based Spark applications to
@@ -65,6 +68,12 @@ class CliOnpremLocalMode:  # pylint: disable=too-few-public-methods
                 "JOB": recommend optimal GPU cluster by cost per job
         :param jvm_heap_size: The maximum heap size of the JVM in gigabytes
         :param verbose: True or False to enable verbosity to the wrapper script
+        :param cpu_discount: A percent discount for the cpu cluster cost in the form of an integer value
+                (e.g. 30 for 30% discount).
+        :param gpu_discount: A percent discount for the gpu cluster cost in the form of an integer value
+                (e.g. 30 for 30% discount).
+        :param global_discount: A percent discount for both the cpu and gpu cluster costs in the form of an
+                integer value (e.g. 30 for 30% discount).
         :param rapids_options: A list of valid Qualification tool options.
                 Note that the wrapper ignores ["output-directory", "platform"] flags, and it does not support
                 multiple "spark-property" arguments.
@@ -103,7 +112,10 @@ class CliOnpremLocalMode:  # pylint: disable=too-few-public-methods
             'filterApps': filter_apps,
             'toolsJar': tools_jar,
             'gpuClusterRecommendation': gpu_cluster_recommendation,
-            'targetPlatform': target_platform
+            'targetPlatform': target_platform,
+            'cpuDiscount': cpu_discount,
+            'gpuDiscount': gpu_discount,
+            'globalDiscount': global_discount
         }
         tool_obj = QualificationAsLocal(platform_type=CspEnv.ONPREM,
                                         output_folder=local_folder,

--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -303,12 +303,18 @@ class QualifyUserArgModel(ToolUserArgModel):
     target_platform: Optional[CspEnv] = None
     filter_apps: Optional[QualFilterApp] = None
     gpu_cluster_recommendation: Optional[QualGpuClusterReshapeType] = None
+    cpu_discount: Optional[int] = None
+    gpu_discount: Optional[int] = None
+    global_discount: Optional[int] = None
 
     def init_tool_args(self):
         self.p_args['toolArgs']['platform'] = self.platform
         self.p_args['toolArgs']['savingsCalculations'] = True
         self.p_args['toolArgs']['filterApps'] = self.filter_apps
         self.p_args['toolArgs']['targetPlatform'] = self.target_platform
+        self.p_args['toolArgs']['cpuDiscount'] = self.cpu_discount
+        self.p_args['toolArgs']['gpuDiscount'] = self.gpu_discount
+        self.p_args['toolArgs']['globalDiscount'] = self.global_discount
         # check the reshapeType argument
         if self.gpu_cluster_recommendation is None:
             self.p_args['toolArgs']['gpuClusterRecommendation'] = QualGpuClusterReshapeType.get_default()
@@ -401,7 +407,10 @@ class QualifyUserArgModel(ToolUserArgModel):
             'toolsJar': None,
             'gpuClusterRecommendation': self.p_args['toolArgs']['gpuClusterRecommendation'],
             # used to initialize the pricing information
-            'targetPlatform': self.p_args['toolArgs']['targetPlatform']
+            'targetPlatform': self.p_args['toolArgs']['targetPlatform'],
+            'cpuDiscount': self.p_args['toolArgs']['cpuDiscount'],
+            'gpuDiscount': self.p_args['toolArgs']['gpuDiscount'],
+            'globalDiscount': self.p_args['toolArgs']['globalDiscount']
         }
         return wrapped_args
 

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -40,6 +40,9 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                       target_platform: str = None,
                       output_folder: str = None,
                       filter_apps: str = None,
+                      cpu_discount: int = None,
+                      gpu_discount: int = None,
+                      global_discount: int = None,
                       gpu_cluster_recommendation: str = QualGpuClusterReshapeType.tostring(
                           QualGpuClusterReshapeType.get_default())):
         """The Qualification cmd provides estimated running costs and speedups by migrating Apache
@@ -75,6 +78,12 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                 'Recommended', or 'Strongly Recommended' based on speedups. "SAVINGS"
                 lists all the apps that have positive estimated GPU savings except for the apps that
                 are "Not Applicable"
+        :param cpu_discount: A percent discount for the cpu cluster cost in the form of an integer value
+                (e.g. 30 for 30% discount).
+        :param gpu_discount: A percent discount for the gpu cluster cost in the form of an integer value
+                (e.g. 30 for 30% discount).
+        :param global_discount: A percent discount for both the cpu and gpu cluster costs in the form of an
+                integer value (e.g. 30 for 30% discount).
         :param gpu_cluster_recommendation: The type of GPU cluster recommendation to generate.
                 Requires "Cluster".
 
@@ -91,6 +100,9 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                                          target_platform=target_platform,
                                                          output_folder=output_folder,
                                                          filter_apps=filter_apps,
+                                                         cpu_discount=cpu_discount,
+                                                         gpu_discount=gpu_discount,
+                                                         global_discount=global_discount,
                                                          gpu_cluster_recommendation=gpu_cluster_recommendation)
         if qual_args:
             tool_obj = QualificationAsLocal(platform_type=qual_args['runtimePlatform'],


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/476

We add three new user qualification tool options (for both `spark_rapids_user_tools` and `ascli` CLI)

- `--cpu_discount`: the specified percentage discount for the CPU cluster cost to be reduced by (e.g. 30 for 30% discount)
- `--gpu_discount`: the specified percentage discount for the GPU cluster cost to be reduced by
- `--global_discount`: the specified percentage discount for both cluster costs to be reduced by. Note that if `--global_discount` is specified, neither `--cpu_discount` nor `--gpu_discount` should be specified, otherwise the tool will raise an exception

**Follow up work:**
We need to update documentation, issue tracked here: https://github.com/NVIDIA/spark-rapids-tools/issues/584