### PR TITLE
[FEA] Skip Spark Structured Streaming event logs for Qualification tool

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
@@ -90,10 +90,12 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
       case _: SparkListenerSQLAdaptiveSQLMetricUpdates =>
         doSparkListenerSQLAdaptiveSQLMetricUpdates(app,
           event.asInstanceOf[SparkListenerSQLAdaptiveSQLMetricUpdates])
-      case _: StreamingQueryListener.QueryStartedEvent
-        | _: StreamingQueryListener.QueryTerminatedEvent =>
-        throw StreamingEventLogException(
-          "Encountered Spark Structured Streaming Job: skipping this file!")
+      case _: StreamingQueryListener.QueryStartedEvent =>
+        doSparkListenerStreamingQuery(app,
+          event.asInstanceOf[StreamingQueryListener.QueryStartedEvent])
+      case _: StreamingQueryListener.QueryTerminatedEvent =>
+        doSparkListenerStreamingQuery(app,
+          event.asInstanceOf[StreamingQueryListener.QueryTerminatedEvent])
       case _ =>
         val wasResourceProfileAddedEvent = doSparkListenerResourceProfileAddedReflect(app, event)
         if (!wasResourceProfileAddedEvent) doOtherEvent(app, event)
@@ -231,6 +233,13 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
       exec.isActive = true
       exec.maxMemory = event.maxMem
     }
+  }
+
+  def doSparkListenerStreamingQuery(
+      app: T,
+      event: SparkListenerEvent): Unit = {
+    throw StreamingEventLogException(
+      "Encountered Spark Structured Streaming Job: skipping this file!")
   }
 
   override def onBlockManagerAdded(blockManagerAdded: SparkListenerBlockManagerAdded): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
@@ -25,6 +25,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler._
 import org.apache.spark.sql.execution.ui._
 import org.apache.spark.sql.rapids.tool.util.{EventUtils, StringUtils}
+import org.apache.spark.sql.streaming.StreamingQueryListener
 
 abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener with Logging {
 
@@ -89,6 +90,10 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
       case _: SparkListenerSQLAdaptiveSQLMetricUpdates =>
         doSparkListenerSQLAdaptiveSQLMetricUpdates(app,
           event.asInstanceOf[SparkListenerSQLAdaptiveSQLMetricUpdates])
+      case _: StreamingQueryListener.QueryStartedEvent
+        | _: StreamingQueryListener.QueryTerminatedEvent =>
+        throw StreamingEventLogException(
+          "Encountered Spark Structured Streaming Job: skipping this file!")
       case _ =>
         val wasResourceProfileAddedEvent = doSparkListenerResourceProfileAddedReflect(app, event)
         if (!wasResourceProfileAddedEvent) doOtherEvent(app, event)

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -484,6 +484,8 @@ case class GpuEventLogException(message: String) extends Exception(message)
 
 case class PhotonEventLogException(message: String) extends Exception(message)
 
+case class StreamingEventLogException(message: String) extends Exception(message)
+
 // Class used a container to hold the information of the Tuple<sqlID, PlanInfo, SparkGraph>
 // to simplify arguments of methods and caching.
 case class SqlPlanInfoGraphEntry(

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -28,7 +28,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEnvironmentUpdate, SparkListenerEvent, SparkListenerJobStart}
 import org.apache.spark.sql.execution.SparkPlanInfo
-import org.apache.spark.sql.rapids.tool.{AppBase, ClusterSummary, GpuEventLogException, PhotonEventLogException, SqlPlanInfoGraphBuffer, SupportedMLFuncsName, ToolUtils}
+import org.apache.spark.sql.rapids.tool.{AppBase, ClusterSummary, GpuEventLogException, PhotonEventLogException, SqlPlanInfoGraphBuffer, StreamingEventLogException, SupportedMLFuncsName, ToolUtils}
 
 
 class QualificationAppInfo(
@@ -977,6 +977,8 @@ object QualificationAppInfo extends Logging {
 
   private def handleException(e: Exception, path: EventLogInfo): FailureApp = {
     val (status, message): (String, String) = e match {
+      case streamingLog: StreamingEventLogException =>
+        ("skipped", streamingLog.message)
       case photonLog: PhotonEventLogException =>
         ("skipped", photonLog.message)
       case gpuLog: GpuEventLogException =>


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/845

**Changes**
Skip event logs with Structured Streaming jobs at app level


**Testing**
```
spark_rapids_user_tools databricks-aws qualification --cpu_cluster my_cpu_cluster --tools_jar my_tools_jar --eventlogs my_event_logs
```

Before this PR:
<details>
<summary>rapids_4_spark_qualification_output_status.csv</summary>
<pre>
Event Log,Status,Description
".../app-20240301000442-0000.zstd","SUCCESS","app-20240301000442-0000,Took 3358ms to process"
"...app-20240229193423-0000.zstd","SUCCESS","app-20240229193423-0000,Took 10926ms to process"
".../app-20240217160846-0000.zstd","SUCCESS","app-20240217160846-0000,Took 5462ms to process"
".../app-20240301020723-0000.zstd","SUCCESS","app-20240301020723-0000,Took 6137ms to process"
".../app-20240301050638-0000.zstd","SKIPPED","PhotonEventLogException: Encountered Databricks Photon event log: skipping this file!"
".../app-20240301015116-0000.zstd","SKIPPED","PhotonEventLogException: Encountered Databricks Photon event log: skipping this file!"
".../app-20240229075540-0000.zstd","SKIPPED","PhotonEventLogException: Encountered Databricks Photon event log: skipping this file!"
"...app-20240301093312-0000.zstd","SUCCESS","app-20240301093312-0000,Took 3575ms to process"
</pre>
</details>

After this PR:
<details>
<summary>rapids_4_spark_qualification_output_status.csv</summary>
<pre>
Event Log,Status,Description
".../app-20240301000442-0000.zstd","SUCCESS","app-20240301000442-0000,Took 3151ms to process"
"...app-20240229193423-0000.zstd","SUCCESS","app-20240229193423-0000,Took 11449ms to process"
".../app-20240217160846-0000.zstd","SUCCESS","app-20240217160846-0000,Took 5271ms to process"
".../app-20240301020723-0000.zstd","SUCCESS","app-20240301020723-0000,Took 5946ms to process"
".../app-20240301050638-0000.zstd","SKIPPED","PhotonEventLogException: Encountered Databricks Photon event log: skipping this file!"
".../app-20240301015116-0000.zstd","SKIPPED","PhotonEventLogException: Encountered Databricks Photon event log: skipping this file!"
".../app-20240229075540-0000.zstd","SKIPPED","PhotonEventLogException: Encountered Databricks Photon event log: skipping this file!"
".../app-20240301093312-0000.zstd","SKIPPED","StreamingEventLogException: Encountered Spark Structured Streaming Job: skipping this file!"
</pre>
</details>

**Note**
Tested on spark_rapids with cmd: `spark_rapids qualification --cluster my_cpu_cluster --eventlogs my_event_logs --tools_jar my_tools_jar`