### PR TITLE
Fix ReadSchema in Qualification tool and NPE in Profiling tool

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -428,8 +428,9 @@ abstract class AppBase(
         readSchema.contains(trimmedNode)
       }).filter(ReadParser.isScanNode(_))
 
-      // If the ReadSchema is empty or if the Scan is not supported, then we don't need to
+      // If the ReadSchema is empty or if it is PhotonScan, then we don't need to
       // add it to the dataSourceInfo
+      // Processing Photon eventlogs issue: https://github.com/NVIDIA/spark-rapids-tools/issues/251
       if (scanNode.nonEmpty) {
         dataSourceInfo += DataSourceCase(sqlID,
           scanNode.head.id,

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -426,15 +426,19 @@ abstract class AppBase(
         // Get ReadSchema of each Node and sanitize it for comparison
         val trimmedNode = trimSchema(ReadParser.parseReadNode(node).schema)
         readSchema.contains(trimmedNode)
-      }).filter(ReadParser.isScanNode(_)).head
+      }).filter(ReadParser.isScanNode(_))
 
-      dataSourceInfo += DataSourceCase(sqlID,
-        scanNode.id,
-        meta.getOrElse("Format", "unknown"),
-        meta.getOrElse("Location", "unknown"),
-        meta.getOrElse("PushedFilters", "unknown"),
-        readSchema
-      )
+      // If the ReadSchema is empty or if the Scan is not supported, then we don't need to
+      // add it to the dataSourceInfo
+      if (scanNode.nonEmpty) {
+        dataSourceInfo += DataSourceCase(sqlID,
+          scanNode.head.id,
+          meta.getOrElse("Format", "unknown"),
+          meta.getOrElse("Location", "unknown"),
+          meta.getOrElse("PushedFilters", "unknown"),
+          readSchema
+        )
+      }
     }
     // "scan hive" has no "ReadSchema" defined. So, we need to look explicitly for nodes
     // that are scan hive and add them one by one to the dataSource

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -335,7 +335,7 @@ class ApplicationInfo(
             nodeIds.contains((j.sqlID.get, n.id))
           }
           validNodes.map(n => s"${n.name}(${n.id.toString})")
-        }.getOrElse(null)
+        }.getOrElse(Seq.empty)
         SQLStageInfoProfileResult(index, j.sqlID.get, jobId, s, sa, info.duration, nodeNames)
       }
     }


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids-tools/issues/824

In this PR, we fix 2 cases:
1. Fix NPE in profiling tool which is seen in some cases  where nodeNames are empty
2. Qualification tool: Make sure only supported Scan nodes are captured.

Tested it on custom eventlogs. 

<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

4. Please ensure that you have written units tests for the changes made/features
   added.

5. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

6. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

7. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

8. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
