### PR TITLE
Remove databricks profiling recommendation for dynamicFilePruning

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -63,7 +63,8 @@ abstract class Platform(var gpuDevice: Option[GpuDevice]) {
   /**
    * Recommendations to be included in the final list of recommendations.
    * These properties should be specific to the platform and not general Spark properties.
-   * For example: "spark.databricks.optimizer.dynamicFilePruning" for the Databricks platform.
+   * For example: we used to set "spark.databricks.optimizer.dynamicFilePruning" to false for the
+   *              Databricks platform.
    *
    * Represented as a tuple of (propertyKey, propertyValue).
    */
@@ -134,9 +135,6 @@ abstract class DatabricksPlatform(gpuDevice: Option[GpuDevice]) extends Platform
     "spark.executor.instances",
     "spark.executor.memory",
     "spark.executor.memoryOverhead"
-  )
-  override val recommendationsToInclude: Seq[(String, String)] = Seq(
-    ("spark.databricks.optimizer.dynamicFilePruning", "false")
   )
 
   override def createClusterInfo(coresPerExecutor: Int, numExecutorNodes: Int,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -1115,7 +1115,7 @@ object AutoTuner extends Logging {
     "spark.executor.instances" ->
       "'spark.executor.instances' should be set to (gpuCount * numWorkers).",
     "spark.task.resource.gpu.amount" ->
-      "'spark.task.resource.gpu.amount' should be set to Max(1, (numCores / gpuCount)).",
+      "'spark.task.resource.gpu.amount' should be set to Min(1, (gpuCount / numCores)).",
     "spark.rapids.sql.concurrentGpuTasks" ->
       s"'spark.rapids.sql.concurrentGpuTasks' should be set to Min(4, (gpuMemory / 7.5G)).",
     "spark.rapids.memory.pinnedPool.size" ->

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -235,7 +235,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
           |- 'spark.sql.files.maxPartitionBytes' was not set.
           |- 'spark.sql.shuffle.partitions' was not set.
-          |- 'spark.task.resource.gpu.amount' should be set to Max(1, (numCores / gpuCount)).
+          |- 'spark.task.resource.gpu.amount' should be set to Min(1, (gpuCount / numCores)).
           |- RAPIDS Accelerator for Apache Spark plugin jar is missing
           |  from the classpath entries.
           |  If the Spark RAPIDS jar is being bundled with your
@@ -273,7 +273,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
           |- 'spark.sql.files.maxPartitionBytes' was not set.
           |- 'spark.sql.shuffle.partitions' was not set.
-          |- 'spark.task.resource.gpu.amount' should be set to Max(1, (numCores / gpuCount)).
+          |- 'spark.task.resource.gpu.amount' should be set to Min(1, (gpuCount / numCores)).
           |- Incorrect values in worker system information: {numCores: 0, memory: 122880MiB, numWorkers: 4}.
           |- RAPIDS Accelerator for Apache Spark plugin jar is missing
           |  from the classpath entries.
@@ -312,7 +312,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
           |- 'spark.sql.files.maxPartitionBytes' was not set.
           |- 'spark.sql.shuffle.partitions' was not set.
-          |- 'spark.task.resource.gpu.amount' should be set to Max(1, (numCores / gpuCount)).
+          |- 'spark.task.resource.gpu.amount' should be set to Min(1, (gpuCount / numCores)).
           |- Incorrect values in worker system information: {numCores: 32, memory: , numWorkers: 4}.
           |- RAPIDS Accelerator for Apache Spark plugin jar is missing
           |  from the classpath entries.
@@ -351,7 +351,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
           |- 'spark.sql.files.maxPartitionBytes' was not set.
           |- 'spark.sql.shuffle.partitions' was not set.
-          |- 'spark.task.resource.gpu.amount' should be set to Max(1, (numCores / gpuCount)).
+          |- 'spark.task.resource.gpu.amount' should be set to Min(1, (gpuCount / numCores)).
           |- Incorrect values in worker system information: {numCores: 32, memory: 0m, numWorkers: 4}.
           |- RAPIDS Accelerator for Apache Spark plugin jar is missing
           |  from the classpath entries.


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #922

- Remove `spark.databricks.optimizer.dynamicFilePruning` from the recommendations listed by the autoTuner for the Databricks environment.
- Fixes the comment related to the GPU amount to be more accurate `min(1, (gpuCount / numCores))`