### PR TITLE
Implement top candidate filter for user tools CLI output

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -32,6 +32,7 @@ from spark_rapids_pytools.pricing.price_provider import SavingsEstimator
 from spark_rapids_pytools.rapids.rapids_tool import RapidsJarTool
 from spark_rapids_tools.enums import QualFilterApp, QualGpuClusterReshapeType
 from spark_rapids_tools.tools.top_candidates import TopCandidates
+from spark_rapids_tools.tools.unsupported_ops_stage_duration import UnsupportedOpsStageDuration
 
 
 @dataclass
@@ -45,6 +46,7 @@ class QualificationSummary:
     df_result: pd.DataFrame = None
     irrelevant_speedups: bool = False
     savings_report_flag: bool = False
+    top_candidates_flag: bool = False
     sections_generators: List[Callable] = field(default_factory=lambda: [])
 
     def _get_total_durations(self) -> int:
@@ -94,12 +96,7 @@ class QualificationSummary:
                         csp_report_provider: Callable[[], List[str]] = lambda: [],
                         df_pprinter: Any = None,
                         output_pprinter: Any = None):
-
-        def format_float(x: float) -> str:
-            return f'{x:.2f}'
-
         report_content = []
-
         if self.is_empty():
             # Qualification tool has no output
             report_content.append(f'{app_name} tool did not generate any valid rows')
@@ -132,31 +129,8 @@ class QualificationSummary:
         else:
             report_content.append(f'{app_name} tool found no records to show.')
 
-        overall_speedup = 0.0
-        total_apps_durations = 1.0 * self._get_total_durations()
-        total_gpu_durations = self._get_total_gpu_durations()
-        if total_gpu_durations > 0:
-            overall_speedup = total_apps_durations / total_gpu_durations
-
-        if not self.savings_report_flag:
-            report_content.append(Utils.gen_report_sec_header('Report Summary', hrule=False))
-            report_summary = [['Total applications', self._get_stats_total_apps()],
-                              ['Overall estimated speedup', format_float(overall_speedup)]]
-        else:
-            total_app_cost = self._get_stats_total_cost()
-            total_gpu_cost = self._get_stats_total_gpu_cost()
-            estimated_gpu_savings = 0.0
-            if total_app_cost > 0.0:
-                estimated_gpu_savings = 100.0 - (100.0 * total_gpu_cost / total_app_cost)
-
-            report_content.append(Utils.gen_report_sec_header('Report Summary', hrule=False))
-            report_summary = [['Total applications', self._get_stats_total_apps()],
-                              ['Overall estimated speedup', format_float(overall_speedup)],
-                              ['Overall estimated cost savings', f'{format_float(estimated_gpu_savings)}%']]
-        if not self.irrelevant_speedups:
-            # do not display speedups stats if the speedup is being overriden by the shape recommendations
-            report_summary.insert(1, ['RAPIDS candidates', self._get_stats_recommended_apps()])
-        report_content.append(tabulate(report_summary, colalign=('left', 'right')))
+        report_content.append(Utils.gen_report_sec_header('Report Summary', hrule=False))
+        report_content.append(tabulate(self.__generate_report_summary(), colalign=('left', 'right')))
         if self.comments:
             report_content.append(Utils.gen_report_sec_header('Notes'))
             report_content.extend(f' - {line}' for line in self.comments)
@@ -171,6 +145,31 @@ class QualificationSummary:
         # append an empty line at the end of the report
         report_content.append('')
         return report_content
+
+    def __generate_report_summary(self):
+        def format_float(x: float) -> str:
+            return f'{x:.2f}'
+
+        report_summary = [['Total applications', self._get_stats_total_apps()]]
+        if not self.irrelevant_speedups:
+            # do not display RAPIDS candidates count if the speedup is being overridden by the shape recommendations
+            # TODO: We should also include a line that shows number of apps after filtering
+            report_summary.append(['RAPIDS candidates', self._get_stats_recommended_apps()])
+        if not self.top_candidates_flag:
+            overall_speedup = 0.0
+            total_apps_durations = self._get_total_durations()
+            total_gpu_durations = self._get_total_gpu_durations()
+            if total_gpu_durations > 0:
+                overall_speedup = total_apps_durations / total_gpu_durations
+            report_summary.append(['Overall estimated speedup', format_float(overall_speedup)])
+            if self.savings_report_flag:
+                total_app_cost = self._get_stats_total_cost()
+                total_gpu_cost = self._get_stats_total_gpu_cost()
+                estimated_gpu_savings = 0.0
+                if total_app_cost > 0.0:
+                    estimated_gpu_savings = 100.0 - (100.0 * total_gpu_cost / total_app_cost)
+                report_summary.append(['Overall estimated cost savings', f'{format_float(estimated_gpu_savings)}%'])
+        return report_summary
 
 
 @dataclass
@@ -419,7 +418,7 @@ class Qualification(RapidsJarTool):
                                                                       cols_map.get(col_rename),
                                                                       regex=False)
 
