### PR TITLE
Cache CLI calls for node instance description

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
@@ -173,6 +173,9 @@ class DBAWSCMDDriver(CMDDriverBase):
                       '--instance-types', f'{node.instance_type}']
         return cmd_params
 
+    def _get_instance_description_cache_key(self, node: ClusterNode) -> tuple:
+        return node.instance_type, self.get_region()
+
     def get_submit_spark_job_cmd_for_cluster(self, cluster_name: str, submit_args: dict) -> List[str]:
         raise NotImplementedError
 

--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
@@ -176,6 +176,12 @@ class DBAWSCMDDriver(CMDDriverBase):
     def get_submit_spark_job_cmd_for_cluster(self, cluster_name: str, submit_args: dict) -> List[str]:
         raise NotImplementedError
 
+    def _exec_platform_describe_node_instance(self, node: ClusterNode) -> str:
+        raw_instance_descriptions = super()._exec_platform_describe_node_instance(node)
+        instance_descriptions = JSONPropertiesContainer(raw_instance_descriptions, file_load=False)
+        # Return the instance description of node type. Convert to valid JSON string for type matching.
+        return json.dumps(instance_descriptions.get_value('InstanceTypes')[0])
+
 
 @dataclass
 class DatabricksNode(EMRNode):

--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
@@ -237,6 +237,11 @@ class DBAzureCMDDriver(CMDDriverBase):
             self.logger.info('The Azure instance type descriptions catalog is loaded from the cache')
         return fpath
 
+    def _exec_platform_describe_node_instance(self, node: ClusterNode) -> str:
+        instance_descriptions = JSONPropertiesContainer(self.init_instances_description())
+        # Return the instance description of node type. Convert to valid JSON string for type matching.
+        return json.dumps(instance_descriptions.get_value_silent(node.instance_type))
+
     def get_submit_spark_job_cmd_for_cluster(self, cluster_name: str, submit_args: dict) -> List[str]:
         raise NotImplementedError
 
@@ -252,17 +257,13 @@ class DatabricksAzureNode(ClusterNode):
 
     region: str = field(default=None, init=False)
 
-    def _pull_and_set_mc_props(self, cli=None):
-        instances_description_path = cli.init_instances_description()
-        self.mc_props = JSONPropertiesContainer(prop_arg=instances_description_path)
-
     def _set_fields_from_props(self):
         self.name = self.props.get_value_silent('public_dns')
 
     def _pull_sys_info(self, cli=None) -> SysInfo:
-        cpu_mem = self.mc_props.get_value(self.instance_type, 'MemoryInfo', 'SizeInMiB')
+        cpu_mem = self.mc_props.get_value('MemoryInfo', 'SizeInMiB')
         # TODO: should we use DefaultVCpus or DefaultCores
-        num_cpus = self.mc_props.get_value(self.instance_type, 'VCpuInfo', 'DefaultVCpus')
+        num_cpus = self.mc_props.get_value('VCpuInfo', 'DefaultVCpus')
 
         return SysInfo(num_cpus=num_cpus, cpu_mem=cpu_mem)
 

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -195,6 +195,9 @@ class DataprocCMDDriver(CMDDriverBase):  # pylint: disable=abstract-method
                       f'{node.zone}']
         return cmd_params
 
+    def _get_instance_description_cache_key(self, node: ClusterNode) -> tuple:
+        return node.instance_type, node.zone
+
     def _build_platform_list_cluster(self,
                                      cluster,
                                      query_args: dict = None) -> list:

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -359,10 +359,6 @@ class DataprocNode(ClusterNode):
         num_cpus = self.mc_props.get_value('guestCpus')
         return SysInfo(num_cpus=num_cpus, cpu_mem=cpu_mem)
 
-    def _pull_and_set_mc_props(self, cli=None):
-        instance_description = cli.exec_platform_describe_node_instance(self)
-        self.mc_props = JSONPropertiesContainer(prop_arg=instance_description, file_load=False)
-
     def _set_fields_from_props(self):
         # set the machine type
         if not self.props:

