### PR TITLE
Consolidate unsupportedOperators into a single view

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DataWritingCommandExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DataWritingCommandExecParser.scala
@@ -40,7 +40,7 @@ case class DataWritingCommandExecParser(
     // TODO - add in parsing expressions - average speedup across?
     ExecInfo(node, sqlID, s"${node.name.trim} ${wStub.dataFormat.toLowerCase.trim}",
       s"Format: ${wStub.dataFormat.toLowerCase.trim}",
-      finalSpeedup, duration, node.id, writeSupported, None)
+      finalSpeedup, duration, node.id, writeSupported, None, opType = OpTypes.WriteExec)
   }
 }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DataWritingCommandExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DataWritingCommandExecParser.scala
@@ -38,9 +38,10 @@ case class DataWritingCommandExecParser(
     val speedupFactor = checker.getSpeedupFactor(wStub.mappedExec)
     val finalSpeedup = if (writeSupported) speedupFactor else 1
     // TODO - add in parsing expressions - average speedup across?
-    ExecInfo(node, sqlID, s"${node.name.trim} ${wStub.dataFormat.toLowerCase.trim}",
+    // We do not want to parse the node description to avoid mistakenly marking the node as RDD/UDF
+    ExecInfo.createExecNoNode(sqlID, s"${node.name.trim} ${wStub.dataFormat.toLowerCase.trim}",
       s"Format: ${wStub.dataFormat.toLowerCase.trim}",
-      finalSpeedup, duration, node.id, writeSupported, None, opType = OpTypes.WriteExec)
+      finalSpeedup, duration, node.id, opType = OpTypes.WriteExec, writeSupported,  None)
   }
 }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DataWritingCommandExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DataWritingCommandExecParser.scala
