### PR TITLE
Refactor `find_matches_for_node` return values

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
@@ -276,7 +276,7 @@ class DatabricksCluster(ClusterBase):
         :param orig_cluster: the cpu_cluster that does not support the GPU devices.
         """
         # get the map of the instance types
-        mc_type_map, _ = orig_cluster.find_matches_for_node()
+        mc_type_map = orig_cluster.find_matches_for_node()
         new_worker_nodes: list = []
         for anode in orig_cluster.nodes.get(SparkNodeType.WORKER):
             # loop on all worker nodes.

--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
@@ -368,7 +368,7 @@ class DatabricksAzureCluster(ClusterBase):
         :param orig_cluster: the cpu_cluster that does not support the GPU devices.
         """
         # get the map of the instance types
-        mc_type_map, _ = orig_cluster.find_matches_for_node()
+        mc_type_map = orig_cluster.find_matches_for_node()
         new_worker_nodes: list = []
         for anode in orig_cluster.nodes.get(SparkNodeType.WORKER):
             # loop on all worker nodes.

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -460,7 +460,8 @@ class DataprocCluster(ClusterBase):
         :param orig_cluster: the cpu_cluster that does not support the GPU devices.
         """
         # get the map of the instance types
-        mc_type_map, supported_mc_map = orig_cluster.find_matches_for_node()
+        supported_mc_map = orig_cluster.platform.get_supported_gpus()
+        mc_type_map = orig_cluster.find_matches_for_node()
         new_worker_nodes: list = []
         for anode in orig_cluster.nodes.get(SparkNodeType.WORKER):
             # loop on all worker nodes.

--- a/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
@@ -352,7 +352,7 @@ class EMRCluster(ClusterBase):
         self.instance_groups = []
         self.ec2_instances = []
         # get the map of the instance types
-        mc_type_map, _ = orig_cluster.find_matches_for_node()
+        mc_type_map = orig_cluster.find_matches_for_node()
         # convert instances and groups
         # master groups should stay the same
         for curr_group in orig_cluster.instance_groups:

--- a/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
@@ -252,7 +252,7 @@ class OnPremCluster(ClusterBase):
         :param orig_cluster: the cpu_cluster
         """
         # get the map of the instance types
-        _, supported_mc_map = orig_cluster.find_matches_for_node()
+        supported_mc_map = orig_cluster.platform.get_supported_gpus()
         new_worker_nodes: list = []
         for anode in orig_cluster.nodes.get(SparkNodeType.WORKER):
             new_instance_type = anode.instance_type

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -1057,11 +1057,10 @@ class ClusterBase(ClusterGetAccessor):
         self.props = orig_cluster.props
         self._build_migrated_cluster(orig_cluster)
 
-    def find_matches_for_node(self) -> (dict, dict):
+    def find_matches_for_node(self) -> dict:
         """
         Maps the CPU instance types to GPU types
-        :return: a map converting CPU machines to GPU ones and a map
-                containing the supported GPUs.
+        :return: a map converting CPU machines to GPU ones.
         """
         mc_map = {}
         supported_gpus = self.platform.get_supported_gpus()
@@ -1076,7 +1075,7 @@ class ClusterBase(ClusterGetAccessor):
                     if anode.instance_type not in mc_map:
                         best_mc_match = anode.find_best_cpu_conversion(supported_gpus)
                         mc_map.update({anode.instance_type: best_mc_match})
-        return mc_map, supported_gpus
+        return mc_map
 
     def get_all_spark_properties(self) -> dict:
         """Returns a dictionary containing the spark configurations defined in the cluster properties"""


### PR DESCRIPTION
`find_matches_for_node` returns a mapping of CPU to GPU machines and a mapping of supported GPUs. It has 5 use sites, but 4 of them only need one of the mappings.

This PR refactors the function return values. For `onprem`, the implementation can directly get `supported_mc_map` without running `find_matches_for_node`.