--- a/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
@@ -205,6 +205,9 @@ class EMRCMDDriver(CMDDriverBase):
                       '--instance-types', f'{node.instance_type}']
         return cmd_params
 
+    def _get_instance_description_cache_key(self, node: ClusterNode) -> tuple:
+        return node.instance_type, self.get_region()
+
     def get_zone(self) -> str:
         describe_cmd = ['aws ec2 describe-availability-zones',
                         '--region', f'{self.get_region()}']

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -508,6 +508,13 @@ class CMDDriverBase:
         del node  # Unused by super method.
         return []
 
+    def _get_instance_description_cache_key(self, node: ClusterNode) -> tuple:
+        """
+        Generates a cache key from the node's instance type for accessing the instance description cache.
+        This default implementation should be overridden by subclasses that require additional fields.
+        """
+        return (node.instance_type,)
+
     def _exec_platform_describe_node_instance(self, node: ClusterNode) -> str:
         """
         Given a node, execute platform CLI to pull the properties of the instance type running on
@@ -521,12 +528,13 @@ class CMDDriverBase:
     def exec_platform_describe_node_instance(self, node: ClusterNode):
         """
         Returns the instance type description of the cluster node. If the description
-        is not cached, it executes a platform specific CLI to fetch and cache it.
+        is not cached, it executes a platform specific command to fetch and cache it.
         """
-        if node.instance_type not in self.instance_descriptions_cache:
+        key = self._get_instance_description_cache_key(node)
+        if key not in self.instance_descriptions_cache:
             # Cache the instance description
-            self.instance_descriptions_cache[node.instance_type] = self._exec_platform_describe_node_instance(node)
-        return self.instance_descriptions_cache[node.instance_type]
+            self.instance_descriptions_cache[key] = self._exec_platform_describe_node_instance(node)
+        return self.instance_descriptions_cache[key]
 
     def _build_platform_list_cluster(self,
                                      cluster,

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -159,7 +159,8 @@ class ClusterNode:
         pass
 
     def _pull_and_set_mc_props(self, cli=None):
-        pass
+        instances_description = cli.exec_platform_describe_node_instance(self) if cli else None
+        self.mc_props = JSONPropertiesContainer(prop_arg=instances_description, file_load=False)
 
     def _pull_gpu_hw_info(self, cli=None) -> GpuHWInfo:
         raise NotImplementedError
@@ -292,6 +293,7 @@ class CMDDriverBase:
     timeout: int = 0
     env_vars: dict = field(default_factory=dict, init=False)
     logger: Logger = None
+    instance_descriptions_cache: dict = field(default_factory=dict, init=False)
 
     def get_env_var(self, key: str):
         return self.env_vars.get(key)
@@ -506,7 +508,7 @@ class CMDDriverBase:
         del node  # Unused by super method.
         return []
 
-    def exec_platform_describe_node_instance(self, node: ClusterNode) -> str:
+    def _exec_platform_describe_node_instance(self, node: ClusterNode) -> str:
         """
         Given a node, execute platform CLI to pull the properties of the instance type running on
         that node
