### PR TITLE
Bump pyarrow version

### DIFF
--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "pylint-pydantic==0.3.0",
     # used for common API to access remote filesystems like local/s3/gcs/hdfs
     # this will include numpy
-    "pyarrow==12.0.1",
+    "pyarrow==14.0.1",
     # used for ADLS filesystem implementation
     # Issue-568: use 12.17.0 as the new 12.18.0 causes an error in runtime
     "azure-storage-blob==12.17.0",


### PR DESCRIPTION
Fixes #655. Bumps pyarrow version from `12.0.1` to `14.0.1`. Locally tested for `s3` and `gcp` storages.