### PR TITLE
 Infer cluster shape from single event log in Qualification tool

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
@@ -43,6 +43,7 @@ class DBAWSPlatform(EMRPlatform):
 
     def __post_init__(self):
         self.type_id = CspEnv.DATABRICKS_AWS
+        self.cluster_inference_supported = True
         super(EMRPlatform, self).__post_init__()
 
     def _construct_cli_object(self) -> CMDDriverBase:

--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
@@ -51,8 +51,15 @@ class DBAWSPlatform(EMRPlatform):
     def _install_storage_driver(self):
         self.storage = S3StorageDriver(self.cli)
 
-    def _construct_cluster_from_props(self, cluster: str, props: str = None):
-        return DatabricksCluster(self).set_connection(cluster_id=cluster, props=props)
+    def _construct_cluster_from_props(self, cluster: str, props: str = None, is_inferred: bool = False):
+        return DatabricksCluster(self, is_inferred=is_inferred).set_connection(cluster_id=cluster, props=props)
+
+    def _construct_cluster_config(self, cluster_info: dict, default_config: dict):
+        cluster_conf = default_config
+        cluster_conf['driver_node_type_id'] = cluster_info['driver_instance']
+        cluster_conf['node_type_id'] = cluster_info['executor_instance']
+        cluster_conf['num_workers'] = cluster_info['num_executor_nodes']
+        return cluster_conf
 
     def set_offline_cluster(self, cluster_args: dict = None):
         pass

--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
@@ -51,8 +51,16 @@ class DBAzurePlatform(PlatformBase):
     def _install_storage_driver(self):
         self.storage = AzureStorageDriver(self.cli)
 
-    def _construct_cluster_from_props(self, cluster: str, props: str = None):
-        return DatabricksAzureCluster(self).set_connection(cluster_id=cluster, props=props)
+    def _construct_cluster_from_props(self, cluster: str, props: str = None, is_inferred: bool = False):
+        return DatabricksAzureCluster(self, is_inferred=is_inferred).set_connection(cluster_id=cluster, props=props)
+
+    def _construct_cluster_config(self, cluster_info: dict, default_config: dict):
+        cluster_conf = default_config
+        cluster_conf['executors'] = [{'node_id': '1234567890'} for _ in range(cluster_info['num_executor_nodes'])]
+        cluster_conf['driver_node_type_id'] = cluster_info['driver_instance']
+        cluster_conf['node_type_id'] = cluster_info['executor_instance']
+        cluster_conf['num_workers'] = cluster_info['num_executor_nodes']
+        return cluster_conf
 
     def set_offline_cluster(self, cluster_args: dict = None):
         pass