-        # for TCO, group by app name and average durations, then recalculate Estimated GPU Speedup
+        # for TCO, group by app name and average durations, then recalculate metrics
         group_map = self.ctxt.get_value('toolOutput', 'csv', 'summaryReport', 'groupColumns')
         if group_map:
             for group_key, group_value in group_map.items():
@@ -432,7 +431,15 @@ class Qualification(RapidsJarTool):
         if len(subset_data) != len(all_rows):
             notes = 'Apps with the same name are grouped together and their metrics are averaged'
 
+        # recalculate estimated GPU speedup
         subset_data['Estimated GPU Speedup'] = subset_data['App Duration'] / subset_data['Estimated GPU Duration']
+        unsupported_ops_col_name = self.ctxt.get_value('local', 'output', 'unsupportedOperators',
+                                                       'resultColumnName')
+        unsupported_ops_perc_col_name = self.ctxt.get_value('local', 'output', 'unsupportedOperators',
+                                                            'percentResultColumnName')
+        # recalculate unsupported operators stage duration percent
+        subset_data[unsupported_ops_perc_col_name] =\
+            subset_data[unsupported_ops_col_name] * 100.0 / subset_data['App Duration']
 
         return subset_data, notes
 
@@ -662,14 +669,11 @@ class Qualification(RapidsJarTool):
             # No need to run saving estimator or process the data frames.
             return QualificationSummary(comments=self.__generate_mc_types_conversion_report())
 
+        unsupported_ops_obj = UnsupportedOpsStageDuration(self.ctxt.get_value('local', 'output',
+                                                                              'unsupportedOperators'))
+        # Calculate unsupported operators stage duration before grouping
+        all_apps = unsupported_ops_obj.prepare_apps_with_unsupported_stages(all_apps, unsupported_ops_df)
         apps_pruned_df, prune_notes = self.__remap_columns_and_prune(all_apps)
-        if self.ctxt.get_ctxt('filterApps') == QualFilterApp.TOP_CANDIDATES:
-            # TODO: Ideally we should create instance of TopCandidates as class variable using the filter apps flag.
-            #  This should be refactored along with entire filter apps logic to use more object-oriented design.
-            top_candidates_obj = TopCandidates(self.ctxt.get_value('local', 'output', 'topCandidates'))
-            prepared_all_apps = top_candidates_obj.prepare_apps(apps_pruned_df,
-                                                                {'unsupported_ops_df': unsupported_ops_df})
-            top_candidates_obj.filter_apps(prepared_all_apps)
         recommended_apps = self.__get_recommended_apps(apps_pruned_df)
         # if the gpu_reshape_type is set to JOB then, then we should ignore recommended apps
         speedups_irrelevant_flag = self.__recommendation_is_non_standard()
@@ -712,13 +716,15 @@ class Qualification(RapidsJarTool):
                 apps_reshaped_df = apps_reshaped_df.drop(columns=['Estimated Job Frequency (monthly)'])
                 self.logger.info('Generating GPU Estimated Speedup: as %s', csv_out)
                 apps_reshaped_df.to_csv(csv_out, float_format='%.2f')
+        filter_top_candidate_enabled = self.ctxt.get_ctxt('filterApps') == QualFilterApp.TOP_CANDIDATES
         return QualificationSummary(comments=report_comments,
                                     all_apps=apps_pruned_df,
                                     recommended_apps=recommended_apps,
                                     savings_report_flag=launch_savings_calc,
                                     df_result=df_final_result,
                                     irrelevant_speedups=speedups_irrelevant_flag,
-                                    sections_generators=[self.__generate_mc_types_conversion_report])
+                                    sections_generators=[self.__generate_mc_types_conversion_report],
+                                    top_candidates_flag=filter_top_candidate_enabled)
 
     def _process_output(self):
         def process_df_for_stdout(raw_df):
@@ -734,6 +740,7 @@ class Qualification(RapidsJarTool):
             # check if any filters apply
             filter_recommendation_enabled = self.ctxt.get_ctxt('filterApps') == QualFilterApp.SPEEDUPS
             filter_pos_enabled = self.ctxt.get_ctxt('filterApps') == QualFilterApp.SAVINGS
+            filter_top_candidate_enabled = self.ctxt.get_ctxt('filterApps') == QualFilterApp.TOP_CANDIDATES
 
             if self.__recommendation_is_non_standard():
                 # During processing of arguments phase, we verified that the filter does not conflict
@@ -743,6 +750,12 @@ class Qualification(RapidsJarTool):
                                                           self.ctxt.get_ctxt('gpuClusterShapeRecommendation'))
                 # update the selected columns
                 selected_cols = list(raw_df.columns)
+            if filter_top_candidate_enabled:
+                # TODO: Ideally we should create instance of TopCandidates as class variable using the filter apps flag.
+                #  This should be refactored along with entire filter apps logic to use more object-oriented design.
+                top_candidates_obj = TopCandidates(self.ctxt.get_value('local', 'output', 'topCandidates'))
+                filtered_apps = top_candidates_obj.filter_apps(raw_df)
+                return top_candidates_obj.prepare_output(filtered_apps)
 
             # filter by recommendations if enabled
             if filter_recommendation_enabled:

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -5,6 +5,8 @@ toolOutput:
     summaryLog:
       fileName: rapids_4_spark_qualification_output.log
   csv:
