### PR TITLE
[FEA] Add json_tuple function as supported in qualification tool

### DIFF
--- a/core/src/main/resources/operatorsScore-databricks-aws.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws.csv
@@ -129,6 +129,7 @@ IntegralDivide,2.45
 IsNaN,2.45
 IsNotNull,2.45
 IsNull,2.45
+JsonTuple,2.45
 KnownFloatingPointNormalized,2.45
 KnownNotNull,2.45
 Lag,2.45

--- a/core/src/main/resources/operatorsScore-databricks-azure.csv
+++ b/core/src/main/resources/operatorsScore-databricks-azure.csv
@@ -129,6 +129,7 @@ IntegralDivide,2.73
 IsNaN,2.73
 IsNotNull,2.73
 IsNull,2.73
+JsonTuple,2.73
 KnownFloatingPointNormalized,2.73
 KnownNotNull,2.73
 Lag,2.73

--- a/core/src/main/resources/operatorsScore-dataproc-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-l4.csv
@@ -129,6 +129,7 @@ IntegralDivide,4.16
 IsNaN,4.16
 IsNotNull,4.16
 IsNull,4.16
+JsonTuple,4.16
 KnownFloatingPointNormalized,4.16
 KnownNotNull,4.16
 Lag,4.16

--- a/core/src/main/resources/operatorsScore-dataproc-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-t4.csv
@@ -129,6 +129,7 @@ IntegralDivide,4.88
 IsNaN,4.88
 IsNotNull,4.88
 IsNull,4.88
+JsonTuple,4.88
 KnownFloatingPointNormalized,4.88
 KnownNotNull,4.88
 Lag,4.88

--- a/core/src/main/resources/operatorsScore-emr-a10.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10.csv
@@ -129,6 +129,7 @@ IntegralDivide,2.59
 IsNaN,2.59
 IsNotNull,2.59
 IsNull,2.59
+JsonTuple,2.59
 KnownFloatingPointNormalized,2.59
 KnownNotNull,2.59
 Lag,2.59

--- a/core/src/main/resources/operatorsScore-emr-t4.csv
+++ b/core/src/main/resources/operatorsScore-emr-t4.csv
@@ -129,6 +129,7 @@ IntegralDivide,2.07
 IsNaN,2.07
 IsNotNull,2.07
 IsNull,2.07
+JsonTuple,2.07
 KnownFloatingPointNormalized,2.07
 KnownNotNull,2.07
 Lag,2.07

--- a/core/src/main/resources/operatorsScore.csv
+++ b/core/src/main/resources/operatorsScore.csv
@@ -134,6 +134,7 @@ IntegralDivide,4
 IsNaN,4
 IsNotNull,4
 IsNull,4
+JsonTuple,4
 KnownFloatingPointNormalized,4
 KnownNotNull,4
 Lag,4

--- a/core/src/main/resources/supportedExprs.csv
+++ b/core/src/main/resources/supportedExprs.csv
@@ -268,6 +268,9 @@ IsNotNull,S,`isnotnull`,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,P
 IsNotNull,S,`isnotnull`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 IsNull,S,`isnull`,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS
 IsNull,S,`isnull`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+JsonTuple,S,`json_tuple`,None,project,json,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA
+JsonTuple,S,`json_tuple`,None,project,field,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA,NA,NA,NA
+JsonTuple,S,`json_tuple`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA
 KnownFloatingPointNormalized,S, ,None,project,input,NA,NA,NA,NA,NA,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 KnownFloatingPointNormalized,S, ,None,project,result,NA,NA,NA,NA,NA,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 KnownNotNull,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,NS,S,S,PS,PS,PS,NS

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -791,7 +791,6 @@ class SQLPlanParserSuite extends BaseTestSuite {
             |"City":"ABCDE","State":"YZ"}""".stripMargin
         val data = Seq((1, jsonString))
         val df = data.toDF("id", "jsonValues")
-        //json_tuple which is called from GenerateExec is not supported in GPU yet.
         df.select(col("id"), json_tuple(col("jsonValues"), "Zipcode", "ZipCodeType", "City"))
       }
       val pluginTypeChecker = new PluginTypeChecker()
@@ -802,7 +801,7 @@ class SQLPlanParserSuite extends BaseTestSuite {
       }
       val execInfo = getAllExecsFromPlan(parsedPlans.toSeq)
       val generateExprs = execInfo.filter(_.exec == "Generate")
-      assertSizeAndNotSupported(1, generateExprs)
+      assertSizeAndSupported(1, generateExprs)
     }
   }
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -781,7 +781,7 @@ class SQLPlanParserSuite extends BaseTestSuite {
     }
   }
 
-  test("Expression supported in Generate") {
+  test("json_tuple is supported in Generate") {
     TrampolineUtil.withTempDir { eventLogDir =>
       val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
         "Expressions in Generate") { spark =>

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -781,7 +781,7 @@ class SQLPlanParserSuite extends BaseTestSuite {
     }
   }
 
-  test("Expression not supported in Generate") {
+  test("Expression supported in Generate") {
     TrampolineUtil.withTempDir { eventLogDir =>
       val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
         "Expressions in Generate") { spark =>

--- a/user_tools/custom_speedup_factors/operatorsList.csv
+++ b/user_tools/custom_speedup_factors/operatorsList.csv
@@ -122,6 +122,7 @@ IntegralDivide
 IsNaN
 IsNotNull
 IsNull
+JsonTuple
 KnownFloatingPointNormalized
 KnownNotNull
 Lag


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/588

Rapids-plugin added `json_tuple` function GPU support. We updated the tools to treat `json_tuple` as supported and updated unit tests to verify it.