### PR TITLE
Estimate cluster instances and generate cost savings 

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
@@ -55,13 +55,6 @@ class DBAWSPlatform(EMRPlatform):
     def _construct_cluster_from_props(self, cluster: str, props: str = None, is_inferred: bool = False):
         return DatabricksCluster(self, is_inferred=is_inferred).set_connection(cluster_id=cluster, props=props)
 
-    def _construct_cluster_config(self, cluster_info: dict, default_config: dict):
-        cluster_conf = default_config
-        cluster_conf['driver_node_type_id'] = cluster_info['driverInstance']
-        cluster_conf['node_type_id'] = cluster_info['executorInstance']
-        cluster_conf['num_workers'] = cluster_info['numExecutorNodes']
-        return cluster_conf
-
     def set_offline_cluster(self, cluster_args: dict = None):
         pass
 

--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
@@ -57,9 +57,9 @@ class DBAWSPlatform(EMRPlatform):
 
     def _construct_cluster_config(self, cluster_info: dict, default_config: dict):
         cluster_conf = default_config
-        cluster_conf['driver_node_type_id'] = cluster_info['driver_instance']
-        cluster_conf['node_type_id'] = cluster_info['executor_instance']
-        cluster_conf['num_workers'] = cluster_info['num_executor_nodes']
+        cluster_conf['driver_node_type_id'] = cluster_info['driverInstance']
+        cluster_conf['node_type_id'] = cluster_info['executorInstance']
+        cluster_conf['num_workers'] = cluster_info['numExecutorNodes']
         return cluster_conf
 
     def set_offline_cluster(self, cluster_args: dict = None):

--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
@@ -105,9 +105,13 @@ class DBAzurePlatform(PlatformBase):
         return gpu_scopes
 
     def generate_cluster_configuration(self, render_args: dict) -> str | None:
-        executor_names = ','.join([f'{{"node_id": "12345678900{i}"}}' for i in range(render_args['NUM_EXECUTOR_NODES'])])
+        executor_names = ','.join([
+            f'{{"node_id": "12345678900{i}"}}'
+            for i in range(render_args['NUM_EXECUTOR_NODES'])
+        ])
         render_args['EXECUTOR_NAMES'] = f'[{executor_names}]'
         return super().generate_cluster_configuration(render_args)
+
 
 @dataclass
 class DBAzureCMDDriver(CMDDriverBase):

--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
@@ -57,10 +57,10 @@ class DBAzurePlatform(PlatformBase):
 
     def _construct_cluster_config(self, cluster_info: dict, default_config: dict):
         cluster_conf = default_config
-        cluster_conf['executors'] = [{'node_id': '1234567890'} for _ in range(cluster_info['num_executor_nodes'])]
-        cluster_conf['driver_node_type_id'] = cluster_info['driver_instance']
-        cluster_conf['node_type_id'] = cluster_info['executor_instance']
-        cluster_conf['num_workers'] = cluster_info['num_executor_nodes']
+        cluster_conf['executors'] = [{'node_id': '1234567890'} for _ in range(cluster_info['numExecutorNodes'])]
+        cluster_conf['driver_node_type_id'] = cluster_info['driverInstance']
+        cluster_conf['node_type_id'] = cluster_info['executorInstance']
+        cluster_conf['num_workers'] = cluster_info['numExecutorNodes']
         return cluster_conf
 
     def set_offline_cluster(self, cluster_args: dict = None):

--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
@@ -104,7 +104,7 @@ class DBAzurePlatform(PlatformBase):
             gpu_scopes[mc_prof] = NodeHWInfo(sys_info=hw_info_ob, gpu_info=gpu_info_obj)
         return gpu_scopes
 
