### PR TITLE
Accept different GPUs in user tools and add support for Dataproc with L4 GPUs

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -521,14 +521,18 @@ class DataprocCluster(ClusterBase):
     def get_image_version(self) -> str:
         return self.props.get_value_silent('config', 'softwareConfig', 'imageVersion')
 
+    def _get_gpu_device_name(self, gpu_device: str) -> str:
+        """
+        Get the full name of the GPU device
+        """
+        return self.platform.configs.get_value('gpuConfigs', 'user-tools',
+                                               'supportedGpuInstances',
+                                               GpuDevice.fromstring(gpu_device),
+                                               'fullName')
+
     def _set_render_args_create_template(self) -> dict:
         worker_node = self.get_worker_node()
         gpu_per_machine, gpu_device = self.get_gpu_per_worker()
-        # map the gpu device to the equivalent accepted argument
-        gpu_device_hash = {
-            'T4': 'nvidia-tesla-t4',
-            'L4': 'nvidia-l4'
-        }
         return {
             'CLUSTER_NAME': self.get_name(),
             'REGION': self.region,
@@ -539,7 +543,7 @@ class DataprocCluster(ClusterBase):
             'WORKERS_MACHINE': worker_node.instance_type,
             'LOCAL_SSD': worker_node.hw_info.sys_info.num_local_ssd,
             'STORAGE_INTERFACE': worker_node.hw_info.sys_info.storage_interface.upper(),
-            'GPU_DEVICE': gpu_device_hash.get(gpu_device),
+            'GPU_DEVICE': self._get_gpu_device_name(gpu_device),
             'GPU_PER_WORKER': gpu_per_machine
         }
 
