### PR TITLE
[FEA] Qualification user_tools runs AutoTuner by default

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ class Platform(platformName: String) {
    * Recommendations to be excluded from the list of recommendations.
    * These have the highest priority.
    */
-  val recommendationsToExclude: Seq[String] = Seq.empty
+  val recommendationsToExclude: Set[String] = Set.empty
   /**
    * Recommendations to be included in the final list of recommendations.
    * These properties should be specific to the platform and not general Spark properties.
@@ -104,7 +104,7 @@ class Platform(platformName: String) {
 }
 
 class DatabricksPlatform(platformType: String) extends Platform(platformType) {
-  override val recommendationsToExclude: Seq[String] = Seq(
+  override val recommendationsToExclude: Set[String] = Set(
     "spark.executor.cores",
     "spark.executor.instances",
     "spark.executor.memory",

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -17,15 +17,15 @@
 package com.nvidia.spark.rapids.tool.profiling
 
 import java.io.{BufferedReader, InputStreamReader}
-import java.util
 
 import scala.beans.BeanProperty
+import scala.collection.{mutable, Seq}
 import scala.collection.JavaConverters.mapAsScalaMapConverter
-import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.util.matching.Regex
 
 import com.nvidia.spark.rapids.tool.{Platform, PlatformFactory}
+import java.util
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, FSDataInputStream, Path}
 import org.yaml.snakeyaml.{DumperOptions, LoaderOptions, Yaml}
@@ -358,6 +358,11 @@ class AutoTuner(
     val fromProfile = appInfoProvider.getProperty(key)
     // If the value is not found above, fallback to cluster properties
     fromProfile.orElse(Option(clusterProps.softwareProperties.get(key)))
+  }
+
+  def getAllProperties: collection.Map[String, String] = {
+    // the app properties override the cluster properties
+    clusterProps.getSoftwareProperties.asScala ++ appInfoProvider.getAllProperties
   }
 
   def initRecommendations(): Unit = {
@@ -1029,6 +1034,29 @@ class AutoTuner(
 
     (toRecommendationsProfileResult, toCommentProfileResult)
   }
+
+  // Process the properties keys. This is needed in case there are some properties that should not
+  // be listed in the final combined results. For example:
+  // - The UUID of the app is not part of the submitted spark configurations
+  // - make sure that we exclude the skipped list
+  private def processPropKeys(
+      srcMap: collection.Map[String, String]): collection.Map[String, String] = {
+    (srcMap -- skippedRecommendations) -- filteredPropKeys
+  }
+
+  // Combines the original Spark properties with the recommended ones.
+  def combineSparkProperties(
+      recommendedSet: Seq[RecommendedPropertyResult]): Seq[RecommendedPropertyResult] = {
+    // get the original properties after filtering the and removing unnecessary keys
+    val originalPropsFiltered = processPropKeys(getAllProperties)
+    // Combine the original properties with the recommended properties.
+    // The recommendations should always override the original ones
+    val combinedProps = (originalPropsFiltered
+      ++ recommendedSet.map(r => r.property -> r.value).toMap).toSeq.sortBy(_._1)
+    combinedProps.collect {
+      case (pK, pV) => RecommendedPropertyResult(pK, pV)
+    }
+  }
 }
 
 object AutoTuner extends Logging {
@@ -1083,6 +1111,10 @@ object AutoTuner extends Logging {
   private val AQE_DEF_INITIAL_PARTITION_NUM = 800
   private val AQE_MIN_INITIAL_PARTITION_NUM = 200
   private val AQE_AUTOBROADCAST_JOIN_THRESHOLD = "100m"
+  // Set of spark properties to be filtered out from the combined Spark properties.
+  private val filteredPropKeys: Set[String] = Set(
+    "spark.app.id"
+  )
 
   val commentsForMissingProps: Map[String, String] = Map(
     "spark.executor.memory" ->

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -183,18 +183,12 @@ class Qualification(outputPath: String, numRows: Int, hadoopConf: Configuration,
         case Right(app: QualificationAppInfo) =>
           // Case with successful creation of QualificationAppInfo
           val qualSumInfo = app.aggregateStats()
-          tunerContext.collect {
+          tunerContext.foreach { tuner =>
             // Run the autotuner if it is enabled.
             // Note that we call the autotuner anyway without checking the aggregate results
             // because the Autotuner can still make some recommendations based on the information
             // enclosed by the QualificationInfo object
-            case tuner =>
-              // autoTuner is enabled for Qualification
-              tuner.tuneApplication(app, qualSumInfo).collect {
-                case res =>
-                  logInfo(s"RecommendedProps ${app.appId} = ${res.recommendations.mkString("\n")}")
-                  logInfo(s"Comments ${app.appId} = ${res.comments.mkString("\n")}")
-              }
+            tuner.tuneApplication(app, qualSumInfo)
           }
           if (qualSumInfo.isDefined) {
             allApps.add(qualSumInfo.get)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualAppSummaryInfoProvider.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualAppSummaryInfoProvider.scala
@@ -35,6 +35,10 @@ class QualAppSummaryInfoProvider(
     props.get(key)
   }
 
+  override def getAllProperties: Map[String, String] = {
+    appInfo.sparkProperties
+  }
+
   override def getSparkProperty(propKey: String): Option[String] = {
     findPropertyInternal(propKey, appInfo.sparkProperties)
   }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTuner.scala
@@ -33,23 +33,50 @@ import org.apache.spark.sql.rapids.tool.qualification.{QualificationAppInfo, Qua
 class QualificationAutoTuner(val appInfoProvider: QualAppSummaryInfoProvider,
     val tunerContext: TunerContext) {
 
+  // When enabled, the profiler recommendations should only include updated settings.
+  private val filterByUpdatedPropsEnabled: Boolean = false
+
   private def writeTuningReport(tuningResult: TuningResult,
       outputDir: String, hadoopConf: Configuration): Unit = {
+    // First, write down the recommendations and the comments
     val textFileWriter = new ToolTextFileWriter(outputDir,
-      s"${tuningResult.appID}.log", s"Tuning Qual app - ${tuningResult.appID}", Option(hadoopConf))
+      s"${tuningResult.appID}.log", s"Tuning Qual App - ${tuningResult.appID}", Option(hadoopConf))
     try {
-      textFileWriter.write(s"### Recommended Configuration for App: ${tuningResult.appID} ###\n")
+      textFileWriter.write(
+        s"### Recommended SPARK Configuration on GPU Cluster for App: ${tuningResult.appID} ###\n")
       textFileWriter.write(Profiler.getAutoTunerResultsAsString(
         tuningResult.recommendations, tuningResult.comments))
     } finally {
       textFileWriter.close()
     }
+    // Write down the combined configurations
+    tuningResult.combinedProps.collect {
+      case combinedProps =>
+        val textFileWriter = new ToolTextFileWriter(outputDir,
+          s"${tuningResult.appID}.conf",
+          s"Qual combined configurations for App - ${tuningResult.appID}", Option(hadoopConf))
+        try {
+          textFileWriter.write(combinedProps.map(_.toString).reduce(_ + "\n" + _))
+        } finally {
+          textFileWriter.close()
+        }
+    }
   }
+
   def runAutoTuner(): TuningResult = {
     val autoTuner: AutoTuner = AutoTuner.buildAutoTuner(
       tunerContext.workerInfoPath, appInfoProvider, tunerContext.platform)
-    val (recommendations, comments) = autoTuner.getRecommendedProperties()
-    val resultRecord = TuningResult(appInfoProvider.getAppID, recommendations, comments)
+    val (recommendations, comments) =
+      autoTuner.getRecommendedProperties(showOnlyUpdatedProps = filterByUpdatedPropsEnabled)
+    // Combine the GPU recommendations with all others.
+    // There are two ways we can that:
+    // 1- Combine them from the beginning; Or
+    // 2- At the end, get the union of the two properties.
+    // The 2nd needs more effort but it favourite because it keeps two separate lists.
+    // Otherwise, it is difficult to do separate them logically.
+    val combinedProps = autoTuner.combineSparkProperties(recommendations)
+    val resultRecord = TuningResult(appInfoProvider.getAppID, recommendations,
+      comments, Option(combinedProps))
     writeTuningReport(resultRecord, tunerContext.getOutputPath, tunerContext.hadoopConf)
     resultRecord
   }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TunerContext.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TunerContext.scala
@@ -29,7 +29,8 @@ import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
 case class TuningResult(
     appID: String,
     recommendations: Seq[RecommendedPropertyResult],
-    comments: Seq[RecommendedCommentResult])
+    comments: Seq[RecommendedCommentResult],
+    combinedProps: Option[Seq[RecommendedPropertyResult]] = None)
 
 /**
  * Container which holds metadata and arguments specific to the execution of the AutoTuner.

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -817,7 +817,7 @@ class Qualification(RapidsJarTool):
             highlighted_code = TemplateGenerator.highlight_bash_code(script_content)
             return ['```bash', highlighted_code, '```', '']
         if sec_conf.get('sectionID') == 'gpuBootstrapRecommendedConfigs':
-            # This is disabled by default in teh config files
+            # This is disabled by default in the config files
             return self.__generate_recommended_configs_report()
         return super()._generate_section_content(sec_conf)
 

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,12 +22,12 @@ from typing import Any, List, Callable
 import pandas as pd
 from tabulate import tabulate
 
-from spark_rapids_tools.enums import QualFilterApp, QualGpuClusterReshapeType
 from spark_rapids_pytools.cloud_api.sp_types import ClusterReshape, NodeHWInfo
 from spark_rapids_pytools.common.sys_storage import FSUtil
 from spark_rapids_pytools.common.utilities import Utils, TemplateGenerator
 from spark_rapids_pytools.pricing.price_provider import SavingsEstimator
 from spark_rapids_pytools.rapids.rapids_tool import RapidsJarTool
+from spark_rapids_tools.enums import QualFilterApp, QualGpuClusterReshapeType
 
 
 @dataclass
@@ -199,7 +199,8 @@ class Qualification(RapidsJarTool):
                 sys_info = worker_node._pull_sys_info(cli=self.ctxt.platform.cli)  # pylint: disable=protected-access
                 gpu_info = worker_node._pull_gpu_hw_info(cli=self.ctxt.platform.cli)  # pylint: disable=protected-access
                 worker_node.hw_info = NodeHWInfo(sys_info=sys_info, gpu_info=gpu_info)
-            except Exception:  # pylint: disable=broad-except
+            except Exception as e:  # pylint: disable=broad-except
+                self.logger.error('Error while processing worker node hardware info: %s', e)
                 return
 
         gpu_cluster_arg = offline_cluster_opts.get('gpuCluster')
@@ -212,12 +213,16 @@ class Qualification(RapidsJarTool):
                 # Convert the CPU instances to support gpu. Otherwise, gpuCluster is not set
                 self.logger.info('Creating GPU cluster by converting the CPU cluster instances to GPU supported types')
                 gpu_cluster_obj = self.ctxt.platform.migrate_cluster_to_gpu(orig_cluster)
+
         self.ctxt.set_ctxt('gpuClusterProxy', gpu_cluster_obj)
 
         _process_gpu_cluster_worker_node()
-        worker_node_hw_info = gpu_cluster_obj.get_worker_hw_info()
-        if gpu_cluster_obj:
-            self.ctxt.set_ctxt('recommendedConfigs', self._calculate_spark_settings(worker_node_hw_info))
+        if gpu_cluster_obj and self.ctxt.get_rapids_auto_tuner_enabled():
+            # Generate Autotuner input file for the Qualification
+            # Note that we do not call the `_calculate_spark_settings(worker_node_hw_info)` method here
+            # because the Qualification tool does not need to calculate the recommended Spark settings
+            # as it will be part of the generated Autotuner output file.
+            self._generate_autotuner_input_from_cluster(gpu_cluster_obj)
 
         return gpu_cluster_obj is not None
 
@@ -330,6 +335,15 @@ class Qualification(RapidsJarTool):
         else:
             self.ctxt.set_ctxt('cpu_discount', cpu_discount)
             self.ctxt.set_ctxt('gpu_discount', gpu_discount)
+
+    def _create_autotuner_rapids_args(self) -> list:
+        # Add the autotuner argument, also add worker-info if the autotunerPath exists
+        if self.ctxt.get_rapids_auto_tuner_enabled():
+            autotuner_path = self.ctxt.get_ctxt('autoTunerFilePath')
+            if autotuner_path is None:
+                return ['--auto-tuner']
+            return ['--auto-tuner', '--worker-info', autotuner_path]
+        return []
 
     def _process_custom_args(self):
         """
@@ -457,6 +471,8 @@ class Qualification(RapidsJarTool):
         return report_content
 
     def __generate_recommended_configs_report(self) -> list:
+        # This method will generate the report for the recommended configurations.
+        # The configurations disable that section by default.
         report_content = []
         if self.ctxt.get_ctxt('recommendedConfigs'):
             conversion_items = []
@@ -802,8 +818,12 @@ class Qualification(RapidsJarTool):
             highlighted_code = TemplateGenerator.highlight_bash_code(script_content)
             return ['```bash', highlighted_code, '```', '']
         if sec_conf.get('sectionID') == 'gpuBootstrapRecommendedConfigs':
+            # This is disabled by default in teh config files
             return self.__generate_recommended_configs_report()
         return super()._generate_section_content(sec_conf)
+
+    def _init_rapids_arg_list(self) -> List[str]:
+        return super()._init_rapids_arg_list() + self._create_autotuner_rapids_args()
 
 
 @dataclass

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -199,8 +199,7 @@ class Qualification(RapidsJarTool):
                 sys_info = worker_node._pull_sys_info(cli=self.ctxt.platform.cli)  # pylint: disable=protected-access
                 gpu_info = worker_node._pull_gpu_hw_info(cli=self.ctxt.platform.cli)  # pylint: disable=protected-access
                 worker_node.hw_info = NodeHWInfo(sys_info=sys_info, gpu_info=gpu_info)
-            except Exception as e:  # pylint: disable=broad-except
-                self.logger.error('Error while processing worker node hardware info: %s', e)
+            except Exception:  # pylint: disable=broad-except
                 return
 
         gpu_cluster_arg = offline_cluster_opts.get('gpuCluster')

--- a/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
@@ -186,7 +186,7 @@ class ToolContext(YAMLPropertiesContainer):
         return self.get_value('sparkRapids', 'mainClass')
 
     def get_rapids_auto_tuner_enabled(self) -> bool:
-        return self.get_value('sparkRapids', 'autoTunerEnabled')
+        return self.get_value('sparkRapids', 'enableAutoTuner')
 
     def get_rapids_output_folder(self) -> str:
         root_dir = self.get_local('outputFolder')

--- a/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -184,6 +184,9 @@ class ToolContext(YAMLPropertiesContainer):
 
     def get_tool_main_class(self) -> str:
         return self.get_value('sparkRapids', 'mainClass')
+
+    def get_rapids_auto_tuner_enabled(self) -> bool:
+        return self.get_value('sparkRapids', 'autoTunerEnabled')
 
     def get_rapids_output_folder(self) -> str:
         root_dir = self.get_local('outputFolder')

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -225,7 +225,7 @@
         },
         {
           "sectionID": "gpuBootstrapRecommendedConfigs",
-          "requiresBoolFlag": "enableSavingsCalculations",
+          "requiresBoolFlag": "DISABLED",
           "sectionName": "Recommended Spark configurations for running on GPUs",
           "content": {
             "header": [

--- a/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
@@ -255,7 +255,7 @@
         },
         {
           "sectionID": "gpuBootstrapRecommendedConfigs",
-          "requiresBoolFlag": "enableSavingsCalculations",
+          "requiresBoolFlag": "DISABLED",
           "sectionName": "Recommended Spark configurations for running on GPUs",
           "content": {
             "header": [

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -43,6 +43,7 @@ sparkRapids:
   repoUrl: '{}/{}/rapids-4-spark-tools_2.12-{}.jar'
   mainClass: 'com.nvidia.spark.rapids.tool.qualification.QualificationMain'
   outputDocURL: 'https://docs.nvidia.com/spark-rapids/user-guide/latest/spark-qualification-tool.html#understanding-the-qualification-tool-output'
+  enableAutoTuner: true
   gpu:
     device: 't4'
     workersPerNode: 2


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #744, Fixes #772

- The Qualification CLI runs AutoTuner by default
- No changes in the arguments passed to CLI
- A new config is added to `qualification-conf.yaml` to turnOff the AutoTuner if necessary
- The Autotuner generates a sub directory `./tuning` with two files per each app
  - `./tuning/appid.log` contains the GPU recommendations and comments
  - `./tuning/appid.conf` contains the combined Spark properties of the source application and the recommended props generated by the AutoTuner
  - `appid.conf` redacts the values of some Spark properties to prevent sensitive information from leaking.
- Added a redact function to cleanup sensitive Spark properties in `AppBase.scala`


**Sample of the `appid.conf`**

```
--conf spark.app.name=mysubmission.py
--conf spark.cores.max=160
--conf spark.driver.maxResultSize=2G
--conf spark.driver.memory=32G
--conf spark.driver.port=35601
--conf spark.eventLog.enabled=true
--conf spark.executor.cores=16
--conf spark.executor.id=driver
--conf spark.executor.instances=8
--conf spark.executor.memory=32768m
--conf spark.executorEnv.OPENBLAS_NUM_THREADS=1
--conf spark.extraListeners=com.google.cloud.spark.performance.DataprocMetricsListener
--conf spark.hadoop.fs.s3a.access.key=*********(redacted)
--conf spark.hadoop.fs.s3a.connection.maximum=160
--conf spark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem
--conf spark.hadoop.fs.s3a.path.style.access=true
--conf spark.hadoop.fs.s3a.secret.key=*********(redacted)
--conf spark.hadoop.fs.s3a.threads.core=160
--conf spark.locality.wait=0s
--conf spark.network.timeout=1800s
--conf spark.rapids.memory.pinnedPool.size=4096m
--conf spark.rapids.shuffle.multiThreaded.reader.threads=16
--conf spark.rapids.shuffle.multiThreaded.writer.threads=16
--conf spark.rapids.sql.batchSizeBytes=2147483647
--conf spark.rapids.sql.concurrentGpuTasks=2
--conf spark.rapids.sql.multiThreadedRead.numThreads=20
--conf spark.rdd.compress=True
--conf spark.scheduler.mode=FIFO
--conf spark.serializer.objectStreamReset=100
--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark301-SNAPSHOT.RapidsShuffleManager
--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
--conf spark.sql.adaptive.coalescePartitions.minPartitionNum=128
--conf spark.sql.autoBroadcastJoinThreshold=1GB
--conf spark.sql.cbo.enabled=true
--conf spark.sql.files.maxPartitionBytes=1024m
--conf spark.sql.shuffle.partitions=600
--conf spark.submit.deployMode=client
--conf spark.submit.pyFiles=
--conf spark.task.cpus=1
--conf spark.task.resource.gpu.amount=0.0625
--conf spark.ui.port=0
--conf spark.yarn.am.memory=640m
```

**Sample of the `appid.log`**

```
### Recommended Configuration for App: appid ###

Spark Properties:
--conf spark.executor.cores=16
--conf spark.executor.instances=8
--conf spark.executor.memory=32768m
--conf spark.rapids.memory.pinnedPool.size=4096m
--conf spark.rapids.shuffle.multiThreaded.reader.threads=16
--conf spark.rapids.shuffle.multiThreaded.writer.threads=16
--conf spark.rapids.sql.batchSizeBytes=2147483647
--conf spark.rapids.sql.concurrentGpuTasks=2
--conf spark.rapids.sql.multiThreadedRead.numThreads=20
--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark301-SNAPSHOT.RapidsShuffleManager
--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
--conf spark.sql.adaptive.coalescePartitions.minPartitionNum=128
--conf spark.sql.files.maxPartitionBytes=1024m
--conf spark.sql.shuffle.partitions=600
--conf spark.task.resource.gpu.amount=0.0625

Comments:
- 'spark.rapids.memory.pinnedPool.size' was not set.
- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
- 'spark.rapids.sql.batchSizeBytes' was not set.
- 'spark.rapids.sql.concurrentGpuTasks' was not set.
- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
- 'spark.shuffle.manager' was not set.
- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
- 'spark.sql.adaptive.coalescePartitions.minPartitionNum' was not set.
- 'spark.sql.adaptive.enabled' should be enabled for better performance.
- 'spark.task.resource.gpu.amount' was not set.
- RAPIDS Accelerator for Apache Spark jar is missing in "spark.plugins". Please refer to https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html
- RAPIDS Accelerator for Apache Spark plugin jar is missing
  from the classpath entries.
  If the Spark RAPIDS jar is being bundled with your
  Spark distribution, this step is not needed.
- The RAPIDS Shuffle Manager requires spark.driver.extraClassPath
  and spark.executor.extraClassPath settings to include the
  path to the Spark RAPIDS plugin jar.
  If the Spark RAPIDS jar is being bundled with your Spark
  distribution, this step is not needed.

```
