### PR TITLE
Add logic for Top Candidates in user-tools

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -663,6 +663,11 @@ class Qualification(RapidsJarTool):
             return QualificationSummary(comments=self.__generate_mc_types_conversion_report())
 
         apps_pruned_df, prune_notes = self.__remap_columns_and_prune(all_apps)
+        if self.ctxt.get_ctxt('filterApps') == QualFilterApp.TOP_CANDIDATES:
+            # TODO: Dummy placeholder to fetch top candidates
+            top_candidates_obj = TopCandidates(all_apps, unsupported_ops_df,
+                                               self.ctxt.get_value('local', 'output', 'topCandidates'))
+            top_candidates_obj.get_candidates()
         recommended_apps = self.__get_recommended_apps(apps_pruned_df)
         # if the gpu_reshape_type is set to JOB then, then we should ignore recommended apps
         speedups_irrelevant_flag = self.__recommendation_is_non_standard()
@@ -705,11 +710,6 @@ class Qualification(RapidsJarTool):
                 apps_reshaped_df = apps_reshaped_df.drop(columns=['Estimated Job Frequency (monthly)'])
                 self.logger.info('Generating GPU Estimated Speedup: as %s', csv_out)
                 apps_reshaped_df.to_csv(csv_out, float_format='%.2f')
