### PR TITLE
Support extra arguments in new user tools CLI

### DIFF
--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -48,7 +48,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                       global_discount: int = None,
                       gpu_cluster_recommendation: str = QualGpuClusterReshapeType.tostring(
                           QualGpuClusterReshapeType.get_default()),
-                      verbose: bool = False):
+                      verbose: bool = False,
+                      **rapids_options):
         """The Qualification cmd provides estimated running costs and speedups by migrating Apache
         Spark applications to GPU accelerated clusters.
 
@@ -98,6 +99,11 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                 "CLUSTER": recommend optimal GPU cluster by cost for entire cluster;
                 "JOB": recommend optimal GPU cluster by cost per job
         :param verbose: True or False to enable verbosity of the script.
+        :param rapids_options: A list of valid Qualification tool options.
+                Note that the wrapper ignores ["output-directory", "platform"] flags, and it does not support
+                multiple "spark-property" arguments.
+                For more details on Qualification tool options, please visit
+                https://nvidia.github.io/spark-rapids/docs/spark-qualification-tool.html#qualification-tool-options
         """
         if verbose:
             ToolLogging.enable_debug_mode()
@@ -118,7 +124,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         if qual_args:
             tool_obj = QualificationAsLocal(platform_type=qual_args['runtimePlatform'],
                                             output_folder=qual_args['outputFolder'],
-                                            wrapper_options=qual_args)
+                                            wrapper_options=qual_args,
+                                            rapids_options=rapids_options)
             tool_obj.launch()
 
     def profiling(self,
@@ -126,7 +133,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                   cluster: str = None,
                   platform: str = None,
                   output_folder: str = None,
-                  verbose: bool = False):
+                  verbose: bool = False,
+                  **rapids_options):
         """The Profiling cmd provides information which can be used for debugging and profiling
         Apache Spark applications running on accelerated GPU cluster.
 
@@ -145,6 +153,11 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                 and "databricks-azure".
         :param output_folder: path to store the output.
         :param verbose: True or False to enable verbosity of the script.
+        :param rapids_options: A list of valid Profiling tool options.
+                Note that the wrapper ignores ["output-directory", "worker-info"] flags, and it does not support
+                multiple "spark-property" arguments.
+                For more details on Profiling tool options, please visit
+                https://nvidia.github.io/spark-rapids/docs/spark-profiling-tool.html#profiling-tool-options
         """
         if verbose:
             ToolLogging.enable_debug_mode()
@@ -157,7 +170,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         if prof_args:
             tool_obj = ProfilingAsLocal(platform_type=prof_args['runtimePlatform'],
                                         output_folder=prof_args['outputFolder'],
-                                        wrapper_options=prof_args)
+                                        wrapper_options=prof_args,
+                                        rapids_options=rapids_options)
             tool_obj.launch()
 
     def bootstrap(self,

--- a/user_tools/src/spark_rapids_tools/utils/util.py
+++ b/user_tools/src/spark_rapids_tools/utils/util.py
@@ -92,7 +92,7 @@ def dump_tool_usage(tool_name: Optional[str], raise_sys_exit: Optional[bool] = T
     imported_module = __import__('spark_rapids_tools.cmdli', globals(), locals(), ['ToolsCLI'])
     wrapper_clzz = getattr(imported_module, 'ToolsCLI')
     help_name = 'ascli'
-    usage_cmd = f'{tool_name} --help'
+    usage_cmd = f'{tool_name} -- --help'
     try:
         fire.Fire(wrapper_clzz(), name=help_name, command=usage_cmd)
     except fire.core.FireExit:

--- a/user_tools/tests/spark_rapids_tools_ut/test_tool_argprocessor.py
+++ b/user_tools/tests/spark_rapids_tools_ut/test_tool_argprocessor.py
@@ -166,8 +166,8 @@ class TestToolArgProcessor(SparkRapidsToolsUT):  # pylint: disable=too-few-publi
                                                  platform='onprem')
         assert pytest_wrapped_e.type == SystemExit
         captured = capsys.readouterr()
-        # Verify there is no URL in error message
-        assert 'https://' not in captured.err
+        # Verify there is no URL in error message except for the one from the documentation
+        assert 'https://' not in captured.err or 'nvidia.github.io' in captured.err
 
     @pytest.mark.skip(reason='Unit tests are not completed yet')
     def test_arg_cases_coverage(self):


### PR DESCRIPTION
Fixes #574. This PR improves new user tools CLI to support extra arguments that are passed to the JAR (eg. `--csv`, ` --print-plans` etc)

## Testing

### Sample Command 1
```shell
ascii profiling -- --help
```

#### Output
```shell
...
    -v, --verbose=VERBOSE
        Type: bool
        Default: False
        True or False to enable verbosity of the script.
    Additional flags are accepted.
        A list of valid Profiling tool options. Note that the wrapper ignores ["output-directory", "worker-info"] flags, and it does not support multiple "spark-property" arguments. For more details on Profiling tool options, please visit https://nvidia.github.io/spark-rapids/docs/spark-profiling-tool.html#profiling-tool-options

```

### Sample Command 2
```shell
ascli profiling --eventlogs test-eventlog  --print-plans  --csv --platform dataproc
```

#### Output
```shell
...
____________________________________________________________________________________________________
                                          PROFILING Report
____________________________________________________________________________________________________

Output:
--------------------
Profiling tool output: /work_dir/prof_20231101232938_036EBDBc/rapids_4_spark_profile
    prof_20231101232938_036EBDBc
    └── rapids_4_spark_profile
        └── application_1698358295332_0018
            ├── planDescriptions.log
            ├── job_information.csv
            ├── sql_plan_metrics_for_application.csv
            ├── rapids_accelerator_jar_and_cudf_jar.csv
            ├── profile.log
            ├── executor_information.csv
            ├── spark_properties.csv
            ├── application_information.csv
            ├── job_+_stage_level_aggregated_task_metrics.csv
            ├── sql_duration_and_executor_cpu_time_percent.csv
            ├── data_source_information.csv
            ├── sql_to_stage_information.csv
            ├── application_log_path_mapping.csv
            ├── io_metrics.csv
            ├── sql_level_aggregated_task_metrics.csv
            └── spark_rapids_parameters_set_explicitly.csv
    2 directories, 16 files
    - To learn more about the output details, visit https://nvidia.github.io/spark-rapids/docs/spark-profiling-tool.html#understanding-profiling-tool-detailed-output-and-examples

```