### PR TITLE
[FEA] AutoTuner should not skip non-gpu eventlogs

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -73,6 +73,7 @@ class AppSummaryInfoBaseProvider extends AppInfoPropertyGetter
   with AppInfoSqlTaskAggMetricsVisitor
   with AppInfoSQLTaskInputSizes
   with AppInfoReadMetrics {
+  def isAppInfoAvailable = false
   override def getSparkProperty(propKey: String): Option[String] = None
   override def getRapidsProperty(propKey: String): Option[String] = None
   override def getProperty(propKey: String): Option[String] = None
@@ -98,6 +99,7 @@ class SingleAppSummaryInfoProvider(val app: ApplicationSummaryInfo)
   extends AppSummaryInfoBaseProvider {
 
   private lazy val distinctLocations = app.dsInfo.groupBy(_.location)
+  override def isAppInfoAvailable = Option(app).isDefined
 
   private def findPropertyInProfPropertyResults(
       key: String,
@@ -179,6 +181,15 @@ class SingleAppSummaryInfoProvider(val app: ApplicationSummaryInfo)
       app.ioMetrics.map(_.srTotalBytesReadSum).sum * 1.0 / app.ioMetrics.size
     } else {
       0.0
+    }
+  }
+}
+
+object AppSummaryInfoBaseProvider {
+  def fromAppInfo(appInfoInst: Option[ApplicationSummaryInfo]): AppSummaryInfoBaseProvider = {
+    appInfoInst match {
+      case Some(appSummaryInfo) => new SingleAppSummaryInfoProvider(appSummaryInfo)
+      case _ => new AppSummaryInfoBaseProvider()
     }
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -674,8 +674,7 @@ class AutoTuner(
       case Some(version) =>
         if (ToolUtils.isSpark320OrLater(version)) {
           // AQE configs changed in 3.2.0
-          if (getPropertyValue(
-            "spark.sql.adaptive.coalescePartitions.minPartitionSize").isEmpty) {
+          if (getPropertyValue("spark.sql.adaptive.coalescePartitions.minPartitionSize").isEmpty) {
             // the default is 1m, but 4m is slightly better for the GPU as we have a higher
             // per task overhead
             appendRecommendation("spark.sql.adaptive.coalescePartitions.minPartitionSize", "4m")
@@ -1000,9 +999,7 @@ class AutoTuner(
       skipList.foreach(skipSeq => skipSeq.foreach(_ => skippedRecommendations.add(_)))
       skippedRecommendations ++= platform.recommendationsToExclude
       initRecommendations()
-
       calculateJobLevelRecommendations()
-
       if (processPropsAndCheck) {
         calculateClusterLevelRecommendations()
       } else {
@@ -1055,7 +1052,6 @@ object AutoTuner extends Logging {
   val DEF_WORKER_GPU_COUNT = 1
   // GPU default device is T4
   val DEF_WORKER_GPU_NAME = GpuTypes.T4
-
   // Default Number of Workers 1
   val DEF_NUM_WORKERS = 1
   // Default distinct read location thresholds is 50%

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/DriverLogProcessor.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/DriverLogProcessor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #726

- The Autotuner can still make recommendation regardless of the GPU profile info
- Changed the code to avoid Null objects. The Autotuner could throw a NPE when the user not supplying any eventlog.
- Fixed the unit-tests accordingly
- Tested the new changes running a CPU eventlog
