### PR TITLE
Fix system command processing during logging in user tools

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -369,7 +369,7 @@ class CMDDriverBase:
         self._handle_inconsistent_configurations(incorrect_envs)
 
     def run_sys_cmd(self,
-                    cmd: Union[str, list[str]],
+                    cmd: Union[str, list],
                     cmd_input: str = None,
                     fail_ok: bool = False,
                     env_vars: dict = None) -> str:

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -393,10 +393,8 @@ class CMDDriverBase:
                 if len(stdout_splits) > 0:
                     std_out_lines = Utils.gen_multiline_str([f'\t| {line}' for line in stdout_splits])
                     stdout_str = f'\n\t<STDOUT>\n{std_out_lines}'
-                if isinstance(cmd, list):
-                    cmd_list = cmd
-                else:
-                    cmd_list = cmd.split(' ')
+                # if the command is already a list, use it as-is. Otherwise, split the string into a list.
+                cmd_list = cmd if isinstance(cmd, list) else cmd.split(' ')
                 cmd_log_str = Utils.gen_joined_str(' ', process_credentials_option(cmd_list))
                 if len(stderr_splits) > 0:
                     std_err_lines = Utils.gen_multiline_str([f'\t| {line}' for line in stderr_splits])

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -20,7 +20,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
 from logging import Logger
-from typing import Type, Any, List, Callable
+from typing import Type, Any, List, Callable, Union
 
 from spark_rapids_tools import EnumeratedType, CspEnv
 from spark_rapids_pytools.common.prop_manager import AbstractPropertiesContainer, JSONPropertiesContainer, \
@@ -369,7 +369,7 @@ class CMDDriverBase:
         self._handle_inconsistent_configurations(incorrect_envs)
 
     def run_sys_cmd(self,
-                    cmd,
+                    cmd: Union[str, list[str]],
                     cmd_input: str = None,
                     fail_ok: bool = False,
                     env_vars: dict = None) -> str:
@@ -393,7 +393,11 @@ class CMDDriverBase:
                 if len(stdout_splits) > 0:
                     std_out_lines = Utils.gen_multiline_str([f'\t| {line}' for line in stdout_splits])
                     stdout_str = f'\n\t<STDOUT>\n{std_out_lines}'
-                cmd_log_str = Utils.gen_joined_str(' ', process_credentials_option(cmd))
+                if isinstance(cmd, list):
+                    cmd_list = cmd
+                else:
+                    cmd_list = cmd.split(' ')
+                cmd_log_str = Utils.gen_joined_str(' ', process_credentials_option(cmd_list))
                 if len(stderr_splits) > 0:
                     std_err_lines = Utils.gen_multiline_str([f'\t| {line}' for line in stderr_splits])
                     stderr_str = f'\n\t<STDERR>\n{std_err_lines}'


### PR DESCRIPTION
Fixes #632. The `cmd` argument in `run_sys_cmd()` in user tools can be of either list or string type. The inner method `process_credentials_option()` expects `cmd` to be of list type and processes each item. However, if `cmd` is of string type, then `process_credentials_option()` will process each character instead. 

### Changes:
1. Check the type of the `cmd` argument and split it into a list if it is of string type.
2. Add type constraints for the `cmd` argument in `run_sys_cmd()`.

### Testing:

The cmd described in the issue has been tested.

Cmd: `spark_rapids_user_tools dataproc diagnostic psarthi-dataproc-test -v`

**Previous output:**
```
2023-10-24 16:19:46,498 DEBUG rapids.tools.cmd_driver: executing CMD:
 <CMD: g c l o u d   c o m p u t e   s s h   p s a r t h i - d a t a p r o c - t e s t - m   - - z o n e   u s - c e n t r a l 1 - a   - - c o m m a n d = " P R E F I X = d i a g _ 2 0 2 3 1 0 2 4 2 3 1 9 0 2 _ E b 9 E E 5 f d   P L A T F O R M _ T Y P E = d a t a p r o c   / t m p / c o l l e c t . s h "   - - f o r m a t   j s o n>[
        <STDOUT>
        | /usr/lib/spark/bin/pyspark
        | Archive '/tmp/diag_20231024231902_Eb9EE5fd_info.tgz' is successfully created!
        | Archive '/tmp/diag_20231024231902_Eb9EE5fd_log.tgz' is successfully created!
        | []]; [
        <STDERR>
```

**Current output:**
```
 <CMD: gcloud compute ssh psarthi-dataproc-test-m --zone us-central1-a --command="PREFIX=diag_20231024231902_Eb9EE5fdPLATFORM_TYPE=dataproc/tmp/collect.sh"--format json>[
```