### PR TITLE
[FEA] Add new support types in core tools

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -40,6 +40,10 @@ class PluginTypeChecker(platform: Platform = PlatformFactory.createInstance(),
   // configured off
   private val CO = "CO"
   private val NA = "NA"
+  // tools off (explicitly disabled in tools)
+  private val TOFF = "TOFF"
+  // tools new (new ops from plugin which have not been parsed or tested yet)
+  private val TNEW = "TNEW"
 
   private val DEFAULT_DS_FILE = "supportedDataSource.csv"
   private val SUPPORTED_EXECS_FILE = "supportedExecs.csv"
@@ -204,7 +208,8 @@ class PluginTypeChecker(platform: Platform = PlatformFactory.createInstance(),
         if (direction.equals("read")) {
           val dataTypesToSup = header.drop(2).zip(cols.drop(2)).toMap
           val nsTypes = dataTypesToSup.filter { case (_, sup) =>
-            sup.equals(NA) || sup.equals(NS) || sup.equals(CO)
+            sup.equals(NA) || sup.equals(NS) || sup.equals(CO) ||
+            sup.equals(TNEW) || sup.equals(TOFF)
           }.keys.toSeq.map(_.toLowerCase)
           val allNsTypes = nsTypes.flatMap(t => getOtherTypes(t) :+ t)
           val allBySup = HashMap(NS -> allNsTypes)

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
@@ -57,7 +57,7 @@ class PluginTypeCheckerSuite extends FunSuite with Logging {
     }
   }
 
-  test("read not CO datatype") {
+  test("read CO datatype") {
     val checker = new PluginTypeChecker
     TrampolineUtil.withTempDir { outpath =>
       val testSchema = "loan_id:bigint,monthly_reporting_period:string,servicer:string"
@@ -69,6 +69,51 @@ class PluginTypeCheckerSuite extends FunSuite with Logging {
       val (score, nsTypes) = checker.scoreReadDataTypes("parquet", testSchema)
       assert(score == 0.0)
       assert(nsTypes.contains("int"))
+    }
+  }
+
+  test("read TOFF datatype") {
+    val checker = new PluginTypeChecker
+    TrampolineUtil.withTempDir { outpath =>
+      val testSchema = "loan_id:bigint,monthly_reporting_period:string,servicer:string"
+      val header = "Format,Direction,int\n"
+      val supText = (header + "parquet,read,TOFF\n").getBytes(StandardCharsets.UTF_8)
+      val csvSupportedFile = Paths.get(outpath.getAbsolutePath, "testDS.txt")
+      Files.write(csvSupportedFile, supText)
+      checker.setPluginDataSourceFile(csvSupportedFile.toString)
+      val (score, nsTypes) = checker.scoreReadDataTypes("parquet", testSchema)
+      assert(score == 0.0)
+      assert(nsTypes.contains("int"))
+    }
+  }
+
+  test("read TNEW datatype") {
+    val checker = new PluginTypeChecker
+    TrampolineUtil.withTempDir { outpath =>
+      val testSchema = "loan_id:bigint,monthly_reporting_period:string,servicer:string"
+      val header = "Format,Direction,int\n"
+      val supText = (header + "parquet,read,TNEW\n").getBytes(StandardCharsets.UTF_8)
+      val csvSupportedFile = Paths.get(outpath.getAbsolutePath, "testDS.txt")
+      Files.write(csvSupportedFile, supText)
+      checker.setPluginDataSourceFile(csvSupportedFile.toString)
+      val (score, nsTypes) = checker.scoreReadDataTypes("parquet", testSchema)
+      assert(score == 0.0)
+      assert(nsTypes.contains("int"))
+    }
+  }
+
+  test("read TON datatype") {
+    val checker = new PluginTypeChecker
+    TrampolineUtil.withTempDir { outpath =>
+      val testSchema = "loan_id:bigint,monthly_reporting_period:string,servicer:string"
+      val header = "Format,Direction,int\n"
+      val supText = (header + "parquet,read,TON\n").getBytes(StandardCharsets.UTF_8)
+      val csvSupportedFile = Paths.get(outpath.getAbsolutePath, "testDS.txt")
+      Files.write(csvSupportedFile, supText)
+      checker.setPluginDataSourceFile(csvSupportedFile.toString)
+      val (score, nsTypes) = checker.scoreReadDataTypes("parquet", testSchema)
+      assert(score == 1.0)
+      assert(nsTypes.isEmpty)
     }
   }
 


### PR DESCRIPTION
This PR adds support types for data sources/execs/expressions:
- TON: tools on (explicitly enabled in tools)
- TOFF: tools off (explicitly disabled in tools)
- TNEW: tools new (new ops added in plugin which have not been parsed/tested in tools yet)
in the core tools, and corresponding test cases.

This is a prerequisite for https://github.com/NVIDIA/spark-rapids-tools/pull/847. We separate this work into a single PR for easier review.