-    def generate_cluster_configuration(self, render_args: dict) -> str | None:
+    def generate_cluster_configuration(self, render_args: dict):
         executor_names = ','.join([
             f'{{"node_id": "12345678900{i}"}}'
             for i in range(render_args['NUM_EXECUTOR_NODES'])

--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
@@ -55,14 +55,6 @@ class DBAzurePlatform(PlatformBase):
     def _construct_cluster_from_props(self, cluster: str, props: str = None, is_inferred: bool = False):
         return DatabricksAzureCluster(self, is_inferred=is_inferred).set_connection(cluster_id=cluster, props=props)
 
-    def _construct_cluster_config(self, cluster_info: dict, default_config: dict):
-        cluster_conf = default_config
-        cluster_conf['executors'] = [{'node_id': '1234567890'} for _ in range(cluster_info['numExecutorNodes'])]
-        cluster_conf['driver_node_type_id'] = cluster_info['driverInstance']
-        cluster_conf['node_type_id'] = cluster_info['executorInstance']
-        cluster_conf['num_workers'] = cluster_info['numExecutorNodes']
-        return cluster_conf
-
     def set_offline_cluster(self, cluster_args: dict = None):
         pass
 
@@ -112,6 +104,10 @@ class DBAzurePlatform(PlatformBase):
             gpu_scopes[mc_prof] = NodeHWInfo(sys_info=hw_info_ob, gpu_info=gpu_info_obj)
         return gpu_scopes
 
+    def generate_cluster_configuration(self, render_args: dict) -> str | None:
+        executor_names = ','.join([f'{{"node_id": "12345678900{i}"}}' for i in range(render_args['NUM_EXECUTOR_NODES'])])
+        render_args['EXECUTOR_NAMES'] = f'[{executor_names}]'
+        return super().generate_cluster_configuration(render_args)
 
 @dataclass
 class DBAzureCMDDriver(CMDDriverBase):

--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ class DBAzurePlatform(PlatformBase):
     """
     def __post_init__(self):
         self.type_id = CspEnv.DATABRICKS_AZURE
+        self.cluster_inference_supported = True
         super().__post_init__()
 
     def _construct_cli_object(self) -> CMDDriverBase:
@@ -51,8 +52,16 @@ class DBAzurePlatform(PlatformBase):
     def _install_storage_driver(self):
         self.storage = AzureStorageDriver(self.cli)
 
-    def _construct_cluster_from_props(self, cluster: str, props: str = None):
-        return DatabricksAzureCluster(self).set_connection(cluster_id=cluster, props=props)
+    def _construct_cluster_from_props(self, cluster: str, props: str = None, is_inferred: bool = False):
+        return DatabricksAzureCluster(self, is_inferred=is_inferred).set_connection(cluster_id=cluster, props=props)
+
+    def _construct_cluster_config(self, cluster_info: dict, default_config: dict):
+        cluster_conf = default_config
+        cluster_conf['executors'] = [{'node_id': '1234567890'} for _ in range(cluster_info['num_executor_nodes'])]
+        cluster_conf['driver_node_type_id'] = cluster_info['driver_instance']
+        cluster_conf['node_type_id'] = cluster_info['executor_instance']
+        cluster_conf['num_workers'] = cluster_info['num_executor_nodes']
+        return cluster_conf
 
     def set_offline_cluster(self, cluster_args: dict = None):
         pass

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -154,7 +154,7 @@ class DataprocPlatform(PlatformBase):
                 gpu_scopes[prof_name] = NodeHWInfo(sys_info=sys_info_obj, gpu_info=gpu_info_obj)
         return gpu_scopes
 
-    def generate_cluster_configuration(self, render_args: dict) -> str | None:
+    def generate_cluster_configuration(self, render_args: dict):
         executor_names = ','.join([f'"test-node-e{i}"' for i in range(render_args['NUM_EXECUTOR_NODES'])])
         render_args['EXECUTOR_NAMES'] = f'[{executor_names}]'
         return super().generate_cluster_configuration(render_args)

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -85,20 +85,6 @@ class DataprocPlatform(PlatformBase):
     def _construct_cluster_from_props(self, cluster: str, props: str = None, is_inferred: bool = False):
         return DataprocCluster(self, is_inferred=is_inferred).set_connection(cluster_id=cluster, props=props)
 
-    def _construct_cluster_config(self, cluster_info: dict, default_config: dict):
-        cluster_conf = default_config
-        cluster_conf['config']['masterConfig'] = {
-          'instanceNames': 'test-node-d',
-          'machineTypeUri': cluster_info['driverInstance'],
-          'numInstances': 1  # single driver node
-        }
-        cluster_conf['config']['workerConfig'] = {
-          'instanceNames': [f'test-node-e{i}' for i in range(cluster_info['numExecutorNodes'])],
-          'machineTypeUri': cluster_info['executorInstance'],
-          'numInstances': cluster_info['numExecutorNodes']
-        }
-        return cluster_conf
-
     def set_offline_cluster(self, cluster_args: dict = None):
         pass
 
@@ -167,6 +153,11 @@ class DataprocPlatform(PlatformBase):
                 gpu_info_obj = GpuHWInfo(num_gpus=gpu_cnt, gpu_mem=gpu_mem, gpu_device=gpu_device)
                 gpu_scopes[prof_name] = NodeHWInfo(sys_info=sys_info_obj, gpu_info=gpu_info_obj)
         return gpu_scopes
+
+    def generate_cluster_configuration(self, render_args: dict) -> str | None:
+        executor_names = ','.join([f'"test-node-e{i}"' for i in range(render_args['NUM_EXECUTOR_NODES'])])
+        render_args['EXECUTOR_NAMES'] = f'[{executor_names}]'
+        return super().generate_cluster_configuration(render_args)
 
 
 @dataclass

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -89,13 +89,13 @@ class DataprocPlatform(PlatformBase):
         cluster_conf = default_config
         cluster_conf['config']['masterConfig'] = {
           'instanceNames': 'test-node-d',
-          'machineTypeUri': cluster_info['driver_instance'],
+          'machineTypeUri': cluster_info['driverInstance'],
           'numInstances': 1  # single driver node
         }
         cluster_conf['config']['workerConfig'] = {
-          'instanceNames': [f'test-node-e{i}' for i in range(cluster_info['num_executor_nodes'])],
-          'machineTypeUri': cluster_info['executor_instance'],
-          'numInstances': cluster_info['num_executor_nodes']
+          'instanceNames': [f'test-node-e{i}' for i in range(cluster_info['numExecutorNodes'])],
+          'machineTypeUri': cluster_info['executorInstance'],
+          'numInstances': cluster_info['numExecutorNodes']
         }
         return cluster_conf
 

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -154,6 +154,14 @@ class DataprocPlatform(PlatformBase):
                 gpu_scopes[prof_name] = NodeHWInfo(sys_info=sys_info_obj, gpu_info=gpu_info_obj)
         return gpu_scopes
 
+    def get_matching_executor_instance(self, cores_per_executor):
+        executors_from_config = self.configs.get_value('clusterInference', 'defaultCpuInstances', 'executor')
+        # TODO: Currently only single series is supported. Change this to a loop when using multiple series.
+        series_name, unit_info = list(executors_from_config.items())[0]
+        if cores_per_executor in unit_info['vCPUs']:
+            return f'{series_name}-{cores_per_executor}'
+        return None
+
     def generate_cluster_configuration(self, render_args: dict):
         executor_names = ','.join([f'"test-node-e{i}"' for i in range(render_args['NUM_EXECUTOR_NODES'])])
         render_args['EXECUTOR_NAMES'] = f'[{executor_names}]'

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc_gke.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc_gke.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ class DataprocGkePlatform(DataprocPlatform):
     def __post_init__(self):
         super().__post_init__()
         self.type_id = CspEnv.DATAPROC_GKE
+        self.cluster_inference_supported = False
 
     @classmethod
     def get_spark_node_type_fromstring(cls, value: str):
@@ -54,8 +55,8 @@ class DataprocGkePlatform(DataprocPlatform):
     def _construct_cli_object(self) -> CMDDriverBase:
         return DataprocGkeCMDDriver(timeout=0, cloud_ctxt=self.ctxt)
 
-    def _construct_cluster_from_props(self, cluster: str, props: str = None):
-        return DataprocGkeCluster(self).set_connection(cluster_id=cluster, props=props)
+    def _construct_cluster_from_props(self, cluster: str, props: str = None, is_inferred: bool = False):
+        return DataprocGkeCluster(self, is_inferred=is_inferred).set_connection(cluster_id=cluster, props=props)
 
     def migrate_cluster_to_gpu(self, orig_cluster):
         """

--- a/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
@@ -77,10 +77,10 @@ class EMRPlatform(PlatformBase):
         cluster_conf = default_config
         for group in cluster_conf['Cluster']['InstanceGroups']:
             if group.get('Name') == 'CORE':
-                group['InstanceType'] = cluster_info['executor_instance']
-                group['RequestedInstanceCount'] = cluster_info['num_executor_nodes']
+                group['InstanceType'] = cluster_info['executorInstance']
+                group['RequestedInstanceCount'] = cluster_info['numExecutorNodes']
             elif group.get('Name') == 'MASTER':
-                group['InstanceType'] = cluster_info['driver_instance']
+                group['InstanceType'] = cluster_info['driverInstance']
                 group['RequestedInstanceCount'] = 1  # single driver node
         return cluster_conf
 

--- a/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ class OnPremPlatform(PlatformBase):
     def __post_init__(self):
         self.type_id = CspEnv.ONPREM
         self.platform = self.ctxt_args.get('targetPlatform')
+        self.cluster_inference_supported = False
         super().__post_init__()
 
     def _construct_cli_object(self):
@@ -49,11 +50,15 @@ class OnPremPlatform(PlatformBase):
     def create_local_submission_job(self, job_prop, ctxt) -> Any:
         return OnPremLocalRapidsJob(prop_container=job_prop, exec_ctxt=ctxt)
 
-    def _construct_cluster_from_props(self, cluster: str, props: str = None):
+    def _construct_cluster_from_props(self, cluster: str, props: str = None, is_inferred: bool = False):
         if self.platform is not None:
-            onprem_cluster = OnPremCluster(self).set_connection(cluster_id=cluster, props=props)
+            onprem_cluster = OnPremCluster(self, is_inferred=is_inferred).set_connection(
+                cluster_id=cluster, props=props)
             return onprem_cluster
         return None
+
+    def _construct_cluster_config(self, cluster_info: dict, default_config: dict):
+        raise NotImplementedError
 
     def migrate_cluster_to_gpu(self, orig_cluster):
         """

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -600,6 +600,7 @@ class PlatformBase:
     ctxt: dict = field(default_factory=dict, init=False)
     configs: JSONPropertiesContainer = field(default=None, init=False)
     logger: Logger = field(default=ToolLogging.get_and_setup_logger('rapids.tools.csp'), init=False)
+    cluster_inference_supported: bool = field(default=False, init=False)
 
     @classmethod
     def list_supported_gpus(cls):
@@ -780,17 +781,37 @@ class PlatformBase:
 
     def _construct_cluster_from_props(self,
                                       cluster: str,
-                                      props: str = None):
+                                      props: str = None,
+                                      is_inferred: bool = False):
         raise NotImplementedError
+
+    def _construct_cluster_config(self, cluster_info: dict, default_config: dict):
+        """
+        This method should be implemented by subclasses to define the logic for constructing
+        the cluster configuration based on the provided `cluster_info` and `default_config`.
+
+        :param cluster_info: Dictionary storing cluster information such as driver instance
+        :param default_config: Default cluster config obtained using `describe` cmd.
+        :return: Constructed cluster configuration
+        """
+        raise NotImplementedError
+
+    def construct_cluster_config(self, cluster_info: dict):
+        default_cluster = self.configs.get_value('clusterInference', 'defaultClusterConfig')
+        return self._construct_cluster_config(cluster_info, default_cluster)
 
     def set_offline_cluster(self, cluster_args: dict = None):
         raise NotImplementedError
 
+    def load_cluster_by_prop(self, cluster_prop: JSONPropertiesContainer, is_inferred=False):
+        cluster = cluster_prop.get_value_silent('cluster_id')
+        return self._construct_cluster_from_props(cluster=cluster,
+                                                  props=json.dumps(cluster_prop.props),
+                                                  is_inferred=is_inferred)
+
     def load_cluster_by_prop_file(self, cluster_prop_path: str):
         prop_container = JSONPropertiesContainer(prop_arg=cluster_prop_path)
-        cluster = prop_container.get_value_silent('cluster_id')
-        return self._construct_cluster_from_props(cluster=cluster,
-                                                  props=json.dumps(prop_container.props))
+        return self.load_cluster_by_prop(prop_container)
 
     def connect_cluster_by_name(self, cluster: str):
         """
@@ -867,6 +888,7 @@ class ClusterBase(ClusterGetAccessor):
     nodes: dict = field(default_factory=dict, init=False)
     props: AbstractPropertiesContainer = field(default=None, init=False)
     logger: Logger = field(default=ToolLogging.get_and_setup_logger('rapids.tools.cluster'), init=False)
+    is_inferred: bool = field(default=False, init=True)
 
     @staticmethod
     def _verify_workers_exist(has_no_workers_cb: Callable[[], bool]):

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -856,6 +856,11 @@ class PlatformBase:
     def get_footer_message(self) -> str:
         return 'To support acceleration with T4 GPUs, switch the worker node instance types'
 
+    def get_matching_executor_instance(self, cores_per_executor):
+        default_instances = self.configs.get_value('clusterInference', 'defaultCpuInstances', 'executor')
+        return next((instance['name'] for instance in default_instances if instance['vCPUs'] == cores_per_executor),
+                    None)
+
     def generate_cluster_configuration(self, render_args: dict):
         if not self.cluster_inference_supported:
             return None

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -1133,6 +1133,7 @@ class ClusterBase(ClusterGetAccessor):
         template_path = Utils.resource_path(f'templates/cluster_template/{platform_name}_node.ms')
         return TemplateGenerator.render_template_file(template_path, render_args)
 
+
 @dataclass
 class ClusterReshape(ClusterGetAccessor):
     """

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -47,7 +47,7 @@ class ClusterInference:
         # If executor instance is not set, use the default value based on the number of cores
         executor_instance = cluster_info_json.get_value_silent('executorInstance')
         if executor_instance is None:
-            executor_instance = self.platform.Sget_matching_executor_instance(cores_per_executor)
+            executor_instance = self.platform.get_matching_executor_instance(cores_per_executor)
             if executor_instance is None:
                 self.logger.info('Unable to infer CPU cluster. No matching executor instance found for vCPUs = %s',
                                  cores_per_executor)

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module provides functionality for cluster inference"""
+
+from dataclasses import dataclass, field
+
+from typing import Optional
+from logging import Logger
+
+from spark_rapids_pytools.cloud_api.sp_types import PlatformBase, ClusterBase
+from spark_rapids_pytools.common.prop_manager import JSONPropertiesContainer
+from spark_rapids_pytools.common.utilities import ToolLogging
+
+
+@dataclass
+class ClusterInference:
+    """
+    Class for inferring cluster information and constructing CPU clusters.
+
+    :param platform: The platform on which the cluster inference is performed.
+    """
+    platform: PlatformBase = field(default=None, init=True)
+    logger: Logger = field(default=ToolLogging.get_and_setup_logger('rapids.tools.cluster_inference'), init=False)
+
+    def get_cluster_info(self, cluster_info_json: JSONPropertiesContainer) -> dict:
+        """
+        Extract information about drivers and executors from input json
+        """
+        num_executor_nodes = cluster_info_json.get_value_silent('numExecutorNodes')
+        cores_per_executor = cluster_info_json.get_value_silent('coresPerExecutor')
+        driver_instance = cluster_info_json.get_value_silent('driverInstance')
+        executor_instance = cluster_info_json.get_value_silent('executorInstance')
+        # If driver instance is not set, use the default value from platform configurations
+        if driver_instance is None:
+            driver_instance = self.platform.configs.get_value('clusterInference', 'defaultCpuInstances', 'driver')
+        # If executor instance is not set, use the default value based on the number of cores
+        if executor_instance is None:
+            default_instances = self.platform.configs.get_value('clusterInference', 'defaultCpuInstances', 'executor')
+            matching_instance = next(
+                (instance['name'] for instance in default_instances if instance['vCPUs'] == cores_per_executor),
+                None
+            )
+            if matching_instance is None:
+                self.logger.info(
+                    f'Unable to infer CPU cluster. No matching executor instance found for vCPUs = {cores_per_executor}')
+                return None
+            executor_instance = matching_instance
+        return {
+            'driver_instance': driver_instance,
+            'num_executor_nodes': num_executor_nodes,
+            'executor_instance': executor_instance
+        }
+
+    def infer_cpu_cluster(self, cluster_info_json: JSONPropertiesContainer) -> Optional[ClusterBase]:
+        """
+        Infer CPU cluster configuration based on json input and return the constructed cluster object.
+        """
+        # Extract cluster information from parsed logs
+        cluster_info = self.get_cluster_info(cluster_info_json)
+        if cluster_info is None:
+            return None
+        # Construct cluster configuration using platform-specific logic
+        cluster_conf = self.platform.construct_cluster_config(cluster_info)
+        cluster_props = JSONPropertiesContainer(cluster_conf, file_load=False)
+        return self.platform.load_cluster_by_prop(cluster_props, is_inferred=True)

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -58,9 +58,9 @@ class ClusterInference:
                 return None
             executor_instance = matching_instance
         return {
-            'driver_instance': driver_instance,
-            'num_executor_nodes': num_executor_nodes,
-            'executor_instance': executor_instance
+            'driverInstance': driver_instance,
+            'numExecutorNodes': num_executor_nodes,
+            'executorInstance': executor_instance
         }
 
     def infer_cpu_cluster(self, cluster_info_json: JSONPropertiesContainer) -> Optional[ClusterBase]:

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -38,15 +38,17 @@ class ClusterInference:
         """
         Extract information about drivers and executors from input json
         """
-        num_executor_nodes = cluster_info_json.get_value_silent('numExecutorNodes')
-        cores_per_executor = cluster_info_json.get_value_silent('coresPerExecutor')
+        # Currently we support only single driver node for all CSPs
+        num_driver_nodes = 1
         driver_instance = cluster_info_json.get_value_silent('driverInstance')
         # If driver instance is not set, use the default value from platform configurations
         if driver_instance is None:
             driver_instance = self.platform.configs.get_value('clusterInference', 'defaultCpuInstances', 'driver')
-        # If executor instance is not set, use the default value based on the number of cores
+        num_executor_nodes = cluster_info_json.get_value_silent('numExecutorNodes')
         executor_instance = cluster_info_json.get_value_silent('executorInstance')
         if executor_instance is None:
+            # If executor instance is not set, use the default value based on the number of cores
+            cores_per_executor = cluster_info_json.get_value_silent('coresPerExecutor')
             executor_instance = self.platform.get_matching_executor_instance(cores_per_executor)
             if executor_instance is None:
                 self.logger.info('Unable to infer CPU cluster. No matching executor instance found for vCPUs = %s',
@@ -54,6 +56,7 @@ class ClusterInference:
                 return None
         return {
             'DRIVER_INSTANCE': f'"{driver_instance}"',
+            'NUM_DRIVER_NODES': num_driver_nodes,
             'EXECUTOR_INSTANCE': f'"{executor_instance}"',
             'NUM_EXECUTOR_NODES': num_executor_nodes
         }

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -53,8 +53,8 @@ class ClusterInference:
                 None
             )
             if matching_instance is None:
-                self.logger.info(
-                    f'Unable to infer CPU cluster. No matching executor instance found for vCPUs = {cores_per_executor}')
+                self.logger.info('Unable to infer CPU cluster. No matching executor instance found for vCPUs = %s',
+                                 cores_per_executor)
                 return None
             executor_instance = matching_instance
         return {

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -41,22 +41,17 @@ class ClusterInference:
         num_executor_nodes = cluster_info_json.get_value_silent('numExecutorNodes')
         cores_per_executor = cluster_info_json.get_value_silent('coresPerExecutor')
         driver_instance = cluster_info_json.get_value_silent('driverInstance')
-        executor_instance = cluster_info_json.get_value_silent('executorInstance')
         # If driver instance is not set, use the default value from platform configurations
         if driver_instance is None:
             driver_instance = self.platform.configs.get_value('clusterInference', 'defaultCpuInstances', 'driver')
         # If executor instance is not set, use the default value based on the number of cores
+        executor_instance = cluster_info_json.get_value_silent('executorInstance')
         if executor_instance is None:
-            default_instances = self.platform.configs.get_value('clusterInference', 'defaultCpuInstances', 'executor')
-            matching_instance = next(
-                (instance['name'] for instance in default_instances if instance['vCPUs'] == cores_per_executor),
-                None
-            )
-            if matching_instance is None:
+            executor_instance = self.platform.Sget_matching_executor_instance(cores_per_executor)
+            if executor_instance is None:
                 self.logger.info('Unable to infer CPU cluster. No matching executor instance found for vCPUs = %s',
                                  cores_per_executor)
                 return None
-            executor_instance = matching_instance
         return {
             'DRIVER_INSTANCE': f'"{driver_instance}"',
             'EXECUTOR_INSTANCE': f'"{executor_instance}"',

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -853,7 +853,7 @@ class Qualification(RapidsJarTool):
 
         # Read cluster information from cluster info file
         try:
-            with open(cluster_info_file, 'r') as cluster_info_fp:
+            with open(cluster_info_file, 'r', encoding='utf-8') as cluster_info_fp:
                 cluster_info_dict = json.load(cluster_info_fp)
         except (FileNotFoundError, json.JSONDecodeError):
             self.logger.error('Failed to read cluster information from file: %s', cluster_info_file)

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
@@ -292,6 +292,28 @@
       }
     }
   },
+  "clusterInference": {
+    "defaultClusterConfig": {
+      "cluster_id": "1234-5678-test",
+      "cluster_name": "default-cluster-prop",
+      "driver_node_type_id": "m6gd.xlarge",
+      "node_type_id": "m6gd.2xlarge",
+      "num_workers": 1,
+      "state": "TERMINATED"
+    },
+    "defaultCpuInstances": {
+      "driver": "m6gd.xlarge",
+      "executor": [
+        {"name": "m6gd.large", "vCPUs": 2},
+        {"name": "m6gd.xlarge", "vCPUs": 4},
+        {"name": "m6gd.2xlarge", "vCPUs": 8},
+        {"name": "m6gd.4xlarge", "vCPUs": 16},
+        {"name": "m6gd.8xlarge", "vCPUs": 32},
+        {"name": "m6gd.12xlarge", "vCPUs": 48},
+        {"name": "m6gd.16xlarge", "vCPUs": 64}
+      ]
+    }
+  },
   "clusterSpecs": {
     "minWorkerNodes": 2
   }

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
@@ -293,14 +293,6 @@
     }
   },
   "clusterInference": {
-    "defaultClusterConfig": {
-      "cluster_id": "1234-5678-test",
-      "cluster_name": "default-cluster-prop",
-      "driver_node_type_id": "m6gd.xlarge",
-      "node_type_id": "m6gd.2xlarge",
-      "num_workers": 1,
-      "state": "TERMINATED"
-    },
     "defaultCpuInstances": {
       "driver": "m6gd.xlarge",
       "executor": [

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_azure-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_azure-configs.json
@@ -336,22 +336,6 @@
     }
   },
   "clusterInference": {
-    "defaultClusterConfig": {
-      "cluster_id": "1234-5678-1234567",
-      "driver": {
-        "node_id": "1234567890"
-      },
-      "executors": [
-        {
-          "node_id": "1234567890"
-        }
-      ],
-      "cluster_name": "default-cluster-prop",
-      "driver_node_type_id": "Standard_E8ds_v4",
-      "node_type_id": "Standard_DS3_v2",
-      "state": "TERMINATED",
-      "num_workers": 1
-    },
     "defaultCpuInstances": {
       "driver": "Standard_E8ds_v4",
       "executor": [

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_azure-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_azure-configs.json
@@ -335,6 +335,35 @@
       }
     }
   },
+  "clusterInference": {
+    "defaultClusterConfig": {
+      "cluster_id": "1234-5678-1234567",
+      "driver": {
+        "node_id": "1234567890"
+      },
+      "executors": [
+        {
+          "node_id": "1234567890"
+        }
+      ],
+      "cluster_name": "default-cluster-prop",
+      "driver_node_type_id": "Standard_E8ds_v4",
+      "node_type_id": "Standard_DS3_v2",
+      "state": "TERMINATED",
+      "num_workers": 1
+    },
+    "defaultCpuInstances": {
+      "driver": "Standard_E8ds_v4",
+      "executor": [
+        {"name": "Standard_E2ds_v4", "vCPUs": 2},
+        {"name": "Standard_E4ds_v4", "vCPUs": 4},
+        {"name": "Standard_E8ds_v4", "vCPUs": 8},
+        {"name": "Standard_E16ds_v4", "vCPUs": 16},
+        {"name": "Standard_E32ds_v4", "vCPUs": 32},
+        {"name": "Standard_E64ds_v4", "vCPUs": 64}
+      ]
+    }
+  },
   "clusterSpecs": {
     "minWorkerNodes": 2
   }

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -258,6 +258,46 @@
       ]
     }
   },