@@ -549,15 +553,10 @@ class DataprocCluster(ClusterBase):
         """
         worker_node = self.get_worker_node()
         gpu_per_machine, gpu_device = self.get_gpu_per_worker()
-        # Map the gpu device to the equivalent accepted argument
-        gpu_device_hash = {
-            'T4': 'nvidia-tesla-t4',
-            'L4': 'nvidia-l4'
-        }
         return {
             'REGION': self.region,
             'WORKERS_MACHINE': worker_node.instance_type,
-            'GPU_DEVICE': gpu_device_hash.get(gpu_device),
+            'GPU_DEVICE': self._get_gpu_device_name(gpu_device),
             'GPU_PER_WORKER': gpu_per_machine
         }
 

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -547,19 +547,6 @@ class DataprocCluster(ClusterBase):
             'GPU_PER_WORKER': gpu_per_machine
         }
 
-    def _set_render_args_init_template(self) -> dict:
-        """
-        Create arguments for the cluster initialization template
-        """
-        worker_node = self.get_worker_node()
-        gpu_per_machine, gpu_device = self.get_gpu_per_worker()
-        return {
-            'REGION': self.region,
-            'WORKERS_MACHINE': worker_node.instance_type,
-            'GPU_DEVICE': self._get_gpu_device_name(gpu_device),
-            'GPU_PER_WORKER': gpu_per_machine
-        }
-
 
 @dataclass
 class DataprocSavingsEstimator(SavingsEstimator):

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -134,34 +134,33 @@ class DataprocPlatform(PlatformBase):
             return 2 if num_cores >= 16 else 1
 
         gpu_mem = self.gpu_device.get_gpu_mem()[0]
-        gpus_from_configs = self.configs.get_value('gpuConfigs', 'user-tools', 'supportedGpuInstances')
+        gpus_from_configs = self.configs.get_value('gpuConfigs', 'user-tools',
+                                                   'supportedGpuInstances', self.gpu_device, 'instanceList')
         gpu_count_criteria = self.configs.get_value('gpuConfigs',
                                                     'user-tools',
                                                     'gpuPerMachine', 'criteria', 'numCores')
         gpu_scopes = {}
         # Iterate over each instance type and its information
-        for mc_prof, raw_mc_info in gpus_from_configs.items():
-            mc_info = JSONPropertiesContainer(raw_mc_info, file_load=False)
-            # Check if instance's GPU matches the platform's GPU
-            if mc_info.get_value('GpuHWInfo', 'name') == self.gpu_device:
-                # Get storage interface and local ssd (could be missing as part of 'SysInfo')
-                storage_interface = mc_info.get_value('SysInfo', 'storageInterface')
-                local_ssd = mc_info.get_value_silent('SysInfo', 'localSsd')
-                # Iterate over series for this instance type
-                for unit_info in mc_info.get_value('seriesInfo'):
-                    num_gpu = unit_info.get('numGpu')
-                    local_ssd = unit_info.get('localSsd', local_ssd)
-                    # Iterate over each vCPUs in the unit
-                    for num_cpu in unit_info.get('vCPUs'):
-                        instance_name = f'{mc_prof}-{num_cpu}'
-                        memory_mb = num_cpu * unit_info.get('memPerCPU')
-                        sys_info_obj = SysInfo(num_cpus=num_cpu, cpu_mem=memory_mb,
-                                               num_local_ssd=local_ssd, storage_interface=storage_interface)
-                        # Determine the number of GPUs or calculate based on criteria if not provided
-                        num_gpu = num_gpu or calc_num_gpus(gpu_count_criteria, num_cpu)
-                        gpu_info_obj = GpuHWInfo(num_gpus=num_gpu, gpu_mem=gpu_mem, gpu_device=self.gpu_device)
-                        # Store node information with instance name as key
-                        gpu_scopes[instance_name] = NodeHWInfo(sys_info=sys_info_obj, gpu_info=gpu_info_obj)
+        for mc_prof, mc_info in gpus_from_configs.items():
+            # Get storage interface and local ssd
+            sys_info = mc_info.get('SysInfo')
+            storage_interface = sys_info.get('storageInterface', None)
+            local_ssd = sys_info.get('localSsd', None)
+            # Iterate over series for this instance type
+            for unit_info in mc_info.get('seriesInfo'):
+                num_gpu = unit_info.get('numGpu')
+                local_ssd = unit_info.get('localSsd', local_ssd)
+                # Iterate over each vCPUs in the unit
+                for num_cpu in unit_info.get('vCPUs'):
+                    instance_name = f'{mc_prof}-{num_cpu}'
+                    memory_mb = num_cpu * unit_info.get('memPerCPU')
+                    sys_info_obj = SysInfo(num_cpus=num_cpu, cpu_mem=memory_mb,
+                                           num_local_ssd=local_ssd, storage_interface=storage_interface)
+                    # Determine the number of GPUs or calculate based on criteria if not provided
+                    num_gpu = num_gpu or calc_num_gpus(gpu_count_criteria, num_cpu)
+                    gpu_info_obj = GpuHWInfo(num_gpus=num_gpu, gpu_mem=gpu_mem, gpu_device=self.gpu_device)
+                    # Store node information with instance name as key
+                    gpu_scopes[instance_name] = NodeHWInfo(sys_info=sys_info_obj, gpu_info=gpu_info_obj)
         return gpu_scopes
 
     def get_matching_executor_instance(self, cores_per_executor):

--- a/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
@@ -287,9 +287,6 @@ class OnPremCluster(ClusterBase):
     def get_tmp_storage(self) -> str:
         pass
 
-    def _set_render_args_init_template(self) -> dict:
-        pass
-
 
 @dataclass
 class OnpremSavingsEstimator(SavingsEstimator):

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -1172,7 +1172,7 @@ class ClusterBase(ClusterGetAccessor):
     def generate_init_script(self) -> str:
         platform_name = CspEnv.pretty_print(self.platform.type_id)
         template_path = Utils.resource_path(f'templates/{platform_name}-init_gpu_cluster_script.ms')
-        render_args = self._set_render_args_create_template()
+        render_args = self._set_render_args_init_template()
         return TemplateGenerator.render_template_file(template_path, render_args)
 
 

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -1166,15 +1166,6 @@ class ClusterBase(ClusterGetAccessor):
         template_path = Utils.resource_path(f'templates/cluster_template/{platform_name}_node.ms')
         return TemplateGenerator.render_template_file(template_path, render_args)
 
-    def _set_render_args_init_template(self) -> dict:
-        raise NotImplementedError
-
-    def generate_init_script(self) -> str:
-        platform_name = CspEnv.pretty_print(self.platform.type_id)
-        template_path = Utils.resource_path(f'templates/{platform_name}-init_gpu_cluster_script.ms')
-        render_args = self._set_render_args_init_template()
-        return TemplateGenerator.render_template_file(template_path, render_args)
-
 
 @dataclass
 class ClusterReshape(ClusterGetAccessor):

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -805,10 +805,12 @@ class Qualification(RapidsJarTool):
         # TODO: we may like to show the scripts even when the gpu-cluster is not defined
         #      this requires that we allow to generate the script without the gpu-cluster
         if sec_conf.get('sectionID') == 'initializationScript':
+            # TODO: We need to use reshaped cluster here instead of gpu cluster proxy.
             gpu_cluster = self.ctxt.get_ctxt('gpuClusterProxy')
             script_content = gpu_cluster.generate_init_script()
             return [script_content]
         if sec_conf.get('sectionID') == 'gpuClusterCreationScript':
+            # TODO: We need to use reshaped cluster here instead of gpu cluster proxy.
             gpu_cluster = self.ctxt.get_ctxt('gpuClusterProxy')
             script_content = gpu_cluster.generate_create_script()
             highlighted_code = TemplateGenerator.highlight_bash_code(script_content)

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -805,22 +805,9 @@ class Qualification(RapidsJarTool):
         # TODO: we may like to show the scripts even when the gpu-cluster is not defined
         #      this requires that we allow to generate the script without the gpu-cluster
         if sec_conf.get('sectionID') == 'initializationScript':
-            # format the initialization scripts
-            reshaped_gpu_cluster = ClusterReshape(self.ctxt.get_ctxt('gpuClusterProxy'))
-            gpu_per_machine, gpu_device = reshaped_gpu_cluster.get_gpu_per_worker()
-            fill_map = {
-                0: self.ctxt.platform.cli.get_region(),
-                1: [gpu_device.lower(), gpu_per_machine]
-            }
-            res = []
-            for ind, l_str in enumerate(sec_conf['content'].get('lines')):
-                if ind in fill_map:
-                    rep_var = fill_map.get(ind)
-                    new_value = l_str.format(*rep_var) if isinstance(rep_var, list) else l_str.format(rep_var)
-                    res.append(new_value)
-                else:
-                    res.append(l_str)
-            return res
+            gpu_cluster = self.ctxt.get_ctxt('gpuClusterProxy')
+            script_content = gpu_cluster.generate_init_script()
+            return [script_content]
         if sec_conf.get('sectionID') == 'gpuClusterCreationScript':
             gpu_cluster = self.ctxt.get_ctxt('gpuClusterProxy')
             script_content = gpu_cluster.generate_create_script()

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -801,7 +801,7 @@ class RapidsJarTool(RapidsTool):
 
     def _init_rapids_arg_list(self) -> List[str]:
         # TODO: Make sure we add this argument only for jar versions 23.02+
-        return ['--platform', self.ctxt.platform.get_platform_name().replace('_', '-')]
+        return ['--platform', self.ctxt.platform.get_platform_name_with_gpu().replace('_', '-')]
 
     @timeit('Building Job Arguments and Executing Job CMD')  # pylint: disable=too-many-function-args
     def _prepare_local_job_arguments(self):

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -158,38 +158,89 @@
         "n1-standard": {
           "//description": "N1 standard machine types have 3.75 GB of system memory per vCPU",
           "software": {},
-          "SysInfo": {},
-          "GpuHWInfo": {},
-          "seriesInfo": {
+          "SysInfo": {
+            "localSsd": 2,
+            "storageInterface": "scsi"
+          },
+          "GpuHWInfo": {
+            "name": "t4"
+          },
+          "seriesInfo": [{
             "//description": "describe the sys info based on",
             "name": "n1-standard-(\\d+)",
             "vCPUs": [1, 2, 4, 8, 16, 32, 64, 96],
             "memPerCPU": 3840
-          }
+          }]
         },
         "n1-highmem": {
           "//description": "N1 high-memory machine types have 6.5 GB of system memory per vCPU.",
           "software": {},
-          "SysInfo": {},
-          "GpuHWInfo": {},
-          "seriesInfo": {
+          "SysInfo": {
+            "localSsd": 2,
+            "storageInterface": "scsi"
+          },
+          "GpuHWInfo": {
+            "name": "t4"
+          },
+          "seriesInfo": [{
             "//description": "describe the sys info based on",
             "name": "n1-highmem-(\\d+)",
             "vCPUs": [2, 4, 8, 16, 32, 64, 96],
             "memPerCPU": 6656
-          }
+          }]
         },
         "n1-highcpu": {
           "//description": "N1 high-cpu machine types have 0.9 GB of system memory per vCPU",
           "software": {},
-          "SysInfo": {},
-          "GpuHWInfo": {},
-          "seriesInfo": {
+          "SysInfo": {
+            "localSsd": 2,
+            "storageInterface": "scsi"
+          },
+          "GpuHWInfo": {
+            "name": "t4"
+          },
+          "seriesInfo": [{
             "//description": "describe the sys info based on",
             "name": "n1-highcpu-(\\d+)",
             "vCPUs": [2, 4, 8, 16, 32, 64, 96],
             "memPerCPU": 921.6
-          }
+          }]
+        },
+        "g2-standard": {
+          "//description": "G2 standard machine types have 4 GB of system memory per vCPU",
+          "software": {},
+          "SysInfo": {
+            "storageInterface": "nvme"
+          },
+          "GpuHWInfo": {
+            "name": "l4"
+          },
+          "seriesInfo": [
+            {
+              "vCPUs": [4, 8, 12, 16, 32],
+              "memPerCPU": 4096,
+              "numGpu": 1,
+              "localSsd": 1
+            },
+            {
+              "vCPUs": [24],
+              "memPerCPU": 4096,
+              "numGpu": 2,
+              "localSsd": 2
+            },
+            {
+              "vCPUs": [48],
+              "memPerCPU": 4096,
+              "numGpu": 4,
+              "localSsd": 4
+            },
+            {
+              "vCPUs": [96],
+              "memPerCPU": 4096,
+              "numGpu": 8,
+              "localSsd": 8
+            }
+          ]
         }
       }
     }
@@ -205,10 +256,6 @@
             "header": [
               "To launch a GPU-accelerated cluster with RAPIDS Accelerator for Apache Spark, add the",
               "  following to your cluster creation script:"
-            ],
-            "lines": [
-              "    --initialization-actions=gs://goog-dataproc-initialization-actions-{}/spark-rapids/spark-rapids.sh \\",
-              "    --worker-accelerator type=nvidia-tesla-{},count={}"
             ]
           }
         },

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -253,7 +253,7 @@
         {
           "sectionID": "gpuClusterCreationScript",
           "requiresBoolFlag": "enableSavingsCalculations",
-          "sectionName": "Initialization Scripts",
+          "sectionName": "Creating a GPU Cluster",
           "content": {
             "header": [
               "To create a GPU cluster, run the following script:",

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -155,92 +155,94 @@
         }
       },
       "supportedGpuInstances": {
-        "n1-standard": {
-          "//description": "N1 standard machine types have 3.75 GB of system memory per vCPU",
-          "software": {},
-          "SysInfo": {
-            "localSsd": 2,
-            "storageInterface": "scsi"
-          },
+        "t4": {
           "GpuHWInfo": {
-            "name": "t4"
+            "fullName": "nvidia-tesla-t4"
           },
-          "seriesInfo": [{
-            "//description": "describe the sys info based on",
-            "name": "n1-standard-(\\d+)",
-            "vCPUs": [1, 2, 4, 8, 16, 32, 64, 96],
-            "memPerCPU": 3840
-          }]
-        },
-        "n1-highmem": {
-          "//description": "N1 high-memory machine types have 6.5 GB of system memory per vCPU.",
-          "software": {},
-          "SysInfo": {
-            "localSsd": 2,
-            "storageInterface": "scsi"
-          },
-          "GpuHWInfo": {
-            "name": "t4"
-          },
-          "seriesInfo": [{
-            "//description": "describe the sys info based on",
-            "name": "n1-highmem-(\\d+)",
-            "vCPUs": [2, 4, 8, 16, 32, 64, 96],
-            "memPerCPU": 6656
-          }]
-        },
-        "n1-highcpu": {
-          "//description": "N1 high-cpu machine types have 0.9 GB of system memory per vCPU",
-          "software": {},
-          "SysInfo": {
-            "localSsd": 2,
-            "storageInterface": "scsi"
-          },
-          "GpuHWInfo": {
-            "name": "t4"
-          },
-          "seriesInfo": [{
-            "//description": "describe the sys info based on",
-            "name": "n1-highcpu-(\\d+)",
-            "vCPUs": [2, 4, 8, 16, 32, 64, 96],
-            "memPerCPU": 921.6
-          }]
-        },
-        "g2-standard": {
-          "//description": "G2 standard machine types have 4 GB of system memory per vCPU",
-          "software": {},
-          "SysInfo": {
-            "storageInterface": "nvme"
-          },
-          "GpuHWInfo": {
-            "name": "l4"
-          },
-          "seriesInfo": [
-            {
-              "vCPUs": [4, 8, 12, 16, 32],
-              "memPerCPU": 4096,
-              "numGpu": 1,
-              "localSsd": 1
+          "instanceList": {
+            "n1-standard": {
+              "//description": "N1 standard machine types have 3.75 GB of system memory per vCPU",
+              "software": {},
+              "SysInfo": {
+                "localSsd": 2,
+                "storageInterface": "scsi"
+              },
+              "seriesInfo": [{
+                "//description": "describe the sys info based on",
+                "name": "n1-standard-(\\d+)",
+                "vCPUs": [1, 2, 4, 8, 16, 32, 64, 96],
+                "memPerCPU": 3840
+              }]
             },
-            {
-              "vCPUs": [24],
-              "memPerCPU": 4096,
-              "numGpu": 2,
-              "localSsd": 2
+            "n1-highmem": {
+              "//description": "N1 high-memory machine types have 6.5 GB of system memory per vCPU.",
+              "software": {},
+              "SysInfo": {
+                "localSsd": 2,
+                "storageInterface": "scsi"
+              },
+              "seriesInfo": [{
+                "//description": "describe the sys info based on",
+                "name": "n1-highmem-(\\d+)",
+                "vCPUs": [2, 4, 8, 16, 32, 64, 96],
+                "memPerCPU": 6656
+              }]
             },
-            {
-              "vCPUs": [48],
-              "memPerCPU": 4096,
-              "numGpu": 4,
-              "localSsd": 4
-            },
-            {
-              "vCPUs": [96],
-              "memPerCPU": 4096,
-              "numGpu": 8,
-              "localSsd": 8
+            "n1-highcpu": {
+              "//description": "N1 high-cpu machine types have 0.9 GB of system memory per vCPU",
+              "software": {},
+              "SysInfo": {
+                "localSsd": 2,
+                "storageInterface": "scsi"
+              },
+              "seriesInfo": [{
+                "//description": "describe the sys info based on",
+                "name": "n1-highcpu-(\\d+)",
+                "vCPUs": [2, 4, 8, 16, 32, 64, 96],
+                "memPerCPU": 921.6
+              }]
             }
-          ]
+          }
+        },
+        "l4": {
+          "GpuHWInfo": {
+            "fullName": "nvidia-l4"
+          },
+          "instanceList": {
+            "g2-standard": {
+              "//description": "G2 standard machine types have 4 GB of system memory per vCPU",
+              "software": {},
+              "SysInfo": {
+                "storageInterface": "nvme"
+              },
+              "seriesInfo": [
+                {
+                  "vCPUs": [4, 8, 12, 16, 32],
+                  "memPerCPU": 4096,
+                  "numGpu": 1,
+                  "localSsd": 1
+                },
+                {
+                  "vCPUs": [24],
+                  "memPerCPU": 4096,
+                  "numGpu": 2,
+                  "localSsd": 2
+                },
+                {
+                  "vCPUs": [48],
+                  "memPerCPU": 4096,
+                  "numGpu": 4,
+                  "localSsd": 4
+                },
+                {
+                  "vCPUs": [96],
+                  "memPerCPU": 4096,
+                  "numGpu": 8,
+                  "localSsd": 8
+                }
+              ]
+            }
+          }
         }
       }
     }

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc_gke-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc_gke-configs.json
@@ -200,7 +200,7 @@
         {
           "sectionID": "gpuClusterCreationScript",
           "requiresBoolFlag": "enableSavingsCalculations",
-          "sectionName": "Initialization Scripts",
+          "sectionName": "Creating a GPU Cluster",
           "content": {
             "header": [
               "To create a GPU cluster, run the following script:",

--- a/user_tools/src/spark_rapids_pytools/resources/templates/dataproc-create_gpu_cluster_script.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/dataproc-create_gpu_cluster_script.ms
@@ -1,15 +1,17 @@
 #!/bin/bash
-
+{{! TODO: Contents of this file should be kept in sync with `https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/google-cloud-dataproc.html` }}
 export CLUSTER_NAME="{{ CLUSTER_NAME }}"
 
 gcloud dataproc clusters create $CLUSTER_NAME \
     --image-version={{ IMAGE }} \
     --region {{ REGION }} \
-    --zone {{ ZONE }}-a \
+    --zone {{ ZONE }} \
     --master-machine-type {{ MASTER_MACHINE }} \
     --num-workers {{ WORKERS_COUNT }} \
     --worker-machine-type {{ WORKERS_MACHINE }} \
     --num-worker-local-ssds {{ LOCAL_SSD }} \
+    --worker-local-ssd-interface {{ STORAGE_INTERFACE }} \
+    --no-shielded-secure-boot \
     --enable-component-gateway \
     --subnet=default \
     --initialization-actions=gs://goog-dataproc-initialization-actions-{{ REGION }}/spark-rapids/spark-rapids.sh \

--- a/user_tools/src/spark_rapids_pytools/resources/templates/dataproc-init_gpu_cluster_script.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/dataproc-init_gpu_cluster_script.ms
@@ -1,3 +1,0 @@
-    --worker-machine-type {{ WORKERS_MACHINE }} \
-    --initialization-actions=gs://goog-dataproc-initialization-actions-{{ REGION }}/spark-rapids/spark-rapids.sh \
-    --worker-accelerator type={{ GPU_DEVICE }},count={{ GPU_PER_WORKER }}

--- a/user_tools/src/spark_rapids_pytools/resources/templates/dataproc-init_gpu_cluster_script.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/dataproc-init_gpu_cluster_script.ms
@@ -1,0 +1,3 @@
+    --worker-machine-type {{ WORKERS_MACHINE }} \
+    --initialization-actions=gs://goog-dataproc-initialization-actions-{{ REGION }}/spark-rapids/spark-rapids.sh \
+    --worker-accelerator type={{ GPU_DEVICE }},count={{ GPU_PER_WORKER }}

--- a/user_tools/src/spark_rapids_pytools/wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrapper.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 import fire
 
+from spark_rapids_pytools.cloud_api.sp_types import GpuDevice
 from spark_rapids_pytools.wrappers.databricks_aws_wrapper import DBAWSWrapper
 from spark_rapids_pytools.wrappers.databricks_azure_wrapper import DBAzureWrapper
 from spark_rapids_pytools.wrappers.dataproc_wrapper import DataprocWrapper
@@ -27,7 +28,8 @@ from spark_rapids_pytools.wrappers.onprem_wrapper import OnPremWrapper
 def main():
     fire.Fire({
         'emr': EMRWrapper,
-        'dataproc': DataprocWrapper,
+        'dataproc': DataprocWrapper(gpu_device=GpuDevice.T4),
+        'dataproc-l4': DataprocWrapper(gpu_device=GpuDevice.L4),
         'dataproc-gke': DataprocGKEWrapper,
         'databricks-aws': DBAWSWrapper,
         'databricks-azure': DBAzureWrapper,


### PR DESCRIPTION
Issue #274. This PR improves user tools to accept different GPUs for a CSP and adds compatibility for qualification, profiling, bootstrap for dataproc with L4 GPU. 

## Comparison between T4 and L4 on Dataproc

| Feature    | T4                                  | L4                             |
|---------------|-------------------------------------|--------------------------------|
| Instance Name | n1-standard-{num_cpu}               | g2-standard-{num_cpu}          |
| Gpu Count     | As many (calculated based on cores) | Fixed number based on instance |
| Local SSD     | As many (hardcoded to 2)            | Fixed number based on instance |
| Storage Interface       | SCSI/NVME (defaults to SCSI)        | NVME required                  |
| Full Name     | nvidia-tesla-t4                     | nvidia-l4                      |


## Implementation
### Part 1: User tools can accept different GPUs
1. Wrapper methods at the entry point can now accept `GpuDevice` and pass it downstream as part of the configuration options.
    ```
     In wrapper.py
        'dataproc': DataprocWrapper(gpu_device=GpuDevice.T4),
        'dataproc-l4': DataprocWrapper(gpu_device=GpuDevice.L4),


     In dataproc_wrapper.py
      'platformOpts': {'gpuDevice': self.gpu_device}
    ``` 

   - `PlatformBase` class initializes its `gpu_device` class variable based on the provided `GpuDevice` or a platform-specific default.


### Part 2: Add L4 GPU support for Dataproc
1. Hardcoded value of `LOCAL_SSD` has been removed. Now, it is determined based on instance configuration.
2. Introduced a `StorageInterface` class to capture storage interface information (SCSI/NVME). This is used by the cluster creation script for compatibility with L4 instances, which require NVME for local SSDs.
3. Updated `dataproc_configs.json` with `g2-standard` instances (these have L4 GPUs).
3. Improved `get_supported_gpus()` to filter instances that match gpu device of the platform.
4. Moved cluster initialisation template to a mustache template for dynamic configuration. This replaces the previous hardcoded string `type=nvidia-tesla-{}.`
 


## Testing
Following cases have been tested manually:
1. Qualification: 
   - `spark_rapids_user_tools dataproc-l4 qualification --cpu_cluster $CPU_CLUSTER  --eventlogs $eventlogs`
2. Qualification (cluster inference):
   - `spark_rapids_user_tools dataproc-l4 qualification --eventlogs $eventlogs`
3. Profiling:
   -  `spark_rapids_user_tools dataproc-l4 profiling --gpu_cluster $GPU_CLUSTER --eventlogs $eventlogs`
5. Bootstrap: 
   -  `spark_rapids_user_tools dataproc-l4 bootstrap --cluster $GPU_CLUSTER`


### TODO Follow Up PRs:
1. Argument `--gpu_cluster_recommendation CLUSTER` should be handled correctly.
2. Add support for L4 in new cli.
3. Add `2.1-ubuntu20` as default image version in cluster creation script for dataproc
4. (maybe) Improve logic for L4 types in the AutoTuner in core tools.