### PR TITLE
Add NativeScan name as filter for Gluten

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -293,7 +293,7 @@ abstract class AppBase(
       val readSchema = ReadParser.formatSchemaStr(meta.getOrElse("ReadSchema", ""))
       val scanNode = allNodes.filter(node => {
         // Get ReadSchema of each Node and sanitize it for comparison
-        // The "NativeScan" name is from Velox engine
+        // The "NativeScan" name is from Gluten engine
         val trimmedNode = trimSchema(ReadParser.parseReadNode(node).schema)
         readSchema.contains(trimmedNode)
       }).filter(x => x.name.startsWith("Scan") || x.name.startsWith("NativeScan")).head

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -293,9 +293,10 @@ abstract class AppBase(
       val readSchema = ReadParser.formatSchemaStr(meta.getOrElse("ReadSchema", ""))
       val scanNode = allNodes.filter(node => {
         // Get ReadSchema of each Node and sanitize it for comparison
+        // The "NativeScan" name is from Velox engine
         val trimmedNode = trimSchema(ReadParser.parseReadNode(node).schema)
         readSchema.contains(trimmedNode)
-      }).filter(x => x.name.startsWith("Scan")).head
+      }).filter(x => x.name.startsWith("Scan") || x.name.startsWith("NativeScan")).head
 
       dataSourceInfo += DataSourceCase(sqlID,
         scanNode.id,


### PR DESCRIPTION
When parsing eventlog generated by Gluten engine, the Scan node name starts with "NativeScan" instead of "Scan". This results the empty output after filtering.

Add the "NativeScan" for filter so it can be parsed successfully.