-        if self.ctxt.get_ctxt('filterApps') == QualFilterApp.TOP_CANDIDATES:
-            # TODO: Dummy placeholder to fetch top candidates
-            top_candidates_obj = TopCandidates(all_apps, unsupported_ops_df,
-                                               self.ctxt.get_value('local', 'output', 'topCandidates'))
-            top_candidates_obj.get_candidates()
         return QualificationSummary(comments=report_comments,
                                     all_apps=apps_pruned_df,
                                     recommended_apps=recommended_apps,

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -664,11 +664,14 @@ class Qualification(RapidsJarTool):
 
         apps_pruned_df, prune_notes = self.__remap_columns_and_prune(all_apps)
         if self.ctxt.get_ctxt('filterApps') == QualFilterApp.TOP_CANDIDATES:
-            # TODO: Dummy placeholder to fetch top candidates
-            top_candidates_obj = TopCandidates(all_apps, unsupported_ops_df,
-                                               self.ctxt.get_value('local', 'output', 'topCandidates'))
-            top_candidates_obj.get_candidates()
-        recommended_apps = self.__get_recommended_apps(apps_pruned_df)
+            # TODO: Ideally we should create instance of TopCandidates as class variable using the filter apps flag.
+            #  This should be refactored along with entire filter apps logic to use more object-oriented design.
+            top_candidates_obj = TopCandidates(self.ctxt.get_value('local', 'output', 'topCandidates'))
+            prepared_all_apps = top_candidates_obj.prepare_apps(apps_pruned_df,
+                                                                {'unsupported_ops_df': unsupported_ops_df})
+            top_candidates_obj.filter_apps(prepared_all_apps)
+        else:
+            recommended_apps = self.__get_recommended_apps(apps_pruned_df)
         # if the gpu_reshape_type is set to JOB then, then we should ignore recommended apps
         speedups_irrelevant_flag = self.__recommendation_is_non_standard()
         reshaped_notes = self.__generate_cluster_shape_report()

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -670,8 +670,7 @@ class Qualification(RapidsJarTool):
             prepared_all_apps = top_candidates_obj.prepare_apps(apps_pruned_df,
                                                                 {'unsupported_ops_df': unsupported_ops_df})
             top_candidates_obj.filter_apps(prepared_all_apps)
-        else:
-            recommended_apps = self.__get_recommended_apps(apps_pruned_df)
+        recommended_apps = self.__get_recommended_apps(apps_pruned_df)
         # if the gpu_reshape_type is set to JOB then, then we should ignore recommended apps
         speedups_irrelevant_flag = self.__recommendation_is_non_standard()
         reshaped_notes = self.__generate_cluster_shape_report()

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -176,7 +176,7 @@ local:
           value: 'Expr'
         - operator: 'NOT_EQUAL'
           columnName: 'Stage ID'
-          value: '-1'
+          value: -1
       inputColumns:
         - 'App ID'
         - 'App Duration'

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -201,6 +201,7 @@ local:
         sum:
           - 'App ID'
           - 'App Duration'
+      resultColumnName: 'Unsupported Stage Duration Percentage'
       ranges:
           - columnName: 'Estimated GPU Speedup'
             lowerBound: 1.3

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -5,6 +5,8 @@ toolOutput:
     summaryLog:
       fileName: rapids_4_spark_qualification_output.log
   csv:
+    unsupportedOperatorsReport:
+      fileName: rapids_4_spark_qualification_output_unsupportedOperators.csv
     summaryReport:
       fileName: rapids_4_spark_qualification_output.csv
       columns:
@@ -164,6 +166,48 @@ local:
           - '^(\.+).*'
           - '^(\$+).*'
           - '^.+(_\$folder\$)$'
+    topCandidates:
+      mask:
+        - operator: 'NOT_EQUAL'
+          columnName: 'Action'
+          value: 'IgnoreNoPerf'
+        - operator: 'NOT_EQUAL'
+          columnName: 'Unsupported Type'
+          value: 'Expr'
+        - operator: 'NOT_EQUAL'
+          columnName: 'Stage ID'
+          value: '-1'
+      inputColumns:
+        - 'App ID'
+        - 'App Duration'
+        - 'Stage ID'
+        - 'Stage Duration'
+      outputColumns:
+        - 'App ID'
+        - 'App Duration'
+        - 'Estimated GPU Speedup'
+        - 'Unsupported Stage Duration Percentage'
+      sortingColumns:
+        - 'Estimated GPU Speedup'
+        - 'Unsupported Stage Duration Percentage'
+      joinColumns:
+        - 'App ID'
+        - 'App Duration'
+      groupingColumns:
+        max:
+          - 'App ID'
+          - 'App Duration'
+          - 'Stage ID'
+        sum:
+          - 'App ID'
+          - 'App Duration'
+      ranges:
+          - columnName: 'Estimated GPU Speedup'
+            lowerBound: 1.3
+            upperBound: 1000000.0
+          - columnName: 'Unsupported Stage Duration Percentage'
+            lowerBound: 0.0
+            upperBound: 25.0
 platform:
   shortName: 'qual'
   outputDir: qual-tool-output

--- a/user_tools/src/spark_rapids_tools/enums.py
+++ b/user_tools/src/spark_rapids_tools/enums.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
 
 """Enumeration types commonly used through the AS python implementations."""
 
-from enum import Enum
-from typing import Union, cast, Optional
+from enum import Enum, auto
+from typing import Union, cast, Optional, Callable
 
 
 class EnumeratedType(str, Enum):
@@ -113,6 +113,7 @@ class QualFilterApp(EnumeratedType):
     """Values used to filter out the applications in the qualification report"""
     SAVINGS = 'savings'
     SPEEDUPS = 'speedups'
+    TOP_CANDIDATES = 'top_candidates'
     ALL = 'all'
 
     @classmethod
@@ -129,3 +130,31 @@ class QualGpuClusterReshapeType(EnumeratedType):
     @classmethod
     def get_default(cls):
         return cls.MATCH
+
+
+class ConditionOperator(EnumeratedType):
+    """Enum representing comparison operators for conditions."""
+    EQUAL = auto()
+    NOT_EQUAL = auto()
+    GREATER_THAN = auto()
+    LESS_THAN = auto()
+    GREATER_THAN_OR_EQUAL = auto()
+    LESS_THAN_OR_EQUAL = auto()
+
+    @classmethod
+    def get_operator_fn(cls, operator: str) -> Callable[[any, any], bool]:
+        """
+        Returns the operator function for a given operator input.
+        """
+        operator_functions = {
+            cls.EQUAL: lambda x, y: x == y,
+            cls.NOT_EQUAL: lambda x, y: x != y,
+            cls.GREATER_THAN: lambda x, y: x > y,
+            cls.LESS_THAN: lambda x, y: x < y,
+            cls.GREATER_THAN_OR_EQUAL: lambda x, y: x >= y,
+            cls.LESS_THAN_OR_EQUAL: lambda x, y: x <= y,
+        }
+        try:
+            return operator_functions[ConditionOperator.fromstring(operator)]
+        except (KeyError, ValueError) as e:
+            raise ValueError(f'Operator function not defined for {operator}') from e

--- a/user_tools/src/spark_rapids_tools/tools/top_candidates.py
+++ b/user_tools/src/spark_rapids_tools/tools/top_candidates.py
@@ -33,8 +33,9 @@ class TopCandidates:
         """
         unsupported_ops_df = additional_info.get('unsupported_ops_df')
         unsupported_stage_duration_percentage = self.__calculate_unsupported_stages_duration(unsupported_ops_df)
-        # Merge results with all app DataFrame and select columns followed by sorting
-        return pd.merge(all_apps, unsupported_stage_duration_percentage)
+        # Merge results using left join as all applications might not have unsupported stage duration
+        # percentage since we use masking
+        return pd.merge(all_apps, unsupported_stage_duration_percentage, how='left')
 
     def __calculate_unsupported_stages_duration(self, unsupported_ops_df: pd.DataFrame) -> pd.DataFrame:
         """

--- a/user_tools/src/spark_rapids_tools/tools/top_candidates.py
+++ b/user_tools/src/spark_rapids_tools/tools/top_candidates.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation class for Top Candidates logic."""
+
+from dataclasses import dataclass, field
+import pandas as pd
+
+from spark_rapids_tools.enums import ConditionOperator
+
+
+@dataclass
+class TopCandidates:
+    """
+    Encapsulates the logic to get top candidates from the Qualification report.
+    """
+    all_apps_df: pd.DataFrame = field(default=None, init=True)
+    unsupported_ops_df: pd.DataFrame = field(default=None, init=True)
+    props: dict = field(default=None, init=True)
+
+    def get_candidates(self) -> pd.DataFrame:
+        """
+        Returns top candidates based on:
+        1. Calculates the percentage of total stage duration for unsupported operators for each application
+        2. Join the results with all candidates.
+        3. Filter the top candidates based on criteria.
+        """
+        # Define mask to remove rows invalid entries
+        mask = self.__create_column_mask(self.props.get('mask'))
+        unsupported_ops_df = self.unsupported_ops_df.loc[mask, self.props.get('inputColumns')]
+
+        # Calculate total duration of stages with unsupported operators
+        grouping_cols = self.props.get('groupingColumns')
+        unsupported_stage_duration = unsupported_ops_df \
+            .groupby(grouping_cols.get('max'))['Stage Duration'].max().reset_index() \
+            .groupby(grouping_cols.get('sum'))['Stage Duration'].sum().reset_index()
+
+        # Calculate percentage of app duration
+        unsupported_stage_duration_percentage = unsupported_stage_duration \
+            .assign(unsupported_duration_perc=lambda df: (df['Stage Duration'] * 100) / df['App Duration']) \
+            .rename(columns={'unsupported_duration_perc': 'Unsupported Stage Duration Percentage'})
+
+        # Merge results with all app DF and select columns followed by sort
+        all_candidates = pd.merge(self.all_apps_df, unsupported_stage_duration_percentage, how='inner',
+                                  on=self.props.get('joinColumns'))
+        top_candidates = all_candidates[all_candidates.apply(self.__filter_top_candidates, axis=1)]
+        return top_candidates[self.props.get('outputColumns')] \
+            .sort_values(by=self.props.get('sortingColumns'), ascending=False)
+
+    def __create_column_mask(self, raw_mask: dict) -> bool:
+        """
+        Creates a column mask based on the provided condition.
+        Note: Current implementation is primitive and not a complete AST implementation.
+        Example:
+            raw_mask = [
+              {'columnName': 'colA', 'value': 30, 'operator': 'NOT_EQUAL'},
+              {'columnName': 'colB', 'value': 0, 'operator': 'EQUAL'},
+              {'columnName': 'colC', 'value': 'dummy', 'operator': 'EQUAL'}
+            ]
+
+            mask = True and (colA != 30) and (colB == 0) and (colC == 'dummy')
+        """
+        mask = True
+        for condition in raw_mask:
+            column_name, value, operator = condition['columnName'], condition['value'], condition['operator']
+            operator_fn = ConditionOperator.get_operator_fn(operator)
+            mask &= operator_fn(self.unsupported_ops_df[column_name], value)
+        return mask
+
+    def __filter_top_candidates(self, single_row: pd.Series) -> bool:
+        """
+        Used to create a filter for top candidates based on specified ranges.
+        Example:
+        self.props['ranges'] = [
+            {'columnName': 'colA', 'lowerBound': 18, 'upperBound': 30},
+            {'columnName': 'colB', 'lowerBound': 70, 'upperBound': 100}
+        ]
+        single_row = pd.Series({'colA': 25, 'colB': 85})
+        The function will return True because the colA (25) is within the range (18-30)
+        and the colB (85) is within the range (70-100).
+        """
+        for criteria in self.props.get('ranges'):
+            col_value = single_row[criteria.get('columnName')]
+            if not criteria.get('lowerBound') <= col_value <= criteria.get('upperBound'):
+                return False
+        return True


### PR DESCRIPTION
Fixes #854. This PR introduces the logic for `TOP_CANDIDATES` in user tools.

### Changes:
1. Add a new module `TopCandidates` add implement the logic as follows  
   - Calculates the percentage of total stage duration for unsupported operators for each application
   - Join the results with all candidates.
   - Filter the top candidates based on criteria.
2. Update `qualification.yaml` with configs/column names used in this module.
3. Introduce a new Enum class `ConditionOperator` to get conditional functions from string.
4. Add a new filter `top_candidates` to be used as argument in user tools.


Note: This PR does not make any changes in the output. 