### PR TITLE
Fix spinner animation blocking user input in diagnostic tool

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/diagnostic.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/diagnostic.py
@@ -40,16 +40,20 @@ class Diagnostic(RapidsTool):
 
         self.thread_num = thread_num
         self.logger.debug('Set thread number as: %d', self.thread_num)
-
-        self.logger.warning('This operation will collect sensitive information from your cluster, '
-                            'such as OS & HW info, Yarn/Spark configurations and log files etc.')
+        log_message = ('This operation will collect sensitive information from your cluster, '
+                       'such as OS & HW info, Yarn/Spark configurations and log files etc.')
         yes = self.wrapper_options.get('yes', False)
         if yes:
+            self.logger.warning(log_message)
             self.logger.info('Confirmed by command line option.')
         else:
+            # Pause the spinner for user prompt
+            self.spinner.pause(insert_newline=True)
+            print(log_message)
             user_input = input('Do you want to continue (yes/no): ')
             if user_input.lower() not in ['yes', 'y']:
                 raise RuntimeError('User canceled the operation.')
+            self.spinner.resume()
 
     def requires_cluster_connection(self) -> bool:
         return True

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -59,6 +59,7 @@ class RapidsTool(object):
     name: str = field(default=None, init=False)
     ctxt: ToolContext = field(default=None, init=False)
     logger: Logger = field(default=None, init=False)
+    spinner: ToolsSpinner = field(default=None, init=False)
 
     def pretty_name(self):
         return self.name.capitalize()
@@ -272,7 +273,9 @@ class RapidsTool(object):
         self._handle_non_running_exec_cluster(msg)
 
     def launch(self):
-        with ToolsSpinner(in_debug_mode=ToolLogging.is_debug_mode_enabled()):
+        # Spinner should not be enabled in debug mode
+        enable_spinner = not ToolLogging.is_debug_mode_enabled()
+        with ToolsSpinner(enabled=enable_spinner) as self.spinner:
             self._init_tool()
             self._connect_to_execution_cluster()
             self._process_arguments()


### PR DESCRIPTION
Fixes #630. This PR fixes spinner animation in diagnostic tool as it interferes with the user input.

### Changes:
1. Add `pause()` and `resume()` methods in `ToolsSpinner`.
2. Store the spinner as a class variable and toggle it later.
3. Update the logging - write to log only if user input is skipped (using `-y` flag), else print to console and ask for user input.
4. Fix cursor getting disappeared by using the flag `hide_cursor=False` in the spinner.


### Output

1. Default mode and user input is required
```
psarthi@work:~/tools_dir/$ spark_rapids_user_tools dataproc diagnostic --cluster test-cluster
Processing...⢿
This operation will collect sensitive information from your cluster, such as OS & HW info, Yarn/Spark configurations and log files etc.
Do you want to continue (yes/no): yes
Processing...⣻
Processing Completed!
```

2. Default mode and user input is skipped
```
psarthi@work:~/tools_dir/$ spark_rapids_user_tools dataproc diagnostic --cluster test-cluster -y
Processing...⣻
Processing Completed!
```

3. Verbose/Debug mode and user input is required.
```
psarthi@work:~/tools_dir/$ spark_rapids_user_tools dataproc diagnostic --cluster test-cluster -v
...
INFO rapids.tools.diagnostic.ctxt: Local output folder is set as: /home/psarthi/tools_dir/xyz
DEBUG rapids.tools.diagnostic: Set thread number as: 3
This operation will collect sensitive information from your cluster, such as OS & HW info, Yarn/Spark configurations and log files etc.
Do you want to continue (yes/no): yes
INFO rapids.tools.diagnostic: ======= [Process-Arguments]: Finished =======
INFO rapids.tools.diagnostic: ******* [Execution]: Starting *******
...
```

4. Verbose/Debug mode and user input is skipped
```
psarthi@work:~/tools_dir/$ spark_rapids_user_tools dataproc diagnostic --cluster test-cluster -v -y
...
INFO rapids.tools.diagnostic.ctxt: Local output folder is set as: /home/psarthi/tools_dir/xyz
DEBUG rapids.tools.diagnostic: Set thread number as: 3
WARNING rapids.tools.diagnostic: This operation will collect sensitive information from your cluster, such as OS & HW info, Yarn/Spark configurations and log files etc.
INFO rapids.tools.diagnostic: Confirmed by command line option.
INFO rapids.tools.diagnostic: ======= [Process-Arguments]: Finished =======
INFO rapids.tools.diagnostic: ******* [Execution]: Starting *******
...
```

