### PR TITLE
Add support for unsupported expressions reasons per Exec

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ExecParser.scala
@@ -20,6 +20,17 @@ import org.apache.spark.sql.rapids.tool.UnsupportedExpr
 
 trait ExecParser {
   def parse: ExecInfo
-  def getUnsupportedExprReasonsForExec(expressions: Array[String]): Seq[UnsupportedExpr] = Seq.empty
   val fullExecName: String
+
+  /**
+   * Returns a sequence of UnsupportedExpr for given expressions if they are not supported
+   * by the exec node.
+   * This default implementation assumes all expressions are supported and returns an empty
+   * sequence. Specific Exec parsers should override this method to provide the list of
+   * unsupported expressions if required.
+   *
+   * @param expressions Array of expression strings to evaluate for support.
+   * @return Empty Seq[UnsupportedExpr], indicating no unsupported expressions by default.
+   */
+  def getUnsupportedExprReasonsForExec(expressions: Array[String]): Seq[UnsupportedExpr] = Seq.empty
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,10 @@
 
 package com.nvidia.spark.rapids.tool.planparser
 
+import org.apache.spark.sql.rapids.tool.UnsupportedExpr
+
 trait ExecParser {
   def parse: ExecInfo
+  def getUnsupportedExprReasonsForExec(expressions: Array[String]): Seq[UnsupportedExpr] = Seq.empty
   val fullExecName: String
 }


### PR DESCRIPTION

This contributes to #715.

`collect_set` is now supported by plugin, so we don't need to mark it as unsupported in qualification tool anymore.
This PR adds a framework to add custom reasons for expressions not supported by a particular exec.
Currently, "row_number" is not supported in WindowGroupLimitExec but that would not show up in unsupported_ops.csv file.
With this PR, "row_number" would show up in unsupported_ops.csv.
This can be extended to other Execs if there are any expressions particularly not supported by an Exec.


<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