--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
@@ -43,6 +43,7 @@ class DBAzurePlatform(PlatformBase):
     """
     def __post_init__(self):
         self.type_id = CspEnv.DATABRICKS_AZURE
+        self.cluster_inference_supported = True
         super().__post_init__()
 
     def _construct_cli_object(self) -> CMDDriverBase:

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -81,8 +81,22 @@ class DataprocPlatform(PlatformBase):
     def _install_storage_driver(self):
         self.storage = GStorageDriver(self.cli)
 
-    def _construct_cluster_from_props(self, cluster: str, props: str = None):
-        return DataprocCluster(self).set_connection(cluster_id=cluster, props=props)
+    def _construct_cluster_from_props(self, cluster: str, props: str = None, is_inferred: bool = False):
+        return DataprocCluster(self, is_inferred=is_inferred).set_connection(cluster_id=cluster, props=props)
+
+    def _construct_cluster_config(self, cluster_info: dict, default_config: dict):
+        cluster_conf = default_config
+        cluster_conf['config']['masterConfig'] = {
+          'instanceNames': [f'test-node-d{i}' for i in range(cluster_info['num_driver_nodes'])],
+          'machineTypeUri': cluster_info['driver_instance'],
+          'numInstances': cluster_info['num_driver_nodes']
+        }
+        cluster_conf['config']['workerConfig'] = {
+          'instanceNames': [f'test-node-e{i}' for i in range(cluster_info['num_executor_nodes'])],
+          'machineTypeUri': cluster_info['executor_instance'],
+          'numInstances': cluster_info['num_executor_nodes']
+        }
+        return cluster_conf
 
     def set_offline_cluster(self, cluster_args: dict = None):
         pass

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -44,6 +44,7 @@ class DataprocPlatform(PlatformBase):
 
     def __post_init__(self):
         self.type_id = CspEnv.DATAPROC
+        self.cluster_inference_supported = True
         super().__post_init__()
 
     def _set_remaining_configuration_list(self) -> None:

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -88,9 +88,9 @@ class DataprocPlatform(PlatformBase):
     def _construct_cluster_config(self, cluster_info: dict, default_config: dict):
         cluster_conf = default_config
         cluster_conf['config']['masterConfig'] = {
-          'instanceNames': [f'test-node-d{i}' for i in range(cluster_info['num_driver_nodes'])],
+          'instanceNames': 'test-node-d',
           'machineTypeUri': cluster_info['driver_instance'],
-          'numInstances': cluster_info['num_driver_nodes']
+          'numInstances': 1  # single driver node
         }
         cluster_conf['config']['workerConfig'] = {
           'instanceNames': [f'test-node-e{i}' for i in range(cluster_info['num_executor_nodes'])],

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc_gke.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc_gke.py
@@ -42,6 +42,7 @@ class DataprocGkePlatform(DataprocPlatform):
     def __post_init__(self):
         super().__post_init__()
         self.type_id = CspEnv.DATAPROC_GKE
+        self.cluster_inference_supported = False
 
     @classmethod
     def get_spark_node_type_fromstring(cls, value: str):

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc_gke.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc_gke.py
@@ -54,8 +54,8 @@ class DataprocGkePlatform(DataprocPlatform):
     def _construct_cli_object(self) -> CMDDriverBase:
         return DataprocGkeCMDDriver(timeout=0, cloud_ctxt=self.ctxt)
 
-    def _construct_cluster_from_props(self, cluster: str, props: str = None):
-        return DataprocGkeCluster(self).set_connection(cluster_id=cluster, props=props)
+    def _construct_cluster_from_props(self, cluster: str, props: str = None, is_inferred: bool = False):
+        return DataprocGkeCluster(self, is_inferred=is_inferred).set_connection(cluster_id=cluster, props=props)
 
     def migrate_cluster_to_gpu(self, orig_cluster):
         """

--- a/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
@@ -81,7 +81,7 @@ class EMRPlatform(PlatformBase):
                 group['RequestedInstanceCount'] = cluster_info['num_executor_nodes']
             elif group.get('Name') == 'MASTER':
                 group['InstanceType'] = cluster_info['driver_instance']
-                group['RequestedInstanceCount'] = cluster_info['num_driver_nodes']
+                group['RequestedInstanceCount'] = 1  # single driver node
         return cluster_conf
 
     def migrate_cluster_to_gpu(self, orig_cluster):

--- a/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
@@ -69,10 +69,19 @@ class EMRPlatform(PlatformBase):
     def _install_storage_driver(self):
         self.storage = S3StorageDriver(self.cli)
 
