### PR TITLE
Add AQEShuffleRead WriteFiles execs to the supportedOps and score files

### DIFF
--- a/core/src/main/resources/operatorsScore-databricks-aws-a10G.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws-a10G.csv
@@ -295,3 +295,5 @@ BloomFilterAggregate,2.45
 EphemeralSubstring,2.45
 KnownNullable,2.45
 InSubqueryExec,2.45
+AQEShuffleReadExec,2.45
+CheckOverflowInTableInsert,2.45

--- a/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
@@ -295,3 +295,5 @@ BloomFilterAggregate,2.45
 EphemeralSubstring,2.45
 KnownNullable,2.45
 InSubqueryExec,2.45
+AQEShuffleReadExec,2.45
+CheckOverflowInTableInsert,2.45

--- a/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
@@ -283,3 +283,5 @@ BloomFilterAggregate,2.73
 EphemeralSubstring,2.73
 KnownNullable,2.73
 InSubqueryExec,2.73
+AQEShuffleReadExec,2.73
+CheckOverflowInTableInsert,2.73

--- a/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
@@ -277,3 +277,5 @@ BloomFilterAggregate,3.74
 EphemeralSubstring,3.74
 KnownNullable,3.74
 InSubqueryExec,3.74
+AQEShuffleReadExec,3.74
+CheckOverflowInTableInsert,3.74

--- a/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
@@ -277,3 +277,5 @@ BloomFilterAggregate,3.65
 EphemeralSubstring,3.65
 KnownNullable,3.65
 InSubqueryExec,3.65
+AQEShuffleReadExec,3.65
+CheckOverflowInTableInsert,3.65

--- a/core/src/main/resources/operatorsScore-dataproc-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-l4.csv
@@ -283,3 +283,5 @@ BloomFilterAggregate,4.16
 EphemeralSubstring,4.16
 KnownNullable,4.16
 InSubqueryExec,4.16
+AQEShuffleReadExec,4.16
+CheckOverflowInTableInsert,4.16

--- a/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
@@ -277,3 +277,5 @@ BloomFilterAggregate,4.25
 EphemeralSubstring,4.25
 KnownNullable,4.25
 InSubqueryExec,4.25
+AQEShuffleReadExec,4.25
+CheckOverflowInTableInsert,4.25

--- a/core/src/main/resources/operatorsScore-dataproc-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-t4.csv
@@ -283,3 +283,5 @@ BloomFilterAggregate,4.88
 EphemeralSubstring,4.88
 KnownNullable,4.88
 InSubqueryExec,4.88
+AQEShuffleReadExec,4.88
+CheckOverflowInTableInsert,4.88

--- a/core/src/main/resources/operatorsScore-emr-a10.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10.csv
@@ -283,3 +283,5 @@ BloomFilterAggregate,2.59
 EphemeralSubstring,2.59
 KnownNullable,2.59
 InSubqueryExec,2.59
+AQEShuffleReadExec,2.59
+CheckOverflowInTableInsert,2.59

--- a/core/src/main/resources/operatorsScore-emr-a10G.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10G.csv
@@ -283,3 +283,5 @@ BloomFilterAggregate,2.59
 EphemeralSubstring,2.59
 KnownNullable,2.59
 InSubqueryExec,2.59
+AQEShuffleReadExec,2.59
+CheckOverflowInTableInsert,2.59

--- a/core/src/main/resources/operatorsScore-emr-t4.csv
+++ b/core/src/main/resources/operatorsScore-emr-t4.csv
@@ -283,3 +283,5 @@ BloomFilterAggregate,2.07
 EphemeralSubstring,2.07
 KnownNullable,2.07
 InSubqueryExec,2.07
+AQEShuffleReadExec,2.07
+CheckOverflowInTableInsert,2.07

--- a/core/src/main/resources/operatorsScore-onprem-a100.csv
+++ b/core/src/main/resources/operatorsScore-onprem-a100.csv
@@ -295,3 +295,5 @@ BloomFilterAggregate,4
 EphemeralSubstring,4
 KnownNullable,4
 InSubqueryExec,4
