### PR TITLE
[FEA] User tool should pass `--platform` option/argument to Profiling tool

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/profiling.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/profiling.py
@@ -247,7 +247,7 @@ class Profiling(RapidsJarTool):
         self.__generate_report_with_recommendations()
 
     def _init_rapids_arg_list(self) -> List[str]:
-        platform_arg = ['--platform', self.ctxt.platform.get_platform_name().replace('_', '-')]
+        platform_arg = super()._init_rapids_arg_list()
         return [platform_arg] + self._create_autotuner_rapids_args()
 
 

--- a/user_tools/src/spark_rapids_pytools/rapids/profiling.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/profiling.py
@@ -247,8 +247,7 @@ class Profiling(RapidsJarTool):
         self.__generate_report_with_recommendations()
 
     def _init_rapids_arg_list(self) -> List[str]:
-        platform_arg = super()._init_rapids_arg_list()
-        return [platform_arg] + self._create_autotuner_rapids_args()
+        return super()._init_rapids_arg_list() + self._create_autotuner_rapids_args()
 
 
 @dataclass

--- a/user_tools/src/spark_rapids_pytools/rapids/profiling.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/profiling.py
@@ -247,7 +247,8 @@ class Profiling(RapidsJarTool):
         self.__generate_report_with_recommendations()
 
     def _init_rapids_arg_list(self) -> List[str]:
-        return self._create_autotuner_rapids_args()
+        platform_arg = ['--platform', self.ctxt.platform.get_platform_name().replace('_', '-')]
+        return [platform_arg] + self._create_autotuner_rapids_args()
 
 
 @dataclass

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -770,10 +770,6 @@ class Qualification(RapidsJarTool):
         if wrapper_out_content is not None:
             print(Utils.gen_multiline_str(wrapper_out_content))
 
-    def _init_rapids_arg_list(self) -> List[str]:
-        # TODO: Make sure we add this argument only for jar versions 23.02+
-        return ['--platform', self.ctxt.platform.get_platform_name().replace('_', '-')]
-
     def _generate_section_lines(self, sec_conf: dict) -> List[str]:
         # TODO: we may like to show the scripts even when the gpu-cluster is not defined
         #      this requires that we allow to generate the script without the gpu-cluster

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -756,7 +756,8 @@ class RapidsJarTool(RapidsTool):
         self.ctxt.update_job_args(job_args)
 
     def _init_rapids_arg_list(self) -> List[str]:
-        return []
+        # TODO: Make sure we add this argument only for jar versions 23.02+
+        return ['--platform', self.ctxt.platform.get_platform_name().replace('_', '-')]
 
     @timeit('Building Job Arguments and Executing Job CMD')  # pylint: disable=too-many-function-args
     def _prepare_local_job_arguments(self):


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/678

This PR adds `--platform` the rapids argument list for running the Profiling tool commands, depending on which platform the user tool is running on.

Note:
This is only working for tools jar with version > 23.10.1, due to change in [commit](https://github.com/NVIDIA/spark-rapids-tools/commit/e612d79426d80a4d7b48a3492bb4c8b526aff6df).