### PR TITLE
[WIP] Add support of HiveTableScan TextHive

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/FileSourceScanExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/FileSourceScanExecParser.scala
@@ -37,12 +37,15 @@ case class FileSourceScanExecParser(
     val nodeName = node.name.trim
     val accumId = node.metrics.find(_.name == "scan time").map(_.accumulatorId)
     val maxDuration = SQLPlanParser.getTotalDuration(accumId, app)
-
-    val readInfo = ReadParser.parseReadNode(node)
+    val (execName, readInfo) = if (HiveParseHelper.isHiveTableScanNode(node)) {
+      (HiveParseHelper.SCAN_HIVE_EXEC_NAME, HiveParseHelper.parseReadNode(node))
+    } else {
+      (fullExecName, ReadParser.parseReadNode(node))
+    }
+    val speedupFactor = checker.getSpeedupFactor(execName)
     // don't use the isExecSupported because we have finer grain.
     val score = ReadParser.calculateReadScoreRatio(readInfo, checker)
-    val speedupFactor = checker.getSpeedupFactor(fullExecName)
-    val overallSpeedup = Math.max((speedupFactor * score), 1.0)
+    val overallSpeedup = Math.max(speedupFactor * score, 1.0)
 
     // TODO - add in parsing expressions - average speedup across?
     new ExecInfo(sqlID, nodeName, "", overallSpeedup, maxDuration, node.id, score > 0, None)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/HiveParseHelper.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/HiveParseHelper.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.planparser
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
+
+case class HiveScanSerdeClasses(className: String, format: String) extends Logging {
+  def parseReadNode(node: SparkPlanGraphNode): ReadMetaData = {
+    logDebug(s"Parsing node as ScanHiveTable: ${node.desc}")
+    // Schema, pushedFilters empty for now as we cannot extract them yet from eventlogs
+    ReadMetaData("", "HiveTableRelation", "unknown", format)
+  }
+}
+
+object HiveParseHelper extends Logging {
+  val SCAN_HIVE_LABEL = "scan hive"
+  val SCAN_HIVE_EXEC_NAME = "HiveTableScanExec"
+  // Classes we can look for is SerDe
+  private val LOADED_SERDE_CLASSES = Seq(
+    HiveScanSerdeClasses("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe", "HiveText"),
+    HiveScanSerdeClasses("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
+      "HiveParquet"),
+    HiveScanSerdeClasses("org.apache.hadoop.hive.serde2.avro.AvroSerDe", "HiveAvro"),
+    HiveScanSerdeClasses("org.apache.hadoop.hive.serde2.OpenCSVSerde", "HiveCSV")
+  )
+
+  def isHiveTableScanNode(node: SparkPlanGraphNode): Boolean = {
+    node.name.toLowerCase.startsWith(SCAN_HIVE_LABEL)
+  }
+
+  def parseReadNode(node: SparkPlanGraphNode): ReadMetaData = {
+    LOADED_SERDE_CLASSES.find(k => node.desc.contains(k.className)).map(
+      _.parseReadNode(node)).getOrElse(ReadMetaData("", "HiveTableRelation", "unknown", "unknown"))
+  }
+
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/HiveParseHelper.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/HiveParseHelper.scala
@@ -36,7 +36,8 @@ object HiveParseHelper extends Logging {
     HiveScanSerdeClasses("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
       "HiveParquet"),
     HiveScanSerdeClasses("org.apache.hadoop.hive.serde2.avro.AvroSerDe", "HiveAvro"),
-    HiveScanSerdeClasses("org.apache.hadoop.hive.serde2.OpenCSVSerde", "HiveCSV")
+    HiveScanSerdeClasses("org.apache.hadoop.hive.serde2.OpenCSVSerde", "HiveCSV"),
+    HiveScanSerdeClasses("org.apache.hadoop.hive.ql.io.orc.OrcSerde", "HiveORC")
   )
 
   def isHiveTableScanNode(node: SparkPlanGraphNode): Boolean = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -257,7 +257,7 @@ object SQLPlanParser extends Logging {
             ShuffledHashJoinExecParser(node, checker, sqlID, app).parse
           case "Sort" =>
             SortExecParser(node, checker, sqlID).parse
-          case s if (s.startsWith("Scan")) =>
+          case s if ReadParser.isScanNode(s) =>
             FileSourceScanExecParser(node, checker, sqlID, app).parse
           case "SortAggregate" =>
             SortAggregateExecParser(node, checker, sqlID).parse

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -295,7 +295,7 @@ abstract class AppBase(
         // Get ReadSchema of each Node and sanitize it for comparison
         val trimmedNode = trimSchema(ReadParser.parseReadNode(node).schema)
         readSchema.contains(trimmedNode)
-      }).filter(x => x.name.startsWith("Scan")).head
+      }).filter(ReadParser.isScanNode(_)).head
 
       dataSourceInfo += DataSourceCase(sqlID,
         scanNode.id,


### PR DESCRIPTION
Fixes #681

- look at the node description for the serde implementation as below
``` 
        org.apache.hadoop.hive.serde2.AbstractSerDe
          org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe -> HiveText
            org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe -> HiveParquet
            org.apache.hadoop.hive.serde2.avro.AvroSerDe -> AvroParquet
            org.apache.hadoop.hive.serde2.OpenCSVSerde -> CSVParquet
```

- Only HiveText is supported for now.
- we cannot pull the schema . So, we leave it empty
