### PR TITLE
Fix incorrect processing of short flags for user tools cli

### DIFF
--- a/user_tools/src/spark_rapids_pytools/common/utilities.py
+++ b/user_tools/src/spark_rapids_pytools/common/utilities.py
@@ -45,6 +45,7 @@ from spark_rapids_pytools import get_version
 
 class Utils:
     """Utility class used to enclose common helpers and utilities."""
+    warning_issued = False
 
     @classmethod
     def gen_random_string(cls, str_length: int) -> str:
@@ -209,20 +210,23 @@ class Utils:
         return os.uname().sysname
 
     @classmethod
-    def get_value_or_pop(cls, provided_value, options_dict, shortcut_key, default_value=None):
+    def get_value_or_pop(cls, provided_value, options_dict, short_flag, default_value=None):
         """
         Gets a value or pops it from the provided options dictionary if the value is not explicitly provided.
 
         :param provided_value: The value to return if not None.
         :param options_dict: Dictionary containing options.
-        :param shortcut_key: Key to look for in options_dict.
+        :param short_flag: Flag to look for in options_dict.
         :param default_value: The default value to return if the target_key is not found. Defaults to None.
         :return: provided_value or the value from options_dict or the default_value.
         """
+        if not cls.warning_issued:
+            cls.warning_issued = True
+            print(f"Warning: Instead of using short flags for argument, consider providing the value directly.")
         if provided_value is not None:
             return provided_value
-        elif shortcut_key in options_dict:
-            return options_dict.pop(shortcut_key)
+        elif short_flag in options_dict:
+            return options_dict.pop(short_flag)
         else:
             return default_value
 

--- a/user_tools/src/spark_rapids_pytools/common/utilities.py
+++ b/user_tools/src/spark_rapids_pytools/common/utilities.py
@@ -222,13 +222,12 @@ class Utils:
         """
         if not cls.warning_issued:
             cls.warning_issued = True
-            print(f"Warning: Instead of using short flags for argument, consider providing the value directly.")
+            print('Warning: Instead of using short flags for argument, consider providing the value directly.')
         if provided_value is not None:
             return provided_value
-        elif short_flag in options_dict:
+        if short_flag in options_dict:
             return options_dict.pop(short_flag)
-        else:
-            return default_value
+        return default_value
 
 
 class ToolLogging:

--- a/user_tools/src/spark_rapids_pytools/common/utilities.py
+++ b/user_tools/src/spark_rapids_pytools/common/utilities.py
@@ -208,6 +208,24 @@ class Utils:
     def get_os_name(cls) -> str:
         return os.uname().sysname
 
+    @classmethod
+    def get_value_or_pop(cls, provided_value, options_dict, shortcut_key, default_value=None):
+        """
+        Gets a value or pops it from the provided options dictionary if the value is not explicitly provided.
+
+        :param provided_value: The value to return if not None.
+        :param options_dict: Dictionary containing options.
+        :param shortcut_key: Key to look for in options_dict.
+        :param default_value: The default value to return if the target_key is not found. Defaults to None.
+        :return: provided_value or the value from options_dict or the default_value.
+        """
+        if provided_value is not None:
+            return provided_value
+        elif shortcut_key in options_dict:
+            return options_dict.pop(shortcut_key)
+        else:
+            return default_value
+
 
 class ToolLogging:
     """Holds global utilities used for logging."""

--- a/user_tools/src/spark_rapids_pytools/common/utilities.py
+++ b/user_tools/src/spark_rapids_pytools/common/utilities.py
@@ -220,12 +220,12 @@ class Utils:
         :param default_value: The default value to return if the target_key is not found. Defaults to None.
         :return: provided_value or the value from options_dict or the default_value.
         """
-        if not cls.warning_issued:
-            cls.warning_issued = True
-            print('Warning: Instead of using short flags for argument, consider providing the value directly.')
         if provided_value is not None:
             return provided_value
         if short_flag in options_dict:
+            if not cls.warning_issued:
+                cls.warning_issued = True
+                print('Warning: Instead of using short flags for argument, consider providing the value directly.')
             return options_dict.pop(short_flag)
         return default_value
 

--- a/user_tools/src/spark_rapids_pytools/wrappers/databricks_aws_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/databricks_aws_wrapper.py
@@ -105,15 +105,23 @@ class CliDBAWSLocalMode:  # pylint: disable=too-few-public-methods
                 For more details on Qualification tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-qualification-tool.html#qualification-tool-options
         """
-        is_verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
-        if is_verbose:
+        verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
+        profile = Utils.get_value_or_pop(profile, rapids_options, 'p')
+        aws_profile = Utils.get_value_or_pop(aws_profile,  rapids_options, 'a')
+        remote_folder = Utils.get_value_or_pop(remote_folder, rapids_options, 'r')
+        jvm_heap_size = Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+        eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
+        filter_apps = Utils.get_value_or_pop(filter_apps, rapids_options, 'f')
+        tools_jar = Utils.get_value_or_pop(tools_jar, rapids_options, 't')
+        local_folder = Utils.get_value_or_pop(local_folder, rapids_options, 'l')
+        if verbose:
             # when debug is set to true set it in the environment.
             ToolLogging.enable_debug_mode()
         wrapper_qual_options = {
             'platformOpts': {
                 # the databricks profile
-                'profile': Utils.get_value_or_pop(profile, rapids_options, 'p'),
-                'awsProfile': Utils.get_value_or_pop(aws_profile,  rapids_options, 'a'),
+                'profile': profile,
+                'awsProfile': aws_profile,
                 'credentialFile': credentials_file,
                 'deployMode': DeployMode.LOCAL,
             },
@@ -122,14 +130,14 @@ class CliDBAWSLocalMode:  # pylint: disable=too-few-public-methods
                 'gpuCluster': gpu_cluster
             },
             'jobSubmissionProps': {
-                'remoteFolder': Utils.get_value_or_pop(remote_folder, rapids_options, 'r'),
+                'remoteFolder': remote_folder,
                 'platformArgs': {
-                    'jvmMaxHeapSize': Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+                    'jvmMaxHeapSize': jvm_heap_size
                 }
             },
-            'eventlogs': Utils.get_value_or_pop(eventlogs, rapids_options, 'e'),
-            'filterApps': Utils.get_value_or_pop(filter_apps, rapids_options, 'f'),
-            'toolsJar': Utils.get_value_or_pop(tools_jar, rapids_options, 't'),
+            'eventlogs': eventlogs,
+            'filterApps': filter_apps,
+            'toolsJar': tools_jar,
             'gpuClusterRecommendation': gpu_cluster_recommendation,
             'cpuDiscount': cpu_discount,
             'gpuDiscount': gpu_discount,
@@ -137,7 +145,7 @@ class CliDBAWSLocalMode:  # pylint: disable=too-few-public-methods
         }
         QualificationAsLocal(platform_type=CspEnv.DATABRICKS_AWS,
                              cluster=None,
-                             output_folder=Utils.get_value_or_pop(local_folder, rapids_options, 'l'),
+                             output_folder=local_folder,
                              wrapper_options=wrapper_qual_options,
                              rapids_options=rapids_options).launch()
 
@@ -193,33 +201,43 @@ class CliDBAWSLocalMode:  # pylint: disable=too-few-public-methods
                 For more details on Profiling tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-profiling-tool.html#profiling-tool-options
         """