+    unsupportedOperatorsReport:
+      fileName: rapids_4_spark_qualification_output_unsupportedOperators.csv
     summaryReport:
       fileName: rapids_4_spark_qualification_output.csv
       columns:
@@ -164,6 +166,49 @@ local:
           - '^(\.+).*'
           - '^(\$+).*'
           - '^.+(_\$folder\$)$'
+    topCandidates:
+      mask:
+        - operator: 'NOT_EQUAL'
+          columnName: 'Action'
+          value: 'IgnoreNoPerf'
+        - operator: 'NOT_EQUAL'
+          columnName: 'Unsupported Type'
+          value: 'Expr'
+        - operator: 'NOT_EQUAL'
+          columnName: 'Stage ID'
+          value: -1
+      inputColumns:
+        - 'App ID'
+        - 'App Duration'
+        - 'Stage ID'
+        - 'Stage Duration'
+      outputColumns:
+        - 'App ID'
+        - 'App Duration'
+        - 'Estimated GPU Speedup'
+        - 'Unsupported Stage Duration Percentage'
+      sortingColumns:
+        - 'Estimated GPU Speedup'
+        - 'Unsupported Stage Duration Percentage'
+      joinColumns:
+        - 'App ID'
+        - 'App Duration'
+      groupingColumns:
+        max:
+          - 'App ID'
+          - 'App Duration'
+          - 'Stage ID'
+        sum:
+          - 'App ID'
+          - 'App Duration'
+      resultColumnName: 'Unsupported Stage Duration Percentage'
+      ranges:
+          - columnName: 'Estimated GPU Speedup'
+            lowerBound: 1.3
+            upperBound: 1000000.0
+          - columnName: 'Unsupported Stage Duration Percentage'
+            lowerBound: 0.0
+            upperBound: 25.0
 platform:
   shortName: 'qual'
   outputDir: qual-tool-output

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -17,6 +17,7 @@ toolOutput:
         - Estimated GPU Duration
         - App Duration
         - Estimated Job Frequency (monthly)
+        - Unsupported Operators Stage Duration
       mapColumns:
         Recommendation: 'Speedup Based Recommendation'
       recommendations:
@@ -33,6 +34,7 @@ toolOutput:
       groupColumns:
          App Duration: 'App Name'
          Estimated GPU Duration: 'App Name'
+         Unsupported Operators Stage Duration: 'App Name'
       dropDuplicates:
          - App Name
   json:
@@ -166,7 +168,7 @@ local:
           - '^(\.+).*'
           - '^(\$+).*'
           - '^.+(_\$folder\$)$'
-    topCandidates:
+    unsupportedOperators:
       mask:
         - operator: 'NOT_EQUAL'
           columnName: 'Action'
@@ -182,17 +184,6 @@ local:
         - 'App Duration'
         - 'Stage ID'
         - 'Stage Duration'
-      outputColumns:
-        - 'App ID'
-        - 'App Duration'
-        - 'Estimated GPU Speedup'
-        - 'Unsupported Stage Duration Percentage'
-      sortingColumns:
-        - 'Estimated GPU Speedup'
-        - 'Unsupported Stage Duration Percentage'
-      joinColumns:
-        - 'App ID'
-        - 'App Duration'
       groupingColumns:
         max:
           - 'App ID'
@@ -201,14 +192,46 @@ local:
         sum:
           - 'App ID'
           - 'App Duration'
-      resultColumnName: 'Unsupported Stage Duration Percentage'
+      resultColumnName: 'Unsupported Operators Stage Duration'
+      percentResultColumnName: 'Unsupported Operators Stage Duration Percent'
+    topCandidates:
+      outputColumns:
+        - 'App ID'
+        - 'App Name'
+        - 'App Duration'
+        - 'Estimated GPU Speedup'
+        - 'Unsupported Operators Stage Duration Percent'
+      sortingColumns:
+        - 'Estimated GPU Speedup'
+        - 'Unsupported Operators Stage Duration Percent'
+      joinColumns:
+        - 'App ID'
+        - 'App Name'
+        - 'App Duration'
       ranges:
           - columnName: 'Estimated GPU Speedup'
             lowerBound: 1.3
             upperBound: 1000000.0
-          - columnName: 'Unsupported Stage Duration Percentage'
+          - columnName: 'Unsupported Operators Stage Duration Percent'
             lowerBound: 0.0
             upperBound: 25.0
+      output: # Configs related to output
+        columns:
+          - 'App ID'
+          - 'App Name'
+          - 'Estimated GPU Speedup'
+        remap:
+          - columnName: 'Estimated GPU Speedup'
+            recommendationRanges:
+              - title: 'Small'
+                lowerBound: 1.3
+                upperBound: 2.0
+              - title: 'Medium'
+                lowerBound: 2.0
+                upperBound: 3.0
+              - title: 'Large'
+                lowerBound: 3.0
+                upperBound: 1000000.0
 platform:
   shortName: 'qual'
   outputDir: qual-tool-output

