### PR TITLE
Profiling tool : Update readSchema string parser

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -272,6 +272,15 @@ abstract class AppBase(
     }
   }
 
+  private def trimSchema(str: String): String = {
+    val index = str.lastIndexOf(",")
+    if (index != -1 && str.contains("...")) {
+      str.substring(0, index)
+    } else {
+      str
+    }
+  }
+
   // The ReadSchema metadata is only in the eventlog for DataSource V1 readers
   protected def checkMetadataForReadSchema(sqlID: Long, planInfo: SparkPlanInfo): Unit = {
     // check if planInfo has ReadSchema
@@ -284,7 +293,7 @@ abstract class AppBase(
       val readSchema = ReadParser.formatSchemaStr(meta.getOrElse("ReadSchema", ""))
       val scanNode = allNodes.filter(node => {
         // Get ReadSchema of each Node and sanitize it for comparison
-        val trimmedNode = ReadParser.parseReadNode(node).schema.replace("...", "")
+        val trimmedNode = trimSchema(ReadParser.parseReadNode(node).schema)
         readSchema.contains(trimmedNode)
       }).filter(x => x.name.startsWith("Scan")).head
 


### PR DESCRIPTION
This fixes a bug  where the readSchema in the eventlog has some characters before the string "...".
Example:
If the eventlog has an entry of trimmed string of node such as:
```
name_26:string,name_30:string,name_27:string,name_31:string,m...
``` 
And the ReadSchema is:
```
name_26:string,name_30:string,name_27:string,name_31:string,name_29:string,name_24:string,name_28:string,name_35:string,name_33:string,name_32:string,name_34:string,name_36:string,name_41:bigint,name_39:bigint,totalmatchscore:bigint,name_42:bigint,name_38:bigint,name_40:bigint,name_52:bigint
```
This PR trims all the characters from the last comma until "..."


<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