@@ -58,6 +58,7 @@ object DataWritingCommandExecParser {
   val insertIntoHadoopCMD = "InsertIntoHadoopFsRelationCommand"
   val appendDataExecV1 = "AppendDataExecV1"
   val overwriteByExprExecV1 = "OverwriteByExpressionExecV1"
+  val atomicReplaceTableExec = "AtomicReplaceTableAsSelect"
   // Note: List of writeExecs that represent a physical command.
   // hardcode because InsertIntoHadoopFsRelationCommand uses this same exec
   // and InsertIntoHadoopFsRelationCommand doesn't have an entry in the
@@ -77,7 +78,8 @@ object DataWritingCommandExecParser {
     insertIntoHadoopCMD,
     HiveParseHelper.INSERT_INTO_HIVE_LABEL,
     appendDataExecV1,
-    overwriteByExprExecV1
+    overwriteByExprExecV1,
+    atomicReplaceTableExec
   )
 
   // Note: Defines a list of the execs that include formatted data.
@@ -90,7 +92,8 @@ object DataWritingCommandExecParser {
     insertIntoHadoopCMD -> defaultPhysicalCMD,
     HiveParseHelper.INSERT_INTO_HIVE_LABEL-> defaultPhysicalCMD,
     appendDataExecV1 -> defaultPhysicalCMD,
-    overwriteByExprExecV1 -> defaultPhysicalCMD
+    overwriteByExprExecV1 -> defaultPhysicalCMD,
+    atomicReplaceTableExec -> defaultPhysicalCMD
   )
 
   // Map to hold the relation between writeExecCmd and the format.
@@ -99,7 +102,9 @@ object DataWritingCommandExecParser {
     // if appendDataExecV1 is not deltaLakeProvider, then we want to mark it as unsupported
     appendDataExecV1 -> "unknown",
     // if overwriteByExprExecV1 is not deltaLakeProvider, then we want to mark it as unsupported
-    overwriteByExprExecV1 -> "unknown"
+    overwriteByExprExecV1 -> "unknown",
+    // if atomicReplaceTableExec is not deltaLakeProvider, then we want to mark it as unsupported
+    atomicReplaceTableExec -> "unknown"
   )
 
   // Checks whether a node is a write CMD Exec

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DeltaLakeHelper.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DeltaLakeHelper.scala
@@ -96,8 +96,24 @@ object DeltaLakeHelper {
   def acceptsWriteOp(node: SparkPlanGraphNode): Boolean = {
     if (exclusiveDeltaExecs.exists(k => node.name.contains(k))) {
       true
+    } else if (deltaExecsFromSpark.contains(node.name)) {
+      if (node.name.contains(appendDataExecV1) || node.name.contains(overwriteByExprExecV1)) {
+        nodeDescKeywords.forall(s => node.desc.contains(s))
+      } else if (node.name.contains(atomicReplaceTableExec)) {
+        // AtomicReplaceTableAsSelectExec has a different format
+        // AtomicReplaceTableAsSelect [num_affected_rows#ID_0L, num_inserted_rows#ID_1L],
+        // com.databricks.sql.managedcatalog.UnityCatalogV2Proxy@XXXXX,
+        // DB.VAR_2, Union false, false,
+        // TableSpec(Map(),Some(delta),Map(),None,None,None,false,Set(),None,None,None),
+        // [replaceWhere=VAR_1 IN ('WHATEVER')], true,
+        // org.apache.spark.sql.execution.datasources.
+        // v2.DataSourceV2Strategy$$Lambda$XXXXX
+        node.desc.matches("(?i).*delta.*")
+      } else {
+        false
+      }
     } else {
-      deltaExecsFromSpark.contains(node.name) && nodeDescKeywords.forall(s => node.desc.contains(s))
+      false
     }
   }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DeltaLakeHelper.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DeltaLakeHelper.scala
@@ -108,7 +108,7 @@ object DeltaLakeHelper {
         // [replaceWhere=VAR_1 IN ('WHATEVER')], true,
         // org.apache.spark.sql.execution.datasources.
         // v2.DataSourceV2Strategy$$Lambda$XXXXX
-        node.desc.matches("(?i).*delta.*")
+        node.desc.matches("""(?i).*delta.*""")
       } else {
         false
       }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DeltaLakeHelper.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DeltaLakeHelper.scala
@@ -64,24 +64,29 @@ object DeltaLakeHelper {
   // [fieldName, type]
   private val schemaRegex =
     "\\s+\\|--\\s+([a-zA-Z]+(?:_[a-zA-Z]+)*):\\s+([a-zA-Z]+(?:_[a-zA-Z]+)*)\\s+\\(".r
+  val saveIntoDataSrcCMD = "SaveIntoDataSourceCommand"
+  private val atomicReplaceTableExec = "AtomicReplaceTableAsSelect"
   private val appendDataExecV1 = "AppendDataExecV1"
   private val overwriteByExprExecV1 = "OverwriteByExpressionExecV1"
-  val saveIntoDataSrcCMD = "SaveIntoDataSourceCommand"
+  private val mergeIntoCommandEdgeExec = "MergeIntoCommandEdge"
   // Note that the SaveIntoDataSourceCommand node name appears as
   // "Execute SaveIntoDataSourceCommand"
+  // Same for Execute MergeIntoCommandEdge
   private val exclusiveDeltaExecs = Set(
-    saveIntoDataSrcCMD
+    saveIntoDataSrcCMD,
+    mergeIntoCommandEdgeExec
   )
   // define the list of writeExecs that also exist in Spark
   private val deltaExecsFromSpark = Set(
     appendDataExecV1,
-    overwriteByExprExecV1
+    overwriteByExprExecV1,
+    atomicReplaceTableExec
   )
 
   // keywords used to verify that the operator provider is DeltaLake
   private val nodeDescKeywords = Set(
     "DeltaTableV2",
-    "WriteIntoDeltaBuilder"
+    "WriteIntoDeltaBuilder",
   )
 
   def accepts(nodeName: String): Boolean = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DeltaLakeHelper.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DeltaLakeHelper.scala
@@ -46,7 +46,7 @@ class DLWriteWithFormatAndSchemaParser(node: SparkPlanGraphNode,
     // TODO get the schema to check if it is supported
     // val schema = DeltaLakeHelper.getSchema(node.desc)
     ExecInfo.createExecNoNode(sqlID, nodeName,
-      s"Format: $dataFormat", speedupFactor, None, node.id,
+      s"Format: $dataFormat", speedupFactor, None, node.id, OpTypes.WriteExec,
       isSupported = writeSupported, children = None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DeltaLakeHelper.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DeltaLakeHelper.scala
@@ -43,8 +43,6 @@ class DLWriteWithFormatAndSchemaParser(node: SparkPlanGraphNode,
     }
     // execs like SaveIntoDataSourceCommand has prefix "Execute". So, we need to get rid of it.
     val nodeName = node.name.replace("Execute ", "")
-    // TODO get the schema to check if it is supported
-    // val schema = DeltaLakeHelper.getSchema(node.desc)
     ExecInfo.createExecNoNode(sqlID, nodeName,
       s"Format: $dataFormat", speedupFactor, None, node.id, OpTypes.WriteExec,
       isSupported = writeSupported, children = None)
@@ -74,20 +72,17 @@ object DeltaLakeHelper {
   // Same for Execute MergeIntoCommandEdge
   private val exclusiveDeltaExecs = Set(
     saveIntoDataSrcCMD,
-    mergeIntoCommandEdgeExec
-  )
+    mergeIntoCommandEdgeExec)
   // define the list of writeExecs that also exist in Spark
   private val deltaExecsFromSpark = Set(
     appendDataExecV1,
     overwriteByExprExecV1,
-    atomicReplaceTableExec
-  )
+    atomicReplaceTableExec)
 
   // keywords used to verify that the operator provider is DeltaLake
   private val nodeDescKeywords = Set(
     "DeltaTableV2",
-    "WriteIntoDeltaBuilder",
-  )
+    "WriteIntoDeltaBuilder")
 
   def accepts(nodeName: String): Boolean = {
     exclusiveDeltaExecs.exists(k => nodeName.contains(k)) || deltaExecsFromSpark.contains(nodeName)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/FileSourceScanExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/FileSourceScanExecParser.scala
@@ -20,7 +20,7 @@ import com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
-import org.apache.spark.sql.rapids.tool.AppBase
+import org.apache.spark.sql.rapids.tool.{AppBase, RDDCheckHelper}
 
 case class FileSourceScanExecParser(
     node: SparkPlanGraphNode,
@@ -35,22 +35,36 @@ case class FileSourceScanExecParser(
     // Remove trailing spaces from node name
     // Example: Scan parquet . ->  Scan parquet.
     val nodeName = node.name.trim
-    val accumId = node.metrics.find(_.name == "scan time").map(_.accumulatorId)
-    val maxDuration = SQLPlanParser.getTotalDuration(accumId, app)
-    val (execName, readInfo) = if (HiveParseHelper.isHiveTableScanNode(node)) {
-      // Use the hive parser
-      (HiveParseHelper.SCAN_HIVE_EXEC_NAME, HiveParseHelper.parseReadNode(node))
+    val rddCheckRes = RDDCheckHelper.isDatasetOrRDDPlan(nodeName, node.desc)
+    if (rddCheckRes.nodeNameRDD) {
+      // This is a scanRDD. we do not need to parse it as a normal node.
+      // cleanup the node name if possible:
+      val newNodeName = if (nodeName.contains("ExistingRDD")) {
+        val nodeNameLength = nodeName.indexOf("ExistingRDD") + "ExistingRDD".length
+        nodeName.substring(0, nodeNameLength)
+      } else {
+        nodeName
+      }
+      ExecInfo.createExecNoNode(sqlID, newNodeName, "", 1.0, duration = None,
+        node.id, OpTypes.ReadRDD, false, None)
     } else {
-      // Use the default parser
-      (fullExecName, ReadParser.parseReadNode(node))
-    }
-    val speedupFactor = checker.getSpeedupFactor(execName)
-    // don't use the isExecSupported because we have finer grain.
-    val score = ReadParser.calculateReadScoreRatio(readInfo, checker)
-    val overallSpeedup = Math.max(speedupFactor * score, 1.0)
+      val accumId = node.metrics.find(_.name == "scan time").map(_.accumulatorId)
+      val maxDuration = SQLPlanParser.getTotalDuration(accumId, app)
+      val (execName, readInfo) = if (HiveParseHelper.isHiveTableScanNode(node)) {
+        // Use the hive parser
+        (HiveParseHelper.SCAN_HIVE_EXEC_NAME, HiveParseHelper.parseReadNode(node))
+      } else {
+        // Use the default parser
+        (fullExecName, ReadParser.parseReadNode(node))
+      }
+      val speedupFactor = checker.getSpeedupFactor(execName)
+      // don't use the isExecSupported because we have finer grain.
+      val score = ReadParser.calculateReadScoreRatio(readInfo, checker)
+      val overallSpeedup = Math.max(speedupFactor * score, 1.0)
 
-    // TODO - add in parsing expressions - average speedup across?
-    ExecInfo.createExecNoNode(sqlID, nodeName, "", overallSpeedup, maxDuration,
-      node.id, OpTypes.ReadExec, score > 0, None)
+      // TODO - add in parsing expressions - average speedup across?
+      ExecInfo.createExecNoNode(sqlID, nodeName, "", overallSpeedup, maxDuration,
+        node.id, OpTypes.ReadExec, score > 0, None)
+    }
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/FileSourceScanExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/FileSourceScanExecParser.scala
@@ -51,6 +51,6 @@ case class FileSourceScanExecParser(
 
     // TODO - add in parsing expressions - average speedup across?
     ExecInfo.createExecNoNode(sqlID, nodeName, "", overallSpeedup, maxDuration,
-      node.id, score > 0, None)
+      node.id, OpTypes.ReadExec, score > 0, None)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
@@ -186,6 +186,28 @@ class QualOutputWriter(outputDir: String, reportReadSchema: Boolean,
     }
   }
 
+  def writeUnsupportedOpsPerStageSummaryCSVReport(
+      sums: Seq[QualificationSummaryInfo]): Unit = {
+    // function to get all the unsupported execs for a given stageID
+    def getUnsupportedExecsPerStage(
+        sumInfo: QualificationSummaryInfo, stageID: Int): Seq[ExecInfo] = {
+      sumInfo.planInfo.collect {
+        case pInfo =>
+          pInfo.execInfo.filter(exec => !exec.isSupported && exec.stages.contains(stageID))
+      }.flatten
+    }
+
+    // loop on all stages and for each stage call getUnsupportedExecsPerStage
+    sums.foreach { appInfo =>
+      appInfo.stageInfo.foreach { sInfo =>
+        getUnsupportedExecsPerStage(appInfo, sInfo.stageId).foreach { execInfo =>
+          println(s"${appInfo.appId} | ${sInfo.stageId} | " +
+            s"${execInfo.getUnsupportedExecSummaryRecord.toString()}")
+        }
+      }
+    }
+  }
+
   def writePerSqlCSVReport(sums: Seq[QualificationSummaryInfo], maxSQLDescLength: Int): Unit = {
     val csvFileWriter = new ToolTextFileWriter(outputDir,
       s"${QualOutputWriter.LOGFILE_NAME}_persql.csv",

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -98,6 +98,7 @@ class Qualification(outputPath: String, numRows: Int, hadoopConf: Configuration,
     qWriter.writeExecReport(allAppsSum, order)
     qWriter.writeStageReport(allAppsSum, order)
     qWriter.writeUnsupportedOperatorsCSVReport(allAppsSum, order)
+    qWriter.writeUnsupportedOpsPerStageSummaryCSVReport(allAppsSum)
     qWriter.writeUnsupportedOperatorsDetailedStageCSVReport(allAppsSum, order)
     val appStatusResult = generateStatusSummary(appStatusReporter.asScala.values.toSeq)
     qWriter.writeStatusReport(appStatusResult, order)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -97,9 +97,7 @@ class Qualification(outputPath: String, numRows: Int, hadoopConf: Configuration,
     }
     qWriter.writeExecReport(allAppsSum, order)
     qWriter.writeStageReport(allAppsSum, order)
-    qWriter.writeUnsupportedOperatorsCSVReport(allAppsSum, order)
-    qWriter.writeUnsupportedOpsPerStageSummaryCSVReport(allAppsSum)
-    qWriter.writeUnsupportedOperatorsDetailedStageCSVReport(allAppsSum, order)
+    qWriter.writeUnsupportedOpsSummaryCSVReport(allAppsSum)
     val appStatusResult = generateStatusSummary(appStatusReporter.asScala.values.toSeq)
     qWriter.writeStatusReport(appStatusResult, order)
     if (mlOpsEnabled) {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -28,7 +28,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler._
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.execution.metric.SQLMetricInfo
-import org.apache.spark.sql.rapids.tool.{AppBase, ExecHelper, ToolUtils}
+import org.apache.spark.sql.rapids.tool.{AppBase, RDDCheckHelper, ToolUtils}
 import org.apache.spark.sql.rapids.tool.util.ToolsPlanGraph
 import org.apache.spark.ui.UIUtils
 
@@ -270,7 +270,7 @@ class ApplicationInfo(
       }
       for (node <- allnodes) {
         checkGraphNodeForReads(sqlID, node)
-        if (ExecHelper.isDatasetOrRDDPlan(node.name, node.desc)) {
+        if (RDDCheckHelper.isDatasetOrRDDPlan(node.name, node.desc).isRDD) {
           sqlIdToInfo.get(sqlID).foreach { sql =>
             sqlIDToDataSetOrRDDCase += sqlID
             sql.hasDatasetOrRDD = true


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #746, Fixes #777, Fixes #759

- Improves the generation of unsupportedReason
- Add support to DeltaLake `Execute MergeIntoCommandEdge`
- Add support to DeltaLake `AtomicReplaceTableAsSelect`
- Moves `ResultQueryStage` to the shouldRemove category yielding  `IgnoreNoPerf`
- Moves `AdaptiveSparkPlan` to the shouldRemove category yielding
  `IgnoreNoPerf`
- Adds "`StructType`" and "`StructField`" to the list of ignoredExpressions
- Once an Exec is detected as RDD, there should be no need to scan its description. This way, we avoid adding unnecessary expressions to the report.