--- a/user_tools/src/spark_rapids_pytools/wrappers/databricks_aws_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/databricks_aws_wrapper.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -80,12 +80,13 @@ class CliDBAWSLocalMode:  # pylint: disable=too-few-public-methods
                to provide the location of a credential file. The default credentials file exists as
                "~/.databrickscfg" on Unix, Linux, or macOS
         :param filter_apps: filtering criteria of the applications listed in the final STDOUT table
-                is one of the following (ALL, SPEEDUPS, savings).
+                is one of the following (ALL, SPEEDUPS, savings, top_candidates).
                 Note that this filter does not affect the CSV report.
                 "ALL" means no filter applied. "SPEEDUPS" lists all the apps that are either
                 'Recommended', or 'Strongly Recommended' based on speedups. "SAVINGS"
                 lists all the apps that have positive estimated GPU savings except for the apps that
-                are "Not Applicable".
+                are "Not Applicable". "TOP_CANDIDATES" lists all apps that have unsupported operators
+                stage duration less than 25% of app duration and speedups greater than 1.3x.
         :param gpu_cluster_recommendation: The type of GPU cluster recommendation to generate.
                It accepts one of the following ("CLUSTER", "JOB" and the default value "MATCH").
                 "MATCH": keep GPU cluster same number of nodes as CPU cluster;

--- a/user_tools/src/spark_rapids_pytools/wrappers/databricks_azure_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/databricks_azure_wrapper.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -78,12 +78,13 @@ class CliDBAzureLocalMode:  # pylint: disable=too-few-public-methods
                to provide the location of a credential file. The default credentials file exists as
                "~/.databrickscfg" on Unix, Linux, or macOS
         :param filter_apps: filtering criteria of the applications listed in the final STDOUT table
-                is one of the following (ALL, SPEEDUPS, SAVINGS).
+                is one of the following (ALL, SPEEDUPS, SAVINGS, TOP_CANDIDATES).
                 Note that this filter does not affect the CSV report.
                 "ALL" means no filter applied. "SPEEDUPS" lists all the apps that are either
                 'Recommended', or 'Strongly Recommended' based on speedups. "SAVINGS"
                 lists all the apps that have positive estimated GPU savings except for the apps that
-                are "Not Applicable".
+                are "Not Applicable". "TOP_CANDIDATES" lists all apps that have unsupported operators
+                stage duration less than 25% of app duration and speedups greater than 1.3x.
         :param gpu_cluster_recommendation: The type of GPU cluster recommendation to generate.
                It accepts one of the following ("CLUSTER", "JOB" and the default value "MATCH").
                 "MATCH": keep GPU cluster same number of nodes as CPU cluster;

--- a/user_tools/src/spark_rapids_pytools/wrappers/dataproc_gke_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/dataproc_gke_wrapper.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -75,12 +75,13 @@ class CliDataprocGKELocalMode:  # pylint: disable=too-few-public-methods
                to provide the location of a credential JSON file. The default credentials file exists as
                "$HOME/.config/gcloud/application_default_credentials.json"
         :param filter_apps: filtering criteria of the applications listed in the final STDOUT table
-                is one of the following (ALL, SPEEDUPS, savings).
+                is one of the following (ALL, SPEEDUPS, savings, top_candidates).
                 Note that this filter does not affect the CSV report.
                 "ALL" means no filter applied. "SPEEDUPS" lists all the apps that are either
                 'Recommended', or 'Strongly Recommended' based on speedups. "SAVINGS"
                 lists all the apps that have positive estimated GPU savings except for the apps that
-                are "Not Applicable"
+                are "Not Applicable". "TOP_CANDIDATES" lists all apps that have unsupported operators
+                stage duration less than 25% of app duration and speedups greater than 1.3x.
         :param gpu_cluster_recommendation: The type of GPU cluster recommendation to generate.
                It accepts one of the following ("CLUSTER", "JOB" and the default value "MATCH").
                 "MATCH": keep GPU cluster same number of nodes as CPU cluster;

--- a/user_tools/src/spark_rapids_pytools/wrappers/dataproc_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/dataproc_wrapper.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -77,12 +77,13 @@ class CliDataprocLocalMode:  # pylint: disable=too-few-public-methods
                to provide the location of a credential JSON file. The default credentials file exists as
                "$HOME/.config/gcloud/application_default_credentials.json"
         :param filter_apps: filtering criteria of the applications listed in the final STDOUT table
-                is one of the following (ALL, SPEEDUPS, savings).
+                is one of the following (ALL, SPEEDUPS, savings, top_candidates).
                 Note that this filter does not affect the CSV report.
                 "ALL" means no filter applied. "SPEEDUPS" lists all the apps that are either
                 'Recommended', or 'Strongly Recommended' based on speedups. "SAVINGS"
                 lists all the apps that have positive estimated GPU savings except for the apps that