-    def _construct_cluster_from_props(self,
-                                      cluster: str,
-                                      props: str = None):
-        return EMRCluster(self).set_connection(cluster_id=cluster, props=props)
+    def _construct_cluster_from_props(self, cluster: str, props: str = None, is_inferred: bool = False):
+        return EMRCluster(self, is_inferred=is_inferred).set_connection(cluster_id=cluster, props=props)
+
+    def _construct_cluster_config(self, cluster_info: dict, default_config: dict):
+        cluster_conf = default_config
+        for group in cluster_conf['Cluster']['InstanceGroups']:
+            if group.get('Name') == 'CORE':
+                group['InstanceType'] = cluster_info['executor_instance']
+                group['RequestedInstanceCount'] = cluster_info['num_executor_nodes']
+            elif group.get('Name') == 'MASTER':
+                group['InstanceType'] = cluster_info['driver_instance']
+                group['RequestedInstanceCount'] = cluster_info['num_driver_nodes']
+        return cluster_conf
 
     def migrate_cluster_to_gpu(self, orig_cluster):
         """
@@ -316,9 +325,16 @@ class EMRCluster(ClusterBase):
         else:
             group_id = group_arg
             group_obj = None
-        query_args = {'instance-group-id': group_id}
-        raw_instance_list = self.cli.exec_platform_list_cluster_instances(self, query_args=query_args)
-        instances_list = json.loads(raw_instance_list).get('Instances')
+        if self.is_inferred:
+            # If cluster settings are inferred, create a list of instances with default configuration
+            default_node_config = self.platform.configs.get_value('clusterInference', 'defaultNodeConfig')
+            default_node_config['InstanceGroupId'] = group_id
+            default_node_config['InstanceType'] = group_obj.instance_type
+            instances_list = [default_node_config for _ in range(group_obj.count)]
+        else:
+            query_args = {'instance-group-id': group_id}
+            raw_instance_list = self.cli.exec_platform_list_cluster_instances(self, query_args=query_args)
+            instances_list = json.loads(raw_instance_list).get('Instances')
         ec2_instances = []
         for raw_inst in instances_list:
             parsed_state = raw_inst['Status']['State']

--- a/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
@@ -61,6 +61,7 @@ class EMRPlatform(PlatformBase):
 
     def __post_init__(self):
         self.type_id = CspEnv.EMR
+        self.cluster_inference_supported = True
         super().__post_init__()
 
     def _construct_cli_object(self) -> CMDDriverBase:

--- a/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
@@ -38,6 +38,7 @@ class OnPremPlatform(PlatformBase):
     def __post_init__(self):
         self.type_id = CspEnv.ONPREM
         self.platform = self.ctxt_args.get('targetPlatform')
+        self.cluster_inference_supported = False
         super().__post_init__()
 
     def _construct_cli_object(self):

--- a/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
@@ -49,11 +49,15 @@ class OnPremPlatform(PlatformBase):
     def create_local_submission_job(self, job_prop, ctxt) -> Any:
         return OnPremLocalRapidsJob(prop_container=job_prop, exec_ctxt=ctxt)
 
-    def _construct_cluster_from_props(self, cluster: str, props: str = None):
+    def _construct_cluster_from_props(self, cluster: str, props: str = None, is_inferred: bool = False):
         if self.platform is not None:
-            onprem_cluster = OnPremCluster(self).set_connection(cluster_id=cluster, props=props)
+            onprem_cluster = OnPremCluster(self, is_inferred=is_inferred).set_connection(cluster_id=cluster,
+                                                                                         props=props)
             return onprem_cluster
         return None
+
+    def _construct_cluster_config(self, cluster_info: dict, default_config: dict):
+        pass
 
     def migrate_cluster_to_gpu(self, orig_cluster):
         """

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -598,6 +598,7 @@ class PlatformBase:
     ctxt: dict = field(default_factory=dict, init=False)
     configs: JSONPropertiesContainer = field(default=None, init=False)
     logger: Logger = field(default=ToolLogging.get_and_setup_logger('rapids.tools.csp'), init=False)
