### PR TITLE
[BUG] Support autoscaling clusters for user qualification tool on Databricks platforms

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
@@ -205,7 +205,20 @@ class DatabricksCluster(ClusterBase):
         master_nodes_from_conf = self.props.get_value_silent('driver')
         worker_nodes_from_conf = self.props.get_value_silent('executors')
         num_workers = self.props.get_value_silent('num_workers')
+        if num_workers is None and self.props.get_value_silent('autoscale') is not None:
+            target_workers = self.props.get_value_silent('autoscale', 'target_workers')
+            # use min_workers since it is usually the same as target_workers
+            min_workers = self.props.get_value_silent('autoscale', 'min_workers')
+            if target_workers is not None:
+                num_workers = target_workers
+                self.logger.info('Autoscaling cluster, will set number of workers to target_workers = %s',
+                                 num_workers)
+            elif min_workers is not None:
+                num_workers = min_workers
+                self.logger.info('Autoscaling cluster, will set number of workers to min_workers = %s',
+                                 num_workers)
         if num_workers is None:
+            self.logger.info('Unable to find number of workers for cluster, will default to 0')
             num_workers = 0
         # construct master node info when cluster is inactive
         if master_nodes_from_conf is None:

--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
@@ -289,7 +289,20 @@ class DatabricksAzureCluster(ClusterBase):
         driver_nodes_from_conf = self.props.get_value_silent('driver')
         worker_nodes_from_conf = self.props.get_value_silent('executors')
         num_workers = self.props.get_value_silent('num_workers')
+        if num_workers is None and self.props.get_value_silent('autoscale') is not None:
+            target_workers = self.props.get_value_silent('autoscale', 'target_workers')
+            # use min_workers since it is usually the same as target_workers
+            min_workers = self.props.get_value_silent('autoscale', 'min_workers')
+            if target_workers is not None:
+                num_workers = target_workers
+                self.logger.info('Autoscaling cluster, will set number of workers to target_workers = %s',
+                                 num_workers)
+            elif min_workers is not None:
+                num_workers = min_workers
+                self.logger.info('Autoscaling cluster, will set number of workers to min_workers = %s',
+                                 num_workers)
         if num_workers is None:
+            self.logger.info('Unable to find number of workers for cluster, will default to 0')
             num_workers = 0
         # construct driver node info when cluster is inactive
         if driver_nodes_from_conf is None:


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/624

The issue was due to that the user qualification tool is unable to find the number of workers for autoscaling clusters on Databricks-AWS/Azure because the key `num_workers` does not exist in the cluster properties file. In this case, the tool defaults num_workers to 0, which leads to `RuntimeError: Invalid cluster: The cluster has no worker nodes.`.

In this PR, we add logic to extract the number of workers from the `autoscale` information for Databricks AWS/Azure autoscaling clusters.