### PR TITLE
[FEA] Extend the list of operators to be ignored in Qualification

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/AggregateInPandasExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/AggregateInPandasExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,6 @@ case class AggregateInPandasExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ArrowEvalPythonExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ArrowEvalPythonExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,6 @@ case class ArrowEvalPythonExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/BatchScanExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/BatchScanExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ case class BatchScanExecParser(
     val overallSpeedup = Math.max((speedupFactor * score), 1.0)
 
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, s"${node.name} ${readInfo.format}", "", overallSpeedup,
-      maxDuration, node.id, score > 0, None)
+    ExecInfo(node, sqlID, s"${node.name} ${readInfo.format}", s"Format: ${readInfo.format}",
+      overallSpeedup, maxDuration, node.id, score > 0, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/BroadcastExchangeExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/BroadcastExchangeExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ case class BroadcastExchangeExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", filterSpeedupFactor,
+    ExecInfo(node, sqlID, node.name, "", filterSpeedupFactor,
       duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/BroadcastHashJoinExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/BroadcastHashJoinExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,6 @@ case class BroadcastHashJoinExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/BroadcastNestedLoopJoinExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/BroadcastNestedLoopJoinExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,6 @@ case class BroadcastNestedLoopJoinExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/CartesianProductExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/CartesianProductExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,6 @@ case class CartesianProductExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/CoalesceExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/CoalesceExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ case class CoalesceExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor,
+    ExecInfo(node, sqlID, node.name, "", speedupFactor,
       duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/CollectLimitExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/CollectLimitExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,6 @@ case class CollectLimitExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor,
-      duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/CustomShuffleReaderExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/CustomShuffleReaderExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,6 @@ case class CustomShuffleReaderExecParser(
     } else {
       (1.0, false)
     }
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DataWritingCommandExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DataWritingCommandExecParser.scala
@@ -38,7 +38,8 @@ case class DataWritingCommandExecParser(
     val speedupFactor = checker.getSpeedupFactor(wStub.mappedExec)
     val finalSpeedup = if (writeSupported) speedupFactor else 1
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, s"${node.name.trim} ${wStub.dataFormat.toLowerCase.trim}", "",
+    ExecInfo(node, sqlID, s"${node.name.trim} ${wStub.dataFormat.toLowerCase.trim}",
+      s"Format: ${wStub.dataFormat.toLowerCase.trim}",
       finalSpeedup, duration, node.id, writeSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ExpandExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ExpandExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ case class ExpandExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor,
-      duration, node.id, isSupported, None, unsupportedExprs = notSupportedExprs)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None,
+      unsupportedExprs = notSupportedExprs)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/FileSourceScanExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/FileSourceScanExecParser.scala
@@ -50,6 +50,6 @@ case class FileSourceScanExecParser(
     val overallSpeedup = Math.max(speedupFactor * score, 1.0)
 
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, nodeName, "", overallSpeedup, maxDuration, node.id, score > 0, None)
+    ExecInfo(node, sqlID, nodeName, "", overallSpeedup, maxDuration, node.id, score > 0, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/FilterExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/FilterExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ case class FilterExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None,
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None,
       unsupportedExprs = notSupportedExprs)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/FlatMapGroupsInPandasExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/FlatMapGroupsInPandasExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,6 @@ case class FlatMapGroupsInPandasExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/GenerateExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/GenerateExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ case class GenerateExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor,
+    ExecInfo(node, sqlID, node.name, "", speedupFactor,
       duration, node.id, isSupported, None, unsupportedExprs = notSupportedExprs)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/GlobalLimitExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/GlobalLimitExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,6 @@ case class GlobalLimitExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/HashAggregateExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/HashAggregateExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ case class HashAggregateExecParser(
     }
 
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor,
-      maxDuration, node.id, isSupported, None, unsupportedExprs = notSupportedExprs)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, maxDuration, node.id, isSupported, None,
+      unsupportedExprs = notSupportedExprs)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/InMemoryTableScanExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/InMemoryTableScanExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,6 @@ case class InMemoryTableScanExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", filterSpeedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", filterSpeedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/LocalLimitExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/LocalLimitExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,6 @@ case class LocalLimitExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/MapInPandasExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/MapInPandasExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,6 @@ case class MapInPandasExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ObjectHashAggregateExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ObjectHashAggregateExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ case class ObjectHashAggregateExecParser(
     }
 
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor,
+    ExecInfo(node, sqlID, node.name, "", speedupFactor,
       maxDuration, node.id, isSupported, None, unsupportedExprs = notSupportedExprs)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ProjectExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ProjectExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ case class ProjectExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None,
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None,
       unsupportedExprs = notSupportedExprs)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/RangeExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/RangeExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,6 @@ case class RangeExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -26,23 +26,25 @@ import com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.execution.ui.{SparkPlanGraph, SparkPlanGraphCluster, SparkPlanGraphNode}
