### PR TITLE
Add cluster details in qualification summary output

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
@@ -826,26 +826,25 @@ object QualOutputWriter {
       prettyPrint: Boolean,
       reformatCSV: Boolean = true): Seq[String] = {
     val reformatCSVFunc = getReformatCSVFunc(reformatCSV)
-    val clusterSummary = sumInfo.clusterSummary
-    val data = ListBuffer[(String, Int)](
-      reformatCSVFunc(clusterSummary.appId) -> headersAndSizes(APP_ID_STR),
-      reformatCSVFunc(clusterSummary.appName) -> headersAndSizes(APP_NAME_STR),
-      reformatCSVFunc(clusterSummary.clusterInfo.map(_.vendor).getOrElse(""))
-        -> headersAndSizes(VENDOR),
-      reformatCSVFunc(clusterSummary.clusterInfo.flatMap(_.driverHost).getOrElse(""))
-        -> headersAndSizes(DRIVER_HOST),
-      reformatCSVFunc(clusterSummary.clusterInfo.flatMap(_.clusterId).getOrElse(""))
-        -> headersAndSizes(CLUSTER_ID),
-      reformatCSVFunc(clusterSummary.clusterInfo.flatMap(_.clusterName).getOrElse(""))
-        -> headersAndSizes(CLUSTER_NAME),
-      reformatCSVFunc(clusterSummary.clusterInfo.flatMap(_.executorInstance).getOrElse(""))
-        -> headersAndSizes(EXEC_INSTANCE),
-      reformatCSVFunc(clusterSummary.clusterInfo.flatMap(_.driverInstance).getOrElse(""))
-        -> headersAndSizes(DRIVER_INSTANCE),
-      reformatCSVFunc(clusterSummary.clusterInfo.map(_.numExecutorNodes.toString).getOrElse(""))
-        -> headersAndSizes(NUM_EXEC_NODES),
-      reformatCSVFunc(clusterSummary.clusterInfo.map(_.coresPerExecutor.toString).getOrElse(""))
-        -> headersAndSizes(CORES_PER_EXEC))
+    val clusterInfo = sumInfo.clusterSummary.clusterInfo
+
+    // Wrapper function around reformatCSVFunc() to handle optional fields and
+    // reduce redundancy
+    def refactorCSVFuncWithOption(field: Option[String], headerConst: String): (String, Int) =
+      reformatCSVFunc(field.getOrElse("")) -> headersAndSizes(headerConst)
+
+    val data = ListBuffer(
+      refactorCSVFuncWithOption(Some(sumInfo.clusterSummary.appId), APP_ID_STR),
+      refactorCSVFuncWithOption(Some(sumInfo.clusterSummary.appName), APP_NAME_STR),
+      refactorCSVFuncWithOption(clusterInfo.map(_.vendor), VENDOR),
+      refactorCSVFuncWithOption(clusterInfo.flatMap(_.driverHost), DRIVER_HOST),
+      refactorCSVFuncWithOption(clusterInfo.flatMap(_.clusterId), CLUSTER_ID),
+      refactorCSVFuncWithOption(clusterInfo.flatMap(_.clusterName), CLUSTER_NAME),
+      refactorCSVFuncWithOption(clusterInfo.flatMap(_.executorInstance), EXEC_INSTANCE),
+      refactorCSVFuncWithOption(clusterInfo.flatMap(_.driverInstance), DRIVER_INSTANCE),
+      refactorCSVFuncWithOption(clusterInfo.map(_.numExecutorNodes.toString), NUM_EXEC_NODES),
+      refactorCSVFuncWithOption(clusterInfo.map(_.coresPerExecutor.toString), CORES_PER_EXEC)
+    )
     constructOutputRow(data, delimiter, prettyPrint) :: Nil
   }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
