### PR TITLE
 Remove redundant initialization scripts from user tools output

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -802,25 +802,6 @@ class Qualification(RapidsJarTool):
             print(Utils.gen_multiline_str(wrapper_out_content))
 
     def _generate_section_lines(self, sec_conf: dict) -> List[str]:
-        # TODO: we may like to show the scripts even when the gpu-cluster is not defined
-        #      this requires that we allow to generate the script without the gpu-cluster
-        if sec_conf.get('sectionID') == 'initializationScript':
-            # format the initialization scripts
-            reshaped_gpu_cluster = ClusterReshape(self.ctxt.get_ctxt('gpuClusterProxy'))
-            gpu_per_machine, gpu_device = reshaped_gpu_cluster.get_gpu_per_worker()
-            fill_map = {
-                0: self.ctxt.platform.cli.get_region(),
-                1: [gpu_device.lower(), gpu_per_machine]
-            }
-            res = []
-            for ind, l_str in enumerate(sec_conf['content'].get('lines')):
-                if ind in fill_map:
-                    rep_var = fill_map.get(ind)
-                    new_value = l_str.format(*rep_var) if isinstance(rep_var, list) else l_str.format(rep_var)
-                    res.append(new_value)
-                else:
-                    res.append(l_str)
-            return res
         if sec_conf.get('sectionID') == 'gpuClusterCreationScript':
             gpu_cluster = self.ctxt.get_ctxt('gpuClusterProxy')
             script_content = gpu_cluster.generate_create_script()

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -198,26 +198,11 @@
     "qualification": {
       "sections": [
         {
-          "sectionID": "initializationScript",
+          "sectionID": "gpuClusterCreationScript",
           "requiresBoolFlag": "enableSavingsCalculations",
           "sectionName": "Initialization Scripts",
           "content": {
             "header": [
-              "To launch a GPU-accelerated cluster with RAPIDS Accelerator for Apache Spark, add the",
-              "  following to your cluster creation script:"
-            ],
-            "lines": [
-              "    --initialization-actions=gs://goog-dataproc-initialization-actions-{}/spark-rapids/spark-rapids.sh \\",
-              "    --worker-accelerator type=nvidia-tesla-{},count={}"
-            ]
-          }
-        },
-        {
-          "sectionID": "gpuClusterCreationScript",
-          "requiresBoolFlag": "enableSavingsCalculations",
-          "content": {
-            "header": [
-              "",
               "To create a GPU cluster, run the following script:",
               ""
             ]

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc_gke-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc_gke-configs.json
@@ -198,26 +198,11 @@
     "qualification": {
       "sections": [
         {
-          "sectionID": "initializationScript",
+          "sectionID": "gpuClusterCreationScript",
           "requiresBoolFlag": "enableSavingsCalculations",
           "sectionName": "Initialization Scripts",
           "content": {
             "header": [
-              "To launch a GPU-accelerated cluster with RAPIDS Accelerator for Apache Spark, add the",
-              "  following to your cluster creation script:"
-            ],
-            "lines": [
-              "    --initialization-actions=gs://goog-dataproc-initialization-actions-{}/spark-rapids/spark-rapids.sh \\",
-              "    --worker-accelerator type=nvidia-tesla-{},count={}"
-            ]
-          }
-        },
-        {
-          "sectionID": "gpuClusterCreationScript",
-          "requiresBoolFlag": "enableSavingsCalculations",
-          "content": {
-            "header": [
-              "",
               "To create a GPU cluster, run the following script:",
               ""
             ]


### PR DESCRIPTION
Fixes #829. As mentioned in the issue description, we should not have redundant scripts for cluster initialisation. This PR removes the redundant subsection `initializationScript`. 

Refer to issue description for more context.  