-                are "Not Applicable"
+                are "Not Applicable". "TOP_CANDIDATES" lists all apps that have unsupported operators
+                stage duration less than 25% of app duration and speedups greater than 1.3x.
         :param gpu_cluster_recommendation: The type of GPU cluster recommendation to generate.
                It accepts one of the following ("CLUSTER", "JOB" and the default value "MATCH").
                 "MATCH": keep GPU cluster same number of nodes as CPU cluster;

--- a/user_tools/src/spark_rapids_pytools/wrappers/emr_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/emr_wrapper.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -75,12 +75,13 @@ class CliEmrLocalMode:  # pylint: disable=too-few-public-methods
                 or remote S3 url. If missing, the wrapper downloads the latest rapids-4-spark-tools_*.jar
                 from maven repo
         :param filter_apps: filtering criteria of the applications listed in the final STDOUT table
-                is one of the following (ALL, SPEEDUPS, SAVINGS). Default is "SAVINGS".
+                is one of the following (ALL, SPEEDUPS, SAVINGS, TOP_CANDIDATES). Default is "SAVINGS".
                 Note that this filter does not affect the CSV report.
                 "ALL" means no filter applied. "SPEEDUPS" lists all the apps that are either
                 'Recommended', or 'Strongly Recommended' based on speedups. "SAVINGS"
                 lists all the apps that have positive estimated GPU savings except for the apps that
-                are "Not Applicable"
+                are "Not Applicable". "TOP_CANDIDATES" lists all apps that have unsupported operators
+                stage duration less than 25% of app duration and speedups greater than 1.3x.
         :param gpu_cluster_recommendation: The type of GPU cluster recommendation to generate.
                It accepts one of the following ("CLUSTER", "JOB" and the default value "MATCH").
                 "MATCH": keep GPU cluster same number of nodes as CPU cluster;

--- a/user_tools/src/spark_rapids_pytools/wrappers/onprem_wrapper.py
+++ b/user_tools/src/spark_rapids_pytools/wrappers/onprem_wrapper.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -55,8 +55,10 @@ class CliOnpremLocalMode:  # pylint: disable=too-few-public-methods
                 named `qual-${EXEC_ID}` where `exec_id` is an auto-generated unique identifier of the execution.
         :param tools_jar: Path to a bundled jar including RAPIDS tool. The path is a local filesystem path
         :param filter_apps:  Filtering criteria of the applications listed in the final STDOUT table is one of
-                the following (`ALL`, `SPEEDUPS`). "`ALL`" means no filter applied. "`SPEEDUPS`" lists all the
-                apps that are either '_Recommended_', or '_Strongly Recommended_' based on speedups.
+                the following (`ALL`, `SPEEDUPS`, `TOP_CANDIDATES`). "`ALL`" means no filter applied. "`SPEEDUPS`"
+                lists all the apps that are either '_Recommended_', or '_Strongly Recommended_' based on speedups.
+                "`TOP_CANDIDATES`" lists all apps that have unsupported operators stage duration less than 25% of
+                app duration and speedups greater than 1.3x.
         :param target_platform: Cost savings and speedup recommendation for comparable cluster in target_platform
                 based on on-premises cluster configuration. Currently only `dataproc` is supported for
                 target_platform.If not provided, the final report will be limited to GPU speedups only

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -75,14 +75,15 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                 cost-savings.
         :param output_folder: path to store the output
         :param filter_apps: filtering criteria of the applications listed in the final STDOUT table
-                is one of the following (ALL, SPEEDUPS, SAVINGS).
+                is one of the following (ALL, SPEEDUPS, SAVINGS, TOP_CANDIDATES).
                 Requires "Cluster".
 
                 Note that this filter does not affect the CSV report.
                 "ALL" means no filter applied. "SPEEDUPS" lists all the apps that are either
                 'Recommended', or 'Strongly Recommended' based on speedups. "SAVINGS"
                 lists all the apps that have positive estimated GPU savings except for the apps that
-                are "Not Applicable"
+                are "Not Applicable". "TOP_CANDIDATES" lists all apps that have unsupported operators
+                stage duration less than 25% of app duration and speedups greater than 1.3x.
         :param cpu_cluster_price: the CPU cluster hourly price provided by the user.
         :param estimated_gpu_cluster_price: the GPU cluster hourly price provided by the user.
         :param cpu_discount: A percent discount for the cpu cluster cost in the form of an integer value

--- a/user_tools/src/spark_rapids_tools/enums.py
+++ b/user_tools/src/spark_rapids_tools/enums.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
 
 """Enumeration types commonly used through the AS python implementations."""
 
-from enum import Enum
-from typing import Union, cast, Optional
+from enum import Enum, auto
+from typing import Union, cast, Optional, Callable
 
 
 class EnumeratedType(str, Enum):
