### PR TITLE
Fix Qualification crash during aggregation of stats

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -547,9 +547,10 @@ class QualificationAppInfo(
       val (allComplexTypes, nestedComplexTypes) = reportComplexTypes
       val problems = getAllPotentialProblems(getPotentialProblemsForDf, nestedComplexTypes)
 
-      val origPlanInfos = sqlPlans.map { case (id, plan) =>
-        val sqlDesc = sqlIdToInfo(id).description
-        SQLPlanParser.parseSQLPlan(appId, plan, id, sqlDesc, pluginTypeChecker, this)
+      val origPlanInfos = sqlPlans.collect {
+        case (id, plan) if sqlIdToInfo.contains(id) =>
+          val sqlDesc = sqlIdToInfo(id).description
+          SQLPlanParser.parseSQLPlan(appId, plan, id, sqlDesc, pluginTypeChecker, this)
       }.toSeq
 
       // filter out any execs that should be removed


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #752

- A minor fix to avoid accessing non existing keys.
- When a SQL has failures, it won't exist in the map which causes the failure