### PR TITLE
Add CheckOverflowInTableInsert support: verify absence from physical plan

### DIFF
--- a/core/src/test/scala/com/nvidia/spark/rapids/BaseTestSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/BaseTestSuite.scala
@@ -21,7 +21,7 @@ import scala.util.{Failure, Success, Try}
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{SparkSession, TrampolineUtil}
+import org.apache.spark.sql.{DataFrame, SparkSession, TrampolineUtil}
 import org.apache.spark.sql.rapids.tool.ToolUtils
 
 class BaseTestSuite extends FunSuite with BeforeAndAfterEach with Logging {
@@ -102,14 +102,13 @@ class BaseTestSuite extends FunSuite with BeforeAndAfterEach with Logging {
     }
   }
 
-  def withTable(tableNames: String*)(f: => Unit): Unit = {
+  def withTable(spark: SparkSession, tableNames: String*)(f: => DataFrame): DataFrame = {
     try {
       f  // Execute the passed block of code.
     } finally {
-      createSparkSession()
       tableNames.foreach { name =>
         // Attempt to drop each table, ignoring any errors if the table doesn't exist.
-        sparkSession.sql(s"DROP TABLE IF EXISTS $name")
+        spark.sql(s"DROP TABLE IF EXISTS $name")
       }
     }
   }

--- a/core/src/test/scala/com/nvidia/spark/rapids/BaseTestSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/BaseTestSuite.scala
@@ -73,6 +73,11 @@ class BaseTestSuite extends FunSuite with BeforeAndAfterEach with Logging {
       "Spark340+ does not support the expression")
   }
 