@@ -113,6 +113,7 @@ class QualFilterApp(EnumeratedType):
     """Values used to filter out the applications in the qualification report"""
     SAVINGS = 'savings'
     SPEEDUPS = 'speedups'
+    TOP_CANDIDATES = 'top_candidates'
     ALL = 'all'
 
     @classmethod
@@ -129,3 +130,31 @@ class QualGpuClusterReshapeType(EnumeratedType):
     @classmethod
     def get_default(cls):
         return cls.MATCH
+
+
+class ConditionOperator(EnumeratedType):
+    """Enum representing comparison operators for conditions."""
+    EQUAL = auto()
+    NOT_EQUAL = auto()
+    GREATER_THAN = auto()
+    LESS_THAN = auto()
+    GREATER_THAN_OR_EQUAL = auto()
+    LESS_THAN_OR_EQUAL = auto()
+
+    @classmethod
+    def get_operator_fn(cls, operator: str) -> Callable[[any, any], bool]:
+        """
+        Returns the operator function for a given operator input.
+        """
+        operator_functions = {
+            cls.EQUAL: lambda x, y: x == y,
+            cls.NOT_EQUAL: lambda x, y: x != y,
+            cls.GREATER_THAN: lambda x, y: x > y,
+            cls.LESS_THAN: lambda x, y: x < y,
+            cls.GREATER_THAN_OR_EQUAL: lambda x, y: x >= y,
+            cls.LESS_THAN_OR_EQUAL: lambda x, y: x <= y,
+        }
+        try:
+            return operator_functions[ConditionOperator.fromstring(operator)]
+        except (KeyError, ValueError) as e:
+            raise ValueError(f'Operator function not defined for {operator}') from e

--- a/user_tools/src/spark_rapids_tools/tools/top_candidates.py
+++ b/user_tools/src/spark_rapids_tools/tools/top_candidates.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation class for Top Candidates logic."""
+
+from dataclasses import dataclass, field
+import pandas as pd
+
+from spark_rapids_tools.enums import ConditionOperator
+
+
+@dataclass
+class TopCandidates:
+    """
+    Encapsulates the logic to get top candidates from the Qualification report.
+    """
+    props: dict = field(default=None, init=True)
+
+    def prepare_apps(self, all_apps: pd.DataFrame, additional_info: dict) -> pd.DataFrame:
+        """
+        Generic method to prepare applications before filtering
+        """
+        unsupported_ops_df = additional_info.get('unsupported_ops_df')
+        unsupported_stage_duration_percentage = self.__calculate_unsupported_stages_duration(unsupported_ops_df)
+        # Note: We might have lost some applications because of masking. Final result should include these
+        # applications with unsupported stage duration percentage as 100.0. Thus implying that
+        # these applications have all stages with unsupported operator and are unusable.
+        result_col_name = self.props.get('resultColumnName')
+        result_df = pd.merge(all_apps, unsupported_stage_duration_percentage, how='left')
+        result_df[result_col_name] = result_df[result_col_name].fillna(100)
+        return result_df
+
+    def __calculate_unsupported_stages_duration(self, unsupported_ops_df: pd.DataFrame) -> pd.DataFrame:
+        """
+        Calculates the percentage of total stage duration for unsupported operators for each application
+        """
+        # Define mask to remove rows invalid entries
+        mask = self.__create_column_mask(unsupported_ops_df)
+        unsupported_ops_df = unsupported_ops_df.loc[mask, self.props.get('inputColumns')]
+
+        # Calculate total duration of stages with unsupported operators
+        grouping_cols = self.props.get('groupingColumns')
+        unsupported_stage_duration = unsupported_ops_df \
+            .groupby(grouping_cols.get('max'))['Stage Duration'].max().reset_index() \
+            .groupby(grouping_cols.get('sum'))['Stage Duration'].sum().reset_index()
+
+        # Calculate percentage of app duration
+        result_col_name = self.props.get('resultColumnName')
+        return unsupported_stage_duration \
+            .assign(unsupported_duration_perc=lambda df: (df['Stage Duration'] * 100) / df['App Duration']) \
+            .rename(columns={'unsupported_duration_perc': result_col_name})
+
+    def __create_column_mask(self, unsupported_ops_df: pd.DataFrame) -> bool:
+        """
+        Creates a column mask based on the provided condition.
+        Note: Current implementation is primitive and not a complete AST implementation.
+        Example:
+            raw_mask = [
+              {'columnName': 'colA', 'value': 30, 'operator': 'NOT_EQUAL'},
+              {'columnName': 'colB', 'value': 0, 'operator': 'EQUAL'},
+              {'columnName': 'colC', 'value': 'dummy', 'operator': 'EQUAL'}
+            ]
+
+            mask = True and (colA != 30) and (colB == 0) and (colC == 'dummy')
+        """
+        mask = True
+        for condition in self.props.get('mask'):
+            column_name, value, operator = condition['columnName'], condition['value'], condition['operator']
+            operator_fn = ConditionOperator.get_operator_fn(operator)
+            mask &= operator_fn(unsupported_ops_df[column_name], value)
+        return mask
+
+    def filter_apps(self, all_apps: pd.DataFrame) -> pd.DataFrame:
+        """
+        Generic method to filter applications based on criteria
+        """
+        filtered_apps = all_apps[all_apps.apply(self.__filter_single_row, axis=1)]
+        # Select output columns and sort
+        output_columns = self.props.get('outputColumns')
+        sorting_columns = self.props.get('sortingColumns')
+        return filtered_apps[output_columns].sort_values(by=sorting_columns, ascending=False)
+
+    def __filter_single_row(self, single_row: pd.Series) -> bool:
+        """
+        Used to create a filter for based on specified ranges.
+        Example:
+        self.props['ranges'] = [
+            {'columnName': 'colA', 'lowerBound': 18, 'upperBound': 30},
+            {'columnName': 'colB', 'lowerBound': 70, 'upperBound': 100}
+        ]
+        single_row = pd.Series({'colA': 25, 'colB': 85})
+        The function will return True because the colA (25) is within the range (18-30)
+        and the colB (85) is within the range (70-100).
+        """
+        for criteria in self.props.get('ranges'):
+            col_value = single_row[criteria.get('columnName')]
+            if not criteria.get('lowerBound') <= col_value <= criteria.get('upperBound'):
+                return False
+        return True

--- a/user_tools/src/spark_rapids_tools/tools/top_candidates.py
+++ b/user_tools/src/spark_rapids_tools/tools/top_candidates.py
@@ -15,9 +15,10 @@
 """Implementation class for Top Candidates logic."""
 
 from dataclasses import dataclass, field
-import pandas as pd
+from typing import Optional
+from functools import partial
 
-from spark_rapids_tools.enums import ConditionOperator
+import pandas as pd
 
 
 @dataclass
@@ -26,60 +27,6 @@ class TopCandidates:
     Encapsulates the logic to get top candidates from the Qualification report.
     """
     props: dict = field(default=None, init=True)