-        is_verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
-        if is_verbose:
+        verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
+        profile = Utils.get_value_or_pop(profile, rapids_options, 'p')
+        aws_profile = Utils.get_value_or_pop(aws_profile,  rapids_options, 'a')
+        credentials_file = Utils.get_value_or_pop(credentials_file, rapids_options, 'c')
+        gpu_cluster = Utils.get_value_or_pop(gpu_cluster, rapids_options, 'g')
+        remote_folder = Utils.get_value_or_pop(remote_folder, rapids_options, 'r')
+        jvm_heap_size = Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+        eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
+        tools_jar = Utils.get_value_or_pop(tools_jar, rapids_options, 't')
+        worker_info = Utils.get_value_or_pop(worker_info, rapids_options, 'w')
+        local_folder = Utils.get_value_or_pop(local_folder, rapids_options, 'l')
+        if verbose:
             # when debug is set to true set it in the environment.
             ToolLogging.enable_debug_mode()
         wrapper_prof_options = {
             'platformOpts': {
                 # the databricks profile
-                'profile': Utils.get_value_or_pop(profile, rapids_options, 'p'),
-                'awsProfile': Utils.get_value_or_pop(aws_profile,  rapids_options, 'a'),
-                'credentialFile': Utils.get_value_or_pop(credentials_file, rapids_options, 'c'),
+                'profile': profile,
+                'awsProfile': aws_profile,
+                'credentialFile': credentials_file,
                 'deployMode': DeployMode.LOCAL,
             },
             'migrationClustersProps': {
-                'gpuCluster': Utils.get_value_or_pop(gpu_cluster, rapids_options, 'g'),
+                'gpuCluster': gpu_cluster
             },
             'jobSubmissionProps': {
-                'remoteFolder': Utils.get_value_or_pop(remote_folder, rapids_options, 'r'),
+                'remoteFolder': remote_folder,
                 'platformArgs': {
-                    'jvmMaxHeapSize': Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+                    'jvmMaxHeapSize': jvm_heap_size
                 }
             },
-            'eventlogs': Utils.get_value_or_pop(eventlogs, rapids_options, 'e'),
-            'toolsJar': Utils.get_value_or_pop(tools_jar, rapids_options, 't'),
-            'autoTunerFileInput': Utils.get_value_or_pop(worker_info, rapids_options, 'w')
+            'eventlogs': eventlogs,
+            'toolsJar': tools_jar,
+            'autoTunerFileInput': worker_info
         }
         ProfilingAsLocal(platform_type=CspEnv.DATABRICKS_AWS,
-                         output_folder=Utils.get_value_or_pop(local_folder, rapids_options, 'l'),
+                         output_folder=local_folder,
                          wrapper_options=wrapper_prof_options,
                          rapids_options=rapids_options).launch()
 

--- a/user_tools/src/spark_rapids_pytools/wrappers/databricks_azure_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/databricks_azure_wrapper.py
@@ -103,14 +103,21 @@ class CliDBAzureLocalMode:  # pylint: disable=too-few-public-methods
                 For more details on Qualification tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-qualification-tool.html#qualification-tool-options
         """
-        is_verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
-        if is_verbose:
+        verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
+        profile = Utils.get_value_or_pop(profile, rapids_options, 'p')
+        remote_folder = Utils.get_value_or_pop(remote_folder, rapids_options, 'r')
+        jvm_heap_size = Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+        eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
+        filter_apps = Utils.get_value_or_pop(filter_apps, rapids_options, 'f')
+        tools_jar = Utils.get_value_or_pop(tools_jar, rapids_options, 't')
+        local_folder = Utils.get_value_or_pop(local_folder, rapids_options, 'l')
+        if verbose:
             # when debug is set to true set it in the environment.
             ToolLogging.enable_debug_mode()
         wrapper_qual_options = {
             'platformOpts': {
                 # the databricks profile
-                'profile': Utils.get_value_or_pop(profile, rapids_options, 'p'),
+                'profile': profile,
                 'credentialFile': credentials_file,
                 'deployMode': DeployMode.LOCAL,
             },
@@ -119,14 +126,14 @@ class CliDBAzureLocalMode:  # pylint: disable=too-few-public-methods
                 'gpuCluster': gpu_cluster
             },
             'jobSubmissionProps': {
-                'remoteFolder': Utils.get_value_or_pop(remote_folder, rapids_options, 'r'),
+                'remoteFolder': remote_folder,
                 'platformArgs': {
-                    'jvmMaxHeapSize': Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+                    'jvmMaxHeapSize': jvm_heap_size
                 }
             },
-            'eventlogs': Utils.get_value_or_pop(eventlogs, rapids_options, 'e'),
-            'filterApps': Utils.get_value_or_pop(filter_apps, rapids_options, 'f'),
-            'toolsJar': Utils.get_value_or_pop(tools_jar, rapids_options, 't'),
+            'eventlogs': eventlogs,
+            'filterApps': filter_apps,
+            'toolsJar': tools_jar,
             'gpuClusterRecommendation': gpu_cluster_recommendation,
             'cpuDiscount': cpu_discount,
             'gpuDiscount': gpu_discount,
@@ -134,7 +141,7 @@ class CliDBAzureLocalMode:  # pylint: disable=too-few-public-methods
         }
         QualificationAsLocal(platform_type=CspEnv.DATABRICKS_AZURE,
                              cluster=None,
-                             output_folder=Utils.get_value_or_pop(local_folder, rapids_options, 'l'),
+                             output_folder=local_folder,
                              wrapper_options=wrapper_qual_options,
                              rapids_options=rapids_options).launch()
 
@@ -187,32 +194,41 @@ class CliDBAzureLocalMode:  # pylint: disable=too-few-public-methods
                 For more details on Profiling tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-profiling-tool.html#profiling-tool-options
         """
