### PR TITLE
AutoTuner should poll maven-meta to retrieve the latest jar version 

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/WebCrawlerUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/WebCrawlerUtil.scala
@@ -18,11 +18,12 @@ package org.apache.spark.sql.rapids.tool.util
 
 import java.io.IOException
 
-import org.jsoup.Jsoup
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.control.NonFatal
 import scala.xml.XML
+
+import org.jsoup.Jsoup
 
 import org.apache.spark.internal.Logging
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/WebCrawlerUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/WebCrawlerUtil.scala
@@ -21,6 +21,8 @@ import java.io.IOException
 import org.jsoup.Jsoup
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.util.control.NonFatal
+import scala.xml.XML
 
 import org.apache.spark.internal.Logging
 
@@ -36,6 +38,7 @@ object WebCrawlerUtil extends Logging {
     "rapids.plugin" -> "rapids-4-spark_2.12",
     "rapids.tools" -> "rapids-4-spark-tools_2.12"
   )
+  private val MAVEN_META_FILE = "maven-metadata.xml"
   // regular expression used to extract the version number from
   // the mvn repository url
   private val ARTIFACT_VERSION_REGEX = "\\d{2}\\.\\d{2}\\.\\d+/"
@@ -44,6 +47,11 @@ object WebCrawlerUtil extends Logging {
   def getMVNArtifactURL(artifactID: String) : String = {
     val artifactUrlPart = NV_ARTIFACTS_LOOKUP.getOrElse(artifactID, artifactID)
     s"$NV_MVN_BASE_URL/$artifactUrlPart"
+  }
+
+  def getMVNMetaURL(artifactID: String) : String = {
+    val artifactUrlPart = getMVNArtifactURL(artifactID)
+    s"$artifactUrlPart/$MAVEN_META_FILE"
   }
 
   /**
@@ -99,10 +107,15 @@ object WebCrawlerUtil extends Logging {
 
   // given an artifactID, will return the latest version if any
   def getLatestMvnReleaseForNVPackage(artifactID: String): Option[String] = {
-    val allVersions = getMvnReleasesForNVPackage(artifactID)
-    allVersions match {
-      case Seq() => None
-      case s: Seq[String] => Some(s.last)
+    // Reads maven-metadata.xml file to extract the latest version
+    val mvnMetaFile = getMVNMetaURL(artifactID)
+    try {
+      val xml = XML.load(mvnMetaFile)
+      Some((xml \\ "metadata" \ "versioning" \ "latest").text)
+    } catch {
+      case NonFatal(e) =>
+        logWarning(s"Exception loading maven-metadata.xml: ${mvnMetaFile}", e)
+      None
     }
   }
 
@@ -124,8 +137,4 @@ object WebCrawlerUtil extends Logging {
   def getLatestToolsRelease: Option[String] = {
     getLatestMvnReleaseForNVPackage(NV_ARTIFACTS_LOOKUP("rapids.tools"))
   }
-
-
-
-
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
@@ -19,9 +19,11 @@ package com.nvidia.spark.rapids.tool.util
 import java.text.SimpleDateFormat
 import java.util.Calendar
 
+import scala.concurrent.duration._
+import scala.xml.XML
+
 import org.scalatest.FunSuite
 import org.scalatest.Matchers.{contain, convertToAnyShouldWrapper, not}
-import scala.concurrent.duration._
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.AccumulableInfo
@@ -120,10 +122,11 @@ class ToolUtilsSuite extends FunSuite with Logging {
       case None => fail("Could not find pull the latest release successfully")
     }
     // get all the links on the page
-    val allLinks = WebCrawlerUtil.getPageLinks(baseURL, None).mkString("\n")
-    val versionPattern = "(\\d{2}\\.\\d{2}\\.\\d+)/".r
+    val mavenMetaXml = XML.load(s"$baseURL/maven-metadata.xml")
+    val allVersions = (mavenMetaXml \\ "metadata" \ "versioning" \ "versions" \ "version").toList
     // get the latest release from the mvn url
-    val actualRelease = versionPattern.findAllMatchIn(allLinks).map(_.group(1)).toSeq.sorted.last
+    val actualRelease = allVersions.last.text
+    actualRelease.matches("\\d{2}\\.\\d{2}\\.\\d+") shouldBe true
     latestRelease shouldBe actualRelease
   }
 


### PR DESCRIPTION
Fixes #704

The AutoTuner could show an old version if the list directory is not
updated.
This change is to make sure that the AutoTuner can find the latest
version by parsing maven-metadata.xml