### PR TITLE
Fix case matching error In AutoTuner

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -954,8 +954,10 @@ class AutoTuner(
    */
   private def addDefaultComments(): Unit = {
     commentsForMissingProps.foreach {
-      case (key, value) if !skippedRecommendations.contains(key) =>
-        appendComment(value)
+      case (key, value) =>
+        if (!skippedRecommendations.contains(key)) {
+          appendComment(value)
+        }
     }
   }
 


### PR DESCRIPTION
Fixes #827. Handles the case match error in `addDefaultComments()` function in AutoTuner 