@@ -437,7 +437,7 @@ object QualOutputWriter {
   val UNSUPPORTED_EXPRS = "Unsupported Expressions"
   val UNSUPPORTED_OPERATOR = "Unsupported Operator"
   val CLUSTER_TAGS = "Cluster Tags"
-  val CLUSTER_ID = "Cluster Id"
+  val CLUSTER_ID = "ClusterId"
   val JOB_ID = "JobId"
   val UNSUPPORTED_TYPE = "Unsupported Type"
   val EXEC_ID = "ExecId"
@@ -456,6 +456,7 @@ object QualOutputWriter {
   val STATUS_REPORT_DESC_STR = "Description"
   val VENDOR = "Vendor"
   val DRIVER_HOST = "Driver Host"
+  val CLUSTER_ID_STR = "Cluster Id" // Different from ClusterId used for Databricks Tags
   val CLUSTER_NAME = "Cluster Name"
   val NUM_EXEC_NODES = "Num Executor Nodes"
   val CORES_PER_EXEC = "Cores Per Executor"
@@ -812,7 +813,7 @@ object QualOutputWriter {
 
   private def getClusterInfoHeaderStrings: mutable.LinkedHashMap[String, Int] = {
     val headersAndFields = Seq(
-      APP_ID_STR, APP_NAME_STR, VENDOR, DRIVER_HOST, CLUSTER_ID, CLUSTER_NAME,
+      APP_ID_STR, APP_NAME_STR, VENDOR, DRIVER_HOST, CLUSTER_ID_STR, CLUSTER_NAME,
       EXEC_INSTANCE, DRIVER_INSTANCE, NUM_EXEC_NODES, CORES_PER_EXEC).map {
       key => (key, key.length)
     }
@@ -838,7 +839,7 @@ object QualOutputWriter {
       refactorCSVFuncWithOption(Some(sumInfo.clusterSummary.appName), APP_NAME_STR),
       refactorCSVFuncWithOption(clusterInfo.map(_.vendor), VENDOR),
       refactorCSVFuncWithOption(clusterInfo.flatMap(_.driverHost), DRIVER_HOST),
-      refactorCSVFuncWithOption(clusterInfo.flatMap(_.clusterId), CLUSTER_ID),
+      refactorCSVFuncWithOption(clusterInfo.flatMap(_.clusterId), CLUSTER_ID_STR),
       refactorCSVFuncWithOption(clusterInfo.flatMap(_.clusterName), CLUSTER_NAME),
       refactorCSVFuncWithOption(clusterInfo.flatMap(_.executorInstance), EXEC_INSTANCE),
       refactorCSVFuncWithOption(clusterInfo.flatMap(_.driverInstance), DRIVER_INSTANCE),

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -258,7 +258,7 @@ class Qualification(outputPath: String, numRows: Int, hadoopConf: Configuration,
       QualificationReportGenerator.generateDashBoard(outputDir, allAppsSum)
     }
     if (clusterReport) {
-      qWriter.writeClusterReport(allAppsSum)
+      qWriter.writeClusterReportCsv(allAppsSum)
     }
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -258,6 +258,7 @@ class Qualification(outputPath: String, numRows: Int, hadoopConf: Configuration,
       QualificationReportGenerator.generateDashBoard(outputDir, allAppsSum)
     }
     if (clusterReport) {
+      qWriter.writeClusterReport(allAppsSum)
       qWriter.writeClusterReportCsv(allAppsSum)
     }
   }

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -44,15 +44,15 @@ class ClusterInference:
         num_driver_nodes = 1
         driver_instance = cluster_info_df.get('Driver Instance')
         # If driver instance is not set, use the default value from platform configurations
-        if driver_instance is None:
+        if pd.isna(driver_instance):
             driver_instance = self.platform.configs.get_value('clusterInference', 'defaultCpuInstances', 'driver')
         num_executor_nodes = cluster_info_df.get('Num Executor Nodes')
         executor_instance = cluster_info_df.get('Executor Instance')
-        if executor_instance is None:
+        if pd.isna(executor_instance):
             # If executor instance is not set, use the default value based on the number of cores
             cores_per_executor = cluster_info_df.get('Cores Per Executor')
             executor_instance = self.platform.get_matching_executor_instance(cores_per_executor)
-            if executor_instance is None:
+            if pd.isna(executor_instance):
                 self.logger.info('Unable to infer CPU cluster. No matching executor instance found for vCPUs = %s',
                                  cores_per_executor)
                 return None

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -71,7 +71,7 @@ class ClusterInference:
             self.logger.info('Cannot infer CPU cluster from event logs. Only single cluster is supported.')
             return None
 
-        # Extract cluster information from parsed logs
+        # Extract cluster information from parsed logs. Above check ensures df contains single row.
         cluster_template_args = self.get_cluster_template_args(cluster_info_df.iloc[0])
         if cluster_template_args is None:
             return None

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -42,15 +42,15 @@ class ClusterInference:
         """
         # Currently we support only single driver node for all CSPs
         num_driver_nodes = 1
-        driver_instance = cluster_info_df.get('driverInstance')
+        driver_instance = cluster_info_df.get('Driver Instance')
         # If driver instance is not set, use the default value from platform configurations
         if driver_instance is None:
             driver_instance = self.platform.configs.get_value('clusterInference', 'defaultCpuInstances', 'driver')
-        num_executor_nodes = cluster_info_df.get('numExecutorNodes')
-        executor_instance = cluster_info_df.get('executorInstance')
+        num_executor_nodes = cluster_info_df.get('Num Executor Nodes')
+        executor_instance = cluster_info_df.get('Executor Instance')
         if executor_instance is None:
             # If executor instance is not set, use the default value based on the number of cores
-            cores_per_executor = cluster_info_df.get('coresPerExecutor')
+            cores_per_executor = cluster_info_df.get('Cores Per Executor')
             executor_instance = self.platform.get_matching_executor_instance(cores_per_executor)
             if executor_instance is None:
                 self.logger.info('Unable to infer CPU cluster. No matching executor instance found for vCPUs = %s',

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -42,15 +42,15 @@ class ClusterInference:
         """
         # Currently we support only single driver node for all CSPs
         num_driver_nodes = 1
-        driver_instance = cluster_info_df.loc['driverInstance']
+        driver_instance = cluster_info_df.get('driverInstance')
         # If driver instance is not set, use the default value from platform configurations
         if driver_instance is None:
             driver_instance = self.platform.configs.get_value('clusterInference', 'defaultCpuInstances', 'driver')
-        num_executor_nodes = cluster_info_df.loc['numExecutorNodes']
-        executor_instance = cluster_info_df.loc['executorInstance']
+        num_executor_nodes = cluster_info_df.get('numExecutorNodes')
+        executor_instance = cluster_info_df.get('executorInstance')
         if executor_instance is None:
             # If executor instance is not set, use the default value based on the number of cores
-            cores_per_executor = cluster_info_df.loc['coresPerExecutor']
+            cores_per_executor = cluster_info_df.get('coresPerExecutor')
             executor_instance = self.platform.get_matching_executor_instance(cores_per_executor)
             if executor_instance is None:
                 self.logger.info('Unable to infer CPU cluster. No matching executor instance found for vCPUs = %s',

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -846,7 +846,7 @@ class Qualification(RapidsJarTool):
         cluster_info_df = pd.read_csv(cluster_info_file)
         # Merge using a left join on 'App Name' and 'App ID'. This ensures `df` includes all cluster
         # info columns, even if `cluster_info_df` is empty.
-        df = pd.merge(df, cluster_info_df, on=['App Name', 'App ID'])
+        df = pd.merge(df, cluster_info_df, on=['App Name', 'App ID'], how='left')
         if len(cluster_info_df) > 0:
             self.__infer_cluster_and_update_savings(cluster_info_df)
 

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -57,6 +57,13 @@ toolOutput:
   json:
     clusterInformation:
       fileName: rapids_4_spark_qualification_output_cluster_information.json
+      requiredColumns:
+        - vendor
+        - driverHost
+        - clusterId
+        - clusterName
+        - appName
+        - appId
       mapColumns:
         vendor: 'Vendor'
         driverHost: 'Driver Host'

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -10,6 +10,10 @@ toolOutput:
     summaryReport:
       fileName: rapids_4_spark_qualification_output.csv
       columns:
+        - Vendor
+        - Driver Host
+        - Cluster ID
+        - Cluster Name
         - App Name
         - App ID
         - Recommendation
@@ -34,14 +38,32 @@ toolOutput:
             - 'Strongly Recommended'
             - 'Recommended'
       groupColumns:
-         App Duration: 'App Name'
-         Estimated GPU Duration: 'App Name'
-         Unsupported Operators Stage Duration: 'App Name'
+         keys:
+           - Vendor
+           - Driver Host
+           - Cluster ID
+           - Cluster Name
+           - App Name
+         columns:
+           - App Duration
+           - Estimated GPU Duration
+           - Unsupported Operators Stage Duration
       dropDuplicates:
-         - App Name
+        - Vendor
+        - Driver Host
+        - Cluster ID
+        - Cluster Name
+        - App Name
   json:
     clusterInformation:
       fileName: rapids_4_spark_qualification_output_cluster_information.json
+      mapColumns:
+        vendor: 'Vendor'
+        driverHost: 'Driver Host'
+        clusterId: 'Cluster ID'
+        clusterName: 'Cluster Name'
+        appName: 'App Name'
+        appId: 'App ID'
   stdout:
     summaryReport:
       compactWidth: true

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -7,12 +7,14 @@ toolOutput:
   csv:
     unsupportedOperatorsReport:
       fileName: rapids_4_spark_qualification_output_unsupportedOperators.csv
+    clusterInformation:
+      fileName: rapids_4_spark_qualification_output_cluster_information.csv
     summaryReport:
       fileName: rapids_4_spark_qualification_output.csv
       columns:
         - Vendor
         - Driver Host
-        - Cluster ID
+        - Cluster Id
         - Cluster Name
         - App Name
         - App ID
@@ -41,7 +43,7 @@ toolOutput:
          keys:
            - Vendor
            - Driver Host
-           - Cluster ID
+           - Cluster Id
            - Cluster Name
            - App Name
          columns:
@@ -51,26 +53,9 @@ toolOutput:
       dropDuplicates:
         - Vendor
         - Driver Host
-        - Cluster ID
+        - Cluster Id
         - Cluster Name
         - App Name
-  json:
-    clusterInformation:
-      fileName: rapids_4_spark_qualification_output_cluster_information.json
-      requiredColumns:
-        - vendor
-        - driverHost
-        - clusterId
-        - clusterName
-        - appName
-        - appId
-      mapColumns:
-        vendor: 'Vendor'
-        driverHost: 'Driver Host'
-        clusterId: 'Cluster ID'
-        clusterName: 'Cluster Name'
-        appName: 'App Name'
-        appId: 'App ID'
   stdout:
     summaryReport:
       compactWidth: true

--- a/user_tools/src/spark_rapids_tools/utils/util.py
+++ b/user_tools/src/spark_rapids_tools/utils/util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ from typing import Any, Optional
 
 import certifi
 import fire
+import pandas as pd
 from packaging.version import Version
 from pydantic import ValidationError, AnyHttpUrl, TypeAdapter
 
@@ -225,3 +226,10 @@ class Utilities:
         defined_version = Version(get_version(main=None))
         # get the release from version
         return cls.reformat_release_version(defined_version)
+
+    @classmethod
+    def get_valid_df_columns(cls, input_cols, input_df: pd.DataFrame) -> list:
+        """
+        Returns a subset of input_cols that are present in the input_df
+        """
+        return [col for col in input_cols if col in input_df.columns]


### PR DESCRIPTION
Fixes #918.  This PR adds columns `Vendor`, `Driver Host`, `Cluster ID`, `Cluster Name` in the user tools qualification summary. This will assist the customers distinguish different jobs especially when in Databricks where all applications have the same name.

### User Tools Output:

File: qualification_summary.csv

```
,Vendor,Driver Host,Cluster ID,Cluster Name,App Name,App ID,Speedup Based Recommendation,Estimated GPU Speedup,Estimated GPU Duration,App Duration,Unsupported Operators Stage Duration,Unsupported Operators Stage Duration Percent,Speed Up Estimation Model
0,databricks-azure,123.11.11.11,0220-012345-aaabbcc,job-name-test1,Databricks Shell,app-20240220075000-0000,Recommended,1.89,1206911.55,2282520.00,17298.00,0.76,SPEEDUPS
1,databricks-azure,123.11.11.12,0220-012345-xxxyyzz,job-name-test2,Databricks Shell,app-20240220074214-0000,Recommended,1.62,418620.75,676256.00,2576.00,0.38,SPEEDUPS
2,databricks-azure,123.11.11.13,0220-012345-pppqqrr,job-name-test3,Databricks Shell,app-20240220075434-0000,Recommended,1.56,1122375.53,1750824.00,11822.00,0.68,SPEEDUPS
3,databricks-azure,123.11.11.14,0220-012345-dddeeff,job-name-test4,Databricks Shell,app-20240220083138-0000,Recommended,1.44,209442.94,300577.00,455.00,0.15,SPEEDUPS
4,databricks-azure,123.11.11.15,0220-012345-ggghhii,job-name-test5,Databricks Shell,app-20240220065555-0000,Not Applicable,1.33,1718690.03,2282016.00,17709.00,0.78,SPEEDUPS
```

### Note: 

1. For TCO, we will still group apps but instead of `App Name`, we will group by `[Vendor,Driver Host,Cluster ID,Cluster Name,App Name]`
2. This change also ensures `Top Candidates` view shows meaningful results 

```
+----+-------------------------+------------------+-------------------------+
|    | App ID                  | App Name         | Estimated GPU Speedup   |
|----+-------------------------+------------------+-------------------------|
|  0 | app-20240220075000-0000 | Databricks Shell | Small                   |
|  1 | app-20240220074214-0000 | Databricks Shell | Small                   |
|  2 | app-20240220075434-0000 | Databricks Shell | Small                   |
|  3 | app-20240220083138-0000 | Databricks Shell | Small                   |
|  4 | app-20240220065555-0000 | Databricks Shell | Small                   |
+----+-------------------------+------------------+-------------------------+

Report Summary:
------------------  -
Total applications  5
Top candidates      5
------------------  -
```

### How To Test
1. Use latest dev jar while testing
  `spark_rapids qualification --platform $PLATFORM --eventlogs $EVENTLOGS --tools_jar $SPARK_RAPIDS_TOOLS_DEV_JAR`
2. Tested on Databricks, Dataproc and EMR