### PR TITLE
Add auto-copyright for precommits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ target/
 
 # prepackage locations
 csp-resources*
+
+# precommit files
+*-E

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+repos:
+  - repo: local
+    hooks:
+      - id: auto-copyrighter
+        name: Update copyright year
+        entry: scripts/auto-copyrighter.sh
+        language: script
+        pass_filenames: true
+        verbose: true
+  - repo: https://github.com/pre-commit/pre-commit-hooks.git
+    rev: v4.0.1
+    hooks:
+      - id: check-added-large-files
+        name: Check for file over 1.5MiB
+        args: ['--maxkb=1500', '--enforce-all']
+

--- a/scripts/auto-copyrighter.sh
+++ b/scripts/auto-copyrighter.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+SPARK_RAPIDS_AUTO_COPYRIGHTER=${SPARK_RAPIDS_AUTO_COPYRIGHTER:-OFF}
+
+case "$SPARK_RAPIDS_AUTO_COPYRIGHTER" in
+
+    OFF)
+        echo "Copyright updater is DISABLED. Automatic Copyright Updater can be enabled/disabled by setting \
+SPARK_RAPIDS_AUTO_COPYRIGHTER=ON or SPARK_RAPIDS_AUTO_COPYRIGHTER=OFF, \
+correspondingly"
+        exit 0
+        ;;
+
+    ON)
+        ;;
+
+    *)
+        echo "Invalid value of SPARK_RAPIDS_AUTO_COPYRIGHTER=$SPARK_RAPIDS_AUTO_COPYRIGHTER.
+        Only ON or OFF are allowed"
+        exit 1
+        ;;
+esac
+
+set -x
+echo "$@" | xargs -L1 sed -i -E \
+    "s/Copyright *\(c\) *([0-9,-]+)*-([0-9]{4}), *NVIDIA *CORPORATION/Copyright (c) \\1-`date +%Y`, NVIDIA CORPORATION/; /`date +%Y`/! s/Copyright *\(c\) ([0-9]{4}), *NVIDIA *CORPORATION/Copyright (c) \\1-`date +%Y`, NVIDIA CORPORATION/"


### PR DESCRIPTION
Fixes #730

This PR adds auto-copyright script to the repository.

- follow the installation instructions on the
[pre-commit homepage](https://pre-commit.com/)
- install pre-commit for the repository using `pre-commit install --allow-missing-config`
- set the environment variable `SPARK_RAPIDS_AUTO_COPYRIGHTER` to `ON`.
- the script will automatically update the copyrights of the modified files