-        is_verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
-        if is_verbose:
+        verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
+        profile = Utils.get_value_or_pop(profile, rapids_options, 'p')
+        credentials_file = Utils.get_value_or_pop(credentials_file, rapids_options, 'c')
+        gpu_cluster = Utils.get_value_or_pop(gpu_cluster, rapids_options, 'g')
+        remote_folder = Utils.get_value_or_pop(remote_folder, rapids_options, 'r')
+        jvm_heap_size = Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+        eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
+        tools_jar = Utils.get_value_or_pop(tools_jar, rapids_options, 't')
+        worker_info = Utils.get_value_or_pop(worker_info, rapids_options, 'w')
+        local_folder = Utils.get_value_or_pop(local_folder, rapids_options, 'l')
+        if verbose:
             # when debug is set to true set it in the environment.
             ToolLogging.enable_debug_mode()
         wrapper_prof_options = {
             'platformOpts': {
                 # the databricks profile
-                'profile': Utils.get_value_or_pop(profile, rapids_options, 'p'),
-                'credentialFile': Utils.get_value_or_pop(credentials_file, rapids_options, 'c'),
+                'profile': profile,
+                'credentialFile': credentials_file,
                 'deployMode': DeployMode.LOCAL,
             },
             'migrationClustersProps': {
-                'gpuCluster': Utils.get_value_or_pop(gpu_cluster, rapids_options, 'g'),
+                'gpuCluster': gpu_cluster
             },
             'jobSubmissionProps': {
-                'remoteFolder': Utils.get_value_or_pop(remote_folder, rapids_options, 'r'),
+                'remoteFolder': remote_folder,
                 'platformArgs': {
-                    'jvmMaxHeapSize': Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+                    'jvmMaxHeapSize': jvm_heap_size
                 }
             },
-            'eventlogs': Utils.get_value_or_pop(eventlogs, rapids_options, 'e'),
-            'toolsJar': Utils.get_value_or_pop(tools_jar, rapids_options, 't'),
-            'autoTunerFileInput': Utils.get_value_or_pop(worker_info, rapids_options, 'w')
+            'eventlogs': eventlogs,
+            'toolsJar': tools_jar,
+            'autoTunerFileInput': worker_info
         }
         ProfilingAsLocal(platform_type=CspEnv.DATABRICKS_AZURE,
-                         output_folder=Utils.get_value_or_pop(local_folder, rapids_options, 'l'),
+                         output_folder=local_folder,
                          wrapper_options=wrapper_prof_options,
                          rapids_options=rapids_options).launch()
 

--- a/user_tools/src/spark_rapids_pytools/wrappers/databricks_azure_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/databricks_azure_wrapper.py
@@ -16,7 +16,7 @@
 """Wrapper class to run tools associated with RAPIDS Accelerator for Apache Spark plugin on DATABRICKS_AZURE."""
 from spark_rapids_tools import CspEnv
 from spark_rapids_pytools.cloud_api.sp_types import DeployMode
-from spark_rapids_pytools.common.utilities import ToolLogging
+from spark_rapids_pytools.common.utilities import Utils, ToolLogging
 from spark_rapids_pytools.rapids.diagnostic import Diagnostic
 from spark_rapids_pytools.rapids.profiling import ProfilingAsLocal
 from spark_rapids_pytools.rapids.qualification import QualFilterApp, QualificationAsLocal, QualGpuClusterReshapeType
@@ -39,8 +39,8 @@ class CliDBAzureLocalMode:  # pylint: disable=too-few-public-methods
                       filter_apps: str = QualFilterApp.tostring(QualFilterApp.SAVINGS),
                       gpu_cluster_recommendation: str = QualGpuClusterReshapeType.tostring(
                           QualGpuClusterReshapeType.get_default()),
-                      jvm_heap_size: int = 24,
-                      verbose: bool = False,
+                      jvm_heap_size: int = None,
+                      verbose: bool = None,
                       cpu_discount: int = None,
                       gpu_discount: int = None,
                       global_discount: int = None,
@@ -103,13 +103,14 @@ class CliDBAzureLocalMode:  # pylint: disable=too-few-public-methods
                 For more details on Qualification tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-qualification-tool.html#qualification-tool-options
         """
-        if verbose:
+        is_verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
+        if is_verbose:
             # when debug is set to true set it in the environment.
             ToolLogging.enable_debug_mode()
         wrapper_qual_options = {
             'platformOpts': {
                 # the databricks profile
-                'profile': profile,
+                'profile': Utils.get_value_or_pop(profile, rapids_options, 'p'),
                 'credentialFile': credentials_file,
                 'deployMode': DeployMode.LOCAL,
             },
@@ -118,14 +119,14 @@ class CliDBAzureLocalMode:  # pylint: disable=too-few-public-methods
                 'gpuCluster': gpu_cluster
             },
             'jobSubmissionProps': {
-                'remoteFolder': remote_folder,
+                'remoteFolder': Utils.get_value_or_pop(remote_folder, rapids_options, 'r'),
                 'platformArgs': {
-                    'jvmMaxHeapSize': jvm_heap_size
+                    'jvmMaxHeapSize': Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
                 }
             },
-            'eventlogs': eventlogs,
-            'filterApps': filter_apps,
-            'toolsJar': tools_jar,
+            'eventlogs': Utils.get_value_or_pop(eventlogs, rapids_options, 'e'),
+            'filterApps': Utils.get_value_or_pop(filter_apps, rapids_options, 'f'),
+            'toolsJar': Utils.get_value_or_pop(tools_jar, rapids_options, 't'),
             'gpuClusterRecommendation': gpu_cluster_recommendation,
             'cpuDiscount': cpu_discount,
             'gpuDiscount': gpu_discount,
@@ -133,7 +134,7 @@ class CliDBAzureLocalMode:  # pylint: disable=too-few-public-methods
         }
         QualificationAsLocal(platform_type=CspEnv.DATABRICKS_AZURE,
                              cluster=None,
-                             output_folder=local_folder,
+                             output_folder=Utils.get_value_or_pop(local_folder, rapids_options, 'l'),
                              wrapper_options=wrapper_qual_options,
                              rapids_options=rapids_options).launch()
 
@@ -146,8 +147,8 @@ class CliDBAzureLocalMode:  # pylint: disable=too-few-public-methods
                   remote_folder: str = None,
                   tools_jar: str = None,
                   credentials_file: str = None,
-                  jvm_heap_size: int = 24,
-                  verbose: bool = False,
+                  jvm_heap_size: int = None,
+                  verbose: bool = None,
                   **rapids_options) -> None:
         """
         The Profiling tool analyzes both CPU or GPU generated event logs and generates information
