### PR TITLE
Extend supportLevels in PluginTypeChecker

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -49,8 +49,7 @@ object OpSuppLevel extends Enumeration {
   }
 
   import scala.language.implicitConversions
-  implicit def valueToOpSupportLevelsVal(x: Value):
-  OpSuppLevelVal = x.asInstanceOf[OpSuppLevelVal]
+  implicit def valueToOpSupportLevelsVal(x: Value): OpSuppLevelVal = x.asInstanceOf[OpSuppLevelVal]
 
   val S = OpSuppLevelVal("S", true, "Enabled by the Plugin")
   val TON = OpSuppLevelVal("TON", true, "Force enabled by the Tools")
@@ -368,13 +367,6 @@ class PluginTypeChecker(platform: Platform = PlatformFactory.createInstance(),
   }
 
   def isExecSupported(exec: String): Boolean = {
-    // special case ColumnarToRow and assume it will be removed or will we replace
-    // with GPUColumnarToRow. TODO - we can add more logic here to look at operator
-    //  before and after
-    // TODO: This is very tricky that we have this special case handled here.
-    if (exec == "ColumnarToRow") {
-      return true
-    }
     val opSupLevel = supportedExecs.getOrElse(exec, OpSuppLevel.NS)
     opSupLevel.isSupported
   }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
@@ -123,8 +123,6 @@ class PluginTypeCheckerSuite extends FunSuite with Logging {
     assert(checker.isExecSupported("ShuffledHashJoinExec"))
     assert(checker.isExecSupported("ShuffledHashJoinExec"))
     assert(checker.isExecSupported("CollectLimitExec") == false)
-    assert(checker.isExecSupported("ColumnarToRow"))
-
   }
 
   test("supported Expressions") {

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,7 +131,7 @@ class PluginTypeCheckerSuite extends FunSuite with Logging {
     val checker = new PluginTypeChecker
     val result = checker.getSupportedExprs
     assert(result.contains("add"))
-    assert(result("add") == "S")
+    assert(result("add").equals(OpSuppLevel.S))
     assert(result.contains("isnull"))
   }
 
@@ -183,5 +183,50 @@ class PluginTypeCheckerSuite extends FunSuite with Logging {
     val checker = new PluginTypeChecker(speedupFactorFile=Some(speedupFactorFile))
     assert(checker.getSpeedupFactor("SortExec") == 13.11)
     assert(checker.getSpeedupFactor("FilterExec") == 3.14)
+  }
+
+  test("read TOFF datatype") {
+    val checker = new PluginTypeChecker
+    TrampolineUtil.withTempDir { outpath =>
+      val testSchema = "loan_id:bigint,monthly_reporting_period:string,servicer:string"
+      val header = "Format,Direction,int\n"
+      val supText = (header + "parquet,read,TOFF\n").getBytes(StandardCharsets.UTF_8)
+      val csvSupportedFile = Paths.get(outpath.getAbsolutePath, "testDS.txt")
+      Files.write(csvSupportedFile, supText)
+      checker.setPluginDataSourceFile(csvSupportedFile.toString)
+      val (score, nsTypes) = checker.scoreReadDataTypes("parquet", testSchema)
+      assert(score == 0.0)
+      assert(nsTypes.contains("int"))
+    }
+  }
+
+  test("read TNEW datatype") {
+    val checker = new PluginTypeChecker
+    TrampolineUtil.withTempDir { outpath =>
+      val testSchema = "loan_id:bigint,monthly_reporting_period:string,servicer:string"
+      val header = "Format,Direction,int\n"
+      val supText = (header + "parquet,read,TNEW\n").getBytes(StandardCharsets.UTF_8)
+      val csvSupportedFile = Paths.get(outpath.getAbsolutePath, "testDS.txt")
+      Files.write(csvSupportedFile, supText)
+      checker.setPluginDataSourceFile(csvSupportedFile.toString)
+      val (score, nsTypes) = checker.scoreReadDataTypes("parquet", testSchema)
+      assert(score == 0.0)
+      assert(nsTypes.contains("int"))
+    }
+  }
+
+  test("read TON datatype") {
+    val checker = new PluginTypeChecker
+    TrampolineUtil.withTempDir { outpath =>
+      val testSchema = "loan_id:bigint,monthly_reporting_period:string,servicer:string"
+      val header = "Format,Direction,int\n"
+      val supText = (header + "parquet,read,TON\n").getBytes(StandardCharsets.UTF_8)
+      val csvSupportedFile = Paths.get(outpath.getAbsolutePath, "testDS.txt")
+      Files.write(csvSupportedFile, supText)
+      checker.setPluginDataSourceFile(csvSupportedFile.toString)
+      val (score, nsTypes) = checker.scoreReadDataTypes("parquet", testSchema)
+      assert(score == 1.0)
+      assert(nsTypes.isEmpty)
+    }
   }
 }


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #862

- Adds new Enum `OpSuppLevel` to handle the different types of op support
- Adds new custom operators such as "TNEW", "TOFF", and "TON" to make it easier to deal with overriding the configurations