+  protected def execsSupportedSparkGTE331(): (Boolean, String) = {
+    (ToolUtils.isSpark331OrLater(),
+      "Spark331+ supports the Exec/Expression")
+  }
+
   protected def execsSupportedSparkGTE340(): (Boolean, String) = {
     (ToolUtils.isSpark340OrLater(),
       "Spark340+ supports the Exec/Expression")

--- a/core/src/test/scala/com/nvidia/spark/rapids/BaseTestSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/BaseTestSuite.scala
@@ -38,15 +38,12 @@ class BaseTestSuite extends FunSuite with BeforeAndAfterEach with Logging {
     TrampolineUtil.cleanupAnyExistingSession()
   }
 
-  protected def createSparkSession(enableHive: Boolean = false): Unit = {
-    val sparkBuilder = SparkSession
+  protected def createSparkSession(): Unit = {
+    sparkSession = SparkSession
       .builder()
       .master("local[*]")
       .appName(testAppName)
-    if (enableHive) {
-      sparkBuilder.enableHiveSupport()
-    }
-    sparkSession = sparkBuilder.getOrCreate()
+      .getOrCreate()
   }
 
   protected def checkDeltaLakeSparkRelease(): (Boolean, String) = {
@@ -109,9 +106,7 @@ class BaseTestSuite extends FunSuite with BeforeAndAfterEach with Logging {
     try {
       f  // Execute the passed block of code.
     } finally {
-      // The newly created SparkSession would require metadata from the hive metastore to locate
-      // the tables.
-      createSparkSession(enableHive = true)
+      createSparkSession()
       tableNames.foreach { name =>
         // Attempt to drop each table, ignoring any errors if the table doesn't exist.
         sparkSession.sql(s"DROP TABLE IF EXISTS $name")

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -1668,11 +1668,11 @@ class SQLPlanParserSuite extends BaseTestSuite {
             spark.sql(s"CREATE TABLE $tbl_name (foo STRING, bar STRING) USING PARQUET")
             val query =
               s"""
-            SELECT foo, bar FROM (
-                SELECT foo, bar,
-                    RANK() OVER (PARTITION BY foo ORDER BY bar) as rank
-                FROM $tbl_name)
-            WHERE rank <= 2"""
+              SELECT foo, bar FROM (
+                  SELECT foo, bar,
+                      RANK() OVER (PARTITION BY foo ORDER BY bar) as rank
+                  FROM $tbl_name)
+              WHERE rank <= 2"""
             spark.sql(query)
           }
         }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -1665,7 +1665,7 @@ class SQLPlanParserSuite extends BaseTestSuite {
     TrampolineUtil.withTempDir { eventLogDir =>
       withTable(tbl_name) {
         val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
-          windowGroupLimitExecCmd, enableHive = true) { spark =>
+          windowGroupLimitExecCmd) { spark =>
           spark.sql(s"CREATE TABLE $tbl_name (foo STRING, bar STRING) USING PARQUET")
           val query =
             s"""
@@ -1696,7 +1696,7 @@ class SQLPlanParserSuite extends BaseTestSuite {
     TrampolineUtil.withTempDir { eventLogDir =>
       withTable(tbl_name) {
         val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
-          windowGroupLimitExecCmd, enableHive = true) { spark =>
+          windowGroupLimitExecCmd) { spark =>
           spark.sql(s"CREATE TABLE $tbl_name (foo STRING, bar STRING) USING PARQUET")
           val query =
             s"""
@@ -1736,7 +1736,7 @@ class SQLPlanParserSuite extends BaseTestSuite {
     var planDf: Option[DataFrame] = None
     TrampolineUtil.withTempDir { eventLogDir =>
       withTable(tableName) {
-        ToolTestUtils.generateEventLog(eventLogDir, overflowExprStr, enableHive = true) { spark =>
+        ToolTestUtils.generateEventLog(eventLogDir, overflowExprStr) { spark =>
           spark.sql(s"CREATE TABLE $tableName (foo INT) USING PARQUET")
           // Store the Spark Plan in a variable
           planDf = Some(spark.sql(s"INSERT INTO $tableName VALUES (2L)"))

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -29,7 +29,6 @@ import org.scalatest.Matchers.{be, convertToAnyShouldWrapper}
 import org.scalatest.exceptions.TestFailedException
 
 import org.apache.spark.sql.{DataFrame, TrampolineUtil}
-import org.apache.spark.sql.catalyst.expressions.CheckOverflowInTableInsert
 import org.apache.spark.sql.execution.ui.SQLPlanMetric
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
@@ -1726,12 +1725,13 @@ class SQLPlanParserSuite extends BaseTestSuite {
     }
   }
 
-  test("CheckOverflowInsert should not exist in Physical Plan") {
+  runConditionalTest("CheckOverflowInsert should not exist in Physical Plan",
+    execsSupportedSparkGTE331) {
     // This test verifies that the 'CheckOverflowInsert' expression exists in the logical plan
     // but is absent in the physical plan as of Spark 3.5.0. If in future Spark versions,
     // 'CheckOverflowInsert' expression appears in the physical plan, this test will fail,
     // and we should to handle it appropriately.
-    val overflowExprStr = CheckOverflowInTableInsert.toString()
+    val overflowExprStr = "CheckOverflowInTableInsert"
     val tableName = "foobar_tbl"
     var planDf: Option[DataFrame] = None
     TrampolineUtil.withTempDir { eventLogDir =>

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -1665,7 +1665,7 @@ class SQLPlanParserSuite extends BaseTestSuite {
     TrampolineUtil.withTempDir { eventLogDir =>
       withTable(tbl_name) {
         val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
-          windowGroupLimitExecCmd) { spark =>
+          windowGroupLimitExecCmd, enableHive = true) { spark =>
           spark.sql(s"CREATE TABLE $tbl_name (foo STRING, bar STRING) USING PARQUET")
           val query =
             s"""
@@ -1696,7 +1696,7 @@ class SQLPlanParserSuite extends BaseTestSuite {
     TrampolineUtil.withTempDir { eventLogDir =>
       withTable(tbl_name) {
         val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
-          windowGroupLimitExecCmd) { spark =>
+          windowGroupLimitExecCmd, enableHive = true) { spark =>
           spark.sql(s"CREATE TABLE $tbl_name (foo STRING, bar STRING) USING PARQUET")
           val query =
             s"""
@@ -1736,7 +1736,7 @@ class SQLPlanParserSuite extends BaseTestSuite {
     var planDf: Option[DataFrame] = None
     TrampolineUtil.withTempDir { eventLogDir =>
       withTable(tableName) {
-        ToolTestUtils.generateEventLog(eventLogDir, overflowExprStr) { spark =>
+        ToolTestUtils.generateEventLog(eventLogDir, overflowExprStr, enableHive = true) { spark =>
           spark.sql(s"CREATE TABLE $tableName (foo INT) USING PARQUET")
           // Store the Spark Plan in a variable
           planDf = Some(spark.sql(s"INSERT INTO $tableName VALUES (2L)"))


### PR DESCRIPTION
Fixes #882, this PR adds unit test to capture the current state for `CheckOverflowInTableInsert`. After multiple attempts, I was unable to reproduce this expression in the physical plan. 

### Details:

- This test verifies that the `CheckOverflowInsert` expression exists in the logical plan but absent in the physical plan as of Spark 3.5.0. 
- If in future Spark versions, `CheckOverflowInsert` expression appears in the physical plan, this test will fail, and we should to handle it appropriately.

### Additional changes:
- Unit tests using `withTable()` were not able to remove the tables because we create a new SparkSession in `withTable()` and this new session is unable to detect the table.
- Moved `withTable()` to inner methods where we are creating the tables and pass the current spark session as argument. 