-import org.apache.spark.sql.rapids.tool.{AppBase, BuildSide, JoinType, ToolUtils}
+import org.apache.spark.sql.rapids.tool.{AppBase, BuildSide, ExecHelper, JoinType, ToolUtils}
 import org.apache.spark.sql.rapids.tool.util.ToolsPlanGraph
 
-class ExecInfo(
-    val sqlID: Long,
-    val exec: String,
-    val expr: String,
-    val speedupFactor: Double,
-    val duration: Option[Long],
-    val nodeId: Long,
-    val isSupported: Boolean,
-    val children: Option[Seq[ExecInfo]], // only one level deep
-    val stages: Set[Int] = Set.empty,
-    val shouldRemove: Boolean = false,
-    val unsupportedExprs: Array[String] = Array.empty,
-    val dataSet: Boolean = false,
-    val udf: Boolean = false) {
+case class ExecInfo(
+    sqlID: Long,
+    exec: String,
+    expr: String,
+    speedupFactor: Double,
+    duration: Option[Long],
+    nodeId: Long,
+    isSupported: Boolean,
+    children: Option[Seq[ExecInfo]], // only one level deep
+    var stages: Set[Int],
+    var shouldRemove: Boolean,
+    unsupportedExprs: Array[String],
+    dataSet: Boolean,
+    udf: Boolean,
+    shouldIgnore: Boolean) {
+
   private def childrenToString = {
     val str = children.map { c =>
       c.map("       " + _.toString).mkString("\n")
@@ -53,12 +55,72 @@ class ExecInfo(
       str
     }
   }
+
   override def toString: String = {
     s"exec: $exec, expr: $expr, sqlID: $sqlID , speedupFactor: $speedupFactor, " +
       s"duration: $duration, nodeId: $nodeId, " +
       s"isSupported: $isSupported, children: " +
       s"${childrenToString}, stages: ${stages.mkString(",")}, " +
       s"shouldRemove: $shouldRemove"
+  }
+
+  def setStages(stageIDs: Set[Int]): Unit = {
+    stages = stageIDs
+  }
+
+  def setShouldRemove(value: Boolean): Unit = {
+    shouldRemove ||= value
+  }
+}
+
+object ExecInfo {
+  def apply(
+      node: SparkPlanGraphNode,
+      sqlID: Long,
+      exec: String,
+      expr: String,
+      speedupFactor: Double,
+      duration: Option[Long],
+      nodeId: Long,
+      isSupported: Boolean,
+      children: Option[Seq[ExecInfo]], // only one level deep
+      stages: Set[Int] = Set.empty,
+      shouldRemove: Boolean = false,
+      unsupportedExprs: Array[String] = Array.empty,
+      dataSet: Boolean = false,
+      udf: Boolean = false): ExecInfo = {
+    // Some execs need to be trimmed such as "Scan"
+    // Example: Scan parquet . ->  Scan parquet.
+    // scan nodes needs trimming
+    val nodeName = node.name.trim
+    // we don't want to mark the *InPandas and ArrowEvalPythonExec as unsupported with UDF
+    val containsUDF = udf || ExecHelper.isUDF(node)
+    // check is the node has a dataset operations and if so change to not supported
+    val ds = dataSet || ExecHelper.isDatasetOrRDDPlan(nodeName, node.desc)
+    // Set the supported Flag
+    val supportedFlag = isSupported && !containsUDF && !ds
+    // Set the ignoreFlag
+    // 1- we ignore any exec with UDF
+    // 2- we ignore any exec with dataset
+    // 3- Finally we ignore any exec matching the lookup table
+    val shouldIgnore = containsUDF || ds || ExecHelper.shouldIgnore(exec)
+    val removeFlag = shouldRemove || ExecHelper.shouldBeRemoved(nodeName)
+    ExecInfo(
+      sqlID,
+      exec,
+      expr,
+      speedupFactor,
+      duration,
+      nodeId,
+      supportedFlag,
+      children,
+      stages,
+      removeFlag,
+      unsupportedExprs,
+      dataSet,
+      udf,
+      shouldIgnore
+    )
   }
 }
 
@@ -82,10 +144,10 @@ object SQLPlanParser extends Logging {
   val ignoreExpressions = Array("any", "cast", "ansi_cast", "decimal", "decimaltype", "every",
     "some", "merge_max", "merge_min", "merge_sum", "merge_count", "merge_avg", "merge_first",
     "list",
-    // current_database does not cause any CPU fallbacks
-    "current_database",
+    // some ops turn into literals and they should not cause any fallbacks
+    "current_database", "current_user", "current_timestamp",
     // ArrayBuffer is a Scala function and may appear in some of the JavaRDDs/UDAFs)
-    "arraybuffer")
+    "arraybuffer", "arraytype")
 
   /**
    * This function is used to create a set of nodes that should be skipped while parsing the Execs
@@ -162,20 +224,10 @@ object SQLPlanParser extends Logging {
     }.flatten.toSet
   }
 
-  private val skipUDFCheckExecs = Seq("ArrowEvalPython", "AggregateInPandas",
-    "FlatMapGroupsInPandas", "MapInPandas", "WindowInPandas")
-
   // Set containing execs that refers to other expressions. We need this to be a list to allow
   // appending more execs in teh future as necessary.
   // Note that Spark graph may create duplicate nodes when any of the following execs exists.
   private val reuseExecs = Set("ReusedExchange")
-
-  // Set containing execs that should be labeled as "shouldRemove"
-  private val execsToBeRemoved = Set(
-    "GenerateBloomFilter",   // Exclusive on AWS. Ignore it as metrics cannot be evaluated.
-    "ReusedExchange",        // reusedExchange should not be added to speedups
-    "ColumnarToRow"          // for now, assume everything is columnar
-  )
 
   def parsePlanNode(
       node: SparkPlanGraphNode,
@@ -217,10 +269,10 @@ object SQLPlanParser extends Logging {
             CoalesceExecParser(node, checker, sqlID).parse
           case "CollectLimit" =>
             CollectLimitExecParser(node, checker, sqlID).parse
-          case c if (c.contains("CreateDataSourceTableAsSelectCommand")) =>
+          case c if c.contains("CreateDataSourceTableAsSelectCommand") =>
             // create data source table doesn't show the format so we can't determine
             // if we support it
-            new ExecInfo(sqlID, node.name, expr = "", 1, duration = None, node.id,
+            ExecInfo(node, sqlID, node.name, expr = "", 1, duration = None, node.id,
               isSupported = false, None)
           case "CustomShuffleReader" | "AQEShuffleRead" =>
             CustomShuffleReaderExecParser(node, checker, sqlID).parse
@@ -278,7 +330,7 @@ object SQLPlanParser extends Logging {
             // Execs that are members of reuseExecs (i.e., ReusedExchange) should be marked as
             // supported but with shouldRemove flag set to True.
             // Setting the "shouldRemove" is handled at the end of the function.
-            new ExecInfo(sqlID, node.name, expr = "", 1, duration = None, node.id,
+            ExecInfo(node, sqlID, node.name, expr = "", 1, duration = None, node.id,
               isSupported = reuseExecs.contains(node.name), None)
         }
       } catch {
@@ -292,25 +344,15 @@ object SQLPlanParser extends Logging {
         case NonFatal(e) =>
           logWarning(s"Unexpected error parsing plan node ${node.name}. " +
           s" sqlID = ${sqlID}", e)
-          new ExecInfo(sqlID, node.name, expr = "", 1, duration = None, node.id,
+          ExecInfo(node, sqlID, node.name, expr = "", 1, duration = None, node.id,
             isSupported = false, None)
       }
-      // check is the node has a dataset operations and if so change to not supported
-      val ds = app.isDataSetOrRDDPlan(node.desc)
-      // we don't want to mark the *InPandas and ArrowEvalPythonExec as unsupported with UDF
-      val containsUDF = if (skipUDFCheckExecs.contains(node.name)) {
-        false
-      } else {
-        app.containsUDF(node.desc)
-      }
       val stagesInNode = getStagesInSQLNode(node, app)
-      val supported = execInfos.isSupported && !ds && !containsUDF
+      execInfos.setStages(stagesInNode)
       // shouldRemove is set to true if the exec is a member of "execsToBeRemoved" or if the node
       // is a duplicate
-      val removeFlag = execInfos.shouldRemove || isDupNode || execsToBeRemoved.contains(node.name)
-      Seq(new ExecInfo(execInfos.sqlID, execInfos.exec, execInfos.expr, execInfos.speedupFactor,
-        execInfos.duration, execInfos.nodeId, supported, execInfos.children,
-        stagesInNode, removeFlag, execInfos.unsupportedExprs, ds, containsUDF))
+      execInfos.setShouldRemove(isDupNode)
+      Seq(execInfos)
     }
   }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SampleExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SampleExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,6 @@ case class SampleExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ShuffleExchangeExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ShuffleExchangeExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,6 @@ case class ShuffleExchangeExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", filterSpeedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", filterSpeedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ShuffledHashJoinExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ShuffledHashJoinExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ case class ShuffledHashJoinExecParser(
     }
 
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor,
+    ExecInfo(node, sqlID, node.name, "", speedupFactor,
       maxDuration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SortAggregateExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SortAggregateExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ case class SortAggregateExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None,
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None,
       unsupportedExprs = notSupportedExprs)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SortExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SortExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ case class SortExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None,
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None,
       unsupportedExprs = notSupportedExprs)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SortMergeJoinExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SortMergeJoinExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,6 @@ case class SortMergeJoinExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SubqueryBroadcastExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SubqueryBroadcastExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,6 @@ case class SubqueryBroadcastExecParser(
     }
     // TODO - check is broadcast associated can be replaced
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", filterSpeedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", filterSpeedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/TakeOrderedAndProjectExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/TakeOrderedAndProjectExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ case class TakeOrderedAndProjectExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor,
+    ExecInfo(node, sqlID, node.name, "", speedupFactor,
       duration, node.id, isSupported, None, unsupportedExprs = notSupportedExprs)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/UnionExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/UnionExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,6 @@ case class UnionExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/WholeStageExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/WholeStageExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ case class WholeStageExecParser(
     // can't rely on the wholeStagecodeGen having a stage if children do so aggregate them together
     // for now
     val allStagesIncludingChildren = childNodes.flatMap(_.stages).toSet ++ stagesInNode.toSet
-    val execInfo = new ExecInfo(sqlID, node.name, node.name, avSpeedupFactor, maxDuration,
+    val execInfo = ExecInfo(node, sqlID, node.name, node.name, avSpeedupFactor, maxDuration,
       node.id, anySupported, Some(childNodes), allStagesIncludingChildren,
       shouldRemove = isDupNode, unsupportedExprs = unSupportedExprsArray)
     Seq(execInfo)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/WindowExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/WindowExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ case class WindowExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None,
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None,
       unsupportedExprs = notSupportedExprs)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/WindowInPandasExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/WindowInPandasExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,6 @@ case class WindowInPandasExecParser(
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    new ExecInfo(sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -278,15 +278,6 @@ abstract class AppBase(
     }
   }
 
-  def isDataSetOrRDDPlan(desc: String): Boolean = {
-    desc match {
-      case l if l.matches(".*\\$Lambda\\$.*") => true
-      case a if a.endsWith(".apply") => true
-      case r if r.matches(".*SerializeFromObject.*") => true
-      case _ => false
-    }
-  }
-
   private val UDFRegex = ".*UDF.*"
 
   private val potentialIssuesRegexMap = Map(

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -27,6 +27,7 @@ import org.json4s.jackson.JsonMethods.parse
 
 import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
 
 object ToolUtils extends Logging {
   // List of recommended file-encodings on the GPUs.
@@ -303,13 +304,65 @@ object SQLMetricsStats {
   }
 }
 
-object IgnoreExecs {
+object ExecHelper {
+  // regular expression to search for RDDs in node descriptions
+  private val dataSetRDDRegExDescLookup = Set(
+    ".*\\$Lambda\\$.*".r,
+    ".*\\.apply$".r
+  )
+  // regular expression to search for RDDs in node names
+  private val dataSetOrRDDRegExLookup = Set(
+    "ExistingRDD$".r,
+    "^Scan ExistingRDD.*".r,
+    "SerializeFromObject$".r,
+    "DeserializeToObject$".r,
+    "MapPartitions$".r,
+    "MapElements$".r,
+    "AppendColumns$".r,
+    "AppendColumnsWithObject$".r,
+    "MapGroups$".r,
+    "FlatMapGroupsInR$".r,
+    "FlatMapGroupsInRWithArrow$".r,
+    "CoGroup$".r
+  )
+  private val UDFRegExLookup = Set(
+    ".*UDF.*".r
+  )
+
+  // we don't want to mark the *InPandas and ArrowEvalPythonExec as unsupported with UDF
+  private val skipUDFCheckExecs = Seq("ArrowEvalPython", "AggregateInPandas",
+    "FlatMapGroupsInPandas", "MapInPandas", "WindowInPandas")
+
+  // Set containing execs that should be labeled as "shouldRemove"
+  private val execsToBeRemoved = Set(
+    "GenerateBloomFilter",   // Exclusive on AWS. Ignore it as metrics cannot be evaluated.
+    "ReusedExchange",        // reusedExchange should not be added to speedups
+    "ColumnarToRow"          // for now, assume everything is columnar
+  )
+
+  def isDatasetOrRDDPlan(nodeName: String, nodeDesc: String): Boolean = {
+    dataSetRDDRegExDescLookup.exists(regEx => nodeDesc.matches(regEx.regex)) ||
+      dataSetOrRDDRegExLookup.exists(regEx => nodeName.trim.matches(regEx.regex))
+  }
+
+  def isUDF(node: SparkPlanGraphNode): Boolean = {
+    if (skipUDFCheckExecs.exists(node.name.contains(_))) {
+      false
+    } else {
+      UDFRegExLookup.exists(regEx => node.desc.matches(regEx.regex))
+    }
+  }
+
+  def shouldBeRemoved(nodeName: String): Boolean = {
+    execsToBeRemoved.contains(nodeName)
+  }
+
+  ///////////////////////////////////////////
+  // start definitions of execs to be ignored
   // AdaptiveSparkPlan is not a real exec. It is a wrapper for the whole plan.
   private val AdaptiveSparkPlan = "AdaptiveSparkPlan"
   // Collect Limit replacement can be slower on the GPU. Disabled by default.
   private val CollectLimit = "CollectLimit"
-  private val ScanExistingRDD = "Scan ExistingRDD"
-  private val ExistingRDD = "ExistingRDD"
   // Some DDL's  and table commands which can be ignored
   private val ExecuteCreateViewCommand = "Execute CreateViewCommand"
   private val LocalTableScan = "LocalTableScan"
@@ -322,16 +375,56 @@ object IgnoreExecs {
     "CreateDataSourceTableAsSelectCommand"
   private val SetCatalogAndNamespace = "SetCatalogAndNamespace"
   private val ExecuteSetCommand = "Execute SetCommand"
+  private val ResultQueryStage = "ResultQueryStage"
+  private val ExecAddJarsCommand = "Execute AddJarsCommand"
+  private val ExecInsertIntoHadoopFSRelationCommand = "Execute InsertIntoHadoopFsRelationCommand"
+  private val ScanJDBCRelation = "Scan JDBCRelation"
+  private val ScanOneRowRelation = "Scan OneRowRelation"
+  private val CommandResult = "CommandResult"
+  private val ExecuteAlterTableRecoverPartitionsCommand =
+    "Execute AlterTableRecoverPartitionsCommand"
+  private val ExecuteCreateFunctionCommand = "Execute CreateFunctionCommand"
+  private val CreateHiveTableAsSelectCommand = "Execute CreateFunctionCommand"
+  private val ExecuteDeleteCommand = "Execute DeleteCommand"
+  private val ExecuteDescribeTableCommand = "Execute DescribeTableCommand"
+  private val ExecuteRefreshTable = "Execute RefreshTable"
+  private val ExecuteRepairTableCommand = "Execute RepairTableCommand"
+  private val ExecuteShowPartitionsCommand = "Execute ShowPartitionsCommand"
+  // DeltaLakeOperations
+  private val ExecUpdateCommandEdge = "Execute UpdateCommandEdge"
+  private val ExecDeleteCommandEdge = "Execute DeleteCommandEdge"
+  private val ExecDescribeDeltaHistoryCommand = "Execute DescribeDeltaHistoryCommand"
+  private val ExecShowPartitionsDeltaCommand = "Execute ShowPartitionsDeltaCommand"
 
-
-  val True = "true"
-  val False = "false"
-
-  def getAllIgnoreExecs: Set[String] = Set(AdaptiveSparkPlan, CollectLimit, ScanExistingRDD,
-    ExecuteCreateViewCommand, ExistingRDD, LocalTableScan, ExecuteCreateTableCommand,
+  def getAllIgnoreExecs: Set[String] = Set(AdaptiveSparkPlan, CollectLimit,
+    ExecuteCreateViewCommand, LocalTableScan, ExecuteCreateTableCommand,
     ExecuteDropTableCommand, ExecuteCreateDatabaseCommand, ExecuteDropDatabaseCommand,
     ExecuteCreateTableAsSelectCommand, ExecuteCreateDataSourceTableAsSelectCommand,
-    SetCatalogAndNamespace, ExecuteSetCommand)
+    SetCatalogAndNamespace, ExecuteSetCommand,
+    ResultQueryStage,
+    ExecAddJarsCommand,
+    ExecAddJarsCommand,
+    ExecInsertIntoHadoopFSRelationCommand,
+    ScanJDBCRelation,
+    ScanOneRowRelation,
+    CommandResult,
+    ExecUpdateCommandEdge,
+    ExecDeleteCommandEdge,
+    ExecDescribeDeltaHistoryCommand,
+    ExecShowPartitionsDeltaCommand,
+    ExecuteAlterTableRecoverPartitionsCommand,
+    ExecuteCreateFunctionCommand,
+    CreateHiveTableAsSelectCommand,
+    ExecuteDeleteCommand,
+    ExecuteDescribeTableCommand,
+    ExecuteRefreshTable,
+    ExecuteRepairTableCommand,
+    ExecuteShowPartitionsCommand
+  )
+
+  def shouldIgnore(execName: String): Boolean = {
+    getAllIgnoreExecs.contains(execName)
+  }
 }
 
 object MlOps {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -403,7 +403,6 @@ object ExecHelper {
     SetCatalogAndNamespace, ExecuteSetCommand,
     ResultQueryStage,
     ExecAddJarsCommand,
-    ExecAddJarsCommand,
     ExecInsertIntoHadoopFSRelationCommand,
     ScanJDBCRelation,
     ScanOneRowRelation,

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -28,7 +28,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler._
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.execution.metric.SQLMetricInfo
-import org.apache.spark.sql.rapids.tool.{AppBase, ToolUtils}
+import org.apache.spark.sql.rapids.tool.{AppBase, ExecHelper, ToolUtils}
 import org.apache.spark.sql.rapids.tool.util.ToolsPlanGraph
 import org.apache.spark.ui.UIUtils
 
@@ -270,7 +270,7 @@ class ApplicationInfo(
       }
       for (node <- allnodes) {
         checkGraphNodeForReads(sqlID, node)
-        if (isDataSetOrRDDPlan(node.desc)) {
+        if (ExecHelper.isDatasetOrRDDPlan(node.name, node.desc)) {
           sqlIdToInfo.get(sqlID).foreach { sql =>
             sqlIDToDataSetOrRDDCase += sqlID
             sql.hasDatasetOrRDD = true

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -489,8 +489,7 @@ class QualificationAppInfo(
         val filteredChildren = e.children.map { c =>
           c.filterNot(_.shouldRemove)
         }
-        new ExecInfo(e.sqlID, e.exec, e.expr, e.speedupFactor, e.duration,
-          e.nodeId, e.isSupported, filteredChildren, e.stages, e.shouldRemove, e.unsupportedExprs)
+        e.copy(children = filteredChildren)
       }
       val filteredPlanInfos = execFilteredChildren.filterNot(_.shouldRemove)
       p.copy(execInfo = filteredPlanInfos)

--- a/core/src/test/resources/ProfilingExpectations/unsupported_sql_eventlog_expectation.csv
+++ b/core/src/test/resources/ProfilingExpectations/unsupported_sql_eventlog_expectation.csv
@@ -2,4 +2,5 @@ appIndex,sqlID,nodeID,nodeName,nodeDescription,reason
 1,0,2,"SerializeFromObject","SerializeFromObject [staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromSt","Contains Dataset or RDD"
 1,0,3,"MapElements","MapElements com.nvidia.spark.rapids.tool.profiling.QualificationInfoSuite$$$Lambda$1571/993650587@7b","Contains Dataset or RDD"
 1,0,4,"Filter","Filter com.nvidia.spark.rapids.tool.profiling.QualificationInfoSuite$$$Lambda$1569/1828787392@2eb6d3","Contains Dataset or RDD"
+1,0,5,"DeserializeToObject","DeserializeToObject newInstance(class com.nvidia.spark.rapids.tool.profiling.RapidsFriends), obj#30:","Contains Dataset or RDD"
 1,0,10,"SerializeFromObject","SerializeFromObject [staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromSt","Contains Dataset or RDD"

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -350,17 +350,17 @@ class SQLPlanParserSuite extends BaseTestSuite {
           SQLPlanParser.parseSQLPlan(app.appId, plan, sqlID, "", pluginTypeChecker, app)
         }
         val allExecInfo = getAllExecsFromPlan(parsedPlans.toSeq)
-        val text = allExecInfo.filter(_.exec.contains(s"$dataWriteCMD text"))
-        val json = allExecInfo.filter(_.exec.contains(s"$dataWriteCMD json"))
-        val orc = allExecInfo.filter(_.exec.contains(s"$dataWriteCMD orc"))
-        val parquet =
-          allExecInfo.filter(_.exec.contains(s"$dataWriteCMD parquet"))
-        val csv = allExecInfo.filter(_.exec.contains(s"$dataWriteCMD csv"))
+        val writeExecs = allExecInfo.filter(_.exec.contains(s"$dataWriteCMD"))
+        val text = writeExecs.filter(_.expr.contains("text"))
+        val json = writeExecs.filter(_.expr.contains("json"))
+        val orc = writeExecs.filter(_.expr.contains("orc"))
+        val parquet = writeExecs.filter(_.expr.contains("parquet"))
+        val csv = writeExecs.filter(_.expr.contains("csv"))
         for (t <- Seq(json, csv, text)) {
-          assertSizeAndNotSupported(1, t.toSeq)
+          assertSizeAndNotSupported(1, t)
         }
         for (t <- Seq(orc, parquet)) {
-          assertSizeAndSupported(1, t.toSeq)
+          assertSizeAndSupported(1, t)
         }
       }
     }


### PR DESCRIPTION
Fixes #743

- Add a new field shouldIgnore to the `execInfo`. Then we can use that flag in the final reporting schema
- Converted ExecInfo into `case class` and used an object to consistently set the default arguments
- The new column is dumped as one of the columns in `rapids_4_spark_qualification_output_execs.csv`