### PR TITLE
Support parsing of inprogress eventlogs

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -80,6 +80,10 @@ object ToolUtils extends Logging {
             val targetEx = i.getTargetException
             if (targetEx != null) {
               targetEx match {
+                case k: com.fasterxml.jackson.core.io.JsonEOFException =>
+                  // Spark3.41+ embeds JsonEOFException in the InvocationTargetException
+                  // We need to show a warning message instead of failing the entire app.
+                  logWarning(s"Incomplete eventlog, ${k.getMessage}")
                 case j: com.fasterxml.jackson.core.JsonParseException =>
                   // this is a parser error thrown by spark-3.4+ which indicates the log is
                   // malformed

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -94,10 +94,15 @@ object ToolUtils extends Logging {
               // Normally it should not happen that invocation target is null.
               logError(s"Unknown exception while parsing an event", i)
             }
-          case j: com.fasterxml.jackson.core.JsonParseException =>
+          case j: com.fasterxml.jackson.core.io.JsonEOFException =>
+            // Note that JsonEOFException is child of JsonParseException
+            // In case the eventlog is incomplete (i.e., inprogress), we show a warning message
+            // because we do not want to cause the entire app to fail.
+            logWarning(s"Incomplete eventlog, ${j.getMessage}")
+          case k: com.fasterxml.jackson.core.JsonParseException =>
             // this is a parser error thrown by version prior to spark-3.4+ which indicates the
             // log is malformed
-            throw j
+            throw k
         }
         None
     }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -80,14 +80,14 @@ object ToolUtils extends Logging {
             val targetEx = i.getTargetException
             if (targetEx != null) {
               targetEx match {
-                case k: com.fasterxml.jackson.core.io.JsonEOFException =>
+                case j: com.fasterxml.jackson.core.io.JsonEOFException =>
                   // Spark3.41+ embeds JsonEOFException in the InvocationTargetException
                   // We need to show a warning message instead of failing the entire app.
-                  logWarning(s"Incomplete eventlog, ${k.getMessage}")
-                case j: com.fasterxml.jackson.core.JsonParseException =>
+                  logWarning(s"Incomplete eventlog, ${j.getMessage}")
+                case k: com.fasterxml.jackson.core.JsonParseException =>
                   // this is a parser error thrown by spark-3.4+ which indicates the log is
                   // malformed
-                  throw j
+                  throw k
                 case z: ClassNotFoundException if z.getMessage != null =>
                   logWarning(s"ClassNotFoundException while parsing an event: ${z.getMessage}")
                 case t: Throwable =>

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids.tool.qualification
 
-import java.io.{BufferedWriter, File, FileWriter, PrintWriter}
+import java.io.{File, PrintWriter}
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #685

* Added feature: support parsing of "inprogress" eventlogs
* Catches exception thrown by Json Parser when an unexpected EOF occurs
* Added a warning message when the eventlog has unexpected EOF (incomplete events)
* Added UT to verify that an incomplete eventlog can be parsed successfully 


**Before Changes:**

For an incomplete eventlog (i.e., `eventlog.inprogress`), the "app" resulting from processing the eventlog is skipped. It is considered as "N/A".


**After Changes:**

The "app" is considered successful.