### PR TITLE
Updating new CLI name from ascli to spark_rapids

### DIFF
--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -49,7 +49,7 @@ dynamic=["entry-points", "version"]
 
 [project.scripts]
 spark_rapids_user_tools = "spark_rapids_pytools.wrapper:main"
-ascli = "spark_rapids_tools.cmdli.tools_cli:main"
+spark_rapids = "spark_rapids_tools.cmdli.tools_cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/user_tools/src/spark_rapids_tools/utils/util.py
+++ b/user_tools/src/spark_rapids_tools/utils/util.py
@@ -91,7 +91,7 @@ def to_snake_case(word: str) -> str:
 def dump_tool_usage(tool_name: Optional[str], raise_sys_exit: Optional[bool] = True):
     imported_module = __import__('spark_rapids_tools.cmdli', globals(), locals(), ['ToolsCLI'])
     wrapper_clzz = getattr(imported_module, 'ToolsCLI')
-    help_name = 'ascli'
+    help_name = 'spark_rapids'
     usage_cmd = f'{tool_name} -- --help'
     try:
         fire.Fire(wrapper_clzz(), name=help_name, command=usage_cmd)


### PR DESCRIPTION
Changing new CLI from `ascli` to `spark_rapids` ahead of formal documentation updates to the new User Guide