### PR TITLE
Qualification tool should mark SubqueryExec as IgnoreNoPerf

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -496,6 +496,8 @@ object SQLPlanParser extends Logging {
             SortMergeJoinExecParser(node, checker, sqlID).parse
           case "SubqueryBroadcast" =>
             SubqueryBroadcastExecParser(node, checker, sqlID, app).parse
+          case sqe if SubqueryExecParser.accepts(sqe) =>
+            SubqueryExecParser.parseNode(node, checker, sqlID, app)
           case "TakeOrderedAndProject" =>
             TakeOrderedAndProjectExecParser(node, checker, sqlID).parse
           case "Union" =>

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SubqueryExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SubqueryExecParser.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.planparser
+
+import com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker
+
+import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
+import org.apache.spark.sql.rapids.tool.AppBase
+
+// SubQuery is simply a "collect" execution.
+// It points to the actual execution. RAPIDS plugin usually skips that exec. Here we
+// can represent it to be ignored with shouldRemove set to true.
+// The reason we are implementing this as class is for future extensibility and to read the metrics.
+case class SubqueryExecParser(
+    node: SparkPlanGraphNode,
+    checker: PluginTypeChecker,
+    sqlID: Long,
+    app: AppBase) extends ExecParser {
+  val fullExecName = node.name + "Exec"
+
+  override def parse: ExecInfo = {
+    // Note: the name of the metric may not be trailed by "(ms)" So, we only check for the prefix
+    val collectTimeId = node.metrics.find(_.name.contains("time to collect")).map(_.accumulatorId)
+    // TODO: Should we also collect the "data size" metric?
+    val duration = SQLPlanParser.getDriverTotalDuration(collectTimeId, app)
+    // should remove is kept in 1 place. So no need to set it here.
+    ExecInfo(node, sqlID, node.name, "", 1.0, duration, node.id, isSupported = false, None)
+  }
+}
+
+object SubqueryExecParser {
+  val execName = "Subquery"
+
+  def accepts(nodeName: String): Boolean = {
+    nodeName.equals(execName)
+  }
+
+  def parseNode(node: SparkPlanGraphNode,
+      checker: PluginTypeChecker,
+      sqlID: Long,
+      app: AppBase): ExecInfo = {
+    SubqueryExecParser(node, checker, sqlID, app).parse
+  }
+}

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -25,7 +25,7 @@ import scala.util.control.NonFatal
 import com.nvidia.spark.rapids.BaseTestSuite
 import com.nvidia.spark.rapids.tool.{EventLogPathProcessor, ToolTestUtils}
 import com.nvidia.spark.rapids.tool.qualification._
-import org.scalatest.Matchers.convertToAnyShouldWrapper
+import org.scalatest.Matchers.{be, convertToAnyShouldWrapper}
 import org.scalatest.exceptions.TestFailedException
 
 import org.apache.spark.sql.TrampolineUtil
@@ -325,6 +325,37 @@ class SQLPlanParserSuite extends BaseTestSuite {
     assertSizeAndSupported(1, csv.toSeq)
     for (t <- Seq(orc, parquet)) {
       assertSizeAndSupported(2, t.toSeq)
+    }
+  }
+
+  test("Subquery exec should be ignored without impact on performance") {
+    TrampolineUtil.withTempDir { outputLoc =>
+      TrampolineUtil.withTempDir { eventLogDir =>
+        val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir, "subqueryTest") { spark =>
+          import spark.implicits._
+          val df = spark.sparkContext.makeRDD(1 to 10000, 6).toDF
+          df.createOrReplaceTempView("t1")
+          val df2WithSubquery =
+            spark.sql("select * from t1 where value < (select avg(value) from t1)")
+          df2WithSubquery
+        }
+        val pluginTypeChecker = new PluginTypeChecker()
+        val app = createAppFromEventlog(eventLog)
+        app.sqlPlans.size shouldBe 2
+        val parsedPlans = app.sqlPlans.map { case (sqlID, plan) =>
+          SQLPlanParser.parseSQLPlan(app.appId, plan, sqlID, "", pluginTypeChecker, app)
+        }
+        val allExecInfo = getAllExecsFromPlan(parsedPlans.toSeq)
+        val subqueryExecs = allExecInfo.filter(_.exec.contains(s"Subquery"))
+        val summaryRecs = subqueryExecs.flatten { sqExec =>
+          sqExec.isSupported  shouldNot be(true)
+          sqExec.getUnsupportedExecSummaryRecord(0)
+        }
+        summaryRecs.size shouldBe 1
+        val summaryRec = summaryRecs.head
+        summaryRec.opType shouldBe OpTypes.Exec
+        summaryRec.opAction shouldBe OpActions.IgnoreNoPerf
+      }
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #749

This fixes how the `SubQuery` node is handled by the Qualification tool. Instead of marking it as unsupported, the tool marks it as `ignoreNoPerf`