@@ -186,31 +187,32 @@ class CliDBAzureLocalMode:  # pylint: disable=too-few-public-methods
                 For more details on Profiling tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-profiling-tool.html#profiling-tool-options
         """
-        if verbose:
+        is_verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
+        if is_verbose:
             # when debug is set to true set it in the environment.
             ToolLogging.enable_debug_mode()
         wrapper_prof_options = {
             'platformOpts': {
                 # the databricks profile
-                'profile': profile,
-                'credentialFile': credentials_file,
+                'profile': Utils.get_value_or_pop(profile, rapids_options, 'p'),
+                'credentialFile': Utils.get_value_or_pop(credentials_file, rapids_options, 'c'),
                 'deployMode': DeployMode.LOCAL,
             },
             'migrationClustersProps': {
-                'gpuCluster': gpu_cluster
+                'gpuCluster': Utils.get_value_or_pop(gpu_cluster, rapids_options, 'g'),
             },
             'jobSubmissionProps': {
-                'remoteFolder': remote_folder,
+                'remoteFolder': Utils.get_value_or_pop(remote_folder, rapids_options, 'r'),
                 'platformArgs': {
-                    'jvmMaxHeapSize': jvm_heap_size
+                    'jvmMaxHeapSize': Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
                 }
             },
-            'eventlogs': eventlogs,
-            'toolsJar': tools_jar,
-            'autoTunerFileInput': worker_info
+            'eventlogs': Utils.get_value_or_pop(eventlogs, rapids_options, 'e'),
+            'toolsJar': Utils.get_value_or_pop(tools_jar, rapids_options, 't'),
+            'autoTunerFileInput': Utils.get_value_or_pop(worker_info, rapids_options, 'w')
         }
         ProfilingAsLocal(platform_type=CspEnv.DATABRICKS_AZURE,
-                         output_folder=local_folder,
+                         output_folder=Utils.get_value_or_pop(local_folder, rapids_options, 'l'),
                          wrapper_options=wrapper_prof_options,
                          rapids_options=rapids_options).launch()
 

--- a/user_tools/src/spark_rapids_pytools/wrappers/dataproc_gke_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/dataproc_gke_wrapper.py
@@ -100,8 +100,14 @@ class CliDataprocGKELocalMode:  # pylint: disable=too-few-public-methods
                 For more details on Qualification tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-qualification-tool.html#qualification-tool-options
         """
-        is_verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
-        if is_verbose:
+        verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
+        remote_folder = Utils.get_value_or_pop(remote_folder, rapids_options, 'r')
+        jvm_heap_size = Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+        eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
+        filter_apps = Utils.get_value_or_pop(filter_apps, rapids_options, 'f')
+        tools_jar = Utils.get_value_or_pop(tools_jar, rapids_options, 't')
+        local_folder = Utils.get_value_or_pop(local_folder, rapids_options, 'l')
+        if verbose:
             # when debug is set to true set it in the environment.
             ToolLogging.enable_debug_mode()
         wrapper_qual_options = {
@@ -114,14 +120,14 @@ class CliDataprocGKELocalMode:  # pylint: disable=too-few-public-methods
                 'gpuCluster': gpu_cluster
             },
             'jobSubmissionProps': {
-                'remoteFolder': Utils.get_value_or_pop(remote_folder, rapids_options, 'r'),
+                'remoteFolder': remote_folder,
                 'platformArgs': {
-                    'jvmMaxHeapSize': Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+                    'jvmMaxHeapSize': jvm_heap_size
                 }
             },
-            'eventlogs': Utils.get_value_or_pop(eventlogs, rapids_options, 'e'),
-            'filterApps': Utils.get_value_or_pop(filter_apps, rapids_options, 'f'),
-            'toolsJar': Utils.get_value_or_pop(tools_jar, rapids_options, 't'),
+            'eventlogs': eventlogs,
+            'filterApps': filter_apps,
+            'toolsJar': tools_jar,
             'gpuClusterRecommendation': gpu_cluster_recommendation,
             'cpuDiscount': cpu_discount,
             'gpuDiscount': gpu_discount,
@@ -129,7 +135,7 @@ class CliDataprocGKELocalMode:  # pylint: disable=too-few-public-methods
         }
 
         tool_obj = QualificationAsLocal(platform_type=CspEnv.DATAPROC_GKE,
-                                        output_folder=Utils.get_value_or_pop(local_folder, rapids_options, 'l'),
+                                        output_folder=local_folder,
                                         wrapper_options=wrapper_qual_options,
                                         rapids_options=rapids_options)
         tool_obj.launch()

--- a/user_tools/src/spark_rapids_pytools/wrappers/dataproc_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/dataproc_wrapper.py
@@ -102,8 +102,14 @@ class CliDataprocLocalMode:  # pylint: disable=too-few-public-methods
                 For more details on Qualification tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-qualification-tool.html#qualification-tool-options
         """
-        is_verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
-        if is_verbose:
+        verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
+        remote_folder = Utils.get_value_or_pop(remote_folder, rapids_options, 'r')
+        jvm_heap_size = Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+        eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
+        filter_apps = Utils.get_value_or_pop(filter_apps, rapids_options, 'f')
+        tools_jar = Utils.get_value_or_pop(tools_jar, rapids_options, 't')
+        local_folder = Utils.get_value_or_pop(local_folder, rapids_options, 'l')
+        if verbose:
             # when debug is set to true set it in the environment.
             ToolLogging.enable_debug_mode()
         wrapper_qual_options = {
@@ -116,14 +122,14 @@ class CliDataprocLocalMode:  # pylint: disable=too-few-public-methods
                 'gpuCluster': gpu_cluster
             },
             'jobSubmissionProps': {
-                'remoteFolder': Utils.get_value_or_pop(remote_folder, rapids_options, 'r'),
+                'remoteFolder': remote_folder,
                 'platformArgs': {
-                    'jvmMaxHeapSize': Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+                    'jvmMaxHeapSize': jvm_heap_size
                 }
             },
-            'eventlogs': Utils.get_value_or_pop(eventlogs, rapids_options, 'e'),
-            'filterApps': Utils.get_value_or_pop(filter_apps, rapids_options, 'f'),
-            'toolsJar': Utils.get_value_or_pop(tools_jar, rapids_options, 't'),
+            'eventlogs': eventlogs,
+            'filterApps': filter_apps,
+            'toolsJar': tools_jar,
             'gpuClusterRecommendation': gpu_cluster_recommendation,
             'cpuDiscount': cpu_discount,
             'gpuDiscount': gpu_discount,
@@ -131,7 +137,7 @@ class CliDataprocLocalMode:  # pylint: disable=too-few-public-methods
         }
 
         tool_obj = QualificationAsLocal(platform_type=CspEnv.DATAPROC,
-                                        output_folder=Utils.get_value_or_pop(local_folder, rapids_options, 'l'),
+                                        output_folder=local_folder,
                                         wrapper_options=wrapper_qual_options,
                                         rapids_options=rapids_options)
         tool_obj.launch()
@@ -184,31 +190,39 @@ class CliDataprocLocalMode:  # pylint: disable=too-few-public-methods
                 For more details on Profiling tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-profiling-tool.html#profiling-tool-options
         """
