### PR TITLE
Fix invalid values in cluster creation script

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -165,6 +165,9 @@ class DataprocPlatform(PlatformBase):
     def generate_cluster_configuration(self, render_args: dict):
         executor_names = ','.join([f'"test-node-e{i}"' for i in range(render_args['NUM_EXECUTOR_NODES'])])
         render_args['EXECUTOR_NAMES'] = f'[{executor_names}]'
+        image_version = self.configs.get_value('clusterInference', 'defaultImage')
+        render_args['IMAGE'] = f'"{image_version}"'
+        render_args['ZONE'] = f'"{self.cli.get_zone()}"'
         return super().generate_cluster_configuration(render_args)
 
 

--- a/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
@@ -205,7 +205,7 @@ class EMRCMDDriver(CMDDriverBase):
                       '--instance-types', f'{node.instance_type}']
         return cmd_params
 
-    def get_zone(self) -> str | None:
+    def get_zone(self) -> str:
         describe_cmd = ['aws ec2 describe-availability-zones',
                         '--region', f'{self.get_region()}']
         selected_zone = ''

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -299,7 +299,7 @@ class CMDDriverBase:
     def get_region(self) -> str:
         return self.env_vars.get('region')
 
-    def get_zone(self) -> str | None:
+    def get_zone(self) -> str:
         return self.env_vars.get('zone')
 
     def get_cmd_run_configs(self) -> dict:

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -299,6 +299,9 @@ class CMDDriverBase:
     def get_region(self) -> str:
         return self.env_vars.get('region')
 
+    def get_zone(self) -> str | None:
+        return self.env_vars.get('zone')
+
     def get_cmd_run_configs(self) -> dict:
         return self.env_vars.get('cmdRunnerProperties')
 

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -267,7 +267,8 @@
       "executor": {
         "n1-standard": {"vCPUs": [1, 2, 4, 8, 16, 32, 64, 96]}
       }
-    }
+    },
+    "defaultImage": "2.1.41-debian11"
   },
   "clusterSpecs": {
     "minWorkerNodes": 2,

--- a/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
@@ -391,7 +391,8 @@
         {"name": "m5d.12xlarge", "vCPUs": 48},
         {"name": "m5d.16xlarge", "vCPUs": 64}
       ]
-    }
+    },
+    "defaultImage": "emr-6.10.0"
   },
   "clusterSpecs": {
     "minWorkerNodes": 2

--- a/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/dataproc.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/dataproc.ms
@@ -3,7 +3,7 @@
   "clusterUuid": "1234-5678-1234567",
   "config": {
     "gceClusterConfig": {
-      "zoneUri": "us-central1-a"
+      "zoneUri": {{{ ZONE }}}
     },
     "masterConfig": {
       "instanceNames": [
@@ -16,6 +16,9 @@
       "instanceNames": {{{ EXECUTOR_NAMES }}},
       "machineTypeUri": {{{ EXECUTOR_INSTANCE }}},
       "numInstances": {{ NUM_EXECUTOR_NODES }}
+    },
+    "softwareConfig": {
+        "imageVersion": {{{ IMAGE }}}
     }
   },
   "status": {

--- a/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/emr.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/emr.ms
@@ -6,7 +6,7 @@
 	    "State": "TERMINATED"
 	  },
 	  "Ec2InstanceAttributes": {
-	    "Ec2AvailabilityZone": "us-west-2a"
+	    "Ec2AvailabilityZone": {{{ ZONE }}}
 	  },
 	  "InstanceGroups": [
 	    {
@@ -25,6 +25,7 @@
 	      "InstanceType": {{{ DRIVER_INSTANCE }}},
 	      "RequestedInstanceCount": {{ NUM_DRIVER_NODES }}
 	    }
-	  ]
+	  ],
+      "ReleaseLabel": {{{ IMAGE }}}
 	}
 }

--- a/user_tools/src/spark_rapids_pytools/resources/templates/dataproc-create_gpu_cluster_script.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/dataproc-create_gpu_cluster_script.ms
@@ -5,7 +5,7 @@ export CLUSTER_NAME="{{ CLUSTER_NAME }}"
 gcloud dataproc clusters create $CLUSTER_NAME \
     --image-version={{ IMAGE }} \
     --region {{ REGION }} \
-    --zone {{ ZONE }}-a \
+    --zone {{ ZONE }} \
     --master-machine-type {{ MASTER_MACHINE }} \
     --num-workers {{ WORKERS_COUNT }} \
     --worker-machine-type {{ WORKERS_MACHINE }} \


### PR DESCRIPTION
Fixes #934. This PR fixes the invalid values of zone and image version for dataproc and emr cluster creation scripts.

### Changes:

**Image Version:**
1. Add field `image version` in mustache template of dataproc and emr.
2. Add default value of `image version` in config files.

**Zone:**
1. For dataproc, get zone from environment variable. Remove `{{ ZONE }}-a` from template file.
2. For emr, get list of available zones from region using `aws cli` and select  the first one.


### Testing

CMD:
```
spark_rapids qualification --platform dataproc --eventlogs $SINGLE_EVENTLOG --tools_jar $SPARK_RAPIDS_TOOLS_JAR
```

Manually tested on Dataproc and EMR.
 