-
-    def prepare_apps(self, all_apps: pd.DataFrame, additional_info: dict) -> pd.DataFrame:
-        """
-        Generic method to prepare applications before filtering
-        """
-        unsupported_ops_df = additional_info.get('unsupported_ops_df')
-        unsupported_stage_duration_percentage = self.__calculate_unsupported_stages_duration(unsupported_ops_df)
-        # Note: We might have lost some applications because of masking. Final result should include these
-        # applications with unsupported stage duration percentage as 100.0. Thus implying that
-        # these applications have all stages with unsupported operator and are unusable.
-        result_col_name = self.props.get('resultColumnName')
-        result_df = pd.merge(all_apps, unsupported_stage_duration_percentage, how='left')
-        result_df[result_col_name] = result_df[result_col_name].fillna(100)
-        return result_df
-
-    def __calculate_unsupported_stages_duration(self, unsupported_ops_df: pd.DataFrame) -> pd.DataFrame:
-        """
-        Calculates the percentage of total stage duration for unsupported operators for each application
-        """
-        # Define mask to remove rows invalid entries
-        mask = self.__create_column_mask(unsupported_ops_df)
-        unsupported_ops_df = unsupported_ops_df.loc[mask, self.props.get('inputColumns')]
-
-        # Calculate total duration of stages with unsupported operators
-        grouping_cols = self.props.get('groupingColumns')
-        unsupported_stage_duration = unsupported_ops_df \
-            .groupby(grouping_cols.get('max'))['Stage Duration'].max().reset_index() \
-            .groupby(grouping_cols.get('sum'))['Stage Duration'].sum().reset_index()
-
-        # Calculate percentage of app duration
-        result_col_name = self.props.get('resultColumnName')
-        return unsupported_stage_duration \
-            .assign(unsupported_duration_perc=lambda df: (df['Stage Duration'] * 100) / df['App Duration']) \
-            .rename(columns={'unsupported_duration_perc': result_col_name})
-
-    def __create_column_mask(self, unsupported_ops_df: pd.DataFrame) -> bool:
-        """
-        Creates a column mask based on the provided condition.
-        Note: Current implementation is primitive and not a complete AST implementation.
-        Example:
-            raw_mask = [
-              {'columnName': 'colA', 'value': 30, 'operator': 'NOT_EQUAL'},
-              {'columnName': 'colB', 'value': 0, 'operator': 'EQUAL'},
-              {'columnName': 'colC', 'value': 'dummy', 'operator': 'EQUAL'}
-            ]
-
-            mask = True and (colA != 30) and (colB == 0) and (colC == 'dummy')
-        """
-        mask = True
-        for condition in self.props.get('mask'):
-            column_name, value, operator = condition['columnName'], condition['value'], condition['operator']
-            operator_fn = ConditionOperator.get_operator_fn(operator)
-            mask &= operator_fn(unsupported_ops_df[column_name], value)
-        return mask
 
     def filter_apps(self, all_apps: pd.DataFrame) -> pd.DataFrame:
         """
@@ -108,3 +55,24 @@ class TopCandidates:
             if not criteria.get('lowerBound') <= col_value <= criteria.get('upperBound'):
                 return False
         return True
+
+    def prepare_output(self, all_apps: pd.DataFrame) -> pd.DataFrame:
+        """
+        Generic method to transform applications for the output
+        """
+        output_props = self.props.get('output')
+
+        # Function to remap column values based on recommended ranges
+        def remap_column(col_value, recommended_ranges: dict) -> Optional[str]:
+            for s_range in recommended_ranges:
+                if s_range['lowerBound'] <= col_value < s_range['upperBound']:
+                    return s_range['title']
+            return None
+
+        # Iterate over each entry and apply remapping to respective columns
+        for remap_entry in output_props.get('remap', []):
+            column_name = remap_entry.get('columnName')
+            recommendation_ranges = remap_entry.get('recommendationRanges')
+            remap_func = partial(remap_column, recommended_ranges=recommendation_ranges)
+            all_apps[column_name] = all_apps[column_name].apply(remap_func)
+        return all_apps[output_props.get('columns', [])]

--- a/user_tools/src/spark_rapids_tools/tools/unsupported_ops_stage_duration.py
+++ b/user_tools/src/spark_rapids_tools/tools/unsupported_ops_stage_duration.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation class for Unsupported Operators Stage Duration logic."""
+
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+from spark_rapids_tools.enums import ConditionOperator
+
+
+@dataclass
+class UnsupportedOpsStageDuration:
+    """
+    Encapsulates the logic to calculate stage duration for unsupported operators
+    """
+    props: dict = field(default=None, init=True)
+
+    def prepare_apps_with_unsupported_stages(self, all_apps: pd.DataFrame,
+                                             unsupported_ops_df: pd.DataFrame) -> pd.DataFrame:
+        """
+        Transform applications to include additional column having stage durations for unsupported operators.
+        """
+        unsupported_stage_duration_percentage = self.__calculate_unsupported_stages_duration(unsupported_ops_df)
+        # Note: We might have lost some applications because of masking. Final result should include these
+        # applications with unsupported stage duration percentage as 100.0. Thus implying that
+        # these applications have all stages with unsupported operator and are unusable.
+        result_df = pd.merge(all_apps, unsupported_stage_duration_percentage, how='left')
+        result_col_name = self.props.get('resultColumnName')
+        result_df[result_col_name] = result_df[result_col_name].fillna(result_df['App Duration'])
+        # Update the percentage column
+        perc_result_col_name = self.props.get('percentResultColumnName')
+        result_df[perc_result_col_name] = result_df[result_col_name] * 100.0 / result_df['App Duration']
+        return result_df
+
+    def __calculate_unsupported_stages_duration(self, unsupported_ops_df: pd.DataFrame) -> pd.DataFrame:
+        """
+        Calculates the percentage of total stage duration for unsupported operators for each application
+        """
+        # Define mask to remove rows invalid entries
+        mask = self.__create_column_mask(unsupported_ops_df)
+        unsupported_ops_df = unsupported_ops_df.loc[mask, self.props.get('inputColumns')]
+
+        # Calculate total duration of stages with unsupported operators
+        grouping_cols = self.props.get('groupingColumns')
+        unsupported_ops_stage_duration = unsupported_ops_df \
+            .groupby(grouping_cols.get('max'))['Stage Duration'].max().reset_index() \
+            .groupby(grouping_cols.get('sum'))['Stage Duration'].sum().reset_index()
+
+        # Return the calculated unsupported operators stage duration
+        return unsupported_ops_stage_duration.rename(columns={'Stage Duration':  self.props.get('resultColumnName')})
+
+    def __create_column_mask(self, unsupported_ops_df: pd.DataFrame) -> bool:
+        """
+        Creates a column mask based on the provided condition.
+        Note: Current implementation is primitive and not a complete AST implementation.
+        Example:
+            raw_mask = [
+              {'columnName': 'colA', 'value': 30, 'operator': 'NOT_EQUAL'},
+              {'columnName': 'colB', 'value': 0, 'operator': 'EQUAL'},
+              {'columnName': 'colC', 'value': 'dummy', 'operator': 'EQUAL'}
+            ]
+
+            mask = True and (colA != 30) and (colB == 0) and (colC == 'dummy')
+        """
+        mask = True
+        for condition in self.props.get('mask'):
+            column_name, value, operator = condition['columnName'], condition['value'], condition['operator']
+            operator_fn = ConditionOperator.get_operator_fn(operator)
+            mask &= operator_fn(unsupported_ops_df[column_name], value)
+        return mask


### PR DESCRIPTION
Fixes #807. This PR adds the top candidate filter in user tools. It is not enabled by default currently. See https://github.com/NVIDIA/spark-rapids-tools/issues/807#issuecomment-2015473435 for more details.

### Usage:
- `spark_rapids qualification --eventlogs <eventlogs> --filter_apps top_candidates`
- `spark_rapids_user_tools <platform> qualification --eventlogs <eventlogs> --filter_apps top_candidates`

 