### PR TITLE
[FEA] AutoTuner warns that non-utf8 may not support some GPU expressions

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -112,7 +112,7 @@ class SingleAppSummaryInfoProvider(val app: ApplicationSummaryInfo)
   extends AppSummaryInfoBaseProvider {
 
   private lazy val distinctLocations = app.dsInfo.groupBy(_.location)
-  override def isAppInfoAvailable = Option(app).isDefined
+  override def isAppInfoAvailable: Boolean = Option(app).isDefined
 
   private def findPropertyInProfPropertyResults(
       key: String,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -16,34 +16,38 @@
 
 package com.nvidia.spark.rapids.tool.profiling
 
+import org.apache.spark.sql.rapids.tool.ToolUtils
+
 case class ApplicationSummaryInfo(
-    val appInfo: Seq[AppInfoProfileResults],
-    val dsInfo: Seq[DataSourceProfileResult],
-    val execInfo: Seq[ExecutorInfoProfileResult],
-    val jobInfo: Seq[JobInfoProfileResult],
-    val rapidsProps: Seq[RapidsPropertyProfileResult],
-    val rapidsJar: Seq[RapidsJarProfileResult],
-    val sqlMetrics: Seq[SQLAccumProfileResults],
-    val jsMetAgg: Seq[JobStageAggTaskMetricsProfileResult],
-    val sqlTaskAggMetrics: Seq[SQLTaskAggMetricsProfileResult],
-    val durAndCpuMet: Seq[SQLDurationExecutorTimeProfileResult],
-    val skewInfo: Seq[ShuffleSkewProfileResult],
-    val failedTasks: Seq[FailedTaskProfileResults],
-    val failedStages: Seq[FailedStagesProfileResults],
-    val failedJobs: Seq[FailedJobsProfileResults],
-    val removedBMs: Seq[BlockManagerRemovedProfileResult],
-    val removedExecutors: Seq[ExecutorsRemovedProfileResult],
-    val unsupportedOps: Seq[UnsupportedOpsProfileResult],
-    val sparkProps: Seq[RapidsPropertyProfileResult],
-    val sqlStageInfo: Seq[SQLStageInfoProfileResult],
-    val wholeStage: Seq[WholeStageCodeGenResults],
-    val maxTaskInputBytesRead: Seq[SQLMaxTaskInputSizes],
-    val appLogPath: Seq[AppLogPathProfileResults],
-    val ioMetrics: Seq[IOAnalysisProfileResult])
+    appInfo: Seq[AppInfoProfileResults],
+    dsInfo: Seq[DataSourceProfileResult],
+    execInfo: Seq[ExecutorInfoProfileResult],
+    jobInfo: Seq[JobInfoProfileResult],
+    rapidsProps: Seq[RapidsPropertyProfileResult],
+    rapidsJar: Seq[RapidsJarProfileResult],
+    sqlMetrics: Seq[SQLAccumProfileResults],
+    jsMetAgg: Seq[JobStageAggTaskMetricsProfileResult],
+    sqlTaskAggMetrics: Seq[SQLTaskAggMetricsProfileResult],
+    durAndCpuMet: Seq[SQLDurationExecutorTimeProfileResult],
+    skewInfo: Seq[ShuffleSkewProfileResult],
+    failedTasks: Seq[FailedTaskProfileResults],
+    failedStages: Seq[FailedStagesProfileResults],
+    failedJobs: Seq[FailedJobsProfileResults],
+    removedBMs: Seq[BlockManagerRemovedProfileResult],
+    removedExecutors: Seq[ExecutorsRemovedProfileResult],
+    unsupportedOps: Seq[UnsupportedOpsProfileResult],
+    sparkProps: Seq[RapidsPropertyProfileResult],
+    sqlStageInfo: Seq[SQLStageInfoProfileResult],
+    wholeStage: Seq[WholeStageCodeGenResults],
+    maxTaskInputBytesRead: Seq[SQLMaxTaskInputSizes],
+    appLogPath: Seq[AppLogPathProfileResults],
+    ioMetrics: Seq[IOAnalysisProfileResult],
+    sysProps: Seq[RapidsPropertyProfileResult])
 
 trait AppInfoPropertyGetter {
   def getSparkProperty(propKey: String): Option[String]
   def getRapidsProperty(propKey: String): Option[String]
+  def getSystemProperty(propKey: String): Option[String]
   def getProperty(propKey: String): Option[String]
   def getSparkVersion: Option[String]
   def getRapidsJars: Seq[String]
@@ -76,7 +80,16 @@ class AppSummaryInfoBaseProvider extends AppInfoPropertyGetter
   def isAppInfoAvailable = false
   override def getSparkProperty(propKey: String): Option[String] = None
   override def getRapidsProperty(propKey: String): Option[String] = None
-  override def getProperty(propKey: String): Option[String] = None
+  override def getSystemProperty(propKey: String): Option[String] = None
+  override def getProperty(propKey: String): Option[String] = {
+    if (propKey.startsWith(ToolUtils.PROPS_RAPIDS_KEY_PREFIX)) {
+      getRapidsProperty(propKey)
+    } else if (propKey.startsWith("spark")){
+      getSparkProperty(propKey)
+    } else {
+      getSystemProperty(propKey)
+    }
+  }
   override def getSparkVersion: Option[String] = None
   override def getMaxInput: Double = 0.0
   override def getMeanInput: Double = 0.0
@@ -118,12 +131,8 @@ class SingleAppSummaryInfoProvider(val app: ApplicationSummaryInfo)
     findPropertyInProfPropertyResults(propKey, app.rapidsProps)
   }
 
-  override def getProperty(propKey: String): Option[String] = {
-    if (propKey.startsWith("spark.rapids")) {
-      getRapidsProperty(propKey)
-    } else {
-      getSparkProperty(propKey)
-    }
+  override def getSystemProperty(propKey: String): Option[String] = {
+    findPropertyInProfPropertyResults(propKey, app.sysProps)
   }
 
   override def getSparkVersion: Option[String] = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -753,11 +753,9 @@ class AutoTuner(
    */
   private def recommendSystemProperties(): Unit = {
     appInfoProvider.getSystemProperty("file.encoding").collect {
-      case encoding =>
-        if (!ToolUtils.isFileEncodingRecommended(encoding)) {
-          appendComment(s"file.encoding should be [${ToolUtils.SUPPORTED_ENCODINGS.mkString}]" +
-            s" because GPU only supports the charset when using some expressions.")
-        }
+      case encoding if !ToolUtils.isFileEncodingRecommended(encoding) =>
+        appendComment(s"file.encoding should be [${ToolUtils.SUPPORTED_ENCODINGS.mkString}]" +
+            " because GPU only supports the charset when using some expressions.")
     }
   }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -34,7 +34,7 @@ import org.yaml.snakeyaml.representer.Representer
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.rapids.tool.{GpuTypes, ToolUtils}
-import org.apache.spark.sql.rapids.tool.util.WebCrawlerUtil
+import org.apache.spark.sql.rapids.tool.util.{StringUtils, WebCrawlerUtil}
 
 /**
  * A wrapper class that stores all the GPU properties.
@@ -222,9 +222,9 @@ class RecommendationEntry(val name: String,
     propValue match {
       case None => None
       case Some(value) =>
-        if (AutoTuner.containsMemoryUnits(value)) {
+        if (StringUtils.isMemorySize(value)) {
           // if it is memory return the bytes unit
-          Some(s"${AutoTuner.convertFromHumanReadableSize(value)}")
+          Some(s"${StringUtils.convertMemorySizeToBytes(value)}")
         } else {
           propValue
         }
@@ -466,7 +466,7 @@ class AutoTuner(
    */
   def calcGpuConcTasks(): Long = {
     Math.min(MAX_CONC_GPU_TASKS,
-      convertToMB(clusterProps.gpu.memory) / DEF_GPU_MEM_PER_TASK_MB)
+      StringUtils.convertToMB(clusterProps.gpu.memory) / DEF_GPU_MEM_PER_TASK_MB)
   }
 
   /**
@@ -477,7 +477,7 @@ class AutoTuner(
   private def calcAvailableMemPerExec(): Double = {
     // account for system overhead
     val usableWorkerMem =
-      Math.max(0, convertToMB(clusterProps.system.memory) - DEF_SYSTEM_RESERVE_MB)
+      Math.max(0, StringUtils.convertToMB(clusterProps.system.memory) - DEF_SYSTEM_RESERVE_MB)
     // clusterProps.gpu.getCount can never be 0. This is verified in processPropsAndCheck()
     (1.0 * usableWorkerMem) / clusterProps.gpu.getCount
   }
@@ -608,6 +608,7 @@ class AutoTuner(
     recommendShufflePartitions()
     recommendGCProperty()
     recommendClassPathEntries()
+    recommendSystemProperties()
   }
 
   def getShuffleManagerClassName() : Option[String] = {
@@ -735,11 +736,11 @@ class AutoTuner(
     }
 
     val autoBroadcastJoinThresholdProperty =
-      getPropertyValue("spark.sql.adaptive.autoBroadcastJoinThreshold").map(convertToMB)
+      getPropertyValue("spark.sql.adaptive.autoBroadcastJoinThreshold").map(StringUtils.convertToMB)
     if (autoBroadcastJoinThresholdProperty.isEmpty) {
       appendComment("'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.")
     } else if (autoBroadcastJoinThresholdProperty.get >
-        convertToMB(AQE_AUTOBROADCAST_JOIN_THRESHOLD)) {
+        StringUtils.convertToMB(AQE_AUTOBROADCAST_JOIN_THRESHOLD)) {
       appendComment("Setting 'spark.sql.adaptive.autoBroadcastJoinThreshold' > " +
         s"$AQE_AUTOBROADCAST_JOIN_THRESHOLD could lead to performance\n" +
         "  regression. Should be set to a lower number.")
@@ -747,10 +748,24 @@ class AutoTuner(
   }
 
   /**
+   * Checks the system properties and give feedback to the user.
+   * For example file.encoding=UTF-8 is required for some ops like GpuRegEX.
+   */
+  private def recommendSystemProperties(): Unit = {
+    appInfoProvider.getSystemProperty("file.encoding").collect {
+      case encoding =>
+        if (!ToolUtils.isFileEncodingRecommended(encoding)) {
+          appendComment(s"file.encoding should be [${ToolUtils.SUPPORTED_ENCODINGS.mkString}]" +
+            s" because GPU only supports the charset when using some expressions.")
+        }
+    }
+  }
+
+  /**
    * Check the class path entries with the following rules:
    * 1- If ".*rapids-4-spark.*jar" is missing then add a comment that the latest jar should be
    *    included in the classpath unless it is part of the spark
-   * 2- If there are more than 1 entry for ".*rapids-4-spark.*jar", then add a comment that the
+   * 2- If there are more than 1 entry for ".*rapids-4-spark.*jar", then add a comment that
    *    there should be only 1 jar in the class path.
    * 3- If there are cudf jars, ignore that for now.
    * 4- If there is a new release recommend that to the user
@@ -811,7 +826,7 @@ class AutoTuner(
   private def calculateMaxPartitionBytes(maxPartitionBytes: String): String = {
     // AutoTuner only supports a single app right now, so we get whatever value is here
     val inputBytesMax = appInfoProvider.getMaxInput / 1024 / 1024
-    val maxPartitionBytesNum = convertToMB(maxPartitionBytes)
+    val maxPartitionBytesNum = StringUtils.convertToMB(maxPartitionBytes)
     if (inputBytesMax == 0.0) {
       maxPartitionBytesNum.toString
     } else {
@@ -860,7 +875,7 @@ class AutoTuner(
       if (isCalculationEnabled("spark.sql.files.maxPartitionBytes")) {
         calculateMaxPartitionBytes(maxPartitionProp)
       } else {
-        s"${convertToMB(maxPartitionProp)}"
+        s"${StringUtils.convertToMB(maxPartitionProp)}"
       }
     appendRecommendationForMemoryMB("spark.sql.files.maxPartitionBytes", recommended)
   }
@@ -1218,59 +1233,6 @@ object AutoTuner extends Logging {
     } catch {
       case e: Exception =>
         handleException(e, singleAppProvider, platform, driverInfoProvider)
-    }
-  }
-
-  /**
-   * Converts size from human readable to bytes.
-   * Eg, "4m" -> 4194304.
-   */
-  def convertFromHumanReadableSize(size: String): Long = {
-    val sizesArr = size.toLowerCase.split("(?=[a-z])")
-    val sizeNum = sizesArr(0).toDouble
-    if (sizesArr.length > 1) {
-      val sizeUnit = sizesArr(1)
-      assert(SUPPORTED_SIZE_UNITS.contains(sizeUnit), s"$size is not a valid human readable size")
-      (sizeNum * Math.pow(1024, SUPPORTED_SIZE_UNITS.indexOf(sizeUnit))).toLong
-    } else {
-      sizeNum.toLong
-    }
-  }
-
-  def containsMemoryUnits(size: String): Boolean = {
-    val sizesArr = size.toLowerCase.split("(?=[a-z])")
-    if (sizesArr.length > 1) {
-      SUPPORTED_SIZE_UNITS.contains(sizesArr(1))
-    } else {
-      false
-    }
-  }
-
-  def convertToMB(size: String): Long = {
-    convertFromHumanReadableSize(size) / (1024 * 1024)
-  }
-
-  /**
-   * Converts size from bytes to human readable.
-   * Eg, 4194304 -> "4m", 633554 -> "618.70k".
-   */
-  def convertToHumanReadableSize(size: Long): String = {
-    if (size < 0L) {
-      return "0b"
-    }
-
-    val unitIndex = (Math.log10(size) / Math.log10(1024)).toInt
-    assert(unitIndex < SUPPORTED_SIZE_UNITS.size,
-      s"$size is too large to convert to human readable size")
-
-    val sizeNum = size * 1.0/Math.pow(1024, unitIndex)
-    val sizeUnit = SUPPORTED_SIZE_UNITS(unitIndex)
-
-    // If sizeNum is an integer omit fraction part
-    if ((sizeNum % 1) == 0) {
-      f"${sizeNum.toLong}$sizeUnit"
-    } else {
-      f"$sizeNum%.2f$sizeUnit"
     }
   }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
@@ -22,7 +22,7 @@ import com.nvidia.spark.rapids.tool.ToolTextFileWriter
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.resource.ResourceProfile
-import org.apache.spark.sql.rapids.tool.SQLMetricsStats
+import org.apache.spark.sql.rapids.tool.{SQLMetricsStats, ToolUtils}
 import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
 
 case class StageMetrics(numTasks: Int, duration: String)
@@ -53,7 +53,7 @@ class CollectInformation(apps: Seq[ApplicationInfo]) extends Logging {
       AppLogPathProfileResults(app.index, a.appName, a.appId, app.eventLogPath)
     }
     if (allRows.nonEmpty) {
-      allRows.sortBy(cols => (cols.appIndex))
+      allRows.sortBy(cols => cols.appIndex)
     } else {
       Seq.empty
     }
@@ -63,12 +63,18 @@ class CollectInformation(apps: Seq[ApplicationInfo]) extends Logging {
   def getRapidsJARInfo: Seq[RapidsJarProfileResult] = {
     val allRows = apps.flatMap { app =>
       if (app.gpuMode) {
-        // Look for rapids-4-spark and cuDF jar
-        val rapidsJar = app.classpathEntries.filterKeys(_ matches ".*rapids-4-spark.*jar")
-        val cuDFJar = app.classpathEntries.filterKeys(_ matches ".*cudf.*jar")
-        val cols = (rapidsJar.keys ++ cuDFJar.keys).toSeq
-        val rowsWithAppindex = cols.map(jar => RapidsJarProfileResult(app.index, jar))
-        rowsWithAppindex
+        // Look for rapids-4-spark and cuDF jar in classPathEntries
+        val rapidsJars = app.classpathEntries.filterKeys(_ matches ToolUtils.RAPIDS_JAR_REGEX.regex)
+        if (rapidsJars.nonEmpty) {
+          val cols = rapidsJars.keys.toSeq
+          val rowsWithAppindex = cols.map(jar => RapidsJarProfileResult(app.index, jar))
+          rowsWithAppindex
+        } else {
+          // Look for the rapids-4-spark and cuDF jars in Spark Properties
+          ToolUtils.extractRAPIDSJarsFromProps(app.sparkProperties).map {
+            jar => RapidsJarProfileResult(app.index, jar)
+          }
+        }
       } else {
         Seq.empty
       }
@@ -203,25 +209,30 @@ class CollectInformation(apps: Seq[ApplicationInfo]) extends Logging {
     }
   }
 
-  // Print RAPIDS related or all Spark Properties
-  // This table is inverse of the other tables where the row keys are
-  // property keys and the columns are the application values. So
-  // column1 would be all the key values for app index 1.
-  def getProperties(rapidsOnly: Boolean): Seq[RapidsPropertyProfileResult] = {
+  /**
+   * Print RAPIDS related or all Spark Properties when the propSource is set to "rapids".
+   * Note that RAPIDS related properties are not necessarily starting with prefix 'spark.rapids'.
+   * This table is inverse of the other tables where the row keys are property keys and the columns
+   * are the application values. So column1 would be all the key values for app index 1.
+   * @param propSource defines which type of properties to be retrieved the properties from.
+   *                   It can be: rapids, spark, or system
+   * @return List of properties relevant to the source.
+   */
+  private def getProperties(propSource: String): Seq[RapidsPropertyProfileResult] = {
     val outputHeaders = ArrayBuffer("propertyName")
     val props = HashMap[String, ArrayBuffer[String]]()
     var numApps = 0
     apps.foreach { app =>
       numApps += 1
       outputHeaders += s"appIndex_${app.index}"
-      val propsToKeep = if (rapidsOnly) {
-        app.sparkProperties.filterKeys { key =>
-          key.startsWith("spark.rapids") || key.startsWith("spark.executorEnv.UCX") ||
-            key.startsWith("spark.shuffle.manager") || key.equals("spark.shuffle.service.enabled")
-        }
-      } else {
+      val propsToKeep = if (propSource.equals("rapids")) {
+        app.sparkProperties.filterKeys { ToolUtils.isRapidsPropKey(_) }
+      } else if (propSource.equals("spark")) {
         // remove the rapids related ones
-        app.sparkProperties.filterKeys(key => !(key.contains("spark.rapids")))
+        app.sparkProperties.filterKeys(key => !key.contains(ToolUtils.PROPS_RAPIDS_KEY_PREFIX))
+      } else {
+        // get the system properties
+        app.systemProperties
       }
       CollectInformation.addNewProps(propsToKeep, props, numApps)
     }
@@ -232,6 +243,16 @@ class CollectInformation(apps: Seq[ApplicationInfo]) extends Logging {
     } else {
       Seq.empty
     }
+  }
+
+  def getRapidsProperties: Seq[RapidsPropertyProfileResult] = {
+    getProperties("rapids")
+  }
+  def getSparkProperties: Seq[RapidsPropertyProfileResult] = {
+    getProperties("spark")
+  }
+  def getSystemProperties: Seq[RapidsPropertyProfileResult] = {
+    getProperties("system")
   }
 
   // Print SQL whole stage code gen mapping

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
@@ -67,8 +67,7 @@ class CollectInformation(apps: Seq[ApplicationInfo]) extends Logging {
         val rapidsJars = app.classpathEntries.filterKeys(_ matches ToolUtils.RAPIDS_JAR_REGEX.regex)
         if (rapidsJars.nonEmpty) {
           val cols = rapidsJars.keys.toSeq
-          val rowsWithAppindex = cols.map(jar => RapidsJarProfileResult(app.index, jar))
-          rowsWithAppindex
+          cols.map(jar => RapidsJarProfileResult(app.index, jar))
         } else {
           // Look for the rapids-4-spark and cuDF jars in Spark Properties
           ToolUtils.extractRAPIDSJarsFromProps(app.sparkProperties).map {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileUtils.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,13 +33,6 @@ object ProfileUtils {
         .getOrCreate()
   }
 
-  // Convert a null-able String to Option[Long]
-  def stringToLong(in: String): Option[Long] = try {
-    Some(in.toLong)
-  } catch {
-    case _: NumberFormatException => None
-  }
-
   // Convert Option[Long] to String
   def optionLongToString(in: Option[Long]): String = try {
     in.get.toString
@@ -48,7 +41,7 @@ object ProfileUtils {
   }
 
   // Check if the job/stage is GPU mode is on
-  def isPluginEnabled(properties: collection.mutable.Map[String, String]): Boolean = {
+  def isPluginEnabled(properties: collection.Map[String, String]): Boolean = {
     ToolUtils.isPluginEnabled(properties.toMap)
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -26,36 +26,64 @@ import scala.io.{Codec, Source}
 import com.nvidia.spark.rapids.tool.{DatabricksEventLog, DatabricksRollingEventLogFilesFileReader, EventLogInfo}
 import com.nvidia.spark.rapids.tool.planparser.{HiveParseHelper, ReadParser}
 import com.nvidia.spark.rapids.tool.planparser.HiveParseHelper.isHiveTableScanNode
-import com.nvidia.spark.rapids.tool.profiling.{DataSourceCase, DriverAccumCase, JobInfoClass, SQLExecutionInfoClass, StageInfoClass, TaskStageAccumCase}
+import com.nvidia.spark.rapids.tool.profiling.{DataSourceCase, DriverAccumCase, JobInfoClass, ProfileUtils, SQLExecutionInfoClass, StageInfoClass, TaskStageAccumCase}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.deploy.history.{EventLogFileReader, EventLogFileWriter}
 import org.apache.spark.internal.Logging
-import org.apache.spark.scheduler.{SparkListenerEnvironmentUpdate, SparkListenerEvent, SparkListenerJobStart, StageInfo}
+import org.apache.spark.scheduler.{SparkListenerEnvironmentUpdate, SparkListenerEvent, SparkListenerJobStart, SparkListenerLogStart, StageInfo}
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.execution.ui.{SparkPlanGraph, SparkPlanGraphNode}
 import org.apache.spark.sql.rapids.tool.qualification.MLFunctions
-import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
+import org.apache.spark.sql.rapids.tool.util.{EventUtils, RapidsToolsConfUtil}
 import org.apache.spark.util.Utils
 
 // Handles updating and caching Spark Properties for a Spark application.
-// Properties stored in this container can be accessed to make decision about
-// certain analysis that depends on the context of the Spark properties.
-// TODO: we need to migrate SparkProperties, GpuMode to this trait.
+// Properties stored in this container can be accessed to make decision about certain analysis
+// that depends on the context of the Spark properties.
 trait CacheableProps {
+  private val RETAINED_SYSTEM_PROPS = Set(
+    "file.encoding", "java.version", "os.arch", "os.name",
+    "os.version", "user.timezone")
+  // caches the spark-version from the eventlogs
+  var sparkVersion: String = ""
+  var gpuMode = false
   // A flag whether hive is enabled or not. Note that we assume that the
   // property is global to the entire application once it is set. a.k.a, it cannot be disabled
   // once it is was set to true.
   var hiveEnabled = false
+  var sparkProperties = Map[String, String]()
+  var classpathEntries = Map[String, String]()
+  // set the fileEncoding to UTF-8 by default
+  var systemProperties = Map[String, String]()
+
   def handleEnvUpdateForCachedProps(event: SparkListenerEnvironmentUpdate): Unit = {
-    val sparkProperties = event.environmentDetails("Spark Properties").toMap
+
+    sparkProperties ++= event.environmentDetails("Spark Properties").toMap
+    classpathEntries ++= event.environmentDetails("Classpath Entries").toMap
+
+    gpuMode ||=  ProfileUtils.isPluginEnabled(sparkProperties)
     hiveEnabled ||= HiveParseHelper.isHiveEnabled(sparkProperties)
+
+    // Update the properties if system environments are set.
+    // No need to capture all the properties in memory. We only capture important ones.
+    systemProperties ++= event.environmentDetails("System Properties").toMap.filterKeys(
+      RETAINED_SYSTEM_PROPS.contains(_))
+
   }
 
   def handleJobStartForCachedProps(event: SparkListenerJobStart): Unit = {
     // TODO: we need to improve this in order to support per-job-level
     hiveEnabled ||= HiveParseHelper.isHiveEnabled(event.properties.asScala)
+  }
+
+  def handleLogStartForCachedProps(event: SparkListenerLogStart): Unit = {
+    sparkVersion = event.sparkVersion
+  }
+
+  def isGPUModeEnabledForJob(event: SparkListenerJobStart): Boolean = {
+    gpuMode || ProfileUtils.isPluginEnabled(event.properties.asScala)
   }
 }
 
@@ -63,7 +91,6 @@ abstract class AppBase(
     val eventLogInfo: Option[EventLogInfo],
     val hadoopConf: Option[Configuration]) extends Logging with CacheableProps {
 
-  var sparkVersion: String = ""
   var appEndTime: Option[Long] = None
   // The data source information
   val dataSourceInfo: ArrayBuffer[DataSourceCase] = ArrayBuffer[DataSourceCase]()
@@ -91,8 +118,6 @@ abstract class AppBase(
     HashMap[Long, ArrayBuffer[DriverAccumCase]]()
   var mlEventLogType = ""
   var pysparkLogFlag = false
-
-  var gpuMode = false
 
   def getOrCreateStage(info: StageInfo): StageInfoClass = {
     val stage = stageIdToInfo.getOrElseUpdate((info.stageId, info.attemptNumber()),
@@ -240,7 +265,7 @@ abstract class AppBase(
               // Do NOT use a while loop as it is much much slower.
               lines.find { line =>
                 totalNumEvents += 1
-                ToolUtils.getEventFromJsonMethod(line) match {
+                EventUtils.getEventFromJsonMethod(line) match {
                   case Some(e) => processEvent(e)
                   case None => false
                 }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -59,7 +59,6 @@ trait CacheableProps {
   var systemProperties = Map[String, String]()
 
   def handleEnvUpdateForCachedProps(event: SparkListenerEnvironmentUpdate): Unit = {
-
     sparkProperties ++= event.environmentDetails("Spark Properties").toMap
     classpathEntries ++= event.environmentDetails("Classpath Entries").toMap
 
@@ -70,7 +69,6 @@ trait CacheableProps {
     // No need to capture all the properties in memory. We only capture important ones.
     systemProperties ++= event.environmentDetails("System Properties").toMap.filterKeys(
       RETAINED_SYSTEM_PROPS.contains(_))
-
   }
 
   def handleJobStartForCachedProps(event: SparkListenerJobStart): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppFilterImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppFilterImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,19 +142,15 @@ class AppFilterImpl(
       val validConfigsMap = keyValueConfigs.map(a => a(0) -> a(1)).toMap
 
       val configFilteredResult = userNameLogicFiltered.filter { appFilterReturnParameters =>
-        appFilterReturnParameters.appInfo.sparkProperties.exists { sparkProp =>
-          if (keyValueConfigs.nonEmpty || keysOnlyConfigs.nonEmpty) {
-            val allConfigs = sparkProp.configName // all configs from eventlog
-            val allConfigKeys = sparkProp.configName.keys.toList // for keys only confs
-            // Intersection of configs provided in the filter args with event log configs.
-            val commonConfigsKeys = validConfigsMap.keySet.intersect(allConfigs.keySet)
-
-            commonConfigsKeys.filter { key =>
-              allConfigs(key) == validConfigsMap(key)
-            }.nonEmpty || keysOnlyConfigs.intersect(allConfigKeys).nonEmpty
-          } else {
-            false
-          }
+        if (keyValueConfigs.nonEmpty || keysOnlyConfigs.nonEmpty) {
+          val appSparkProps = appFilterReturnParameters.appInfo.sparkProperties
+          val commonConfigsKeys = validConfigsMap.keySet.intersect(appSparkProps.keySet)
+          val allConfigKeys = appSparkProps.keys.toList // for keys only confs
+          commonConfigsKeys.filter { key =>
+            appSparkProps(key) == validConfigsMap(key)
+          }.nonEmpty || keysOnlyConfigs.intersect(allConfigKeys).nonEmpty
+        } else {
+          false
         }
       }
       configFilteredResult

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/FilterAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/FilterAppInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,6 @@ case class ApplicationStartInfo(
     startTime: Long,
     userName: String)
 
-case class EnvironmentInfo(configName: Map[String, String])
-
 class FilterAppInfo(
     eventLogInfo: EventLogInfo,
     hadoopConf: Configuration) extends AppBase(Some(eventLogInfo), Some(hadoopConf)) {
@@ -45,13 +43,10 @@ class FilterAppInfo(
 
   def doSparkListenerEnvironmentUpdate(event: SparkListenerEnvironmentUpdate): Unit = {
     logDebug("Processing event: " + event.getClass)
-    val envSparkProperties = event.environmentDetails("Spark Properties").toMap
     handleEnvUpdateForCachedProps(event)
-    sparkProperties = Some(EnvironmentInfo(envSparkProperties))
   }
 
   var appStartInfo: Option[ApplicationStartInfo] = None
-  var sparkProperties: Option[EnvironmentInfo] = None
   // We are currently processing 2 events. This is used as counter to send true when both the
   // event are processed so that we can stop processing further events.
   var eventsToProcess: Int = 2

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -198,10 +198,6 @@ class ApplicationInfo(
 
   var blockManagersRemoved: ArrayBuffer[BlockManagerRemovedCase] =
      ArrayBuffer[BlockManagerRemovedCase]()
-
-  // From SparkListenerEnvironmentUpdate
-  var sparkProperties = Map.empty[String, String]
-  var classpathEntries = Map.empty[String, String]
 
   var appInfo: ApplicationCase = null
   var appId: String = ""

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationEventProcessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationEventProcessor.scala
@@ -25,29 +25,13 @@ import com.nvidia.spark.rapids.tool.profiling._
 
 import org.apache.spark.scheduler._
 import org.apache.spark.sql.execution.ui._
-import org.apache.spark.sql.rapids.tool.{EventProcessorBase, GpuEventLogException, ToolUtils}
+import org.apache.spark.sql.rapids.tool.EventProcessorBase
+import org.apache.spark.sql.rapids.tool.util.StringUtils
 
 class QualificationEventProcessor(app: QualificationAppInfo, perSqlOnly: Boolean)
   extends EventProcessorBase[QualificationAppInfo](app) {
 
   type T = QualificationAppInfo
-
-  override def doSparkListenerEnvironmentUpdate(
-      app: QualificationAppInfo,
-      event: SparkListenerEnvironmentUpdate): Unit = {
-    logDebug("Processing event: " + event.getClass)
-    app.handleEnvUpdateForCachedProps(event)
-    val sparkProperties = event.environmentDetails("Spark Properties").toMap
-    if (ToolUtils.isPluginEnabled(sparkProperties)) {
-      throw GpuEventLogException(s"Cannot parse event logs from GPU run")
-    }
-    app.clusterTags = sparkProperties.getOrElse(
-      "spark.databricks.clusterUsageTags.clusterAllTags", "")
-    app.clusterTagClusterId = sparkProperties.getOrElse(
-      "spark.databricks.clusterUsageTags.clusterId", "")
-    app.clusterTagClusterName = sparkProperties.getOrElse(
-      "spark.databricks.clusterUsageTags.clusterName", "")
-  }
 
   override def doSparkListenerApplicationStart(
       app: QualificationAppInfo,
@@ -133,12 +117,12 @@ class QualificationEventProcessor(app: QualificationAppInfo, perSqlOnly: Boolean
     logDebug("Processing event: " + event.getClass)
     super.doSparkListenerJobStart(app, event)
     val sqlIDString = event.properties.getProperty("spark.sql.execution.id")
-    ProfileUtils.stringToLong(sqlIDString).foreach { sqlID =>
+    StringUtils.stringToLong(sqlIDString).foreach { sqlID =>
       event.stageIds.foreach { stageId =>
         app.stageIdToSqlID.getOrElseUpdate(stageId, sqlID)
       }
     }
-    val sqlID = ProfileUtils.stringToLong(sqlIDString)
+    val sqlID = StringUtils.stringToLong(sqlIDString)
     // don't store if we are only processing per sql queries and the job isn't
     // related to a SQL query
     if ((perSqlOnly && sqlID.isDefined) || !perSqlOnly) {
@@ -152,22 +136,9 @@ class QualificationEventProcessor(app: QualificationAppInfo, perSqlOnly: Boolean
         None,
         None,
         None,
-        ProfileUtils.isPluginEnabled(event.properties.asScala) || app.gpuMode
+        app.isGPUModeEnabledForJob(event)
       )
       app.jobIdToInfo.put(event.jobId, thisJob)
-    }
-    // If the confs are set after SparkSession initialization, it is captured in this event.
-    if (app.clusterTags.isEmpty) {
-      app.clusterTags = event.properties.getProperty(
-        "spark.databricks.clusterUsageTags.clusterAllTags", "")
-    }
-    if (app.clusterTagClusterId.isEmpty) {
-      app.clusterTagClusterId = event.properties.getProperty(
-        "spark.databricks.clusterUsageTags.clusterId", "")
-    }
-    if (app.clusterTagClusterName.isEmpty) {
-      app.clusterTagClusterName = event.properties.getProperty(
-        "spark.databricks.clusterUsageTags.clusterName", "")
     }
   }
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -694,7 +694,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
     assert(apps.size == 1)
     val collect = new CollectInformation(apps)
     for (_ <- apps) {
-      val rapidsProps = collect.getProperties(rapidsOnly = true)
+      val rapidsProps = collect.getRapidsProperties
       val rows = rapidsProps.map(_.rows.head)
       assert(rows.length == 5) // 5 properties captured.
       // verify  ucx parameters are captured.
@@ -703,7 +703,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
       //verify gds parameters are captured.
       assert(rows.contains("spark.rapids.memory.gpu.direct.storage.spill.alignedIO"))
 
-      val sparkProps = collect.getProperties(rapidsOnly = false)
+      val sparkProps = collect.getSparkProperties
       val sparkPropsRows = sparkProps.map(_.rows.head)
       assert(sparkPropsRows.contains("spark.eventLog.dir"))
       assert(sparkPropsRows.contains("spark.plugins"))
@@ -766,7 +766,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
       val dotDirs = ToolTestUtils.listFilesMatching(tempSubDir, { f =>
         f.endsWith(".csv")
       })
-      assert(dotDirs.length === 17)
+      assert(dotDirs.length === 18)
       for (file <- dotDirs) {
         assert(file.getAbsolutePath.endsWith(".csv"))
         // just load each one to make sure formatted properly
@@ -793,7 +793,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
       val dotDirs = ToolTestUtils.listFilesMatching(tempSubDir, { f =>
         f.endsWith(".csv")
       })
-      assert(dotDirs.length === 13)
+      assert(dotDirs.length === 14)
       for (file <- dotDirs) {
         assert(file.getAbsolutePath.endsWith(".csv"))
         // just load each one to make sure formatted properly
@@ -823,7 +823,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
       val dotDirs = ToolTestUtils.listFilesMatching(tempSubDir, { f =>
         f.endsWith(".csv")
       })
-      assert(dotDirs.length === 17)
+      assert(dotDirs.length === 18)
       for (file <- dotDirs) {
         assert(file.getAbsolutePath.endsWith(".csv"))
         // just load each one to make sure formatted properly
@@ -853,7 +853,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
       val dotDirs = ToolTestUtils.listFilesMatching(tempSubDir, { f =>
         f.endsWith(".csv")
       })
-      assert(dotDirs.length === 15)
+      assert(dotDirs.length === 16)
       for (file <- dotDirs) {
         assert(file.getAbsolutePath.endsWith(".csv"))
         // just load each one to make sure formatted properly

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.rapids.tool.util.WebCrawlerUtil
 
 case class DriverInfoProviderMockTest(unsupportedOps: Seq[DriverLogUnsupportedOperators])
   extends BaseDriverLogInfoProvider(None) {
-  override def getUnsupportedOperators = unsupportedOps
+  override def getUnsupportedOperators: Seq[DriverLogUnsupportedOperators] = unsupportedOps
 }
 
 class AppInfoProviderMockTest(val maxInput: Double,
@@ -53,7 +53,9 @@ class AppInfoProviderMockTest(val maxInput: Double,
   override def getMeanShuffleRead: Double = meanShuffleRead
   override def getSpilledMetrics: Seq[Long] = spilledMetrics
   override def getJvmGCFractions: Seq[Double] = jvmGCFractions
-  override def getProperty(propKey: String): Option[String] = propsFromLog.get(propKey)
+  override def getRapidsProperty(propKey: String): Option[String] = propsFromLog.get(propKey)
+  override def getSparkProperty(propKey: String): Option[String] = propsFromLog.get(propKey)
+  override def getSystemProperty(propKey: String): Option[String] = propsFromLog.get(propKey)
   override def getSparkVersion: Option[String] = sparkVersion
   override def getRapidsJars: Seq[String] = rapidsJars
   override def getDistinctLocationPct: Double = distinctLocationPct
@@ -749,6 +751,74 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     assert(expectedResults == autoTunerOutput)
   }
 
+  test("AutoTuner detects non UTF-8 file-encoding") {
+    // When system properties has an entry for file-encoding that is not supported by GPU for
+    // certain expressions. Then the AutoTuner should show generate a comment warning that the
+    // file-encoding is not one of the supported ones.
+    val customProps = mutable.LinkedHashMap(
+      "spark.executor.cores" -> "8",
+      "spark.executor.memory" -> "47222m",
+      "spark.rapids.shuffle.multiThreaded.reader.threads" -> "8",
+      "spark.rapids.shuffle.multiThreaded.writer.threads" -> "8",
+      "spark.rapids.sql.concurrentGpuTasks" -> "2",
+      "spark.rapids.sql.multiThreadedRead.numThreads" -> "20",
+      "spark.shuffle.manager" -> "com.nvidia.spark.rapids.spark311.RapidsShuffleManager",
+      "spark.task.resource.gpu.amount" -> "0.0625")
+    // mock the properties loaded from eventLog
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        // set the file-encoding to non UTF-8
+        "file.encoding" -> "ISO-8859-1",
+        "spark.executor.cores" -> "16",
+        "spark.executor.instances" -> "1",
+        "spark.executor.memory" -> "80g",
+        "spark.executor.resource.gpu.amount" -> "1",
+        "spark.executor.instances" -> "1",
+        "spark.sql.shuffle.partitions" -> "200",
+        "spark.sql.files.maxPartitionBytes" -> "1g",
+        "spark.task.resource.gpu.amount" -> "0.0625",
+        "spark.rapids.memory.pinnedPool.size" -> "5g",
+        "spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
+        "spark.rapids.sql.concurrentGpuTasks" -> "4")
+    val dataprocWorkerInfo = buildWorkerInfoAsString(Some(customProps), Some(32),
+      Some("212992MiB"), Some(5), Some(4), Some("15109MiB"), Some("Tesla T4"))
+    val infoProvider = getMockInfoProvider(8126464.0, Seq(0), Seq(0.004), logEventsProps,
+      Some(defaultSparkVersion))
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider)
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.executor.cores=8
+          |--conf spark.executor.instances=20
+          |--conf spark.executor.memory=16384m
+          |--conf spark.executor.memoryOverhead=6758m
+          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.concurrentGpuTasks=2
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionNum=160
+          |--conf spark.sql.files.maxPartitionBytes=4096m
+          |--conf spark.task.resource.gpu.amount=0.125
+          |
+          |Comments:
+          |- 'spark.executor.memoryOverhead' must be set if using 'spark.rapids.memory.pinnedPool.size
+          |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.coalescePartitions.minPartitionNum' was not set.
+          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+          |- ${AutoTuner.classPathComments("rapids.jars.missing")}
+          |- ${AutoTuner.classPathComments("rapids.shuffle.jars")}
+          |- file.encoding should be [UTF-8] because GPU only supports the charset when using some expressions.
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    assert(expectedResults == autoTunerOutput)
+  }
   // Test that the properties from the eventlogs will be used to calculate the recommendations.
   // For example, the output should recommend "spark.executor.cores" -> 8. Although the cluster
   // "spark.executor.cores" is the same as the recommended value, the property is set to 16 in

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -753,7 +753,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
 
   test("AutoTuner detects non UTF-8 file-encoding") {
     // When system properties has an entry for file-encoding that is not supported by GPU for
-    // certain expressions. Then the AutoTuner should show generate a comment warning that the
+    // certain expressions. Then the AutoTuner should generate a comment warning that the
     // file-encoding is not one of the supported ones.
     val customProps = mutable.LinkedHashMap(
       "spark.executor.cores" -> "8",


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #713, Fixes #734

This PR changes the behavior of the AutoTuner to display a comment when the file-encoding of an application is set to a value that is not "utf-8".

The AutoTuner will generate the folllowing line:

```
file.encoding should be [UTF-8] because GPU only supports the charset when using some expressions.
```

The changes also improves the extraction of the RAPIDS jars values.

*Changes for 713*:

- Added a new field in `ApplicationSummaryInfo` that represents the systemProperties
- Capture SystemProperties in the App in order to be able to check the file-encoding
- Moved map properties to `CacheableProps` so that it can be used by the Qualification as well.
- Moved String-conversion methods from AutTuner to StringUtils
- Moved `getEventFromJsonMethod` to EventUtils object
- Added a new UnitTest for the AutoTuner
- Updated `ApplicationInfoSuite` unitTests

*Changes for 734*:

- Fixed the implementation of `CollectInformation.getRapidsJARInfo`