-        is_verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
-        if is_verbose:
+        verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
+        credentials_file = Utils.get_value_or_pop(credentials_file, rapids_options, 'c')
+        gpu_cluster = Utils.get_value_or_pop(gpu_cluster, rapids_options, 'g')
+        remote_folder = Utils.get_value_or_pop(remote_folder, rapids_options, 'r')
+        jvm_heap_size = Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+        eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
+        tools_jar = Utils.get_value_or_pop(tools_jar, rapids_options, 't')
+        worker_info = Utils.get_value_or_pop(worker_info, rapids_options, 'w')
+        local_folder = Utils.get_value_or_pop(local_folder, rapids_options, 'l')
+        if verbose:
             # when debug is set to true set it in the environment.
             ToolLogging.enable_debug_mode()
         wrapper_prof_options = {
             'platformOpts': {
-                'credentialFile': Utils.get_value_or_pop(credentials_file, rapids_options, 'c'),
+                'credentialFile': credentials_file,
                 'deployMode': DeployMode.LOCAL,
             },
             'migrationClustersProps': {
-                'gpuCluster': Utils.get_value_or_pop(gpu_cluster, rapids_options, 'g')
+                'gpuCluster': gpu_cluster
             },
             'jobSubmissionProps': {
-                'remoteFolder': Utils.get_value_or_pop(remote_folder, rapids_options, 'r'),
+                'remoteFolder': remote_folder,
                 'platformArgs': {
-                    'jvmMaxHeapSize': Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+                    'jvmMaxHeapSize': jvm_heap_size
                 }
             },
-            'eventlogs': Utils.get_value_or_pop(eventlogs, rapids_options, 'e'),
-            'toolsJar': Utils.get_value_or_pop(tools_jar, rapids_options, 't'),
-            'autoTunerFileInput': Utils.get_value_or_pop(worker_info, rapids_options, 'w')
+            'eventlogs': eventlogs,
+            'toolsJar': tools_jar,
+            'autoTunerFileInput': worker_info
         }
 
         ProfilingAsLocal(platform_type=CspEnv.DATAPROC,
-                         output_folder=Utils.get_value_or_pop(local_folder, rapids_options, 'l'),
+                         output_folder=local_folder,
                          wrapper_options=wrapper_prof_options,
                          rapids_options=rapids_options).launch()
 

--- a/user_tools/src/spark_rapids_pytools/wrappers/dataproc_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/dataproc_wrapper.py
@@ -16,7 +16,7 @@
 
 from spark_rapids_tools import CspEnv
 from spark_rapids_pytools.cloud_api.sp_types import DeployMode
-from spark_rapids_pytools.common.utilities import ToolLogging
+from spark_rapids_pytools.common.utilities import Utils, ToolLogging
 from spark_rapids_pytools.rapids.bootstrap import Bootstrap
 from spark_rapids_pytools.rapids.diagnostic import Diagnostic
 from spark_rapids_pytools.rapids.profiling import ProfilingAsLocal
@@ -39,8 +39,8 @@ class CliDataprocLocalMode:  # pylint: disable=too-few-public-methods
                       filter_apps: str = QualFilterApp.tostring(QualFilterApp.SAVINGS),
                       gpu_cluster_recommendation: str = QualGpuClusterReshapeType.tostring(
                           QualGpuClusterReshapeType.get_default()),
-                      jvm_heap_size: int = 24,
-                      verbose: bool = False,
+                      jvm_heap_size: int = None,
+                      verbose: bool = None,
                       cpu_discount: int = None,
                       gpu_discount: int = None,
                       global_discount: int = None,
@@ -102,7 +102,8 @@ class CliDataprocLocalMode:  # pylint: disable=too-few-public-methods
                 For more details on Qualification tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-qualification-tool.html#qualification-tool-options
         """
-        if verbose:
+        is_verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
+        if is_verbose:
             # when debug is set to true set it in the environment.
             ToolLogging.enable_debug_mode()
         wrapper_qual_options = {
@@ -115,14 +116,14 @@ class CliDataprocLocalMode:  # pylint: disable=too-few-public-methods
                 'gpuCluster': gpu_cluster
             },
             'jobSubmissionProps': {
-                'remoteFolder': remote_folder,
+                'remoteFolder': Utils.get_value_or_pop(remote_folder, rapids_options, 'r'),
                 'platformArgs': {
-                    'jvmMaxHeapSize': jvm_heap_size
+                    'jvmMaxHeapSize': Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
                 }
             },
-            'eventlogs': eventlogs,
-            'filterApps': filter_apps,
-            'toolsJar': tools_jar,
+            'eventlogs': Utils.get_value_or_pop(eventlogs, rapids_options, 'e'),
+            'filterApps': Utils.get_value_or_pop(filter_apps, rapids_options, 'f'),
+            'toolsJar': Utils.get_value_or_pop(tools_jar, rapids_options, 't'),
             'gpuClusterRecommendation': gpu_cluster_recommendation,
             'cpuDiscount': cpu_discount,
             'gpuDiscount': gpu_discount,
@@ -130,7 +131,7 @@ class CliDataprocLocalMode:  # pylint: disable=too-few-public-methods
         }
 
         tool_obj = QualificationAsLocal(platform_type=CspEnv.DATAPROC,
-                                        output_folder=local_folder,
+                                        output_folder=Utils.get_value_or_pop(local_folder, rapids_options, 'l'),
                                         wrapper_options=wrapper_qual_options,
                                         rapids_options=rapids_options)
         tool_obj.launch()
@@ -143,8 +144,8 @@ class CliDataprocLocalMode:  # pylint: disable=too-few-public-methods
                   remote_folder: str = None,
                   tools_jar: str = None,
                   credentials_file: str = None,
-                  jvm_heap_size: int = 24,
-                  verbose: bool = False,
+                  jvm_heap_size: int = None,
+                  verbose: bool = None,
                   **rapids_options) -> None:
         """
         The Profiling tool analyzes both CPU or GPU generated event logs and generates information
