### PR TITLE
Cluster inference should not run for unsupported platform

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -902,7 +902,7 @@ class Qualification(RapidsJarTool):
         Update savings if CPU cluster can be inferred and corresponding GPU cluster can be defined.
         :param cluster_info_df: Parsed cluster information.
         """
-        if self.ctxt.get_ctxt('cpuClusterProxy') is not None:
+        if self.ctxt.get_ctxt('cpuClusterProxy') is not None or not self.ctxt.platform.cluster_inference_supported:
             return
 
         # Infer the CPU cluster from the cluster information


### PR DESCRIPTION
Fixes #940. As mentioned in the issue description, this PR disables user tools from using cluster inference for unsupported platforms.


