### PR TITLE
Polling maven-metadata.xml to pull the latest tools jar

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -393,7 +393,7 @@ class RapidsJarTool(RapidsTool):
         jar_file_name = FSUtil.get_resource_name(jar_path)
         version_match = re.search(r'\d{2}\.\d{2}\.\d+', jar_file_name)
         jar_version = version_match.group() if version_match else 'Unknown'
-        self.logger.info('Using Spark RAPIDS accelerator jar version %s', jar_version)
+        self.logger.info('Using Spark RAPIDS Accelerator Tools jar version %s', jar_version)
         #  add jar file name to the tool args
         self.ctxt.add_rapids_args('jarFileName', jar_file_name)
         self.ctxt.add_rapids_args('jarFilePath', jar_path)

--- a/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
@@ -16,16 +16,17 @@
 
 import os
 import tarfile
-from glob import glob
 from dataclasses import dataclass, field
+from glob import glob
 from logging import Logger
 from typing import Type, Any, ClassVar, List
 
-from spark_rapids_tools import CspEnv
 from spark_rapids_pytools.cloud_api.sp_types import PlatformBase
 from spark_rapids_pytools.common.prop_manager import YAMLPropertiesContainer
 from spark_rapids_pytools.common.sys_storage import FSUtil
 from spark_rapids_pytools.common.utilities import ToolLogging, Utils
+from spark_rapids_tools import CspEnv
+from spark_rapids_tools.utils import Utilities
 
 
 @dataclass
@@ -177,7 +178,7 @@ class ToolContext(YAMLPropertiesContainer):
                 raise FileNotFoundError('In Fat Mode. No matching JAR files found.')
             return matching_files[0]
         mvn_base_url = self.get_value('sparkRapids', 'mvnUrl')
-        jar_version = Utils.get_latest_available_jar_version(mvn_base_url, Utils.get_base_release())
+        jar_version = Utilities.get_latest_mvn_jar_from_metadata(mvn_base_url)
         rapids_url = self.get_value('sparkRapids', 'repoUrl').format(mvn_base_url, jar_version, jar_version)
         return rapids_url
 

--- a/user_tools/src/spark_rapids_pytools/resources/dev/prepackage_mgr.py
+++ b/user_tools/src/spark_rapids_pytools/resources/dev/prepackage_mgr.py
@@ -25,11 +25,11 @@ from typing import Optional
 
 import fire
 
-from spark_rapids_tools import CspEnv
 from spark_rapids_pytools.common.prop_manager import JSONPropertiesContainer
 from spark_rapids_pytools.common.sys_storage import FSUtil
 from spark_rapids_pytools.common.utilities import Utils
-
+from spark_rapids_tools import CspEnv
+from spark_rapids_tools.utils import Utilities
 
 # Defines the constants and static configurations
 prepackage_conf = {
@@ -87,8 +87,7 @@ class PrepackageMgr:   # pylint: disable=too-few-public-methods
             self.dest_dir = FSUtil.get_abs_path(self.dest_dir)
 
     def _get_spark_rapids_jar_url(self) -> str:
-        jar_version = Utils.get_latest_available_jar_version(self._mvn_base_url,  # pylint: disable=no-member
-                                                             Utils.get_base_release())
+        jar_version = Utilities.get_latest_mvn_jar_from_metadata(self._mvn_base_url)  # pylint: disable=no-member
         return (f'{self._mvn_base_url}/'  # pylint: disable=no-member
                 f'{jar_version}/rapids-4-spark-tools_2.12-{jar_version}.jar')
 

--- a/user_tools/src/spark_rapids_pytools/resources/dev/prepackage_mgr.py
+++ b/user_tools/src/spark_rapids_pytools/resources/dev/prepackage_mgr.py
@@ -27,7 +27,6 @@ import fire
 
 from spark_rapids_pytools.common.prop_manager import JSONPropertiesContainer
 from spark_rapids_pytools.common.sys_storage import FSUtil
-from spark_rapids_pytools.common.utilities import Utils
 from spark_rapids_tools import CspEnv
 from spark_rapids_tools.utils import Utilities
 

--- a/user_tools/src/spark_rapids_tools/utils/__init__.py
+++ b/user_tools/src/spark_rapids_tools/utils/__init__.py
@@ -15,7 +15,7 @@
 """init file of the utils package for the Accelerated Spark tools"""
 
 from .util import (
-    get_elem_from_dict, get_elem_non_safe, is_http_file
+    get_elem_from_dict, get_elem_non_safe, is_http_file, Utilities
 )
 
 from .propmanager import (
@@ -28,5 +28,6 @@ __all__ = [
     'get_elem_non_safe',
     'AbstractPropContainer',
     'PropValidatorSchema',
-    'is_http_file'
+    'is_http_file',
+    'Utilities'
 ]


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #702

This PR is an alternative implementation to pull the latest version of the Tools jar.
The python module parses the maven-metadata.xml to get the available releases. It was found that this file is usually up-to-date with the releases.

* Move some utility functions to the new package
* Fix the logging message of the python module to avoid confusing RAPIDS jars with Tools jars