+    cluster_inference_supported: bool = field(default=False, init=False)
 
     @classmethod
     def list_supported_gpus(cls):

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module provides functionality for cluster inference using Spark event logs"""
+
+from dataclasses import dataclass, field
+
+from pathlib import Path
+from logging import Logger
+
+from spark_rapids_pytools.cloud_api.databricks_aws import DBAWSPlatform
+from spark_rapids_pytools.cloud_api.databricks_azure import DBAzurePlatform
+from spark_rapids_pytools.cloud_api.sp_types import PlatformBase
+from spark_rapids_pytools.common.prop_manager import JSONPropertiesContainer
+from spark_rapids_pytools.common.utilities import ToolLogging
+
+
+@dataclass
+class ClusterInference:
+    """
+    Class for inferring cluster information from Spark event logs and constructing CPU clusters.
+
+    :param platform: The platform on which the cluster inference is performed.
+    """
+    platform: PlatformBase = field(default=None, init=True)
+    logger: Logger = field(default=ToolLogging.get_and_setup_logger('rapids.tools.cluster_inference'), init=False)
+
+    @staticmethod
+    def _load_event_logs(eventlog_arg) -> list:
+        """
+        Read the event log file and return a list of event log properties containers.
+        """
+        eventlog_path = Path(eventlog_arg)
+        if not eventlog_path.exists():
+            raise FileNotFoundError(f"Path '{eventlog_path}' does not exist.")
+        with eventlog_path.open(encoding='utf-8') as file:
+            event_logs = [JSONPropertiesContainer(line, file_load=False) for line in file]
+        return event_logs
+
+    def get_cluster_info(self, eventlog_props: list):
+        """
+        Process event logs and extract information about drivers and executors.
+        """
+        num_driver_nodes = 0
+        hosts = set()
+        num_cores = None
+        driver_instance = None
+        executor_instance = None
+        is_databricks = isinstance(self.platform, (DBAWSPlatform, DBAzurePlatform))
+
+        for event_prop in eventlog_props:
+            event_type = event_prop.get_value_silent('Event')
+
+            # Check for Databricks environment update event to get driver and executor instances
+            if is_databricks and driver_instance is None and event_type == 'SparkListenerEnvironmentUpdate':
+                driver_instance = event_prop.get_value('Spark Properties', 'spark.databricks.driverNodeTypeId')
+                executor_instance = event_prop.get_value('Spark Properties', 'spark.databricks.workerNodeTypeId')
+
+            # Check for executor added event to get the number of cores
+            if num_cores is None and event_type == 'SparkListenerExecutorAdded':
+                num_cores = event_prop.get_value('Executor Info', 'Total Cores')
+
+            # Check for BlockManager added event to count drivers and collect unique hosts
+            elif event_type == 'SparkListenerBlockManagerAdded':
+                executor_id = event_prop.get_value('Block Manager ID', 'Executor ID')
+                if executor_id == 'driver':
+                    num_driver_nodes += 1
+                else:
+                    host = event_prop.get_value('Block Manager ID', 'Host')
+                    hosts.add(host)
+
+        # If driver instance is not set, use the default value from platform configurations
+        if driver_instance is None:
+            driver_instance = self.platform.configs.get_value('clusterInference', 'defaultCpuInstances', 'driver')
+
+        # If executor instance is not set, use the default value based on the number of cores
+        if executor_instance is None:
+            default_instances = self.platform.configs.get_value('clusterInference', 'defaultCpuInstances', 'executor')
+            matching_instance = next(
+                (instance['name'] for instance in default_instances if instance['vCPUs'] == num_cores),
+                None
+            )
+            if matching_instance is None:
+                self.logger.info(f'No matching executor instance found for vCPUs = {num_cores}')
+                return None
+            executor_instance = matching_instance
+        return {
+            'num_driver_nodes': num_driver_nodes,
+            'driver_instance': driver_instance,
+            'num_executor_nodes': len(hosts),  # Number of unique hosts identify number of executor nodes
+            'executor_instance': executor_instance
+        }
+
+    def infer_cpu_cluster(self, eventlog_arg):
+        """
+        Infer CPU cluster configuration based on event logs and return the constructed cluster object.
+        """
+        parsed_log = self._load_event_logs(eventlog_arg)
+        if len(parsed_log) == 0:
+            return None
+
+        cluster_info = self.get_cluster_info(parsed_log)
+        if cluster_info is None:
+            return None
+        cluster_conf = self.platform.construct_cluster_config(cluster_info)
+        cluster_props = JSONPropertiesContainer(cluster_conf, file_load=False)
+        inferred_cpu_cluster_obj = self.platform.load_cluster_by_prop(cluster_props, is_inferred=True)
+        return inferred_cpu_cluster_obj

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -192,8 +192,8 @@ class Qualification(RapidsJarTool):
             # If cpu_cluster_arg is provided, create a CPU cluster object and set it in the context
             cpu_cluster_obj = self._create_migration_cluster('CPU', cpu_cluster_arg)
             self.ctxt.set_ctxt('cpuClusterProxy', cpu_cluster_obj)
-        else:
-            # If cpu_cluster_arg is not provided, infer CPU cluster from event logs
+        elif self.ctxt.platform.cluster_inference_supported:
+            # If cpu_cluster_arg is not provided, infer CPU cluster from event logs (if supported by the platform)
             self.logger.info('Inferring CPU cluster properties from event logs. This could take a while.')
             cluster_inference = ClusterInference(platform=self.ctxt.platform)
             eventlog_arg = self.wrapper_options.get('eventlogs')

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -23,7 +23,7 @@ import pandas as pd
 from tabulate import tabulate
 
 from spark_rapids_tools.enums import QualFilterApp, QualGpuClusterReshapeType
-from spark_rapids_pytools.cloud_api.sp_types import ClusterReshape, NodeHWInfo
+from spark_rapids_pytools.cloud_api.sp_types import ClusterReshape, NodeHWInfo, SparkNodeType
 from spark_rapids_pytools.common.cluster_inference import ClusterInference
 from spark_rapids_pytools.common.sys_storage import FSUtil
 from spark_rapids_pytools.common.utilities import Utils, TemplateGenerator
@@ -199,6 +199,11 @@ class Qualification(RapidsJarTool):
             eventlog_arg = self.wrapper_options.get('eventlogs')
             cpu_cluster_obj = cluster_inference.infer_cpu_cluster(eventlog_arg)
             if cpu_cluster_obj is not None:
+                driver_instance = cpu_cluster_obj.get_master_node().instance_type
+                executor_instance = cpu_cluster_obj.get_worker_node(0).instance_type
+                num_executor_nodes = cpu_cluster_obj.get_nodes_cnt(SparkNodeType.WORKER)
+                self.logger.info('Inferred Cluster => Driver: %s, Executor: %s X %s', driver_instance,
+                                 num_executor_nodes, executor_instance)
                 self.ctxt.set_ctxt('cpuClusterProxy', cpu_cluster_obj)
             else:
                 self.logger.info('Cannot infer CPU cluster from event logs')

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -194,11 +194,11 @@ class Qualification(RapidsJarTool):
             self.ctxt.set_ctxt('cpuClusterProxy', cpu_cluster_obj)
         else:
             # If cpu_cluster_arg is not provided, infer CPU cluster from event logs
+            self.logger.info('Inferring CPU cluster properties from event logs. This could take a while.')
             cluster_inference = ClusterInference(platform=self.ctxt.platform)
             eventlog_arg = self.wrapper_options.get('eventlogs')
             cpu_cluster_obj = cluster_inference.infer_cpu_cluster(eventlog_arg)
             if cpu_cluster_obj is not None:
-                self.logger.info('Infer CPU cluster properties from event logs')
                 self.ctxt.set_ctxt('cpuClusterProxy', cpu_cluster_obj)
             else:
                 self.logger.info('Cannot infer CPU cluster from event logs')

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
@@ -292,6 +292,29 @@
       }
     }
   },
+  "clusterInference": {
+    "defaultClusterConfig": {
+      "cluster_id": "1234-5678-test",
+      "cluster_name": "default-cluster-prop",
+      "driver_node_type_id": "i3.2xlarge",
+      "node_type_id": "m5d.large",
+      "num_workers": 1,
+      "state": "TERMINATED"
+    },
+    "defaultCpuInstances": {
+      "driver": "i3.2xlarge",
+      "executor": [
+        {"name": "m5d.large", "vCPUs": 2},
+        {"name": "m5d.xlarge", "vCPUs": 4},
+        {"name": "m5d.2xlarge", "vCPUs": 8},
+        {"name": "m5d.4xlarge", "vCPUs": 16},
+        {"name": "m5d.8xlarge", "vCPUs": 32},
+        {"name": "m5d.12xlarge", "vCPUs": 48},
+        {"name": "m5d.16xlarge", "vCPUs": 64},
+        {"name": "m5d.24xlarge", "vCPUs": 96}
+      ]
+    }
+  },
   "clusterSpecs": {
     "minWorkerNodes": 2
   }

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
@@ -296,22 +296,21 @@
     "defaultClusterConfig": {
       "cluster_id": "1234-5678-test",
       "cluster_name": "default-cluster-prop",
-      "driver_node_type_id": "i3.2xlarge",
-      "node_type_id": "m5d.large",
+      "driver_node_type_id": "m6gd.xlarge",
+      "node_type_id": "m6gd.2xlarge",
       "num_workers": 1,
       "state": "TERMINATED"
     },
     "defaultCpuInstances": {
-      "driver": "i3.2xlarge",
+      "driver": "m6gd.xlarge",
       "executor": [
-        {"name": "m5d.large", "vCPUs": 2},
-        {"name": "m5d.xlarge", "vCPUs": 4},
-        {"name": "m5d.2xlarge", "vCPUs": 8},
-        {"name": "m5d.4xlarge", "vCPUs": 16},
-        {"name": "m5d.8xlarge", "vCPUs": 32},
-        {"name": "m5d.12xlarge", "vCPUs": 48},
-        {"name": "m5d.16xlarge", "vCPUs": 64},
-        {"name": "m5d.24xlarge", "vCPUs": 96}
+        {"name": "m6gd.large", "vCPUs": 2},
+        {"name": "m6gd.xlarge", "vCPUs": 4},
+        {"name": "m6gd.2xlarge", "vCPUs": 8},
+        {"name": "m6gd.4xlarge", "vCPUs": 16},
+        {"name": "m6gd.8xlarge", "vCPUs": 32},
+        {"name": "m6gd.12xlarge", "vCPUs": 48},
+        {"name": "m6gd.16xlarge", "vCPUs": 64}
       ]
     }
   },

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_azure-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_azure-configs.json
@@ -347,20 +347,20 @@
         }
       ],
       "cluster_name": "default-cluster-prop",
-      "driver_node_type_id": "Standard_DS3_v2",
+      "driver_node_type_id": "Standard_E8ds_v4",
       "node_type_id": "Standard_DS3_v2",
       "state": "TERMINATED",
       "num_workers": 1
     },
     "defaultCpuInstances": {
-      "driver": "Standard_DS3_v2",
+      "driver": "Standard_E8ds_v4",
       "executor": [
-        {"name": "Standard_DS3_v2", "vCPUs": 4},
-        {"name": "Standard_DS4_v2", "vCPUs": 8},
-        {"name": "Standard_DS5_v2", "vCPUs": 16},
-        {"name": "Standard_D32_v3", "vCPUs": 32},
-        {"name": "Standard_D64_v3", "vCPUs": 64},
-        {"name": "Standard_D96a_v4", "vCPUs": 96}
+        {"name": "Standard_E2ds_v4", "vCPUs": 2},
+        {"name": "Standard_E4ds_v4", "vCPUs": 4},
+        {"name": "Standard_E8ds_v4", "vCPUs": 8},
+        {"name": "Standard_E16ds_v4", "vCPUs": 16},
+        {"name": "Standard_E32ds_v4", "vCPUs": 32},
+        {"name": "Standard_E64ds_v4", "vCPUs": 64}
       ]
     }
   },

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_azure-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_azure-configs.json
@@ -335,6 +335,35 @@
       }
     }
   },
+  "clusterInference": {
+    "defaultClusterConfig": {
+      "cluster_id": "1234-5678-1234567",
+      "driver": {
+        "node_id": "1234567890"
+      },
+      "executors": [
+        {
+          "node_id": "1234567890"
+        }
+      ],
+      "cluster_name": "default-cluster-prop",
+      "driver_node_type_id": "Standard_DS3_v2",
+      "node_type_id": "Standard_DS3_v2",
+      "state": "TERMINATED",
+      "num_workers": 1
+    },
+    "defaultCpuInstances": {
+      "driver": "Standard_DS3_v2",
+      "executor": [
+        {"name": "Standard_DS3_v2", "vCPUs": 4},
+        {"name": "Standard_DS4_v2", "vCPUs": 8},
+        {"name": "Standard_DS5_v2", "vCPUs": 16},
+        {"name": "Standard_D32_v3", "vCPUs": 32},
+        {"name": "Standard_D64_v3", "vCPUs": 64},
+        {"name": "Standard_D96a_v4", "vCPUs": 96}
+      ]
+    }
+  },
   "clusterSpecs": {
     "minWorkerNodes": 2
   }

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -258,6 +258,47 @@
       ]
     }
   },
+  "clusterInference": {
+    "defaultClusterConfig": {
+      "clusterName": "default-cluster-prop",
+      "clusterUuid": "1234-5678-1234567",
+      "config": {
+        "gceClusterConfig": {
+          "zoneUri": "us-central1-a"
+        },
+        "masterConfig": {
+          "instanceNames": [
+            "test-node"
+          ],
+          "machineTypeUri": "n1-standard-16",
+          "numInstances": 1
+        },
+        "workerConfig": {
+          "instanceNames": [
+            "test-node"
+          ],
+          "machineTypeUri": "n1-standard-16",
+          "numInstances": 1
+        }
+      },
+      "status": {
+        "state": "STOPPED"
+      }
+    },
+    "defaultCpuInstances": {
+      "driver": "n1-standard-16",
+      "executor": [
+        {"name": "n1-standard-1", "vCPUs": 1},
+        {"name": "n1-standard-2", "vCPUs": 2},
+        {"name": "n1-standard-4", "vCPUs": 4},
+        {"name": "n1-standard-8", "vCPUs": 8},
+        {"name": "n1-standard-16", "vCPUs": 16},
+        {"name": "n1-standard-32", "vCPUs": 32},
+        {"name": "n1-standard-64", "vCPUs": 64},
+        {"name": "n1-standard-96", "vCPUs": 96}
+      ]
+    }
+  },
   "clusterSpecs": {
     "minWorkerNodes": 2,
     "gpuScaleFactor": 0.80

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -277,7 +277,7 @@
           "instanceNames": [
             "test-node"
           ],
-          "machineTypeUri": "n1-standard-16",
+          "machineTypeUri": "n1-standard-32",
           "numInstances": 1
         }
       },
@@ -294,8 +294,7 @@
         {"name": "n1-standard-8", "vCPUs": 8},
         {"name": "n1-standard-16", "vCPUs": 16},
         {"name": "n1-standard-32", "vCPUs": 32},
-        {"name": "n1-standard-64", "vCPUs": 64},
-        {"name": "n1-standard-96", "vCPUs": 96}
+        {"name": "n1-standard-64", "vCPUs": 64}
       ]
     }
   },

--- a/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
@@ -305,7 +305,7 @@
             "Name": "CORE",
             "Market": "ON_DEMAND",
             "InstanceGroupType": "CORE",
-            "InstanceType": "m5d.large",
+            "InstanceType": "m5d.8xlarge",
             "RequestedInstanceCount": 1
           },
           {
@@ -339,8 +339,7 @@
         {"name": "m5d.4xlarge", "vCPUs": 16},
         {"name": "m5d.8xlarge", "vCPUs": 32},
         {"name": "m5d.12xlarge", "vCPUs": 48},
-        {"name": "m5d.16xlarge", "vCPUs": 64},
-        {"name": "m5d.24xlarge", "vCPUs": 96}
+        {"name": "m5d.16xlarge", "vCPUs": 64}
       ]
     }
   },

--- a/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
@@ -288,6 +288,62 @@
       ]
     }
   },
+  "clusterInference": {
+    "defaultClusterConfig": {
+      "Cluster": {
+        "Id": "j-123456789",
+        "Name": "default-cluster-prop",
+        "Status": {
+          "State": "TERMINATED"
+        },
+        "Ec2InstanceAttributes": {
+          "Ec2AvailabilityZone": "us-west-2a"
+        },
+        "InstanceGroups": [
+          {
+            "Id": "ig-123456789012e",
+            "Name": "CORE",
+            "Market": "ON_DEMAND",
+            "InstanceGroupType": "CORE",
+            "InstanceType": "m5d.large",
+            "RequestedInstanceCount": 1
+          },
+          {
+            "Id": "ig-123456789012d",
+            "Name": "MASTER",
+            "Market": "ON_DEMAND",
+            "InstanceGroupType": "MASTER",
+            "InstanceType": "i3.2xlarge",
+            "RequestedInstanceCount": 1
+          }
+        ]
+      }
+    },
+    "defaultNodeConfig": {
+      "Id": "ci-123456789",
+      "Ec2InstanceId": "i-123456789",
+      "PublicDnsName": "ec2-12-34-567-890.us-west-2.compute.amazonaws.com",
+      "Status": {
+          "State": "TERMINATED"
+      },
+      "InstanceGroupId": "ig-123456789012d",
+      "Market": "ON_DEMAND",
+      "InstanceType": "m5d.large"
+    },
+    "defaultCpuInstances": {
+      "driver": "i3.2xlarge",
+      "executor": [
+        {"name": "m5d.large", "vCPUs": 2},
+        {"name": "m5d.xlarge", "vCPUs": 4},
+        {"name": "m5d.2xlarge", "vCPUs": 8},
+        {"name": "m5d.4xlarge", "vCPUs": 16},
+        {"name": "m5d.8xlarge", "vCPUs": 32},
+        {"name": "m5d.12xlarge", "vCPUs": 48},
+        {"name": "m5d.16xlarge", "vCPUs": 64},
+        {"name": "m5d.24xlarge", "vCPUs": 96}
+      ]
+    }
+  },
   "clusterSpecs": {
     "minWorkerNodes": 2
   }


### PR DESCRIPTION
Contributes #581. This PR infers CPU cluster shape by parsing the event log. This will be used for savings estimation.

### Inference Logic
1. `num_drivers_nodes`:
    - Set as 1 for all CSPs.
2. `driver_instance`: 
    - For Databricks use: `Spark Properties` -> `spark.databricks.driverNodeTypeId`
    - For rest, use default driver instance from config file
3. `num_executor_nodes`:
    - Count unique hosts IPs from `SparkListenerBlockManagerAdded` -> `Block Manager ID` -> `Executor ID` != `driver`
4. `executor_instance`:
   - For Databricks use: `Spark Properties` -> `spark.databricks.executorNodeTypeId`
   - For rest, 
       - Extract `num_cores`: `SparkListenerExecutorAdded` -> `Executor Info` -> `Total Cores`
       - Use default instance type with matching cores from config, eg: `{"name": "m5d.2xlarge", "vCPUs": 8},`

### Changes
1. `cluster_inference.py` - Implements the above logic.
    - Parses event log
    - Extracts information based on platform
    - Create CPU cluster object
2. `qualification.py` - Modify code to use above inference 
3. Cloud APIs - Each Platform implements `_construct_cluster_config` to read default cluster config and update fields related to shape (`num_executors`, `executor_instance`)
4. JSON Configs - Every config file now includes:
    - Default template for Cluster (output from `describe`)
    - Default template for Node 
    - List of CPU instances based on num cores

### Input/Output
#### EMR - Inference Supported
CMD: `spark_rapids_user_tools emr qualification --eventlogs ~/eventlog_file -v`

```
INFO rapids.tools.qualification: Inferring CPU cluster properties from event logs. This could take a while.
...
INFO rapids.tools.qualification: Inferred Cluster => Driver: i3.2xlarge, Executor: 8 X m5d.4xlarge
```


#### Dataproc - Inference Supported
CMD: `spark_rapids_user_tools dataproc qualification --eventlogs ~/eventlog_file -v`

```
INFO rapids.tools.qualification: Inferring CPU cluster properties from event logs. This could take a while.
...
INFO rapids.tools.qualification: Inferred Cluster => Driver: n1-standard-16, Executor: 4 X n1-standard-16
```

#### Databricks AWS - Inference Supported
CMD: `spark_rapids_user_tools databricks-aws qualification --eventlogs ~/eventlog_file -v`

```
INFO rapids.tools.qualification: Inferring CPU cluster properties from event logs. This could take a while.
...
INFO rapids.tools.qualification: Inferred Cluster => Driver: m6gd.xlarge, Executor: 2 X m6gd.2xlarge
```

#### Databricks Azure - Inference Supported
CMD: `spark_rapids_user_tools databricks-azure qualification --eventlogs ~/eventlog_file -v`

```
INFO rapids.tools.qualification: Inferring CPU cluster properties from event logs. This could take a while.
...
INFO rapids.tools.qualification: Inferred Cluster => Driver: Standard_E8ds_v4, Executor: 2 X Standard_E8ds_v4
```

#### OnPrem - Inference Not Supported
CMD: `spark_rapids_user_tools onprem qualification --eventlogs ~/eventlog_file -v`

```
INFO rapids.tools.qualification: Savings estimates are disabled because the cluster-information is not provided.
```

#### Dataproc-GKE - Inference Not Supported
CMD: `spark_rapids_user_tools dataproc-gke qualification --eventlogs ~/eventlog_file -v`

```
INFO rapids.tools.qualification: Savings estimates are disabled because the cluster-information is not provided.
```

#### Eventlog is a directory - Inference Not Supported
CMD: `spark_rapids_user_tools emr qualification --eventlogs ~/eventlog_dir -v`

```
INFO rapids.tools.qualification: Inferring CPU cluster properties from event logs. This could take a while.
INFO rapids.tools.cluster_inference: Unable to infer CPU cluster. Path ~/eventlog_dir should be a file.
INFO rapids.tools.qualification: Cannot infer CPU cluster from event logs
```