+AQEShuffleReadExec,4
+CheckOverflowInTableInsert,4

--- a/core/src/main/resources/supportedExecs.csv
+++ b/core/src/main/resources/supportedExecs.csv
@@ -14,7 +14,7 @@ SortExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,NS,NS
 SubqueryBroadcastExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
 TakeOrderedAndProjectExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,PS,PS,PS,NS,NS,NS
 UnionExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,PS,PS,PS,NS,NS,NS
-AQEShuffleReadExec,TNEW,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,NS,NS
+AQEShuffleReadExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,NS,NS
 HashAggregateExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,PS,NS,PS,PS,PS,NS,NS,NS
 ObjectHashAggregateExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,PS,NS,PS,PS,PS,NS,NS,NS
 SortAggregateExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,PS,NS,PS,PS,PS,NS,NS,NS
@@ -53,7 +53,7 @@ WindowInPandasExec,NS,This is disabled by default because it only supports row b
 WindowExec,S,None,partitionSpec,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NS,PS,NS,NS,NS
 WindowExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,NS,NS
 HiveTableScanExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NS,NS,NS,NS,NS
-WriteFilesExec,TNEW,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
+WriteFilesExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
 CustomShuffleReaderExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,NS,NS
 WindowGroupLimitExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,PS,PS,PS,NS,NS,NS
 MapInArrowExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,NS,NS,NS,NS,PS,NS,PS,NS,NS,NS

--- a/core/src/main/resources/supportedExprs.csv
+++ b/core/src/main/resources/supportedExprs.csv
@@ -123,8 +123,8 @@ Ceil,S,`ceil`; `ceiling`,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,
 Ceil,S,`ceil`; `ceiling`,None,project,result,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NS,NS
 CheckOverflow,S, ,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NS,NS
 CheckOverflow,S, ,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NS,NS
-CheckOverflowInTableInsert,TNEW, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
-CheckOverflowInTableInsert,TNEW, ,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
+CheckOverflowInTableInsert,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
+CheckOverflowInTableInsert,S, ,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
 Coalesce,S,`coalesce`,None,project,param,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 Coalesce,S,`coalesce`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 Concat,S,`concat`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NS,NA,PS,NA,NA,NA,NS,NS

--- a/scripts/sync_plugin_files/override_supported_configs.json
+++ b/scripts/sync_plugin_files/override_supported_configs.json
@@ -56,28 +56,6 @@
       ]
     },
     {
-      "Expression": "CheckOverflowInTableInsert",
-      "Context": "project",
-      "Params": "input",
-      "override": [
-        {
-          "key": "Supported",
-          "value": "TNEW"
-        }
-      ]
-    },
-    {
-      "Expression": "CheckOverflowInTableInsert",
-      "Context": "project",
-      "Params": "result",
-      "override": [
-        {
-          "key": "Supported",
-          "value": "TNEW"
-        }
-      ]
-    },
-    {
       "Expression": "PythonUDAF",
       "Context": "aggregation",
       "Params": "param",
@@ -272,28 +250,6 @@
         {
           "key": "SQL Func",
           "value": "`bloom_filter_agg`"
-        }
-      ]
-    }
-  ],
-  "supportedExecs.csv": [
-    {
-      "Exec": "AQEShuffleReadExec",
-      "Params": "Input/Output",
-      "override": [
-        {
-          "key": "Supported",
-          "value": "TNEW"
-        }
-      ]
-    },
-    {
-      "Exec": "WriteFilesExec",
-      "Params": "Input/Output",
-      "override": [
-        {
-          "key": "Supported",
-          "value": "TNEW"
         }
       ]
     }


### PR DESCRIPTION
Closes #865
This PR updates the CSV and override files for all remaining execs or expressions marked as `TNEW` in https://github.com/NVIDIA/spark-rapids-tools/issues/865.