### PR TITLE
[FEA] Skip Databricks Photon jobs at app level in Qualification tool

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -29,6 +29,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.rapids.tool.qualification._
 import org.apache.spark.sql.rapids.tool.ui.{ConsoleProgressBar, QualificationReportGenerator}
 import org.apache.spark.sql.rapids.tool.util._
+import org.apache.spark.sql.rapids.tool.PhotonEventLogException
 
 class Qualification(outputPath: String, numRows: Int, hadoopConf: Configuration,
     timeout: Option[Long], nThreads: Int, order: String,
@@ -187,6 +188,11 @@ class Qualification(outputPath: String, numRows: Int, hadoopConf: Configuration,
       case o: Error =>
         logError(s"Error occured while processing file: $pathStr", o)
         System.exit(1)
+      case e: PhotonEventLogException =>
+        progressBar.foreach(_.reportSkippedProcess())
+        val skippedAppResult = SkippedQualAppResult(pathStr, e.message)
+        skippedAppResult.logMessage()
+        appStatusReporter.put(pathStr, skippedAppResult)
       case e: Exception =>
         progressBar.foreach(_.reportFailedProcess())
         val failureAppResult = FailureQualAppResult(pathStr,
@@ -213,6 +219,8 @@ class Qualification(outputPath: String, numRows: Int, hadoopConf: Configuration,
         StatusSummaryInfo(path, "SUCCESS", appId, message)
       case FailureQualAppResult(path, message) =>
         StatusSummaryInfo(path, "FAILURE", "", message)
+      case SkippedQualAppResult(path, message) =>
+        StatusSummaryInfo(path, "SKIPPED", "", message)
       case UnknownQualAppResult(path, appId, message) =>
         StatusSummaryInfo(path, "UNKNOWN", appId, message)
       case qualAppResult: QualAppResult =>

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -150,7 +150,7 @@ class Qualification(outputPath: String, numRows: Int, hadoopConf: Configuration,
         reportSqlLevel, mlOpsEnabled, penalizeTransitions)
       val qualAppResult = appResult match {
         case Left(FailureApp("skipped", errorMessage)) =>
-          // Case when encountered DataBricks Photon event log during QualificationAppInfo creation
+          // Case to be skipped, e.g. encountered Databricks Photon event log
           progressBar.foreach(_.reportSkippedProcess())
           SkippedQualAppResult(pathStr, errorMessage)
         case Left(FailureApp(_, errorMessage)) =>

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -478,6 +478,8 @@ object SupportedMLFuncsName {
 
 case class GpuEventLogException(message: String) extends Exception(message)
 
+case class PhotonEventLogException(message: String) extends Exception(message)
+
 // Class used a container to hold the information of the Tuple<sqlID, PlanInfo, SparkGraph>
 // to simplify arguments of methods and caching.
 case class SqlPlanInfoGraphEntry(

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -795,7 +795,7 @@ class QualificationAppInfo(
     val sqlPlanInfoGraphEntry = SqlPlanInfoGraphBuffer.createEntry(sqlID, planInfo)
     checkMetadataForReadSchema(sqlPlanInfoGraphEntry)
     for (node <- sqlPlanInfoGraphEntry.sparkPlanGraph.allNodes) {
-      if (node.name.contains("Photon")) {
+      if (node.name.startsWith("Photon")) {
         throw PhotonEventLogException(
           "Encountered Databricks Photon event log: skipping this file!")
       }
@@ -978,7 +978,7 @@ object QualificationAppInfo extends Logging {
       case photonLog: PhotonEventLogException =>
         ("skipped", photonLog.message)
       case gpuLog: GpuEventLogException =>
-        ("unknow", gpuLog.message)
+        ("unknown", gpuLog.message)
       case _: com.fasterxml.jackson.core.JsonParseException =>
         ("unknown", s"Error parsing JSON: ${path.eventLog.toString}")
       case _: IllegalArgumentException =>

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ui/ConsoleProgressBar.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ui/ConsoleProgressBar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ui/ConsoleProgressBar.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ui/ConsoleProgressBar.scala
@@ -33,7 +33,7 @@ import org.apache.spark.internal.Logging
  *
  * By default, the progress bar will be shown in the stdout.
  * Sample generated line:
- *   (.)+ Progress (\\d+)% [==> ] ((\\d+) succeeded + (\\d+) failed + (\\d+) skipped + (\\d+) N/A) / [(\\d+)]
+ *   .+ Progress (\d+)% [==> ] ((\d+) succeeded + (\d+) failed + (\d+) skipped + (\d+) N/A) / (\d+)
  *   toolName Progress 71% [=======>   ] (81 succeeded + 3 failed + 1 skipped + 0 N/A) / 119
  *
  * At the end of execution, it dumps all the defined the counters.

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/OperationResult.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/OperationResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/OperationResult.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/OperationResult.scala
@@ -49,3 +49,6 @@ case class FailureQualAppResult(path: String, message: String)
 
 case class UnknownQualAppResult(path: String, appId: String, message: String)
   extends QualAppResult(path, message) {}
+
+case class SkippedQualAppResult(path: String, message: String)
+  extends QualAppResult(path, message) {}


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/804

This PR implements the logic to skip Databricks Photon jobs at app level in Qualification tool. Each Photon event log will be marked at `SKIPPED` in `rapids_4_spark_qualification_output_status.csv` and removed from other generated files.

**Changes**

- Add class `SkippedQualAppResult` to represent skipped Qualification App creation and `skippedCounter` for console progress bar visualization
- Look for keyword `Photon` when processing SQL plans and short-circuit the process if there exists one
- Add case class `FailureApp` for handling different kinds of exceptions when creating Qualification App


**Tests**

```
spark_rapids_user_tools databricks-azure qualification --cpu_cluster my_cpu_cluster --eventlogs my_event_logs --tools_jar my_tools_jar
```

Before this PR:

<details>
<summary>rapids_4_spark_qualification_output.csv</summary>
<pre>
App Name,App ID,Recommendation,Estimated GPU Speedup,Estimated GPU Duration,Estimated GPU Time Saved,SQL DF Duration,SQL Dataframe Task Duration,App Duration,GPU Opportunity,Executor CPU Time Percent,SQL Ids with Failures,Unsupported Read File Formats and Types,Unsupported Write Data Format,Complex Types,Nested Complex Types,Potential Problems,Longest SQL Duration,NONSQL Task Duration Plus Overhead,Unsupported Task Duration,Supported SQL DF Task Duration,Task Speedup Factor,App Duration Estimated,Unsupported Execs,Unsupported Expressions,Estimated Job Frequency (monthly),Cluster Tags
"Databricks Shell","app-20240220023733-0000","Not Recommended",1.0,3520729.91,22972.08,501797,1682938390,3543702,41203,41.59,"","JSON[timestamp:map:string:array:boolean:date:int:struct:bigint:dec:byte]","","struct<appId:string,version:bigint,lastUpdated:bigint>;struct<path:string,partitionValues:map<string,string>,size:bigint,modificationTime:bigint,dataChange:boolean,stats:string,tags:map<string,string>,deletionVector:struct<storageType:string,pathOrInlineDv:string,offset:int,sizeInBytes:int,cardinality:bigint,maxRowIndex:bigint>,baseRowId:bigint,defaultRowCommitVersion:bigint,clusteringProvider:string>;struct<path:string,deletionTimestamp:bigint,dataChange:boolean,extendedFileMetadata:boolean,partitionValues:map<string,string>,size:bigint,tags:map<string,string>,deletionVector:struct<storageType:string,pathOrInlineDv:string,offset:int,sizeInBytes:int,cardinality:bigint,maxRowIndex:bigint>,baseRowId:bigint,defaultRowCommitVersion:bigint>;struct<id:string,name:string,description:string,format:struct<provider:string,options:map<string,string>>,schemaString:string,partitionColumns:array<string>,configuration:map<string,string>,createdTime:bigint>;struct<minReaderVersion:int,minWriterVersion:int,readerFeatures:array<string>,writerFeatures:array<string>>;struct<path:string,partitionValues:map<string,string>,size:bigint,tags:map<string,string>>;struct<version:bigint,tags:map<string,string>>;struct<path:string,sizeInBytes:bigint,modificationTime:bigint,tags:map<string,string>>;struct<domain:string,configuration:string,removed:boolean>;struct<version:bigint,timestamp:timestamp,userId:string,userName:string,operation:string,operationParameters:map<string,string>,job:struct<jobId:string,jobName:string,jobRunId:string,runId:string,jobOwnerId:string,triggerType:string>,notebook:struct<notebookId:string>,clusterId:string,readVersion:bigint,isolationLevel:string,isBlindAppend:boolean,operationMetrics:map<string,string>,userMetadata:string,tags:map<string,string>,engineInfo:string,txnId:string>","struct<path:string,partitionValues:map<string,string>,size:bigint,modificationTime:bigint,dataChange:boolean,stats:string,tags:map<string,string>,deletionVector:struct<storageType:string,pathOrInlineDv:string,offset:int,sizeInBytes:int,cardinality:bigint,maxRowIndex:bigint>,baseRowId:bigint,defaultRowCommitVersion:bigint,clusteringProvider:string>;struct<path:string,deletionTimestamp:bigint,dataChange:boolean,extendedFileMetadata:boolean,partitionValues:map<string,string>,size:bigint,tags:map<string,string>,deletionVector:struct<storageType:string,pathOrInlineDv:string,offset:int,sizeInBytes:int,cardinality:bigint,maxRowIndex:bigint>,baseRowId:bigint,defaultRowCommitVersion:bigint>;struct<id:string,name:string,description:string,format:struct<provider:string,options:map<string,string>>,schemaString:string,partitionColumns:array<string>,configuration:map<string,string>,createdTime:bigint>;struct<minReaderVersion:int,minWriterVersion:int,readerFeatures:array<string>,writerFeatures:array<string>>;struct<path:string,partitionValues:map<string,string>,size:bigint,tags:map<string,string>>;struct<version:bigint,tags:map<string,string>>;struct<path:string,sizeInBytes:bigint,modificationTime:bigint,tags:map<string,string>>;struct<version:bigint,timestamp:timestamp,userId:string,userName:string,operation:string,operationParameters:map<string,string>,job:struct<jobId:string,jobName:string,jobRunId:string,runId:string,jobOwnerId:string,triggerType:string>,notebook:struct<notebookId:string>,clusterId:string,readVersion:bigint,isolationLevel:string,isBlindAppend:boolean,operationMetrics:map<string,string>,userMetadata:string,tags:map<string,string>,engineInfo:string,txnId:string>","UDF:NESTED COMPLEX TYPE",241288,516242735,1544550551,138387839,2.25,true,"SerializeFromObject;PhotonShuffleMapStage;PhotonGroupingAgg;PhotonShuffleExchangeSink;PhotonShuffleExchangeSource;PhotonProject;MapPartitions;PhotonRowToColumnar;Execute ClearCacheCommand$;Scan ExistingRDD;DeserializeToObject;PhotonFilter;LocalTableScan;Project;Scan json;PhotonResultStage;ObjectHashAggregate;PhotonScan parquet ;MapElements;PhotonParquetWriter;Execute OptimizeTableCommandEdge;PhotonWriteStage","UDF;from_json;filesizehistogramagg",30,"ClusterId -> 0220-023022-xvizld3;created_by -> at657h;DatabricksEnvironment -> workerenv-2876790984019916;ClusterName -> job-518534639051370-run-104068185572167-deDup_lteDist_cluster;BU_Name -> IQI-Standard-Compute-Pool;JobId -> 518534639051370;RunName -> DeviceAnalyzer Production;Creator -> th512d@att.com;Vendor -> Databricks;mots_id -> 30277;contact_dl -> devopshadoop@att.com;env -> prod;BU_Mots_ID -> 26015"
</pre>
</details>

<details>
<summary>rapids_4_spark_qualification_output_status.csv</summary>
<pre>
Event Log,Status,Description
".../photon-eventlogs","SUCCESS","app-20240220023733-0000,Took 37812ms to process"
</pre>
</details>

<details>
<summary>Console Log</summary>
<pre>
| 24/03/26 14:04:08 INFO SuccessQualAppResult: File: .../photon-eventlogs, Message: Took 37812ms to process
| Qual Tool Progress 100% [=========================================================] (1 succeeded + 0 failed + 0 N/A) / 1
| 
| Qual Tool execution time: 37849ms
| 	process.success.count = 1
| 	process.failure.count = 0
| 	process.NA.count = 0
| 	execution.total.count = 1
</pre>
</details>

After this PR:

<details>
<summary>rapids_4_spark_qualification_output.csv</summary>
<pre>
App Name,App ID,Recommendation,Estimated GPU Speedup,Estimated GPU Duration,Estimated GPU Time Saved,SQL DF Duration,SQL Dataframe Task Duration,App Duration,GPU Opportunity,Executor CPU Time Percent,SQL Ids with Failures,Unsupported Read File Formats and Types,Unsupported Write Data Format,Complex Types,Nested Complex Types,Potential Problems,Longest SQL Duration,NONSQL Task Duration Plus Overhead,Unsupported Task Duration,Supported SQL DF Task Duration,Task Speedup Factor,App Duration Estimated,Unsupported Execs,Unsupported Expressions,Estimated Job Frequency (monthly)

</pre>
</details>

<details>
<summary>rapids_4_spark_qualification_output_status.csv</summary>
<pre>
Event Log,Status,Description
".../photon-eventlogs","SKIPPED","PhotonEventLogException: Encountered Databricks Photon event log: skipping this file!"
</pre>
</details>

<details>
<summary>Console Log</summary>
<pre>
| 24/03/26 14:08:35 WARN SkippedQualAppResult: File: .../photon-eventlogs, Message: PhotonEventLogException: Encountered Databricks Photon event log: skipping this file!
| Qual Tool Progress 100% [=============================================] (0 succeeded + 0 failed + 1 skipped + 0 N/A) / 1
| 
| Qual Tool execution time: 683ms
| 	process.success.count = 0
| 	process.failure.count = 0
| 	process.skipped.count = 1
| 	process.NA.count = 0
| 	execution.total.count = 1
</pre>
</details>