### PR TITLE
Qualification fails to detect sortMergeJoin with arguments

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -314,7 +314,7 @@ object SQLPlanParser extends Logging {
             FileSourceScanExecParser(node, checker, sqlID, app).parse
           case "SortAggregate" =>
             SortAggregateExecParser(node, checker, sqlID).parse
-          case "SortMergeJoin" =>
+          case smj if SortMergeJoinExecParser.accepts(smj) =>
             SortMergeJoinExecParser(node, checker, sqlID).parse
           case "SubqueryBroadcast" =>
             SubqueryBroadcastExecParser(node, checker, sqlID, app).parse

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SortMergeJoinExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SortMergeJoinExecParser.scala
@@ -24,22 +24,34 @@ case class SortMergeJoinExecParser(
     node: SparkPlanGraphNode,
     checker: PluginTypeChecker,
     sqlID: Long) extends ExecParser {
+  private val opName = "SortMergeJoin"
 
-  val fullExecName = node.name + "Exec"
+  val fullExecName = opName + "Exec"
 
   override def parse: ExecInfo = {
     // SortMergeJoin doesn't have duration
     val duration = None
-    val exprString = node.desc.replaceFirst("SortMergeJoin ", "")
+    // parse the description after getting rid of the prefix that can include an argument
+    val trimPosition = node.desc.indexOf(" ")
+    val exprString = node.desc.substring(trimPosition + 1)
     val (expressions, supportedJoinType) = SQLPlanParser.parseEquijoinsExpressions(exprString)
     val notSupportedExprs = expressions.filterNot(expr => checker.isExprSupported(expr))
-    val (speedupFactor, isSupported) = if (checker.isExecSupported(fullExecName) &&
-      notSupportedExprs.isEmpty && supportedJoinType) {
+    val (speedupFactor, isSupported) = if (supportedJoinType &&
+      checker.isExecSupported(fullExecName) && notSupportedExprs.isEmpty) {
       (checker.getSpeedupFactor(fullExecName), true)
     } else {
       (1.0, false)
     }
     // TODO - add in parsing expressions - average speedup across?
-    ExecInfo(node, sqlID, node.name, "", speedupFactor, duration, node.id, isSupported, None)
+    ExecInfo(node, sqlID, opName, "", speedupFactor, duration, node.id, isSupported, None)
   }
+}
+
+object SortMergeJoinExecParser {
+  private val execNameRegEx = "(SortMergeJoin)(?:\\(.+\\))?".r
+
+  def accepts(nodeName: String): Boolean = {
+    nodeName.matches(execNameRegEx.regex)
+  }
+
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -934,7 +934,6 @@ class SQLPlanParserSuite extends BaseTestSuite {
         val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
           "ProjectExprsSupported") { spark =>
           import spark.implicits._
-
           import org.apache.spark.sql.types.StringType
           val df1 = Seq(9.9, 10.2, 11.6, 12.5).toDF("value")
           df1.write.parquet(s"$parquetoutputLoc/testtext")
@@ -1274,7 +1273,6 @@ class SQLPlanParserSuite extends BaseTestSuite {
         val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
           "projectPromotePrecision") { spark =>
           import spark.implicits._
-
           import org.apache.spark.sql.types.DecimalType
           val df = Seq(("12347.21", "1234154"), ("92233.08", "1")).toDF
             .withColumn("dec1", col("_1").cast(DecimalType(7, 2)))
@@ -1366,8 +1364,8 @@ class SQLPlanParserSuite extends BaseTestSuite {
     val node = new SparkPlanGraphNode(
       1,
       "SortMergeJoin(skew=true)",
-      "SortMergeJoin(skew=true) [trim(addr_loc_src_addr_key_id#7407, None)], " +
-        "[trim(src_addr_key_id#7415, None)], LeftOuter", Seq[SQLPlanMetric]())
+      "SortMergeJoin(skew=true) [trim(field_00#7407, None)], " +
+        "[trim(field_01#7415, None)], LeftOuter", Seq[SQLPlanMetric]())
     SortMergeJoinExecParser.accepts(node.name) shouldBe true
     val pluginTypeChecker = new PluginTypeChecker()
     val execInfo = SortMergeJoinExecParser(node, pluginTypeChecker, 2).parse


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #751

- Change the SqlPlanParser to handle SMJ with arguments
- Added Unit-test