### PR TITLE
[FEA] Fix empty softwareProperties field in worker_info.yaml file for profiling tool

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -1035,7 +1035,11 @@ object AutoTuner extends Logging {
     representer.getPropertyUtils.setSkipMissingProperties(true)
     val constructor = new Constructor(classOf[ClusterProperties], new LoaderOptions())
     val yamlObjNested = new Yaml(constructor, representer)
-    Option(yamlObjNested.load(clusterProps).asInstanceOf[ClusterProperties])
+    val clusterPropsOpt = Option(yamlObjNested.load(clusterProps).asInstanceOf[ClusterProperties])
+    if (clusterPropsOpt.isDefined && clusterPropsOpt.get.softwareProperties == null) {
+      clusterPropsOpt.get.softwareProperties = new util.LinkedHashMap[String, String]()
+    }
+    clusterPropsOpt
   }
 
   def loadClusterProps(filePath: String): Option[ClusterProperties] = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -1037,6 +1037,7 @@ object AutoTuner extends Logging {
     val yamlObjNested = new Yaml(constructor, representer)
     val loadedClusterProps = yamlObjNested.load(clusterProps).asInstanceOf[ClusterProperties]
     if (loadedClusterProps != null && loadedClusterProps.softwareProperties == null) {
+      logInfo("softwareProperties is empty from input worker_info file")
       loadedClusterProps.softwareProperties = new util.LinkedHashMap[String, String]()
     }
     Option(loadedClusterProps)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -1035,11 +1035,11 @@ object AutoTuner extends Logging {
     representer.getPropertyUtils.setSkipMissingProperties(true)
     val constructor = new Constructor(classOf[ClusterProperties], new LoaderOptions())
     val yamlObjNested = new Yaml(constructor, representer)
-    val clusterPropsOpt = Option(yamlObjNested.load(clusterProps).asInstanceOf[ClusterProperties])
-    if (clusterPropsOpt.isDefined && clusterPropsOpt.get.softwareProperties == null) {
-      clusterPropsOpt.get.softwareProperties = new util.LinkedHashMap[String, String]()
+    val loadedClusterProps = yamlObjNested.load(clusterProps).asInstanceOf[ClusterProperties]
+    if (loadedClusterProps != null && loadedClusterProps.softwareProperties == null) {
+      loadedClusterProps.softwareProperties = new util.LinkedHashMap[String, String]()
     }
-    clusterPropsOpt
+    Option(loadedClusterProps)
   }
 
   def loadClusterProps(filePath: String): Option[ClusterProperties] = {


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/608

Currently, when the `worker_info.yaml` file has empty `softwareProperties` field as below, the profiling tool throws a null pointer exception.

```
system:
  numCores: 32
  memory: 212992MiB
  numWorkers: 5
gpu:
  memory: 15109MiB
  count: 4
  name: T4
softwareProperties:
```

We work around this by assigning an empty `LinkedHashMap` (default) to `softwareProperties` if it is `null` after loading the `worker_info.yaml` file into a `ClusterProperties` instance.