### PR TITLE
[FEA] Add qualification user tool options to support external pricing

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
@@ -69,7 +69,9 @@ class DBAWSPlatform(EMRPlatform):
 
     def create_saving_estimator(self,
                                 source_cluster: ClusterGetAccessor,
-                                reshaped_cluster: ClusterGetAccessor):
+                                reshaped_cluster: ClusterGetAccessor,
+                                target_cost: float = None,
+                                source_cost: float = None):
         raw_pricing_config = self.configs.get_value_silent('pricing')
         if raw_pricing_config:
             pricing_config = JSONPropertiesContainer(prop_arg=raw_pricing_config, file_load=False)
@@ -79,7 +81,9 @@ class DBAWSPlatform(EMRPlatform):
                                                             pricing_configs={'databricks': pricing_config})
         saving_estimator = DBAWSSavingsEstimator(price_provider=databricks_price_provider,
                                                  reshaped_cluster=reshaped_cluster,
-                                                 source_cluster=source_cluster)
+                                                 source_cluster=source_cluster,
+                                                 target_cost=target_cost,
+                                                 source_cost=source_cost)
         return saving_estimator
 
     def create_local_submission_job(self, job_prop, ctxt) -> Any:
@@ -310,8 +314,3 @@ class DBAWSSavingsEstimator(SavingsEstimator):
             cost = self.price_provider.get_instance_price(instance=instance_type)
             dbu_cost += cost * nodes_cnt
         return self.__calculate_ec2_cost(cluster) + dbu_cost
-
-    def _setup_costs(self):
-        # calculate target_cost
-        self.target_cost = self._get_cost_per_cluster(self.reshaped_cluster)
-        self.source_cost = self._get_cost_per_cluster(self.source_cluster)

--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
@@ -69,7 +69,9 @@ class DBAzurePlatform(PlatformBase):
 
     def create_saving_estimator(self,
                                 source_cluster: ClusterGetAccessor,
-                                reshaped_cluster: ClusterGetAccessor):
+                                reshaped_cluster: ClusterGetAccessor,
+                                target_cost: float = None,
+                                source_cost: float = None):
         raw_pricing_config = self.configs.get_value_silent('pricing')
         if raw_pricing_config:
             pricing_config = JSONPropertiesContainer(prop_arg=raw_pricing_config, file_load=False)
@@ -79,7 +81,9 @@ class DBAzurePlatform(PlatformBase):
                                                                pricing_configs={'databricks-azure': pricing_config})
         saving_estimator = DBAzureSavingsEstimator(price_provider=db_azure_price_provider,
                                                    reshaped_cluster=reshaped_cluster,
-                                                   source_cluster=source_cluster)
+                                                   source_cluster=source_cluster,
+                                                   target_cost=target_cost,
+                                                   source_cost=source_cost)
         return saving_estimator
 
     def create_local_submission_job(self, job_prop, ctxt) -> Any:
@@ -381,8 +385,3 @@ class DBAzureSavingsEstimator(SavingsEstimator):
             cost = self.price_provider.get_instance_price(instance=instance_type)
             db_azure_cost += cost * nodes_cnt
         return db_azure_cost
-
-    def _setup_costs(self):
-        # calculate target_cost
-        self.target_cost = self._get_cost_per_cluster(self.reshaped_cluster)
-        self.source_cost = self._get_cost_per_cluster(self.source_cluster)

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -99,7 +99,9 @@ class DataprocPlatform(PlatformBase):
 
     def create_saving_estimator(self,
                                 source_cluster: ClusterGetAccessor,
-                                reshaped_cluster: ClusterGetAccessor):
+                                reshaped_cluster: ClusterGetAccessor,
+                                target_cost: float = None,
+                                source_cost: float = None):
         raw_pricing_config = self.configs.get_value_silent('pricing')
         if raw_pricing_config:
             pricing_config = JSONPropertiesContainer(prop_arg=raw_pricing_config,
@@ -110,7 +112,9 @@ class DataprocPlatform(PlatformBase):
                                                  pricing_configs={'gcloud': pricing_config})
         saving_estimator = DataprocSavingsEstimator(price_provider=pricing_provider,
                                                     reshaped_cluster=reshaped_cluster,
-                                                    source_cluster=source_cluster)
+                                                    source_cluster=source_cluster,
+                                                    target_cost=target_cost,
+                                                    source_cost=source_cost)
         return saving_estimator
 
     def create_local_submission_job(self, job_prop, ctxt) -> Any:
