### PR TITLE
Add support to RoundCeil and RoundFloor expressions

### DIFF
--- a/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
@@ -281,3 +281,5 @@ RandomForestRegressor-pyspark,3.66
 RandomForestRegressor-scala,1.0
 XGBoost-pyspark,1.0
 XGBoost-scala,3.31
+RoundCeil,2.45
+RoundFloor,2.45

--- a/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
@@ -269,3 +269,5 @@ ArrowEvalPythonExec,1.2
 FlatMapGroupsInPandasExec,1.2
 MapInPandasExec,1.2
 WindowInPandasExec,1.2
+RoundCeil,2.73
+RoundFloor,2.73

--- a/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
@@ -263,3 +263,5 @@ FlatMapGroupsInPandasExec,1.2
 FlatMapCoGroupsInPandasExec,1.2
 MapInPandasExec,1.2
 WindowInPandasExec,1.2
+RoundCeil,3.74
+RoundFloor,3.74

--- a/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
@@ -263,3 +263,5 @@ FlatMapGroupsInPandasExec,1.2
 FlatMapCoGroupsInPandasExec,1.2
 MapInPandasExec,1.2
 WindowInPandasExec,1.2
+RoundCeil,3.65
+RoundFloor,3.65

--- a/core/src/main/resources/operatorsScore-dataproc-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-l4.csv
@@ -269,3 +269,5 @@ ArrowEvalPythonExec,1.2
 FlatMapGroupsInPandasExec,1.2
 MapInPandasExec,1.2
 WindowInPandasExec,1.2
+RoundCeil,4.16
+RoundFloor,4.16

--- a/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
@@ -263,3 +263,5 @@ FlatMapGroupsInPandasExec,1.2
 FlatMapCoGroupsInPandasExec,1.2
 MapInPandasExec,1.2
 WindowInPandasExec,1.2
+RoundCeil,4.25
+RoundFloor,4.25

--- a/core/src/main/resources/operatorsScore-dataproc-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-t4.csv
@@ -269,3 +269,5 @@ ArrowEvalPythonExec,1.2
 FlatMapGroupsInPandasExec,1.2
 MapInPandasExec,1.2
 WindowInPandasExec,1.2
+RoundCeil,4.88
+RoundFloor,4.88

--- a/core/src/main/resources/operatorsScore-emr-a10.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10.csv
@@ -269,3 +269,5 @@ ArrowEvalPythonExec,1.2
 FlatMapGroupsInPandasExec,1.2
 MapInPandasExec,1.2
 WindowInPandasExec,1.2
+RoundCeil,2.59
+RoundFloor,2.59

--- a/core/src/main/resources/operatorsScore-emr-t4.csv
+++ b/core/src/main/resources/operatorsScore-emr-t4.csv
@@ -269,3 +269,5 @@ ArrowEvalPythonExec,1.2
 FlatMapGroupsInPandasExec,1.2
 MapInPandasExec,1.2
 WindowInPandasExec,1.2
+RoundCeil,2.07
+RoundFloor,2.07

--- a/core/src/main/resources/operatorsScore-onprem-a100.csv
+++ b/core/src/main/resources/operatorsScore-onprem-a100.csv
@@ -281,3 +281,5 @@ RandomForestRegressor-pyspark,3.66
 RandomForestRegressor-scala,1
 XGBoost-pyspark,1
 XGBoost-scala,3.31
+RoundCeil,4
+RoundFloor,4

--- a/core/src/main/resources/supportedExecs.csv
+++ b/core/src/main/resources/supportedExecs.csv
@@ -18,7 +18,7 @@ AQEShuffleReadExec,TNEW,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS
 HashAggregateExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,PS,NS,PS,PS,PS,NS,NS,NS
 ObjectHashAggregateExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,PS,NS,PS,PS,PS,NS,NS,NS
 SortAggregateExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,PS,NS,PS,PS,PS,NS,NS,NS
-InMemoryTableScanExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,PS,PS,PS,NS,S,S
+InMemoryTableScanExec,S,This is disabled by default because there could be complications when using it with AQE. For more details please check https://github.com/NVIDIA/spark-rapids/issues/10603,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,PS,PS,PS,NS,S,S
 DataWritingCommandExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,PS,NS,S,NS,PS,PS,PS,NS,S,S
 ExecutedCommandExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
 WriteFilesExec,TNEW,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S

--- a/core/src/main/resources/supportedExprs.csv
+++ b/core/src/main/resources/supportedExprs.csv
@@ -476,12 +476,12 @@ Rint,S,`rint`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 Round,S,`round`,None,project,value,NA,S,S,S,S,PS,PS,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NS,NS
 Round,S,`round`,None,project,scale,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
 Round,S,`round`,None,project,result,NA,S,S,S,S,S,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NS,NS
-RoundCeil,TNEW, ,None,project,value,NA,S,S,S,S,PS,PS,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA
-RoundCeil,TNEW, ,None,project,scale,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
-RoundCeil,TNEW, ,None,project,result,NA,S,S,S,S,S,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA
-RoundFloor,TNEW, ,None,project,value,NA,S,S,S,S,PS,PS,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA
-RoundFloor,TNEW, ,None,project,scale,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
-RoundFloor,TNEW, ,None,project,result,NA,S,S,S,S,S,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA
+RoundCeil,S,`ceil`,None,project,value,NA,S,S,S,S,PS,PS,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA
+RoundCeil,S,`ceil`,None,project,scale,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+RoundCeil,S,`ceil`,None,project,result,NA,S,S,S,S,S,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA
+RoundFloor,S,`floor`,None,project,value,NA,S,S,S,S,PS,PS,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA
+RoundFloor,S,`floor`,None,project,scale,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+RoundFloor,S,`floor`,None,project,result,NA,S,S,S,S,S,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA
 RowNumber,S,`row_number`,None,window,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
 ScalaUDF,S, ,None,project,param,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,NS,NS,NS
 ScalaUDF,S, ,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,NS,NS,NS

--- a/scripts/sync_plugin_files/override_supported_configs.json
+++ b/scripts/sync_plugin_files/override_supported_configs.json
@@ -347,8 +347,8 @@
       "Params": "value",
       "override": [
         {
-          "key": "Supported",
-          "value": "TNEW"
+          "key": "SQL Func",
+          "value": "`ceil`"
         }
       ]
     },
@@ -358,8 +358,8 @@
       "Params": "scale",
       "override": [
         {
-          "key": "Supported",
-          "value": "TNEW"
+          "key": "SQL Func",
+          "value": "`ceil`"
         }
       ]
     },
@@ -369,8 +369,8 @@
       "Params": "result",
       "override": [
         {
-          "key": "Supported",
-          "value": "TNEW"
+          "key": "SQL Func",
+          "value": "`ceil`"
         }
       ]
     },
@@ -380,8 +380,8 @@
       "Params": "value",
       "override": [
         {
-          "key": "Supported",
-          "value": "TNEW"
+          "key": "SQL Func",
+          "value": "`floor`"
         }
       ]
     },
@@ -391,8 +391,8 @@
       "Params": "scale",
       "override": [
         {
-          "key": "Supported",
-          "value": "TNEW"
+          "key": "SQL Func",
+          "value": "`floor`"
         }
       ]
     },
@@ -402,8 +402,8 @@
       "Params": "result",
       "override": [
         {
-          "key": "Supported",
-          "value": "TNEW"
+          "key": "SQL Func",
+          "value": "`floor`"
         }
       ]
     },


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

- Adds RoundCeil and RoundFloor to the score sheets
- Adds the two operators to the `supportedExprs.csv`
- There is no need to make any other change since the SQL functions of those operators are already covered by the `Ceil` and `Floor` operators.
- The main difference is in the DTypes which is not checked anyway by the Qual tools.