@@ -183,30 +184,31 @@ class CliDataprocLocalMode:  # pylint: disable=too-few-public-methods
                 For more details on Profiling tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-profiling-tool.html#profiling-tool-options
         """
-        if verbose:
+        is_verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
+        if is_verbose:
             # when debug is set to true set it in the environment.
             ToolLogging.enable_debug_mode()
         wrapper_prof_options = {
             'platformOpts': {
-                'credentialFile': credentials_file,
+                'credentialFile': Utils.get_value_or_pop(credentials_file, rapids_options, 'c'),
                 'deployMode': DeployMode.LOCAL,
             },
             'migrationClustersProps': {
-                'gpuCluster': gpu_cluster
+                'gpuCluster': Utils.get_value_or_pop(gpu_cluster, rapids_options, 'g')
             },
             'jobSubmissionProps': {
-                'remoteFolder': remote_folder,
+                'remoteFolder': Utils.get_value_or_pop(remote_folder, rapids_options, 'r'),
                 'platformArgs': {
-                    'jvmMaxHeapSize': jvm_heap_size
+                    'jvmMaxHeapSize': Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
                 }
             },
-            'eventlogs': eventlogs,
-            'toolsJar': tools_jar,
-            'autoTunerFileInput': worker_info
+            'eventlogs': Utils.get_value_or_pop(eventlogs, rapids_options, 'e'),
+            'toolsJar': Utils.get_value_or_pop(tools_jar, rapids_options, 't'),
+            'autoTunerFileInput': Utils.get_value_or_pop(worker_info, rapids_options, 'w')
         }
 
         ProfilingAsLocal(platform_type=CspEnv.DATAPROC,
-                         output_folder=local_folder,
+                         output_folder=Utils.get_value_or_pop(local_folder, rapids_options, 'l'),
                          wrapper_options=wrapper_prof_options,
                          rapids_options=rapids_options).launch()
 

--- a/user_tools/src/spark_rapids_pytools/wrappers/emr_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/emr_wrapper.py
@@ -100,13 +100,20 @@ class CliEmrLocalMode:  # pylint: disable=too-few-public-methods
                 For more details on Qualification tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-qualification-tool.html#qualification-tool-options
         """
-        is_verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
-        if is_verbose:
+        verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
+        profile = Utils.get_value_or_pop(profile, rapids_options, 'p')
+        remote_folder = Utils.get_value_or_pop(remote_folder, rapids_options, 'r')
+        jvm_heap_size = Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+        eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
+        filter_apps = Utils.get_value_or_pop(filter_apps, rapids_options, 'f')
+        tools_jar = Utils.get_value_or_pop(tools_jar, rapids_options, 't')
+        local_folder = Utils.get_value_or_pop(local_folder, rapids_options, 'l')
+        if verbose:
             # when debug is set to true set it in the environment.
             ToolLogging.enable_debug_mode()
         wrapper_qual_options = {
             'platformOpts': {
-                'profile': Utils.get_value_or_pop(profile, rapids_options, 'p'),
+                'profile': profile,
                 'deployMode': DeployMode.LOCAL,
             },
             'migrationClustersProps': {
@@ -114,14 +121,14 @@ class CliEmrLocalMode:  # pylint: disable=too-few-public-methods
                 'gpuCluster': gpu_cluster
             },
             'jobSubmissionProps': {
-                'remoteFolder': Utils.get_value_or_pop(remote_folder, rapids_options, 'r'),
+                'remoteFolder': remote_folder,
                 'platformArgs': {
-                    'jvmMaxHeapSize': Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+                    'jvmMaxHeapSize': jvm_heap_size
                 }
             },
-            'eventlogs': Utils.get_value_or_pop(eventlogs, rapids_options, 'e'),
-            'filterApps': Utils.get_value_or_pop(filter_apps, rapids_options, 'f'),
-            'toolsJar': Utils.get_value_or_pop(tools_jar, rapids_options, 't'),
+            'eventlogs': eventlogs,
+            'filterApps': filter_apps,
+            'toolsJar': tools_jar,
             'gpuClusterRecommendation': gpu_cluster_recommendation,
             'cpuDiscount': cpu_discount,
             'gpuDiscount': gpu_discount,
@@ -129,7 +136,7 @@ class CliEmrLocalMode:  # pylint: disable=too-few-public-methods
         }
         QualificationAsLocal(platform_type=CspEnv.EMR,
                              cluster=None,
-                             output_folder=Utils.get_value_or_pop(local_folder, rapids_options, 'l'),
+                             output_folder=local_folder,
                              wrapper_options=wrapper_qual_options,
                              rapids_options=rapids_options).launch()
 
