### PR TITLE
Fix user qualification tool runtime error in `get_platform_name` for onprem platform

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
@@ -70,9 +70,8 @@ class OnPremPlatform(PlatformBase):
         This used to get the lower case of the platform of the runtime.
         :return: the name of the platform of the runtime in lower_case.
         """
-        if self.platform is not None:
-            if self.platform == 'dataproc':
-                self_id = CspEnv.DATAPROC
+        if self.platform is not None and self.platform == 'dataproc':
+            self_id = CspEnv.DATAPROC
         else:
             self_id = self.type_id
         return CspEnv.pretty_print(self_id)


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/683

**Changes**
We fix a bug in function `get_platform_name` definition for `onprem` platform. The original implementation could lead to referencing an unassigned variable.

**Testing**
For user qualification tool, we tested the following commands:
```
spark_rapids_user_tools onprem qualification --eventlogs <my-event-logs>
spark_rapids_user_tools onprem qualification --eventlogs <my-event-logs> --cpu_cluster <my-cpu-cluster-file>
spark_rapids_user_tools onprem qualification --eventlogs <my-event-logs> --cpu_cluster <my-cpu-cluster-file> --target_platform dataproc
```
For user profiling tool:
```
spark_rapids_user_tools onprem profiling --eventlogs <my-event-logs>
```