### PR TITLE
AutoTuner does not process arguments skipList and limitedLogic

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -999,10 +999,8 @@ class AutoTuner(
       // Makes recommendations based on information extracted from the AppInfoProvider
       filterByUpdatedPropertiesEnabled = showOnlyUpdatedProps
       recommendPluginProps
-      limitedLogicList.foreach { limitedSeq =>
-        limitedSeq.foreach(_ => limitedLogicRecommendations.add(_))
-      }
-      skipList.foreach(skipSeq => skipSeq.foreach(_ => skippedRecommendations.add(_)))
+      limitedLogicList.foreach(limitedSeq => limitedLogicRecommendations ++= limitedSeq)
+      skipList.foreach(skipSeq => skippedRecommendations ++= skipSeq)
       skippedRecommendations ++= platform.recommendationsToExclude
       initRecommendations()
       calculateJobLevelRecommendations()


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #811

`AutoTuner.getRecommendedProperties` does not process the arguments correctly which results skipping the concatenation of the arguments into the global fields.