@@ -178,30 +185,38 @@ class CliEmrLocalMode:  # pylint: disable=too-few-public-methods
                 For more details on Profiling tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-profiling-tool.html#profiling-tool-options
         """
-        is_verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
-        if is_verbose:
+        verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
+        profile = Utils.get_value_or_pop(profile, rapids_options, 'p')
+        gpu_cluster = Utils.get_value_or_pop(gpu_cluster, rapids_options, 'g')
+        remote_folder = Utils.get_value_or_pop(remote_folder, rapids_options, 'r')
+        jvm_heap_size = Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+        eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
+        tools_jar = Utils.get_value_or_pop(tools_jar, rapids_options, 't')
+        worker_info = Utils.get_value_or_pop(worker_info, rapids_options, 'w')
+        local_folder = Utils.get_value_or_pop(local_folder, rapids_options, 'l')
+        if verbose:
             # when debug is set to true set it in the environment.
             ToolLogging.enable_debug_mode()
         wrapper_prof_options = {
             'platformOpts': {
-                'profile': Utils.get_value_or_pop(profile, rapids_options, 'p'),
+                'profile': profile,
                 'deployMode': DeployMode.LOCAL,
             },
             'migrationClustersProps': {
-                'gpuCluster': Utils.get_value_or_pop(gpu_cluster, rapids_options, 'g')
+                'gpuCluster': gpu_cluster
             },
             'jobSubmissionProps': {
-                'remoteFolder': Utils.get_value_or_pop(remote_folder, rapids_options, 'r'),
+                'remoteFolder': remote_folder,
                 'platformArgs': {
-                    'jvmMaxHeapSize': Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+                    'jvmMaxHeapSize': jvm_heap_size
                 }
             },
-            'eventlogs': Utils.get_value_or_pop(eventlogs, rapids_options, 'e'),
-            'toolsJar': Utils.get_value_or_pop(tools_jar, rapids_options, 't'),
-            'autoTunerFileInput': Utils.get_value_or_pop(worker_info, rapids_options, 'w')
+            'eventlogs': eventlogs,
+            'toolsJar': tools_jar,
+            'autoTunerFileInput': worker_info
         }
         ProfilingAsLocal(platform_type=CspEnv.EMR,
-                         output_folder=Utils.get_value_or_pop(local_folder, rapids_options, 'l'),
+                         output_folder=local_folder,
                          wrapper_options=wrapper_prof_options,
                          rapids_options=rapids_options).launch()
 

--- a/user_tools/src/spark_rapids_pytools/wrappers/onprem_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/onprem_wrapper.py
@@ -80,8 +80,12 @@ class CliOnpremLocalMode:  # pylint: disable=too-few-public-methods
                 For more details on Qualification tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-qualification-tool.html#qualification-tool-options
         """
-        is_verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
-        if is_verbose:
+        verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
+        jvm_heap_size = Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+        eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
+        filter_apps = Utils.get_value_or_pop(filter_apps, rapids_options, 'f')
+        local_folder = Utils.get_value_or_pop(local_folder, rapids_options, 'l')
+        if verbose:
             # when debug is set to true set it in the environment.
             ToolLogging.enable_debug_mode()
         # if target_platform is specified, check if it's valid supported platform and filter the
@@ -106,11 +110,11 @@ class CliOnpremLocalMode:  # pylint: disable=too-few-public-methods
             },
             'jobSubmissionProps': {
                 'platformArgs': {
-                    'jvmMaxHeapSize': Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+                    'jvmMaxHeapSize': jvm_heap_size
                 }
             },
-            'eventlogs': Utils.get_value_or_pop(eventlogs, rapids_options, 'e'),
-            'filterApps': Utils.get_value_or_pop(filter_apps, rapids_options, 'f'),
+            'eventlogs': eventlogs,
+            'filterApps': filter_apps,
             'toolsJar': tools_jar,
             'gpuClusterRecommendation': gpu_cluster_recommendation,
             'targetPlatform': target_platform,
@@ -119,7 +123,7 @@ class CliOnpremLocalMode:  # pylint: disable=too-few-public-methods
             'globalDiscount': global_discount
         }
         tool_obj = QualificationAsLocal(platform_type=CspEnv.ONPREM,
-                                        output_folder=Utils.get_value_or_pop(local_folder, rapids_options, 'l'),
+                                        output_folder=local_folder,
                                         wrapper_options=wrapper_qual_options,
                                         rapids_options=rapids_options)
         tool_obj.launch()
@@ -159,8 +163,13 @@ class CliOnpremLocalMode:  # pylint: disable=too-few-public-methods
         For more details on Profiling tool options, please visit
         https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-profiling-tool.html#profiling-tool-options
         """
-        is_verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
-        if is_verbose:
+        verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
+        jvm_heap_size = Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+        eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
+        tools_jar = Utils.get_value_or_pop(tools_jar, rapids_options, 't')
+        worker_info = Utils.get_value_or_pop(worker_info, rapids_options, 'w')
+        local_folder = Utils.get_value_or_pop(local_folder, rapids_options, 'l')
+        if verbose:
             # when debug is set to true set it in the environment.
             ToolLogging.enable_debug_mode()
         wrapper_prof_options = {
@@ -170,15 +179,15 @@ class CliOnpremLocalMode:  # pylint: disable=too-few-public-methods
             },
             'jobSubmissionProps': {
                 'platformArgs': {
-                    'jvmMaxHeapSize': Utils.get_value_or_pop(jvm_heap_size, rapids_options, 'j', 24)
+                     'jvmMaxHeapSize': jvm_heap_size
                 }
             },
-            'eventlogs': Utils.get_value_or_pop(eventlogs, rapids_options, 'e'),
-            'toolsJar': Utils.get_value_or_pop(tools_jar, rapids_options, 't'),
-            'autoTunerFileInput': Utils.get_value_or_pop(worker_info, rapids_options, 'w')
+            'eventlogs': eventlogs,
+            'toolsJar': tools_jar,
+            'autoTunerFileInput': worker_info
         }
         ProfilingAsLocal(platform_type=CspEnv.ONPREM,
-                         output_folder=Utils.get_value_or_pop(local_folder, rapids_options, 'l'),
+                         output_folder=local_folder,
                          wrapper_options=wrapper_prof_options,
                          rapids_options=rapids_options).launch()
 

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -48,7 +48,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                       global_discount: int = None,
                       gpu_cluster_recommendation: str = QualGpuClusterReshapeType.tostring(
                           QualGpuClusterReshapeType.get_default()),
-                      verbose: bool = False,
+                      verbose: bool = None,
                       **rapids_options):
         """The Qualification cmd provides estimated running costs and speedups by migrating Apache
         Spark applications to GPU accelerated clusters.
@@ -138,7 +138,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                   cluster: str = None,
                   platform: str = None,
                   output_folder: str = None,
-                  verbose: bool = False,
+                  verbose: bool = None,
                   **rapids_options):
         """The Profiling cmd provides information which can be used for debugging and profiling
         Apache Spark applications running on accelerated GPU cluster.

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -19,7 +19,7 @@ import fire
 
 from spark_rapids_tools.enums import QualGpuClusterReshapeType
 from spark_rapids_tools.utils.util import gen_app_banner, init_environment
-from spark_rapids_pytools.common.utilities import ToolLogging
+from spark_rapids_pytools.common.utilities import Utils, ToolLogging
 from spark_rapids_pytools.rapids.bootstrap import Bootstrap
 from spark_rapids_pytools.rapids.profiling import ProfilingAsLocal
 from spark_rapids_pytools.rapids.qualification import QualificationAsLocal
@@ -105,6 +105,11 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                 For more details on Qualification tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-qualification-tool.html#qualification-tool-options
         """