+  "clusterInference": {
+    "defaultClusterConfig": {
+      "clusterName": "default-cluster-prop",
+      "clusterUuid": "1234-5678-1234567",
+      "config": {
+        "gceClusterConfig": {
+          "zoneUri": "us-central1-a"
+        },
+        "masterConfig": {
+          "instanceNames": [
+            "test-node"
+          ],
+          "machineTypeUri": "n1-standard-16",
+          "numInstances": 1
+        },
+        "workerConfig": {
+          "instanceNames": [
+            "test-node"
+          ],
+          "machineTypeUri": "n1-standard-32",
+          "numInstances": 1
+        }
+      },
+      "status": {
+        "state": "STOPPED"
+      }
+    },
+    "defaultCpuInstances": {
+      "driver": "n1-standard-16",
+      "executor": [
+        {"name": "n1-standard-1", "vCPUs": 1},
+        {"name": "n1-standard-2", "vCPUs": 2},
+        {"name": "n1-standard-4", "vCPUs": 4},
+        {"name": "n1-standard-8", "vCPUs": 8},
+        {"name": "n1-standard-16", "vCPUs": 16},
+        {"name": "n1-standard-32", "vCPUs": 32},
+        {"name": "n1-standard-64", "vCPUs": 64}
+      ]
+    }
+  },
   "clusterSpecs": {
     "minWorkerNodes": 2,
     "gpuScaleFactor": 0.80

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -261,15 +261,9 @@
   "clusterInference": {
     "defaultCpuInstances": {
       "driver": "n1-standard-16",
-      "executor": [
-        {"name": "n1-standard-1", "vCPUs": 1},
-        {"name": "n1-standard-2", "vCPUs": 2},
-        {"name": "n1-standard-4", "vCPUs": 4},
-        {"name": "n1-standard-8", "vCPUs": 8},
-        {"name": "n1-standard-16", "vCPUs": 16},
-        {"name": "n1-standard-32", "vCPUs": 32},
-        {"name": "n1-standard-64", "vCPUs": 64}
-      ]
+      "executor": {
+        "n1-standard": {"vCPUs": [1, 2, 4, 8, 16, 32, 64, 96]}
+      }
     }
   },
   "clusterSpecs": {

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -259,32 +259,6 @@
     }
   },
   "clusterInference": {
-    "defaultClusterConfig": {
-      "clusterName": "default-cluster-prop",
-      "clusterUuid": "1234-5678-1234567",
-      "config": {
-        "gceClusterConfig": {
-          "zoneUri": "us-central1-a"
-        },
-        "masterConfig": {
-          "instanceNames": [
-            "test-node"
-          ],
-          "machineTypeUri": "n1-standard-16",
-          "numInstances": 1
-        },
-        "workerConfig": {
-          "instanceNames": [
-            "test-node"
-          ],
-          "machineTypeUri": "n1-standard-32",
-          "numInstances": 1
-        }
-      },
-      "status": {
-        "state": "STOPPED"
-      }
-    },
     "defaultCpuInstances": {
       "driver": "n1-standard-16",
       "executor": [

--- a/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
@@ -289,47 +289,6 @@
     }
   },
   "clusterInference": {
-    "defaultClusterConfig": {
-      "Cluster": {
-        "Id": "j-123456789",
-        "Name": "default-cluster-prop",
-        "Status": {
-          "State": "TERMINATED"
-        },
-        "Ec2InstanceAttributes": {
-          "Ec2AvailabilityZone": "us-west-2a"
-        },
-        "InstanceGroups": [
-          {
-            "Id": "ig-123456789012e",
-            "Name": "CORE",
-            "Market": "ON_DEMAND",
-            "InstanceGroupType": "CORE",
-            "InstanceType": "m5d.8xlarge",
-            "RequestedInstanceCount": 1
-          },
-          {
-            "Id": "ig-123456789012d",
-            "Name": "MASTER",
-            "Market": "ON_DEMAND",
-            "InstanceGroupType": "MASTER",
-            "InstanceType": "i3.2xlarge",
-            "RequestedInstanceCount": 1
-          }
-        ]
-      }
-    },
-    "defaultNodeConfig": {
-      "Id": "ci-123456789",
-      "Ec2InstanceId": "i-123456789",
-      "PublicDnsName": "ec2-12-34-567-890.us-west-2.compute.amazonaws.com",
-      "Status": {
-          "State": "TERMINATED"
-      },
-      "InstanceGroupId": "ig-123456789012d",
-      "Market": "ON_DEMAND",
-      "InstanceType": "m5d.large"
-    },
     "defaultCpuInstances": {
       "driver": "i3.2xlarge",
       "executor": [

--- a/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
@@ -288,6 +288,61 @@
       ]
     }
   },
+  "clusterInference": {
+    "defaultClusterConfig": {
+      "Cluster": {
+        "Id": "j-123456789",
+        "Name": "default-cluster-prop",
+        "Status": {
+          "State": "TERMINATED"
+        },
+        "Ec2InstanceAttributes": {
+          "Ec2AvailabilityZone": "us-west-2a"
+        },
+        "InstanceGroups": [
+          {
+            "Id": "ig-123456789012e",
+            "Name": "CORE",
+            "Market": "ON_DEMAND",
+            "InstanceGroupType": "CORE",
+            "InstanceType": "m5d.8xlarge",
+            "RequestedInstanceCount": 1
+          },
+          {
+            "Id": "ig-123456789012d",
+            "Name": "MASTER",
+            "Market": "ON_DEMAND",
+            "InstanceGroupType": "MASTER",
+            "InstanceType": "i3.2xlarge",
+            "RequestedInstanceCount": 1
+          }
+        ]
+      }
+    },
+    "defaultNodeConfig": {
+      "Id": "ci-123456789",
+      "Ec2InstanceId": "i-123456789",
+      "PublicDnsName": "ec2-12-34-567-890.us-west-2.compute.amazonaws.com",
+      "Status": {
+          "State": "TERMINATED"
+      },
+      "InstanceGroupId": "ig-123456789012d",
+      "Market": "ON_DEMAND",
+      "InstanceType": "m5d.large"
+    },
+    "defaultCpuInstances": {
+      "driver": "i3.2xlarge",
+      "executor": [
+        {"name": "m5d.large", "vCPUs": 2},
+        {"name": "m5d.xlarge", "vCPUs": 4},
+        {"name": "m5d.2xlarge", "vCPUs": 8},
+        {"name": "m5d.4xlarge", "vCPUs": 16},
+        {"name": "m5d.8xlarge", "vCPUs": 32},
+        {"name": "m5d.12xlarge", "vCPUs": 48},
+        {"name": "m5d.16xlarge", "vCPUs": 64}
+      ]
+    }
+  },
   "clusterSpecs": {
     "minWorkerNodes": 2
   }

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -33,6 +33,9 @@ toolOutput:
          Estimated GPU Duration: 'App Name'
       dropDuplicates:
          - App Name
+  json:
+    clusterInformation:
+      fileName: rapids_4_spark_qualification_output_cluster_information.json
   stdout:
     summaryReport:
       compactWidth: true

--- a/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/databricks_aws.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/databricks_aws.ms
@@ -1,6 +1,6 @@
 {
   "cluster_id": "1234-5678-test",
-  "cluster_name": "default-cluster-prop",
+  "cluster_name": "default-cluster-name",
   "driver_node_type_id": {{{ DRIVER_INSTANCE }}},
   "node_type_id": {{{ EXECUTOR_INSTANCE }}},
   "num_workers": {{ NUM_EXECUTOR_NODES }},

--- a/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/databricks_aws.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/databricks_aws.ms
@@ -1,0 +1,8 @@
+{
+  "cluster_id": "1234-5678-test",
+  "cluster_name": "default-cluster-prop",
+  "driver_node_type_id": {{{ DRIVER_INSTANCE }}},
+  "node_type_id": {{{ EXECUTOR_INSTANCE }}},
+  "num_workers": {{ NUM_EXECUTOR_NODES }},
+  "state": "TERMINATED"
+}

--- a/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/databricks_azure.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/databricks_azure.ms
@@ -1,0 +1,12 @@
+{
+  "cluster_id": "1234-5678-1234567",
+  "driver": {
+    "node_id": "1234567890"
+  },
+  "executors": {{{ EXECUTOR_NAMES }}},
+  "cluster_name": "default-cluster-prop",
+  "driver_node_type_id": {{{ DRIVER_INSTANCE }}},
+  "node_type_id": {{{ EXECUTOR_INSTANCE }}},
+  "num_workers": {{ NUM_EXECUTOR_NODES }},
+  "state": "TERMINATED"
+}

--- a/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/databricks_azure.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/databricks_azure.ms
@@ -4,7 +4,7 @@
     "node_id": "1234567890"
   },
   "executors": {{{ EXECUTOR_NAMES }}},
-  "cluster_name": "default-cluster-prop",
+  "cluster_name": "default-cluster-name",
   "driver_node_type_id": {{{ DRIVER_INSTANCE }}},
   "node_type_id": {{{ EXECUTOR_INSTANCE }}},
   "num_workers": {{ NUM_EXECUTOR_NODES }},

--- a/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/dataproc.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/dataproc.ms
@@ -1,5 +1,5 @@
 {
-  "clusterName": "default-cluster-prop",
+  "clusterName": "default-cluster-name",
   "clusterUuid": "1234-5678-1234567",
   "config": {
     "gceClusterConfig": {
@@ -10,7 +10,7 @@
         "test-node-d"
       ],
       "machineTypeUri": {{{ DRIVER_INSTANCE }}},
-      "numInstances": 1
+      "numInstances": {{ NUM_DRIVER_NODES }}
     },
     "workerConfig": {
       "instanceNames": {{{ EXECUTOR_NAMES }}},

--- a/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/dataproc.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/dataproc.ms
@@ -1,0 +1,24 @@
+{
+  "clusterName": "default-cluster-prop",
+  "clusterUuid": "1234-5678-1234567",
+  "config": {
+    "gceClusterConfig": {
+      "zoneUri": "us-central1-a"
+    },
+    "masterConfig": {
+      "instanceNames": [
+        "test-node-d"
+      ],
+      "machineTypeUri": {{{ DRIVER_INSTANCE }}},
+      "numInstances": 1
+    },
+    "workerConfig": {
+      "instanceNames": {{{ EXECUTOR_NAMES }}},
+      "machineTypeUri": {{{ EXECUTOR_INSTANCE }}},
+      "numInstances": {{ NUM_EXECUTOR_NODES }}
+    }
+  },
+  "status": {
+    "state": "STOPPED"
+  }
+}

--- a/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/emr.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/emr.ms
@@ -1,7 +1,7 @@
 {
 	"Cluster": {
 	  "Id": "j-123456789",
-	  "Name": "default-cluster-prop",
+	  "Name": "default-cluster-name",
 	  "Status": {
 	    "State": "TERMINATED"
 	  },
@@ -23,7 +23,7 @@
 	      "Market": "ON_DEMAND",
 	      "InstanceGroupType": "MASTER",
 	      "InstanceType": {{{ DRIVER_INSTANCE }}},
-	      "RequestedInstanceCount": 1
+	      "RequestedInstanceCount": {{ NUM_DRIVER_NODES }}
 	    }
 	  ]
 	}

--- a/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/emr.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/emr.ms
@@ -1,0 +1,30 @@
+{
+	"Cluster": {
+	  "Id": "j-123456789",
+	  "Name": "default-cluster-prop",
+	  "Status": {
+	    "State": "TERMINATED"
+	  },
+	  "Ec2InstanceAttributes": {
+	    "Ec2AvailabilityZone": "us-west-2a"
+	  },
+	  "InstanceGroups": [
+	    {
+	      "Id": "ig-123456789012e",
+	      "Name": "CORE",
+	      "Market": "ON_DEMAND",
+	      "InstanceGroupType": "CORE",
+	      "InstanceType": {{{ EXECUTOR_INSTANCE }}},
+	      "RequestedInstanceCount": {{ NUM_EXECUTOR_NODES }}
+	    },
+	    {
+	      "Id": "ig-123456789012d",
+	      "Name": "MASTER",
+	      "Market": "ON_DEMAND",
+	      "InstanceGroupType": "MASTER",
+	      "InstanceType": {{{ DRIVER_INSTANCE }}},
+	      "RequestedInstanceCount": 1
+	    }
+	  ]
+	}
+}

--- a/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/emr_node.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/emr_node.ms
@@ -1,0 +1,11 @@
+{
+  "Id": "ci-123456789",
+  "Ec2InstanceId": "i-123456789",
+  "PublicDnsName": "ec2-12-34-567-890.us-west-2.compute.amazonaws.com",
+  "Status": {
+      "State": "TERMINATED"
+  },
+  "InstanceGroupId": {{{ INSTANCE_GROUP_ID }}},
+  "Market": "ON_DEMAND",
+  "InstanceType": {{{ INSTANCE_TYPE }}}
+}


### PR DESCRIPTION
This PR generates cost savings in user tools by estimating cluster shape (instances and count). It uses the cluster information json generated by the qualification core tool.


### Usage and Output for EMR Platform:

**CMD:**
```
spark_rapids_user_tools emr qualification -t $TOOLS_JAR --eventlogs $HOME/Work/event-logs/emr-cpu
```

1. Cluster Information Json (from Core Tools):
```
[ {
  "appName" : "NDS - Power Run",
  "appId" : "application_1692643187882_0001",
  "eventLogPath" : "emr-cpu/application_1692643187882_0001",
  "clusterInfo" : {
    "coresPerExecutor" : 16,
    "numExecutorNodes" : 8
  }
} ]
```

2. Inferred Cluster (from User Tools):
```
INFO rapids.tools.qualification: Inferred Cluster => Driver: i3.2xlarge, Executor: 8 X m5d.4xlarge
```

3. Cost Savings:
```
Report Summary:
------------------------------  ------
Total applications                   1
RAPIDS candidates                    1
Overall estimated speedup         1.98
Overall estimated cost savings  35.46%
------------------------------  ------

Instance types conversions:
-----------  --  ------------
m5d.4xlarge  to  g4dn.4xlarge
-----------  --  ------------
```

Output for other platforms can be found here - [Link](https://docs.google.com/document/d/1-QhtviFUvzdJQFzLUynt70gU4bf5x83_YkFuQ8HUQWw/edit?usp=sharing)


### Estimation of Cluster Shape:
1. For EMR, Dataproc - Stores a map of `cores -> instance type`. Using the `coresPerExecutor` value from core tools, we get the instance type.
2. For Databricks - Instance types are already defined in the json output. Use them directly.
3. For each platform,:
     - store a default JSON which is same as the output while describing a cluster (eg for emr: `aws describe-cluster --cluster-id <id>`)
     - Populate this JSON from the cluster shape detected above. 
     - Create an object of CPU cluster instance.
     - Rest of the flow remains same.



### Limitation:
Currently estimation of only single cluster is supported in user tools. Supporting multiple cluster would require deeper design changes in user tools. We inform the user about this limitation in logging.

