### PR TITLE
Add support for KnownNullable and EphemeralSubstring

### DIFF
--- a/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
@@ -285,3 +285,5 @@ RoundCeil,2.45
 RoundFloor,2.45
 BloomFilterMightContain,2.45
 BloomFilterAggregate,2.45
+EphemeralSubstring,2.45
+KnownNullable,2.45

--- a/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
@@ -273,3 +273,5 @@ RoundCeil,2.73
 RoundFloor,2.73
 BloomFilterMightContain,2.73
 BloomFilterAggregate,2.73
+EphemeralSubstring,2.73
+KnownNullable,2.73

--- a/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
@@ -267,3 +267,5 @@ RoundCeil,3.74
 RoundFloor,3.74
 BloomFilterMightContain,3.74
 BloomFilterAggregate,3.74
+EphemeralSubstring,3.74
+KnownNullable,3.74

--- a/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
@@ -267,3 +267,5 @@ RoundCeil,3.65
 RoundFloor,3.65
 BloomFilterMightContain,3.65
 BloomFilterAggregate,3.65
+EphemeralSubstring,3.65
+KnownNullable,3.65

--- a/core/src/main/resources/operatorsScore-dataproc-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-l4.csv
@@ -273,3 +273,5 @@ RoundCeil,4.16
 RoundFloor,4.16
 BloomFilterMightContain,4.16
 BloomFilterAggregate,4.16
+EphemeralSubstring,4.16
+KnownNullable,4.16

--- a/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
@@ -267,3 +267,5 @@ RoundCeil,4.25
 RoundFloor,4.25
 BloomFilterMightContain,4.25
 BloomFilterAggregate,4.25
+EphemeralSubstring,4.25
+KnownNullable,4.25

--- a/core/src/main/resources/operatorsScore-dataproc-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-t4.csv
@@ -273,3 +273,5 @@ RoundCeil,4.88
 RoundFloor,4.88
 BloomFilterMightContain,4.88
 BloomFilterAggregate,4.88
+EphemeralSubstring,4.88
+KnownNullable,4.88

--- a/core/src/main/resources/operatorsScore-emr-a10.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10.csv
@@ -273,3 +273,5 @@ RoundCeil,2.59
 RoundFloor,2.59
 BloomFilterMightContain,2.59
 BloomFilterAggregate,2.59
+EphemeralSubstring,2.59
+KnownNullable,2.59

--- a/core/src/main/resources/operatorsScore-emr-t4.csv
+++ b/core/src/main/resources/operatorsScore-emr-t4.csv
@@ -273,3 +273,5 @@ RoundCeil,2.07
 RoundFloor,2.07
 BloomFilterMightContain,2.07
 BloomFilterAggregate,2.07
+EphemeralSubstring,2.07
+KnownNullable,2.07

--- a/core/src/main/resources/operatorsScore-onprem-a100.csv
+++ b/core/src/main/resources/operatorsScore-onprem-a100.csv
@@ -285,3 +285,5 @@ RoundCeil,4
 RoundFloor,4
 BloomFilterMightContain,4
 BloomFilterAggregate,4
+EphemeralSubstring,4
+KnownNullable,4

--- a/core/src/main/resources/supportedExprs.csv
+++ b/core/src/main/resources/supportedExprs.csv
@@ -193,8 +193,8 @@ DynamicPruningExpression,S, ,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS
 ElementAt,S,`element_at`,None,project,array/map,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,PS,NA,NA,NS,NS
 ElementAt,S,`element_at`,None,project,index/key,PS,PS,PS,S,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NS,NS,NS,NS,NS
 ElementAt,S,`element_at`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,NS,NS
-Empty2Null,S,`empty2null`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
-Empty2Null,S,`empty2null`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+Empty2Null,S, ,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+Empty2Null,S, ,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 EndsWith,S, ,None,project,src,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
 EndsWith,S, ,None,project,search,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
 EndsWith,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
@@ -297,8 +297,8 @@ KnownFloatingPointNormalized,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,S,S
 KnownFloatingPointNormalized,S, ,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
 KnownNotNull,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,NS,S,S,PS,PS,PS,NS,NS,NS
 KnownNotNull,S, ,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,NS,S,S,PS,PS,PS,NS,NS,NS