@@ -532,8 +536,3 @@ class DataprocSavingsEstimator(SavingsEstimator):
         workers_cost = self.__calculate_group_cost(cluster, SparkNodeType.WORKER)
         dataproc_cost = self.price_provider.get_container_cost()
         return master_cost + workers_cost + dataproc_cost
-
-    def _setup_costs(self):
-        # calculate target_cost
-        self.target_cost = self._get_cost_per_cluster(self.reshaped_cluster)
-        self.source_cost = self._get_cost_per_cluster(self.source_cluster)

--- a/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
@@ -95,7 +95,9 @@ class EMRPlatform(PlatformBase):
 
     def create_saving_estimator(self,
                                 source_cluster: ClusterGetAccessor,
-                                reshaped_cluster: ClusterGetAccessor):
+                                reshaped_cluster: ClusterGetAccessor,
+                                target_cost: float = None,
+                                source_cost: float = None):
         raw_pricing_config = self.configs.get_value_silent('pricing')
         if raw_pricing_config:
             pricing_config = JSONPropertiesContainer(prop_arg=raw_pricing_config, file_load=False)
@@ -105,7 +107,9 @@ class EMRPlatform(PlatformBase):
                                                  pricing_configs={'emr': pricing_config})
         saving_estimator = EmrSavingsEstimator(price_provider=emr_price_provider,
                                                reshaped_cluster=reshaped_cluster,
-                                               source_cluster=source_cluster)
+                                               source_cluster=source_cluster,
+                                               target_cost=target_cost,
+                                               source_cost=source_cost)
         return saving_estimator
 
     def create_local_submission_job(self, job_prop, ctxt) -> Any:
@@ -493,8 +497,3 @@ class EmrSavingsEstimator(SavingsEstimator):
             total_cost += self._calculate_ec2_cost(cluster, node_type)
             total_cost += self._calculate_emr_cost(cluster, node_type)
         return total_cost
-
-    def _setup_costs(self):
-        # calculate target_cost
-        self.target_cost = self._get_cost_per_cluster(self.reshaped_cluster)
-        self.source_cost = self._get_cost_per_cluster(self.source_cluster)

--- a/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
@@ -82,7 +82,9 @@ class OnPremPlatform(PlatformBase):
 
     def create_saving_estimator(self,
                                 source_cluster: ClusterGetAccessor,
-                                reshaped_cluster: ClusterGetAccessor):
+                                reshaped_cluster: ClusterGetAccessor,
+                                target_cost: float = None,
+                                source_cost: float = None):
         if self.platform == 'dataproc':
             region = 'us-central1'
             raw_pricing_config = self.configs.get_value_silent('csp_pricing')
@@ -95,7 +97,9 @@ class OnPremPlatform(PlatformBase):
                                                      pricing_configs={'gcloud': pricing_config})
             saving_estimator = OnpremSavingsEstimator(price_provider=pricing_provider,
                                                       reshaped_cluster=reshaped_cluster,
-                                                      source_cluster=source_cluster)
+                                                      source_cluster=source_cluster,
+                                                      target_cost=target_cost,
+                                                      source_cost=source_cost)
         return saving_estimator
 
     def set_offline_cluster(self, cluster_args: dict = None):
@@ -311,8 +315,3 @@ class OnpremSavingsEstimator(SavingsEstimator):
             dataproc_cost = self.price_provider.get_container_cost()
             total_cost = master_cost + workers_cost + dataproc_cost
         return total_cost
-
-    def _setup_costs(self):
-        # calculate target_cost
-        self.target_cost = self._get_cost_per_cluster(self.reshaped_cluster)
-        self.source_cost = self._get_cost_per_cluster(self.source_cluster)

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -806,7 +806,9 @@ class PlatformBase:
 
     def create_saving_estimator(self,
                                 source_cluster: ClusterGetAccessor,
-                                reshaped_cluster: ClusterGetAccessor):
+                                reshaped_cluster: ClusterGetAccessor,
+                                target_cost: float = None,
+                                source_cost: float = None):
         raise NotImplementedError
 
     def create_local_submission_job(self, job_prop, ctxt) -> Any:

--- a/user_tools/src/spark_rapids_pytools/pricing/price_provider.py
+++ b/user_tools/src/spark_rapids_pytools/pricing/price_provider.py
@@ -127,14 +127,20 @@ class SavingsEstimator:
     price_provider: PriceProvider
     source_cluster: ClusterGetAccessor
     reshaped_cluster: ClusterGetAccessor
-    target_cost: float = field(default=None, init=False)
-    source_cost: float = field(default=None, init=False)
+    target_cost: float = field(default=None)
+    source_cost: float = field(default=None)
     comments: list = field(default_factory=lambda: [], init=False)
     logger: Logger = field(default=None, init=False)
 
     def _setup_costs(self):
         # calculate target_cost
-        pass
+        if self.target_cost is None:
+            self.target_cost = self._get_cost_per_cluster(self.reshaped_cluster)
+        if self.source_cost is None:
+            self.source_cost = self._get_cost_per_cluster(self.source_cluster)
+
+        self.logger.info("self.source_cost = %s", self.source_cost)
+        self.logger.info("self.target_cost = %s", self.target_cost)
 
     def __post_init__(self):
         # when debug is set to true set it in the environment.

--- a/user_tools/src/spark_rapids_pytools/pricing/price_provider.py
+++ b/user_tools/src/spark_rapids_pytools/pricing/price_provider.py
@@ -132,15 +132,15 @@ class SavingsEstimator:
     comments: list = field(default_factory=lambda: [], init=False)
     logger: Logger = field(default=None, init=False)
 
+    def _get_cost_per_cluster(self, cluster: ClusterGetAccessor):
+        raise NotImplementedError
+
     def _setup_costs(self):
         # calculate target_cost
         if self.target_cost is None:
             self.target_cost = self._get_cost_per_cluster(self.reshaped_cluster)
         if self.source_cost is None:
             self.source_cost = self._get_cost_per_cluster(self.source_cluster)
-
-        self.logger.info("self.source_cost = %s", self.source_cost)
-        self.logger.info("self.target_cost = %s", self.target_cost)
 
     def __post_init__(self):
         # when debug is set to true set it in the environment.

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -296,6 +296,7 @@ class Qualification(RapidsJarTool):
         estimated_gpu_cluster_price = self.wrapper_options.get('estimatedGpuClusterPrice')
         self.ctxt.set_ctxt('source_cost', cpu_cluster_price)
         self.ctxt.set_ctxt('target_cost', estimated_gpu_cluster_price)
+
     def _process_price_discount_args(self):
         def check_discount_percentage(discount_type: str, discount_value: int):
             if discount_value < 0 or discount_value > 100:
@@ -602,8 +603,8 @@ class Qualification(RapidsJarTool):
                                                   reshape_workers_cnt=lambda x: workers_cnt)
                 estimator_obj = self.ctxt.platform.create_saving_estimator(self.ctxt.get_ctxt('cpuClusterProxy'),
                                                                            reshaped_cluster,
-                                                                           target_cost=self.ctxt.get_ctxt('target_cost'),
-                                                                           source_cost= self.ctxt.get_ctxt('source_cost'))
+                                                                           self.ctxt.get_ctxt('target_cost'),
+                                                                           self.ctxt.get_ctxt('source_cost'))
                 saving_estimator_cache.setdefault(workers_cnt, estimator_obj)
             cost_pd_series = get_costs_for_single_app(df_row, estimator_obj)
             return cost_pd_series
@@ -614,8 +615,8 @@ class Qualification(RapidsJarTool):
             reshaped_gpu_cluster = ClusterReshape(self.ctxt.get_ctxt('gpuClusterProxy'))
             savings_estimator = self.ctxt.platform.create_saving_estimator(self.ctxt.get_ctxt('cpuClusterProxy'),
                                                                            reshaped_gpu_cluster,
-                                                                           target_cost=self.ctxt.get_ctxt('target_cost'),
-                                                                           source_cost= self.ctxt.get_ctxt('source_cost'))
+                                                                           self.ctxt.get_ctxt('target_cost'),
+                                                                           self.ctxt.get_ctxt('source_cost'))
             app_df_set[cost_cols] = app_df_set.apply(
                 lambda row: get_costs_for_single_app(row, estimator=savings_estimator), axis=1)
         else:

--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -307,12 +307,16 @@ class QualifyUserArgModel(ToolUserArgModel):
     target_platform: Optional[CspEnv] = None
     filter_apps: Optional[QualFilterApp] = None
     gpu_cluster_recommendation: Optional[QualGpuClusterReshapeType] = None
+    cpu_cluster_price: Optional[float] = None
+    estimated_gpu_cluster_price: Optional[float] = None
 
     def init_tool_args(self):
         self.p_args['toolArgs']['platform'] = self.platform
         self.p_args['toolArgs']['savingsCalculations'] = True
         self.p_args['toolArgs']['filterApps'] = self.filter_apps
         self.p_args['toolArgs']['targetPlatform'] = self.target_platform
+        self.p_args['toolArgs']['cpuClusterPrice'] = self.cpu_cluster_price
+        self.p_args['toolArgs']['estimatedGpuClusterPrice'] = self.estimated_gpu_cluster_price
         # check the reshapeType argument
         if self.gpu_cluster_recommendation is None:
             self.p_args['toolArgs']['gpuClusterRecommendation'] = QualGpuClusterReshapeType.get_default()
@@ -405,7 +409,9 @@ class QualifyUserArgModel(ToolUserArgModel):
             'toolsJar': None,
             'gpuClusterRecommendation': self.p_args['toolArgs']['gpuClusterRecommendation'],
             # used to initialize the pricing information
-            'targetPlatform': self.p_args['toolArgs']['targetPlatform']
+            'targetPlatform': self.p_args['toolArgs']['targetPlatform'],
+            'cpuClusterPrice': self.p_args['toolArgs']['cpuClusterPrice'],
+            'estimatedGpuClusterPrice': self.p_args['toolArgs']['estimatedGpuClusterPrice']
         }
         return wrapped_args
 

--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -307,28 +307,22 @@ class QualifyUserArgModel(ToolUserArgModel):
     target_platform: Optional[CspEnv] = None
     filter_apps: Optional[QualFilterApp] = None
     gpu_cluster_recommendation: Optional[QualGpuClusterReshapeType] = None
-<<<<<<< HEAD
     cpu_cluster_price: Optional[float] = None
     estimated_gpu_cluster_price: Optional[float] = None
-=======
     cpu_discount: Optional[int] = None
     gpu_discount: Optional[int] = None
     global_discount: Optional[int] = None
->>>>>>> dev
 
     def init_tool_args(self):
         self.p_args['toolArgs']['platform'] = self.platform
         self.p_args['toolArgs']['savingsCalculations'] = True
         self.p_args['toolArgs']['filterApps'] = self.filter_apps
         self.p_args['toolArgs']['targetPlatform'] = self.target_platform
-<<<<<<< HEAD
         self.p_args['toolArgs']['cpuClusterPrice'] = self.cpu_cluster_price
         self.p_args['toolArgs']['estimatedGpuClusterPrice'] = self.estimated_gpu_cluster_price
-=======
         self.p_args['toolArgs']['cpuDiscount'] = self.cpu_discount
         self.p_args['toolArgs']['gpuDiscount'] = self.gpu_discount
         self.p_args['toolArgs']['globalDiscount'] = self.global_discount
->>>>>>> dev
         # check the reshapeType argument
         if self.gpu_cluster_recommendation is None:
             self.p_args['toolArgs']['gpuClusterRecommendation'] = QualGpuClusterReshapeType.get_default()
@@ -422,14 +416,11 @@ class QualifyUserArgModel(ToolUserArgModel):
             'gpuClusterRecommendation': self.p_args['toolArgs']['gpuClusterRecommendation'],
             # used to initialize the pricing information
             'targetPlatform': self.p_args['toolArgs']['targetPlatform'],
-<<<<<<< HEAD
             'cpuClusterPrice': self.p_args['toolArgs']['cpuClusterPrice'],