+        platform = Utils.get_value_or_pop(platform, rapids_options, 'p')
+        target_platform = Utils.get_value_or_pop(target_platform, rapids_options, 't')
+        output_folder = Utils.get_value_or_pop(output_folder, rapids_options, 'o')
+        filter_apps = Utils.get_value_or_pop(filter_apps, rapids_options, 'f')
+        verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v')
         if verbose:
             ToolLogging.enable_debug_mode()
         init_environment('qual')
@@ -159,6 +164,11 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                 For more details on Profiling tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-profiling-tool.html#profiling-tool-options
         """
+        eventlogs = Utils.get_value_or_pop(platform, rapids_options, 'e')
+        cluster = Utils.get_value_or_pop(cluster, rapids_options, 'c')
+        platform = Utils.get_value_or_pop(platform, rapids_options, 'p')
+        output_folder = Utils.get_value_or_pop(output_folder, rapids_options, 'o')
+        verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v')
         if verbose:
             ToolLogging.enable_debug_mode()
         init_environment('prof')

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -109,7 +109,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         target_platform = Utils.get_value_or_pop(target_platform, rapids_options, 't')
         output_folder = Utils.get_value_or_pop(output_folder, rapids_options, 'o')
         filter_apps = Utils.get_value_or_pop(filter_apps, rapids_options, 'f')
-        verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v')
+        verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
         if verbose:
             ToolLogging.enable_debug_mode()
         init_environment('qual')
@@ -168,7 +168,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         cluster = Utils.get_value_or_pop(cluster, rapids_options, 'c')
         platform = Utils.get_value_or_pop(platform, rapids_options, 'p')
         output_folder = Utils.get_value_or_pop(output_folder, rapids_options, 'o')
-        verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v')
+        verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
         if verbose:
             ToolLogging.enable_debug_mode()
         init_environment('prof')

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -164,7 +164,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                 For more details on Profiling tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-profiling-tool.html#profiling-tool-options
         """
-        eventlogs = Utils.get_value_or_pop(platform, rapids_options, 'e')
+        eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
         cluster = Utils.get_value_or_pop(cluster, rapids_options, 'c')
         platform = Utils.get_value_or_pop(platform, rapids_options, 'p')
         output_folder = Utils.get_value_or_pop(output_folder, rapids_options, 'o')


### PR DESCRIPTION
Fixes #671. This PR fixes the bug due to incorrect handling of short flag arguments and keyword arguments in the fire library (https://github.com/NVIDIA/spark-rapids-tools/issues/671#issuecomment-1832916160). 

The problem occurs because the short flag arguments gets stored in the keyword argument dictionary (`rapids_options` in our case). The current resolution involves retrieving the value from this dictionary.

### Design
1. Check if the value is passed as an argument, else check if short flag is present in `rapids_options` dictionary, else return the default value.
2. An alternative approach could be to do this as a pre-processing step at a single place. Since `fire` generates help text from the function documentation, executing the pre-processing function first would impact the generation of help text.

### Code Changes
- Define a method `get_value_or_pop()` to get the correct value of argument based on `#1`.
- Call this method in each wrapper class' `qualification()` and `profiling()` method.
- `bootstrap()` and `diagnostic()` do not need this change because they do not have `rapids_option` argument and hence short flag arguments are processed correctly.

### User Facing Changes
- No user facing changes

### User Tools Short Flag Argument List
#### spark_rapids_user_tools CLI:

- Below table consists of only arguments that have short flags.
-  `-` denotes argument does not exist for the given tool and CSP.
- `Conflict` denotes short flag is not possible due to conflict with other argument 

|    **Tool**   |    **Configs**   | **DB AWS** | **DB Azure** | **Dataproc GKE** | **Dataproc** | **EMR** | **OnPrem** |
|:-------------:|:----------------:|:------------------:|:--------------------:|:----------------:|:------------:|:-------:|:----------:|
|   Profiling   | aws_profile      |          a         |          -         |        -      |      -    |   -   |     -    |
|               | credentials_file |          c         |           c          |      -            |       c      |   -   |     -    |
|               | eventlogs        |          e         |           e          |            -      |       e      |    e    |      e     |
|               | gpu_cluster      |          g         |           g          |      -            |       g      |    g    |     -    |
|               | jvm_heap_size    |          j         |           j          |       -           |       j      |    j    |      j     |
|               | local_folder     |          l         |           l          |        -          |       l      |    l    |      l     |
|               | profile          |          p         |           p          |          -        |      -     |    p    |     -    |
|               | remote_folder    |          r         |           r          |     -             |       r      |    r    |     -    |
|               | tools_jar        |          t         |           t          |          -        |       t      |    t    |      t     |
|               | verbose          |          v         |           v          |         -         |       v      |    v    |      v     |
|               | worker_info      |          w         |           w          |       -           |       w      |    w    |      w     |
|               |                  |                    |                      |                  |              |         |            |
| Qualification | aws_profile      |          a         |          -         |        -       |      -     |   -   |     -    |
|               | eventlogs        |          e         |           e          |         e        |       e      |    e    |      e     |
|               | filter_apps      |          f         |           f          |         f        |       f      |    f    |      f     |
|               | jvm_heap_size    |          j         |           j          |         j        |       j      |    j    |      j     |
|               | local_folder     |          l         |           l          |         l        |       l      |    l    |      l     |
|               | profile          |          p         |           p          |        -       |      -     |    p    |      -     |
|               | remote_folder    |          r         |           r          |         r        |       r      |    r    |     -    |
|               | tools_jar        |          t         |           t          |         t        |       t      |    t    |  _Conflict_  |
|               | verbose          |          v         |           v          |         v        |       v      |    v    |      v     |


#### New CLI:

- In the new CLI many of the above arguments are removed. 
- Short flags are now same for all CSPs.

|      Tool     |     Configs     | ShortFlag |
|:-------------:|:---------------:|:---------:|
|   Profiling   |     cluster     |     c     |
|               |    eventlogs    |     e     |
|               |  output_folder  |     o     |
|               |     platform    |     p     |
|               |     verbose     |     v     |
|               |                 |           |
| Qualification |   filter_apps   |     f     |
|               |  output_folder  |     o     |
|               |     platform    |     p     |
|               | target_platform |     t     |
|               |     verbose     |     v     |