@@ -515,6 +517,16 @@ class CMDDriverBase:
         """
         cmd_params = self._build_platform_describe_node_instance(node=node)
         return self.run_sys_cmd(cmd_params)
+
+    def exec_platform_describe_node_instance(self, node: ClusterNode):
+        """
+        Returns the instance type description of the cluster node. If the description
+        is not cached, it executes a platform specific CLI to fetch and cache it.
+        """
+        if node.instance_type not in self.instance_descriptions_cache:
+            # Cache the instance description
+            self.instance_descriptions_cache[node.instance_type] = self._exec_platform_describe_node_instance(node)
+        return self.instance_descriptions_cache[node.instance_type]
 
     def _build_platform_list_cluster(self,
                                      cluster,


### PR DESCRIPTION
Fixes #949. 

## Description:
- Currently the platform specific CLIs would run commands to fetch instance type description for every node.
   - CMD `aws ec2 describe-instance-types --region us-west-2 --instance-types m5a.12xlarge` will run 10 times if the cluster has 10 nodes.
- This is inefficient and cause significant performance impact especially when running user tools for large clusters. 
- For `databricks-azure`, even though we do not use CLI command, we would be reading the `azure-instances-catalog.json` file for every node. 

This PR fixes this issue by caching the instance description calls in the CLI driver.


## Changes
- Introduce `instance_descriptions_cache` to cache the instance type description in `CMDDriverBase`
- Cache key is a platform specific tuple
   - This is chosen based on variables used in `_build_platform_describe_node_instance()`
   - Default implementation is to use `node.instance_type`.  
   - Other fields such as region, zone are used based on platform.
- Every platform implements `_exec_platform_describe_node_instance(node)` that returns a single entry having the node's instance description.
    - Previously, for `databricks-azure`, we would return the entire `azure-instances-catalog.json` file. 
    - Now, we would return the single entry for the instance type.  
 

## Testing

### emr

<details> 
<summary> STDOUT Before </summary>
<pre>
[time] INFO rapids.tools.qualification: Loading CPU cluster properties from file /Users/psarthi/Work/cluster/emr/emr-cpu.json
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws emr list-instances --cluster-id j-aaabbbbccc --instance-group-id ig-aaabbbcccc&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws emr list-instances --cluster-id j-aaabbbbccc --instance-group-id ig-xxxyyyzzz&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types m5a.12xlarge&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types m5zn.6xlarge&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types m5zn.6xlarge&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types m5zn.6xlarge&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types m5zn.6xlarge&gt;
[time] INFO rapids.tools.qualification: Creating GPU cluster by converting the CPU cluster instances to GPU supported types
[time] DEBUG rapids.tools.cmd_driver: Skip converting Master nodes
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types m5a.12xlarge&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types g5.4xlarge&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types g5.4xlarge&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types g5.4xlarge&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types g5.4xlarge&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types g5.4xlarge&gt;
</pre>
</details>

<details> 
<summary> STDOUT After </summary>
<pre>
[time] INFO rapids.tools.qualification: Loading CPU cluster properties from file /Users/psarthi/Work/cluster/emr/emr-cpu.json
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws emr list-instances --cluster-id j-aaabbbcccc --instance-group-id ig-aaaabbbcc&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws emr list-instances --cluster-id j-aaabbbbccc --instance-group-id ig-xxxyyyzzz&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types m5a.12xlarge&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types m5zn.6xlarge&gt;
[time] INFO rapids.tools.qualification: Creating GPU cluster by converting the CPU cluster instances to GPU supported types
[time] DEBUG rapids.tools.cmd_driver: Skip converting Master nodes
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types g5.4xlarge&gt;
</pre>
</details>


### dataproc
 
<details> 
<summary> STDOUT Before </summary>
<pre>
[time] INFO rapids.tools.qualification: Loading CPU cluster properties from file /Users/psarthi/Work/cluster/dataproc/dataproc-cpu.json
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;gcloud compute machine-types describe n1-standard-16 --format json --zone us-central1-c&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;gcloud compute machine-types describe n1-standard-16 --format json --zone us-central1-c&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;gcloud compute machine-types describe n1-standard-16 --format json --zone us-central1-c&gt;
[time] INFO rapids.tools.qualification: Creating GPU cluster by converting the CPU cluster instances to GPU supported types
[time] DEBUG rapids.tools.cmd_driver: Skip converting Master nodes
[time] INFO rapids.tools.cluster: Node with n1-standard-16 supports GPU devices.
[time] INFO rapids.tools.cluster: Node with n1-standard-16 supports GPU devices.
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;gcloud compute machine-types describe n1-standard-16 --format json --zone us-central1-c&gt;
</pre>
</details>

<details> 
<summary> STDOUT After </summary>
<pre>
[time] INFO rapids.tools.qualification: Loading CPU cluster properties from file /Users/psarthi/Work/cluster/dataproc/dataproc-cpu.json
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;gcloud compute machine-types describe n1-standard-16 --format json --zone us-central1-c&gt;
[time] INFO rapids.tools.qualification: Creating GPU cluster by converting the CPU cluster instances to GPU supported types
[time] DEBUG rapids.tools.cmd_driver: Skip converting Master nodes
[time] INFO rapids.tools.cluster: Node with n1-standard-16 supports GPU devices.
[time] INFO rapids.tools.cluster: Node with n1-standard-16 supports GPU devices.
</pre>
</details>


### databricks-aws
 
<details> 
<summary> STDOUT Before </summary>
<pre>
[time] INFO rapids.tools.qualification: Loading CPU cluster properties from file /Users/psarthi/Work/cluster/databricks-aws/databricks-aws-cpu.json
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types m6gd.xlarge&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types m6gd.xlarge&gt;
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types m6gd.xlarge&gt;
[time] INFO rapids.tools.qualification: Creating GPU cluster by converting the CPU cluster instances to GPU supported types
[time] DEBUG rapids.tools.cmd_driver: Skip converting Master nodes
[time] INFO rapids.tools.cluster: Converting node m6gd.xlarge into GPU supported instance-type g5.xlarge
[time] INFO rapids.tools.cluster: Converting node m6gd.xlarge into GPU supported instance-type g5.xlarge
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types g5.xlarge&gt;
</pre>
</details>

<details> 
<summary> STDOUT After </summary>
<pre>
[time] INFO rapids.tools.qualification: Loading CPU cluster properties from file /Users/psarthi/Work/cluster/databricks-aws/databricks-aws-cpu.json
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types m6gd.xlarge&gt;
[time] INFO rapids.tools.qualification: Creating GPU cluster by converting the CPU cluster instances to GPU supported types
[time] DEBUG rapids.tools.cmd_driver: Skip converting Master nodes
[time] INFO rapids.tools.cluster: Converting node m6gd.xlarge into GPU supported instance-type g5.xlarge
[time] INFO rapids.tools.cluster: Converting node m6gd.xlarge into GPU supported instance-type g5.xlarge
[time] DEBUG rapids.tools.cmd: submitting system command: &lt;aws ec2 describe-instance-types --region us-west-2 --instance-types g5.xlarge&gt;
</pre>
</details>


### databricks-azure: (Multiple file reads)
 
<details> 
<summary> STDOUT Before </summary>
<pre>
[time] INFO rapids.tools.qualification: Loading CPU cluster properties from file /Users/psarthi/Work/cluster/databricks-azure/databricks-azure-cpu.json
[time] INFO rapids.tools.cmd_driver: The Azure instance type descriptions catalog is loaded from the cache
[time] INFO rapids.tools.cmd_driver: The Azure instance type descriptions catalog is loaded from the cache
[time] INFO rapids.tools.cmd_driver: The Azure instance type descriptions catalog is loaded from the cache
[time] INFO rapids.tools.qualification: Creating GPU cluster by converting the CPU cluster instances to GPU supported types
[time] DEBUG rapids.tools.cmd_driver: Skip converting Master nodes
[time] INFO rapids.tools.cluster: Converting node Standard_DS12_v2 into GPU supported instance-type Standard_NC4as_T4_v3
[time] INFO rapids.tools.cluster: Converting node Standard_DS12_v2 into GPU supported instance-type Standard_NC4as_T4_v3
[time] INFO rapids.tools.cmd_driver: The Azure instance type descriptions catalog is loaded from the cache
</pre>
</details>

<details> 
<summary> STDOUT After </summary>
<pre>
[time] INFO rapids.tools.qualification: Loading CPU cluster properties from file /Users/psarthi/Work/cluster/databricks-azure/databricks-azure-cpu.json
[time] INFO rapids.tools.cmd_driver: The Azure instance type descriptions catalog is loaded from the cache
[time] INFO rapids.tools.qualification: Creating GPU cluster by converting the CPU cluster instances to GPU supported types
[time] DEBUG rapids.tools.cmd_driver: Skip converting Master nodes
[time] INFO rapids.tools.cluster: Converting node Standard_DS12_v2 into GPU supported instance-type Standard_NC4as_T4_v3
[time] INFO rapids.tools.cluster: Converting node Standard_DS12_v2 into GPU supported instance-type Standard_NC4as_T4_v3
[time] INFO rapids.tools.cmd_driver: The Azure instance type descriptions catalog is loaded from the cache
</pre>
</details>

### onprem

No Impact