-            'estimatedGpuClusterPrice': self.p_args['toolArgs']['estimatedGpuClusterPrice']
-=======
+            'estimatedGpuClusterPrice': self.p_args['toolArgs']['estimatedGpuClusterPrice'],
             'cpuDiscount': self.p_args['toolArgs']['cpuDiscount'],
             'gpuDiscount': self.p_args['toolArgs']['gpuDiscount'],
             'globalDiscount': self.p_args['toolArgs']['globalDiscount']
->>>>>>> dev
         }
         return wrapped_args
 

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -41,14 +41,11 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                       target_platform: str = None,
                       output_folder: str = None,
                       filter_apps: str = None,
-<<<<<<< HEAD
                       cpu_cluster_price: float = None,
                       estimated_gpu_cluster_price: float = None,
-=======
                       cpu_discount: int = None,
                       gpu_discount: int = None,
                       global_discount: int = None,
->>>>>>> dev
                       gpu_cluster_recommendation: str = QualGpuClusterReshapeType.tostring(
                           QualGpuClusterReshapeType.get_default()),
                       verbose: bool = False):
@@ -85,17 +82,14 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                 'Recommended', or 'Strongly Recommended' based on speedups. "SAVINGS"
                 lists all the apps that have positive estimated GPU savings except for the apps that
                 are "Not Applicable"
-<<<<<<< HEAD
         :param cpu_cluster_price: the CPU cluster hourly price provided by the user.
         :param estimated_gpu_cluster_price: the GPU cluster hourly price provided by the user.
-=======
         :param cpu_discount: A percent discount for the cpu cluster cost in the form of an integer value
                 (e.g. 30 for 30% discount).
         :param gpu_discount: A percent discount for the gpu cluster cost in the form of an integer value
                 (e.g. 30 for 30% discount).
         :param global_discount: A percent discount for both the cpu and gpu cluster costs in the form of an
                 integer value (e.g. 30 for 30% discount).
->>>>>>> dev
         :param gpu_cluster_recommendation: The type of GPU cluster recommendation to generate.
                 Requires "Cluster".
 
@@ -115,14 +109,11 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                                          target_platform=target_platform,
                                                          output_folder=output_folder,
                                                          filter_apps=filter_apps,
-<<<<<<< HEAD
                                                          cpu_cluster_price=cpu_cluster_price,
                                                          estimated_gpu_cluster_price=estimated_gpu_cluster_price,
-=======
                                                          cpu_discount=cpu_discount,
                                                          gpu_discount=gpu_discount,
                                                          global_discount=global_discount,
->>>>>>> dev
                                                          gpu_cluster_recommendation=gpu_cluster_recommendation)
         if qual_args:
             tool_obj = QualificationAsLocal(platform_type=qual_args['runtimePlatform'],

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -41,6 +41,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                       target_platform: str = None,
                       output_folder: str = None,
                       filter_apps: str = None,
+                      cpu_cluster_price: float = None,
+                      estimated_gpu_cluster_price: float = None,
                       gpu_cluster_recommendation: str = QualGpuClusterReshapeType.tostring(
                           QualGpuClusterReshapeType.get_default()),
                       verbose: bool = False):
@@ -77,6 +79,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                 'Recommended', or 'Strongly Recommended' based on speedups. "SAVINGS"
                 lists all the apps that have positive estimated GPU savings except for the apps that
                 are "Not Applicable"
+        :param cpu_cluster_price: the CPU cluster hourly price provided by the user.
+        :param estimated_gpu_cluster_price: the GPU cluster hourly price provided by the user.
         :param gpu_cluster_recommendation: The type of GPU cluster recommendation to generate.
                 Requires "Cluster".
 
@@ -96,6 +100,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                                          target_platform=target_platform,
                                                          output_folder=output_folder,
                                                          filter_apps=filter_apps,
+                                                         cpu_cluster_price=cpu_cluster_price,
+                                                         estimated_gpu_cluster_price=estimated_gpu_cluster_price,
                                                          gpu_cluster_recommendation=gpu_cluster_recommendation)
         if qual_args:
             tool_obj = QualificationAsLocal(platform_type=qual_args['runtimePlatform'],


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/489

We add two qualification user tool options to support external pricing in `ascli`:

- `--cpu_cluster_price`: argument used to specify hourly CPU cluster cost
- `--estimated_gpu_cluster_price`: argument used to specify hourly GPU cluster cost