-KnownNullable,TNEW, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
-KnownNullable,TNEW, ,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
+KnownNullable,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
+KnownNullable,S, ,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
 Lag,S,`lag`,None,window,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,PS,NS,PS,NS,NS,NS
 Lag,S,`lag`,None,window,offset,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
 Lag,S,`lag`,None,window,default,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,PS,NS,PS,NS,NS,NS
@@ -774,3 +774,7 @@ CheckOverflow,S, ,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA
 CheckOverflow,S, ,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NS,NS
 PromotePrecision,S,`promote_precision`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NS,NS
 PromotePrecision,S,`promote_precision`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NS,NS
+EphemeralSubstring,S,`substr`; `substring`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NS,NA,NA,NA,NA,NA,NS,NS
+EphemeralSubstring,S,`substr`; `substring`,None,project,pos,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
+EphemeralSubstring,S,`substr`; `substring`,None,project,len,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
+EphemeralSubstring,S,`substr`; `substring`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NS,NA,NA,NA,NA,NA,NS,NS

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -1643,4 +1643,19 @@ class SQLPlanParserSuite extends BaseTestSuite {
     pluginTypeChecker.getNotSupportedExprs(aggExprArr) shouldBe 'empty
     pluginTypeChecker.getNotSupportedExprs(filterExprArray) shouldBe 'empty
   }
+
+  test("KnownNullable is supported") {
+    // scalastyle:off line.size.limit
+    // The following expression is copied from the Spark explain files
+    val projectDescr = "Project [named_struct(start, precisetimestampconversion(precisetimestampconversion(t#0, TimestampType, LongType), LongType, TimestampType), end, knownnullable(precisetimestampconversion(precisetimestampconversion(cast(t#0 + cast(10 minutes as interval) as timestamp), TimestampType, LongType), LongType, TimestampType))) AS session_window#0, d#0, t#0, s#0, x#0L, wt#0]"
+    // scalastyle:on line.size.limit
+    val projectNode = ToolsPlanGraph.constructGraphNode(
+      2,
+      "Project",
+      projectDescr, Seq[SQLPlanMetric]())
+    val filterExprArray = SQLPlanParser.parseFilterExpressions(
+      projectNode.desc.replaceFirst("Project ", ""))
+    val pluginTypeChecker = new PluginTypeChecker()
+    pluginTypeChecker.getNotSupportedExprs(filterExprArray) shouldBe 'empty
+  }
 }

--- a/scripts/sync_plugin_files/override_supported_configs.json
+++ b/scripts/sync_plugin_files/override_supported_configs.json
@@ -23,28 +23,6 @@
       ]
     },
     {
-      "Expression": "Empty2Null",
-      "Context": "project",
-      "Params": "input",
-      "override": [
-        {
-          "key": "SQL Func",
-          "value": "`empty2null`"
-        }
-      ]
-    },
-    {
-      "Expression": "Empty2Null",
-      "Context": "project",
-      "Params": "result",
-      "override": [
-        {
-          "key": "SQL Func",
-          "value": "`empty2null`"
-        }
-      ]
-    },
-    {
       "Expression": "BloomFilterMightContain",
       "Context": "project",
       "Params": "lhs",
@@ -156,28 +134,6 @@
     },
     {
       "Expression": "DivideYMInterval",
-      "Context": "project",
-      "Params": "result",
-      "override": [
-        {
-          "key": "Supported",
-          "value": "TNEW"
-        }
-      ]
-    },
-    {
-      "Expression": "KnownNullable",
-      "Context": "project",
-      "Params": "input",
-      "override": [
-        {
-          "key": "Supported",
-          "value": "TNEW"
-        }
-      ]
-    },
-    {
-      "Expression": "KnownNullable",
       "Context": "project",
       "Params": "result",
       "override": [


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Contributes to #865

Adds support to two new string expressions
- `EphermalSubstring` is supported by DB, but we add it to the score sheet of all other platforms since we have a single expression.csv file anyway.
- No need for a new unit test for `EphermalSubstring` because it is the same as substring.
- Added a new test for `KnownNullable`
- Removed configuration override related to `Empty2Null` because the sql function is the lower string of the expr-name which should be supported by default.
- Removed the entries of the expressions in `override_supported_configs.json`
