### PR TITLE
Refactor AppBase to use common AppMetaData between Q/P tools

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Analysis.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Analysis.scala
@@ -331,7 +331,7 @@ class Analysis(apps: Seq[ApplicationInfo]) {
       app.sqlIdToInfo.map { case (sqlId, sqlCase) =>
         SQLDurationExecutorTimeProfileResult(app.index, app.appId, sqlCase.rootExecutionID,
           sqlId, sqlCase.duration, sqlCase.hasDatasetOrRDD,
-          Option(app.appInfo).flatMap(_.duration).orElse(Option(0L)), sqlCase.problematic,
+          app.getAppDuration.orElse(Option(0L)), sqlCase.problematic,
           sqlCase.sqlCpuTimePercent)
       }
     }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
@@ -35,10 +35,11 @@ class CollectInformation(apps: Seq[ApplicationInfo]) extends Logging {
 
   def getAppInfo: Seq[AppInfoProfileResults] = {
     val allRows = apps.collect {
-      case app if app.appInfo != null => val a = app.appInfo
-      AppInfoProfileResults(app.index, a.appName, a.appId,
-        a.sparkUser,  a.startTime, a.endTime, a.duration,
-        a.durationStr, a.sparkVersion, a.pluginEnabled)
+      case app if app.isAppMetaDefined =>
+        val a = app.appMetaData.get
+        AppInfoProfileResults(app.index, a.appName, a.appId,
+          a.sparkUser,  a.startTime, a.endTime, app.getAppDuration,
+          a.getDurationString, app.sparkVersion, app.gpuMode)
     }
     if (allRows.nonEmpty) {
       allRows.sortBy(cols => (cols.appIndex))
@@ -49,8 +50,8 @@ class CollectInformation(apps: Seq[ApplicationInfo]) extends Logging {
 
   def getAppLogPath: Seq[AppLogPathProfileResults] = {
     val allRows = apps.collect {
-      case app if app.appInfo != null => val a = app.appInfo
-      AppLogPathProfileResults(app.index, a.appName, a.appId, app.eventLogPath)
+      case app if app.isAppMetaDefined => val a = app.appMetaData.get
+      AppLogPathProfileResults(app.index, a.appName, a.appId, app.getEventLogPath)
     }
     if (allRows.nonEmpty) {
       allRows.sortBy(cols => cols.appIndex)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -293,23 +293,11 @@ case class AppLogPathProfileResults(appIndex: Int, appName: String,
   }
 }
 
-case class ApplicationCase(
-    appName: String, appId: Option[String], sparkUser: String,
-    startTime: Long, endTime: Option[Long], duration: Option[Long],
-    durationStr: String, sparkVersion: String, pluginEnabled: Boolean)
-
 case class SQLPlanMetricsCase(
     sqlID: Long,
     name: String,
     accumulatorId: Long,
     metricType: String)
-
-case class PlanNodeAccumCase(
-    sqlID: Long,
-    nodeID: Long,
-    nodeName: String,
-    nodeDesc: String,
-    accumulatorId: Long)
 
 case class SQLMetricInfoCase(
     sqlID: Long,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningAppMetadata.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningAppMetadata.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.qualification
+
+import org.apache.spark.sql.rapids.tool.AppMetaData
+
+/**
+ * A class to handle appMetadata for a running SparkApplication. This is created when a Spark
+ * Listener is used to analyze an existing App.
+ * The AppMetaData for a running application does not have eventlog.
+ *
+ * @param rName      name of the application
+ * @param rId        application id
+ * @param rUser      user who ran the Spark application
+ * @param rStartTime startTime of a Spark application
+ */
+class RunningAppMetadata(
+    rName: String,
+    rId: Option[String],
+    val rUser: String,
+    val rStartTime: Long) extends AppMetaData(None, rName, rId, rUser, rStartTime) {
+
+}
+
+object RunningAppMetadata {
+  def apply(
+      rName: String,
+      rId: Option[String],
+      rStartTime: Long): RunningAppMetadata = {
+    new RunningAppMetadata(rName, rId, "", rStartTime)
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
@@ -20,6 +20,7 @@ import com.nvidia.spark.rapids.tool.planparser.SQLPlanParser
 import com.nvidia.spark.rapids.tool.qualification.QualOutputWriter.SQL_DESC_STR
 
 import org.apache.spark.SparkEnv
+import org.apache.spark.sql.rapids.tool.AppMetaData
 import org.apache.spark.sql.rapids.tool.qualification._
 
 /**
@@ -77,8 +78,15 @@ class RunningQualificationApp(
 
   // we don't know the max sql query name size so lets cap it at 100
   private val SQL_DESC_LENGTH = 100
-  private lazy val appName = appInfo.map(_.appName).getOrElse("")
-  private lazy val appNameSize = if (appName.nonEmpty) appName.size else 100
+  private lazy val appNameSize = {
+    val runningAppName = getAppName
+    if (runningAppName.nonEmpty) {
+      runningAppName.size
+    } else {
+      100
+    }
+  }
+
   private lazy val perSqlHeadersAndSizes = {
       QualOutputWriter.getDetailedPerSqlHeaderStringsAndSizes(appNameSize,
         appId.size, SQL_DESC_LENGTH)
@@ -95,17 +103,9 @@ class RunningQualificationApp(
     val appStartTime = SparkEnv.get.conf.get("spark.app.startTime", "-1")
 
     // start event doesn't happen so initialize it
-    val thisAppInfo = QualApplicationInfo(
-      appName,
-      appIdConf,
-      appStartTime.toLong,
-      "",
-      None,
-      None,
-      endDurationEstimated = false
-    )
-    appId = appIdConf.getOrElse("")
-    appInfo = Some(thisAppInfo)
+    val newAppMeta =
+      AppMetaData.createRunningAppMetadata(appName, appIdConf, appStartTime.toLong)
+    appMetaData = Some(newAppMeta)
   }
 
   initApp()
@@ -229,7 +229,7 @@ class RunningQualificationApp(
               QualOutputWriter.RUN_NAME_STR_SIZE)
           }
           val appHeadersAndSizes = QualOutputWriter.getSummaryHeaderStringsAndSizes(
-            appName.size, info.appId.size, unSupExecMaxSize, unSupExprMaxSize,
+            getAppName.size, info.appId.size, unSupExecMaxSize, unSupExprMaxSize,
             estimatedFrequencyMaxSize, hasClusterTags, clusterIdMax, jobIdMax, runNameMax)
           val headerStr = QualOutputWriter.constructOutputRowFromMap(appHeadersAndSizes,
             delimiter, prettyPrint)
@@ -293,7 +293,7 @@ class RunningQualificationApp(
         // get task duration ratio
         val sqlStageSums = perSqlStageSummary.filter(_.sqlID == pInfo.sqlID)
         val estimatedInfo = getPerSQLWallClockSummary(sqlStageSums, wallClockDur,
-          sqlIDtoFailures.get(pInfo.sqlID).nonEmpty, appName)
+          sqlIDtoFailures.get(pInfo.sqlID).nonEmpty, getAppName)
         EstimatedPerSQLSummaryInfo(pInfo.sqlID, sqlInfo.rootExecutionID, pInfo.sqlDesc,
           estimatedInfo)
       }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
@@ -20,7 +20,6 @@ import com.nvidia.spark.rapids.tool.planparser.SQLPlanParser
 import com.nvidia.spark.rapids.tool.qualification.QualOutputWriter.SQL_DESC_STR
 
 import org.apache.spark.SparkEnv
-import org.apache.spark.sql.rapids.tool.AppMetaData
 import org.apache.spark.sql.rapids.tool.qualification._
 
 /**
@@ -104,7 +103,7 @@ class RunningQualificationApp(
 
     // start event doesn't happen so initialize it
     val newAppMeta =
-      AppMetaData.createRunningAppMetadata(appName, appIdConf, appStartTime.toLong)
+      RunningAppMetadata(appName, appIdConf, appStartTime.toLong)
     appMetaData = Some(newAppMeta)
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -21,6 +21,7 @@ import java.util.zip.GZIPInputStream
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
+import scala.collection.mutable
 import scala.io.{Codec, Source}
 
 import com.nvidia.spark.rapids.tool.{DatabricksEventLog, DatabricksRollingEventLogFilesFileReader, EventLogInfo}
@@ -35,7 +36,6 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.{SparkListenerEnvironmentUpdate, SparkListenerEvent, SparkListenerJobStart, SparkListenerLogStart, StageInfo}
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
-import org.apache.spark.sql.rapids.tool.qualification.MLFunctions
 import org.apache.spark.sql.rapids.tool.store.{StageModel, StageModelManager}
 import org.apache.spark.sql.rapids.tool.util.{EventUtils, RapidsToolsConfUtil, ToolsPlanGraph}
 import org.apache.spark.util.Utils
@@ -91,10 +91,13 @@ trait CacheableProps {
   var hiveEnabled = false
   // A flag to indicate whether the eventlog being processed is an eventlog from Photon.
   var isPhoton = false
-  var sparkProperties = Map[String, String]()
-  var classpathEntries = Map[String, String]()
+  var mlEventLogType = ""
+  var pysparkLogFlag = false
+
+  var sparkProperties: Map[String, String] = Map[String, String]()
+  var classpathEntries: Map[String, String] = Map[String, String]()
   // set the fileEncoding to UTF-8 by default
-  var systemProperties = Map[String, String]()
+  var systemProperties: Map[String, String] = Map[String, String]()
 
   private def processPropKeys(srcMap: Map[String, String]): Map[String, String] = {
     // Redact the sensitive values in the given map.
@@ -147,12 +150,19 @@ abstract class AppBase(
     val eventLogInfo: Option[EventLogInfo],
     val hadoopConf: Option[Configuration]) extends Logging with CacheableProps {
 
-  var appId: String = ""
+  var appMetaData: Option[AppMetaData] = _
+
+  // appId is string is stored as a field in the AppMetaData class
+  def appId: String = {
+    appMetaData match {
+      case Some(meta) => meta.appId.getOrElse("")
+      case _ => ""
+    }
+  }
 
   // Store map of executorId to executor info
   val executorIdToInfo = new HashMap[String, ExecutorInfoClass]()
 
-  var appEndTime: Option[Long] = None
   // The data source information
   val dataSourceInfo: ArrayBuffer[DataSourceCase] = ArrayBuffer[DataSourceCase]()
 
@@ -176,8 +186,61 @@ abstract class AppBase(
 
   var driverAccumMap: HashMap[Long, ArrayBuffer[DriverAccumCase]] =
     HashMap[Long, ArrayBuffer[DriverAccumCase]]()
-  var mlEventLogType = ""
-  var pysparkLogFlag = false
+
+
+  // Returns the String value of the eventlog or empty if it is not defined. Note that the eventlog
+  // won't be defined for running applications
+  def getEventLogPath: String = {
+    eventLogInfo.map(_.eventLog).getOrElse(new Path("")).toString
+  }
+
+  // Update the endTime of the application and calculate the duration.
+  // This is called while handling ApplicationEnd event
+  def updateEndTime(newEndTime: Long): Unit = {
+    appMetaData.foreach(_.setEndTime(newEndTime))
+  }
+
+  // Returns a boolean flag to indicate whether the endTime was estimated.
+  def isAppDurationEstimated: Boolean = {
+    appMetaData match {
+      case Some(meta) => meta.isDurationEstimated
+      case _ => true
+    }
+  }
+
+  // Returns the AppName
+  def getAppName: String = {
+    appMetaData.map(_.appName).getOrElse("")
+  }
+
+  // Returns optional endTime in ms.
+  def getAppEndTime: Option[Long] = {
+    appMetaData.flatMap(_.endTime)
+  }
+
+  // Returns optional wallClock duration of the Application
+  def getAppDuration: Option[Long] = {
+    appMetaData.flatMap(_.duration)
+  }
+
+  // Returns a boolean true/false. This is used to check whether processing an eventlog was
+  // successful.
+  def isAppMetaDefined: Boolean = appMetaData.isDefined
+
+  /**
+   * Sets an estimated endTime to the application based on the function passed as an argument.
+   * First it checks if the endTime is already defined or not.
+   * This method is a temporary refactor because both QualAppInfo and ProfAppInfo have different
+   * ways of estimating the endTime.
+   *
+   * @param callBack function to estimate the endTime
+   */
+  def estimateAppEndTime(callBack: () => Option[Long]): Unit = {
+    if (getAppEndTime.isEmpty) {
+      val estimatedResult = callBack()
+      estimatedResult.foreach(eT => appMetaData.foreach(_.setEndTime(eT, estimated = true)))
+    }
+  }
 
   def getOrCreateExecutor(executorId: String, addTime: Long): ExecutorInfoClass = {
     executorIdToInfo.getOrElseUpdate(executorId, {
@@ -188,48 +251,6 @@ abstract class AppBase(
   def getOrCreateStage(info: StageInfo): StageModel = {
     val stage = stageManager.addStageInfo(info)
     stage
-  }
-
-  def checkMLOps(appId: Option[String], stageModel: StageModel): Option[MLFunctions] = {
-    val stageInfoDetails = stageModel.sInfo.details
-    val mlOps = if (stageInfoDetails.contains(MlOps.sparkml) ||
-      stageInfoDetails.contains(MlOps.xgBoost)) {
-
-      // Check if it's a pyspark eventlog and set the mleventlogtype to pyspark
-      // Once it is set, do not change it to scala if other stageInfoDetails don't match.
-      if (stageInfoDetails.contains(MlOps.pysparkLog)) {
-        if (!pysparkLogFlag) {
-          mlEventLogType = MlOpsEventLogType.pyspark
-          pysparkLogFlag = true
-        }
-      } else {
-        if (!pysparkLogFlag) {
-          mlEventLogType = MlOpsEventLogType.scala
-        }
-      }
-
-      // Consider stageInfo to have below string as an example
-      //org.apache.spark.rdd.RDD.first(RDD.scala:1463)
-      //org.apache.spark.mllib.feature.PCA.fit(PCA.scala:44)
-      //org.apache.spark.ml.feature.PCA.fit(PCA.scala:93)
-      val splitString = stageInfoDetails.split("\n")
-
-      // filteredString = org.apache.spark.ml.feature.PCA.fit
-      val filteredString = splitString.filter(
-        string => string.contains(MlOps.sparkml) || string.contains(MlOps.xgBoost)).map(
-        packageName => packageName.split("\\(").head
-      )
-      filteredString
-    } else {
-      Array.empty[String]
-    }
-
-    if (mlOps.nonEmpty) {
-      Some(MLFunctions(appId, stageModel.sId, mlOps,
-        stageModel.getDuration))
-    } else {
-      None
-    }
   }
 
   def getAllStagesForJobsInSqlQuery(sqlID: Long): Seq[Int] = {
@@ -285,7 +306,7 @@ abstract class AppBase(
 
   private def openEventLogInternal(log: Path, fs: FileSystem): InputStream = {
     EventLogFileWriter.codecName(log) match {
-      case c if (c.isDefined && c.get.equals("gz")) =>
+      case c if c.isDefined && c.get.equals("gz") =>
         val in = fs.open(log)
         try {
           new GZIPInputStream(in)
@@ -352,49 +373,19 @@ abstract class AppBase(
     ".*second\\(.*\\).*" -> "TIMEZONE second()"
   )
 
-  def containsUDF(desc: String): Boolean = {
-    desc.matches(UDFRegex)
-  }
-
   protected def findPotentialIssues(desc: String): Set[String] =  {
     val potentialIssuesRegexs = potentialIssuesRegexMap
     val issues = potentialIssuesRegexs.filterKeys(desc.matches(_))
     issues.values.toSet
   }
 
-  def getPlanMetaWithSchema(planInfo: SparkPlanInfo): Seq[SparkPlanInfo] = {
-    val childRes = planInfo.children.flatMap(getPlanMetaWithSchema(_))
-    if (planInfo.metadata != null && planInfo.metadata.contains("ReadSchema")) {
-      childRes :+ planInfo
-    } else {
-      childRes
-    }
-  }
 
-  // Finds all the nodes that scan a hive table
-  def getPlanInfoWithHiveScan(planInfo: SparkPlanInfo): Seq[SparkPlanInfo] = {
-    val childRes = planInfo.children.flatMap(getPlanInfoWithHiveScan(_))
-    if (isHiveTableScanNode(planInfo.nodeName)) {
-      childRes :+ planInfo
-    } else {
-      childRes
-    }
-  }
-
-  private def trimSchema(str: String): String = {
-    val index = str.lastIndexOf(",")
-    if (index != -1 && str.contains("...")) {
-      str.substring(0, index)
-    } else {
-      str
-    }
-  }
 
   // The ReadSchema metadata is only in the eventlog for DataSource V1 readers
   protected def checkMetadataForReadSchema(
       sqlPlanInfoGraph: SqlPlanInfoGraphEntry): ArrayBuffer[DataSourceCase] = {
     // check if planInfo has ReadSchema
-    val allMetaWithSchema = getPlanMetaWithSchema(sqlPlanInfoGraph.planInfo)
+    val allMetaWithSchema = AppBase.getPlanMetaWithSchema(sqlPlanInfoGraph.planInfo)
     val allNodes = sqlPlanInfoGraph.sparkPlanGraph.allNodes
     val results = ArrayBuffer[DataSourceCase]()
 
@@ -403,7 +394,7 @@ abstract class AppBase(
       val readSchema = ReadParser.formatSchemaStr(meta.getOrElse("ReadSchema", ""))
       val scanNode = allNodes.filter(node => {
         // Get ReadSchema of each Node and sanitize it for comparison
-        val trimmedNode = trimSchema(ReadParser.parseReadNode(node).schema)
+        val trimmedNode = AppBase.trimSchema(ReadParser.parseReadNode(node).schema)
         readSchema.contains(trimmedNode)
       }).filter(ReadParser.isScanNode(_))
 
@@ -424,7 +415,7 @@ abstract class AppBase(
     // "scan hive" has no "ReadSchema" defined. So, we need to look explicitly for nodes
     // that are scan hive and add them one by one to the dataSource
     if (hiveEnabled) { // only scan for hive when the CatalogImplementation is using hive
-      val allPlanWithHiveScan = getPlanInfoWithHiveScan(sqlPlanInfoGraph.planInfo)
+      val allPlanWithHiveScan = AppBase.getPlanInfoWithHiveScan(sqlPlanInfoGraph.planInfo)
       allPlanWithHiveScan.foreach { hiveReadPlan =>
         val sqlGraph = ToolsPlanGraph(hiveReadPlan)
         val hiveScanNode = sqlGraph.allNodes.head
@@ -472,7 +463,7 @@ abstract class AppBase(
     }
   }
 
-  protected def probNotDataset: HashMap[Long, Set[String]] = {
+  protected def probNotDataset: mutable.HashMap[Long, Set[String]] = {
     sqlIDtoProblematic.filterNot { case (sqlID, _) => sqlIDToDataSetOrRDDCase.contains(sqlID) }
   }
 
@@ -538,10 +529,10 @@ object AppBase {
         individualSchema += tempStringBuilder.toString
         tempStringBuilder.setLength(0)
       } else {
-        tempStringBuilder.append(char);
+        tempStringBuilder.append(char)
       }
     }
-    if (!tempStringBuilder.isEmpty) {
+    if (tempStringBuilder.nonEmpty) {
       individualSchema += tempStringBuilder.toString
     }
 
@@ -601,5 +592,35 @@ object AppBase {
     })
 
     (complexTypes.filter(_.nonEmpty), nestedComplexTypes.filter(_.nonEmpty))
+  }
+
+  private def trimSchema(str: String): String = {
+    val index = str.lastIndexOf(",")
+    if (index != -1 && str.contains("...")) {
+      str.substring(0, index)
+    } else {
+      str
+    }
+  }
+
+  private def getPlanMetaWithSchema(planInfo: SparkPlanInfo): Seq[SparkPlanInfo] = {
+    // TODO: This method does not belong to AppBAse. It should move to another member.
+    val childRes = planInfo.children.flatMap(getPlanMetaWithSchema(_))
+    if (planInfo.metadata != null && planInfo.metadata.contains("ReadSchema")) {
+      childRes :+ planInfo
+    } else {
+      childRes
+    }
+  }
+
+  // Finds all the nodes that scan a hive table
+  private def getPlanInfoWithHiveScan(planInfo: SparkPlanInfo): Seq[SparkPlanInfo] = {
+    // TODO: This method does not belong to AppBAse. It should move to another member.
+    val childRes = planInfo.children.flatMap(getPlanInfoWithHiveScan(_))
+    if (isHiveTableScanNode(planInfo.nodeName)) {
+      childRes :+ planInfo
+    } else {
+      childRes
+    }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -91,7 +91,10 @@ trait CacheableProps {
   var hiveEnabled = false
   // A flag to indicate whether the eventlog being processed is an eventlog from Photon.
   var isPhoton = false
+  // Indicates the ML eventlogType (i.e., Scala or pyspark). It is set only when MLOps are detected.
+  // By default, it is empty.
   var mlEventLogType = ""
+  // A flag to indicate that the eventlog is ML
   var pysparkLogFlag = false
 
   var sparkProperties: Map[String, String] = Map[String, String]()
@@ -150,7 +153,7 @@ abstract class AppBase(
     val eventLogInfo: Option[EventLogInfo],
     val hadoopConf: Option[Configuration]) extends Logging with CacheableProps {
 
-  var appMetaData: Option[AppMetaData] = _
+  var appMetaData: Option[AppMetaData] = None
 
   // appId is string is stored as a field in the AppMetaData class
   def appId: String = {
@@ -202,10 +205,7 @@ abstract class AppBase(
 
   // Returns a boolean flag to indicate whether the endTime was estimated.
   def isAppDurationEstimated: Boolean = {
-    appMetaData match {
-      case Some(meta) => meta.isDurationEstimated
-      case _ => true
-    }
+    appMetaData.map(_.isDurationEstimated).getOrElse(false)
   }
 
   // Returns the AppName
@@ -604,7 +604,7 @@ object AppBase {
   }
 
   private def getPlanMetaWithSchema(planInfo: SparkPlanInfo): Seq[SparkPlanInfo] = {
-    // TODO: This method does not belong to AppBAse. It should move to another member.
+    // TODO: This method does not belong to AppBase. It should move to another member.
     val childRes = planInfo.children.flatMap(getPlanMetaWithSchema(_))
     if (planInfo.metadata != null && planInfo.metadata.contains("ReadSchema")) {
       childRes :+ planInfo

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppMetaData.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppMetaData.scala
@@ -23,7 +23,7 @@ import org.apache.spark.ui.UIUtils
 
 /**
  * A class used to hold the information of a Spark Application
- * @param eventLogPath captures the path of the eventlog being processed by teh tools.
+ * @param eventLogPath captures the path of the eventlog being processed by the tools.
  * @param appName name of the application
  * @param appId application id
  * @param sparkUser user who ran the Spark application
@@ -41,17 +41,14 @@ class AppMetaData(
   // Calculated as time in ms
   var duration: Option[Long] = _
   // Boolean to indicate whether the endTime was estimated.
-  private var durationEstimated: Boolean = _
+  private var durationEstimated: Boolean = false
 
   /**
    * Returns the duration of the application in human readable format
    * @return human readable format or empty String when the endTime is undefined.
    */
   def getDurationString: String = {
-    duration match {
-      case Some(i) => UIUtils.formatDuration(i)
-      case None => ""
-    }
+    duration.map(UIUtils.formatDuration).getOrElse("")
   }
 
   /**
@@ -78,30 +75,12 @@ class AppMetaData(
 
   def isDurationEstimated: Boolean = durationEstimated
 
-  // Initialization code
-  // 1- Calculate the duration based on the constructor argument endTime
-  // 2- Set the estimated flag to true if endTime is not set
+  // Initialization code:
+  // - Calculate the duration based on the constructor argument endTime
   calculateDurationInternal()
-  // initial estimated flag is set to True if endTime is not set
-  setEstimatedFlag(endTime.isEmpty)
 }
 
-/**
- * A class to handle appMetadata for a running SparkApplication. This is created when a Spark
- * Listener is used to analyze an existing App.
- * The AppMetaData for a running application does not have eventlog.
- * @param rName name of the application
- * @param rId application id
- * @param rUser user who ran the Spark application
- * @param rStartTime startTime of a Spark application
- */
-class RunningAppMetadata(
-    rName: String,
-    rId: Option[String],
-    val rUser: String,
-    val rStartTime: Long) extends AppMetaData(None, rName, rId, rUser, rStartTime) {
 
-}
 
 object AppMetaData {
 
@@ -112,12 +91,5 @@ object AppMetaData {
       appStartEv.appName,
       appStartEv.appId, appStartEv.sparkUser,
       appStartEv.time)
-  }
-
-  def createRunningAppMetadata(
-      rName: String,
-      rId: Option[String],
-      rStartTime: Long): RunningAppMetadata = {
-    new RunningAppMetadata(rName, rId, "", rStartTime)
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppMetaData.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppMetaData.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool
+
+import com.nvidia.spark.rapids.tool.profiling.ProfileUtils
+
+import org.apache.spark.scheduler.SparkListenerApplicationStart
+import org.apache.spark.ui.UIUtils
+
+/**
+ * A class used to hold the information of a Spark Application
+ * @param eventLogPath captures the path of the eventlog being processed by teh tools.
+ * @param appName name of the application
+ * @param appId application id
+ * @param sparkUser user who ran the Spark application
+ * @param startTime startTime of a Spark application
+ * @param endTime endTime of the spark Application
+ */
+class AppMetaData(
+    val eventLogPath: Option[String],
+    val appName: String,
+    val appId: Option[String],
+    val sparkUser: String,
+    val startTime: Long,
+    var endTime: Option[Long] = None) {
+
+  // Calculated as time in ms
+  var duration: Option[Long] = _
+  // Boolean to indicate whether the endTime was estimated.
+  private var durationEstimated: Boolean = _
+
+  /**
+   * Returns the duration of the application in human readable format
+   * @return human readable format or empty String when the endTime is undefined.
+   */
+  def getDurationString: String = {
+    duration match {
+      case Some(i) => UIUtils.formatDuration(i)
+      case None => ""
+    }
+  }
+
+  /**
+   * Set the endTime of the application and calculate the duration.
+   * @param newEndTime new endTime in ms
+   * @param estimated flag to indicate whether the endTime was estimated or not.
+   */
+  def setEndTime(newEndTime: Long, estimated: Boolean = false): Unit = {
+    endTime = Some(newEndTime)
+    calculateDurationInternal()
+    setEstimatedFlag(estimated)
+  }
+
+  /**
+   * Recalculate the duration of the application when the endTime is updated
+   */
+  private def calculateDurationInternal(): Unit = {
+    duration = ProfileUtils.OptionLongMinusLong(endTime, startTime)
+  }
+
+  private def setEstimatedFlag(newValue: Boolean): Unit = {
+    durationEstimated = newValue
+  }
+
+  def isDurationEstimated: Boolean = durationEstimated
+
+  // Initialization code
+  // 1- Calculate the duration based on the constructor argument endTime
+  // 2- Set the estimated flag to true if endTime is not set
+  calculateDurationInternal()
+  // initial estimated flag is set to True if endTime is not set
+  setEstimatedFlag(endTime.isEmpty)
+}
+
+/**
+ * A class to handle appMetadata for a running SparkApplication. This is created when a Spark
+ * Listener is used to analyze an existing App.
+ * The AppMetaData for a running application does not have eventlog.
+ * @param rName name of the application
+ * @param rId application id
+ * @param rUser user who ran the Spark application
+ * @param rStartTime startTime of a Spark application
+ */
+class RunningAppMetadata(
+    rName: String,
+    rId: Option[String],
+    val rUser: String,
+    val rStartTime: Long) extends AppMetaData(None, rName, rId, rUser, rStartTime) {
+
+}
+
+object AppMetaData {
+
+  def apply(
+      evtLogPath: String,
+      appStartEv: SparkListenerApplicationStart): AppMetaData = {
+    new AppMetaData(Some(evtLogPath),
+      appStartEv.appName,
+      appStartEv.appId, appStartEv.sparkUser,
+      appStartEv.time)
+  }
+
+  def createRunningAppMetadata(
+      rName: String,
+      rId: Option[String],
+      rStartTime: Long): RunningAppMetadata = {
+    new RunningAppMetadata(rName, rId, "", rStartTime)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
@@ -267,7 +267,10 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
 
   def doSparkListenerApplicationStart(
       app: T,
-      event: SparkListenerApplicationStart): Unit = {}
+      event: SparkListenerApplicationStart): Unit = {
+    val appMeta = AppMetaData(app.getEventLogPath, event)
+    app.appMetaData = Some(appMeta)
+  }
 
   override def onApplicationStart(applicationStart: SparkListenerApplicationStart): Unit = {
     doSparkListenerApplicationStart(app, applicationStart)
@@ -277,7 +280,7 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
       app: T,
       event: SparkListenerApplicationEnd): Unit = {
     logDebug("Processing event: " + event.getClass)
-    app.appEndTime = Some(event.time)
+    app.updateEndTime(event.time)
   }
 
   override def onApplicationEnd(applicationEnd: SparkListenerApplicationEnd): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
@@ -268,8 +268,7 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
   def doSparkListenerApplicationStart(
       app: T,
       event: SparkListenerApplicationStart): Unit = {
-    val appMeta = AppMetaData(app.getEventLogPath, event)
-    app.appMetaData = Some(appMeta)
+    app.appMetaData = Some(AppMetaData(app.getEventLogPath, event))
   }
 
   override def onApplicationStart(applicationStart: SparkListenerApplicationStart): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/FilterAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/FilterAppInfo.scala
@@ -21,10 +21,7 @@ import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.scheduler.{SparkListenerApplicationStart, SparkListenerEnvironmentUpdate, SparkListenerEvent}
 
-case class ApplicationStartInfo(
-    appName: String,
-    startTime: Long,
-    userName: String)
+
 
 class FilterAppInfo(
     eventLogInfo: EventLogInfo,
@@ -33,12 +30,8 @@ class FilterAppInfo(
   def doSparkListenerApplicationStart(
       event: SparkListenerApplicationStart): Unit = {
     logDebug("Processing event: " + event.getClass)
-    val thisAppInfo = ApplicationStartInfo(
-      event.appName,
-      event.time,
-      event.sparkUser
-    )
-    appStartInfo = Some(thisAppInfo)
+    val appMeta = AppMetaData(getEventLogPath, event)
+    appMetaData = Some(appMeta)
   }
 
   def doSparkListenerEnvironmentUpdate(event: SparkListenerEnvironmentUpdate): Unit = {
@@ -46,7 +39,6 @@ class FilterAppInfo(
     handleEnvUpdateForCachedProps(event)
   }
 
-  var appStartInfo: Option[ApplicationStartInfo] = None
   // We are currently processing 2 events. This is used as counter to send true when both the
   // event are processed so that we can stop processing further events.
   var eventsToProcess: Int = 2

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
@@ -117,40 +117,6 @@ class EventsProcessor(app: ApplicationInfo) extends EventProcessorBase[Applicati
     logDebug(s"App's GPU Mode = ${app.gpuMode}")
   }
 
-  override def doSparkListenerApplicationStart(
-      app: ApplicationInfo,
-      event: SparkListenerApplicationStart): Unit = {
-    logDebug("Processing event: " + event.getClass)
-    val thisAppStart = ApplicationCase(
-      event.appName,
-      event.appId,
-      event.sparkUser,
-      event.time,
-      None,
-      None,
-      "",
-      "",
-      pluginEnabled = false
-    )
-    app.appInfo = thisAppStart
-    app.appId = event.appId.getOrElse("")
-  }
-
-  override def doSparkListenerApplicationEnd(
-      app: ApplicationInfo,
-      event: SparkListenerApplicationEnd): Unit = {
-    logDebug("Processing event: " + event.getClass)
-    app.appEndTime = Some(event.time)
-  }
-
-  override def doSparkListenerTaskStart(
-      app: ApplicationInfo,
-      event: SparkListenerTaskStart): Unit = {
-    logDebug("Processing event: " + event.getClass)
-    // currently not used
-    // app.taskStart += event
-  }
-
   override def doSparkListenerTaskEnd(
       app: ApplicationInfo,
       event: SparkListenerTaskEnd): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -973,25 +973,6 @@ class StageTaskQualificationSummary(
     var totalTaskDuration: Long,
     var totalbytesRead: Long)
 
-case class QualApplicationInfo(
-    appName: String,
-    appId: Option[String],
-    startTime: Long,
-    sparkUser: String,
-    endTime: Option[Long], // time in ms
-    duration: Option[Long],
-    endDurationEstimated: Boolean)
-
-case class QualSQLExecutionInfo(
-    sqlID: Long,
-    startTime: Long,
-    endTime: Option[Long],
-    duration: Option[Long],
-    durationStr: String,
-    sqlQualDuration: Option[Long],
-    hasDataset: Boolean,
-    problematic: String = "")
-
 // Case class representing status summary information for a particular application.
 case class StatusSummaryInfo(
     path: String,

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -20,7 +20,6 @@ import scala.collection.mutable.{ArrayBuffer, HashMap}
 
 import com.nvidia.spark.rapids.tool.EventLogInfo
 import com.nvidia.spark.rapids.tool.planparser.{DatabricksParseHelper, DataWritingCommandExecParser, ExecInfo, PlanInfo, SQLPlanParser}
-import com.nvidia.spark.rapids.tool.profiling._
 import com.nvidia.spark.rapids.tool.qualification._
 import com.nvidia.spark.rapids.tool.qualification.QualOutputWriter.DEFAULT_JOB_FREQUENCY
 import org.apache.hadoop.conf.Configuration
@@ -28,8 +27,9 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEnvironmentUpdate, SparkListenerEvent, SparkListenerJobStart}
 import org.apache.spark.sql.execution.SparkPlanInfo
-import org.apache.spark.sql.rapids.tool.{AppBase, AppEventlogProcessException, ClusterInfo, ClusterSummary, GpuEventLogException, IncorrectAppStatusException, PhotonEventLogException, SqlPlanInfoGraphBuffer, SupportedMLFuncsName, ToolUtils}
+import org.apache.spark.sql.rapids.tool.{AppBase, AppEventlogProcessException, ClusterInfo, ClusterSummary, GpuEventLogException, IncorrectAppStatusException, MlOps, MlOpsEventLogType, PhotonEventLogException, SqlPlanInfoGraphBuffer, SupportedMLFuncsName, ToolUtils}
 import org.apache.spark.sql.rapids.tool.annotation.{Calculated, WallClock}
+import org.apache.spark.sql.rapids.tool.store.StageModel
 
 
 class QualificationAppInfo(
@@ -45,8 +45,6 @@ class QualificationAppInfo(
   var lastJobEndTime: Option[Long] = None
   var lastSQLEndTime: Option[Long] = None
   val writeDataFormat: ArrayBuffer[String] = ArrayBuffer[String]()
-
-  var appInfo: Option[QualApplicationInfo] = None
 
   val sqlIDToTaskEndSum: HashMap[Long, StageTaskQualificationSummary] =
     HashMap.empty[Long, StageTaskQualificationSummary]
@@ -150,23 +148,20 @@ class QualificationAppInfo(
   // time in ms
   private def calculateAppDuration(startTime: Long): Option[Long] = {
     if (startTime > 0) {
-      val estimatedResult =
-        this.appEndTime match {
-          case Some(_) => this.appEndTime
-          case None =>
-            if (lastSQLEndTime.isEmpty && lastJobEndTime.isEmpty) {
-              None
-            } else {
-              logWarning(s"Application End Time is unknown for $appId, estimating based on" +
-                " job and sql end times!")
-              // estimate the app end with job or sql end times
-              val sqlEndTime = if (this.lastSQLEndTime.isEmpty) 0L else this.lastSQLEndTime.get
-              val jobEndTime = if (this.lastJobEndTime.isEmpty) 0L else lastJobEndTime.get
-              val maxEndTime = math.max(sqlEndTime, jobEndTime)
-              if (maxEndTime == 0) None else Some(maxEndTime)
-            }
+      estimateAppEndTime { () =>
+        if (!(lastSQLEndTime.isEmpty && lastJobEndTime.isEmpty)) {
+          logWarning(s"Application End Time is unknown for $appId, estimating based on" +
+            " job and sql end times!")
+          // estimate the app end with job or sql end times
+          val sqlEndTime = if (this.lastSQLEndTime.isEmpty) 0L else this.lastSQLEndTime.get
+          val jobEndTime = if (this.lastJobEndTime.isEmpty) 0L else lastJobEndTime.get
+          val maxEndTime = math.max(sqlEndTime, jobEndTime)
+          if (maxEndTime == 0) None else Some(maxEndTime)
+        } else {
+          None
         }
-      ProfileUtils.OptionLongMinusLong(estimatedResult, startTime)
+      }
+      getAppDuration
     } else {
       None
     }
@@ -552,7 +547,7 @@ class QualificationAppInfo(
    *         otherwise None.
    */
   def aggregateStats(): Option[QualificationSummaryInfo] = {
-    appInfo.map { info =>
+    appMetaData.map { info =>
       val appDuration = calculateAppDuration(info.startTime).getOrElse(0L)
 
       // if either job or stage failures then we mark as N/A
@@ -594,7 +589,7 @@ class QualificationAppInfo(
       // a stage for every exec
       val allSQLDurations = getAllSQLDurations
 
-      val appName = appInfo.map(_.appName).getOrElse("")
+      val appName = appMetaData.map(_.appName).getOrElse("")
 
       val allClusterTagsMap = prepareClusterTags
 
@@ -628,7 +623,7 @@ class QualificationAppInfo(
       val sqlDataframeTaskDuration = allStagesSummary.map(s => s.stageTaskTime).sum
       val totalTransitionsTime = allStagesSummary.map(s => s.transitionTime).sum
       val unsupportedSQLTaskDuration = calculateSQLUnsupportedTaskDuration(allStagesSummary)
-      val endDurationEstimated = this.appEndTime.isEmpty && appDuration > 0
+      val endDurationEstimated = this.isAppDurationEstimated && appDuration > 0
       val jobOverheadTime = calculateJobOverHeadTime(info.startTime)
       val nonSQLDataframeTaskDuration =
         calculateNonSQLTaskDataframeDuration(sqlDataframeTaskDuration, totalTransitionsTime)
@@ -762,6 +757,48 @@ class QualificationAppInfo(
 
     if (mlFunctions.nonEmpty) {
       Some(mlFunctions.toSeq.sortBy(mlops => mlops.stageId))
+    } else {
+      None
+    }
+  }
+
+  private def checkMLOps(appId: Option[String], stageModel: StageModel): Option[MLFunctions] = {
+    val stageInfoDetails = stageModel.sInfo.details
+    val mlOps = if (stageInfoDetails.contains(MlOps.sparkml) ||
+      stageInfoDetails.contains(MlOps.xgBoost)) {
+
+      // Check if it's a pyspark eventlog and set the mleventlogtype to pyspark
+      // Once it is set, do not change it to scala if other stageInfoDetails don't match.
+      if (stageInfoDetails.contains(MlOps.pysparkLog)) {
+        if (!pysparkLogFlag) {
+          mlEventLogType = MlOpsEventLogType.pyspark
+          pysparkLogFlag = true
+        }
+      } else {
+        if (!pysparkLogFlag) {
+          mlEventLogType = MlOpsEventLogType.scala
+        }
+      }
+
+      // Consider stageInfo to have below string as an example
+      //org.apache.spark.rdd.RDD.first(RDD.scala:1463)
+      //org.apache.spark.mllib.feature.PCA.fit(PCA.scala:44)
+      //org.apache.spark.ml.feature.PCA.fit(PCA.scala:93)
+      val splitString = stageInfoDetails.split("\n")
+
+      // filteredString = org.apache.spark.ml.feature.PCA.fit
+      val filteredString = splitString.filter(
+        string => string.contains(MlOps.sparkml) || string.contains(MlOps.xgBoost)).map(
+        packageName => packageName.split("\\(").head
+      )
+      filteredString
+    } else {
+      Array.empty[String]
+    }
+
+    if (mlOps.nonEmpty) {
+      Some(MLFunctions(appId, stageModel.sId, mlOps,
+        stageModel.getDuration))
     } else {
       None
     }
@@ -1129,7 +1166,7 @@ object QualificationAppInfo extends Logging {
     try {
       val app = new QualificationAppInfo(Some(path), Some(hadoopConf), pluginTypeChecker,
         reportSqlLevel, false, mlOpsEnabled, penalizeTransitions)
-      if (app.appInfo.isEmpty) {
+      if (!app.isAppMetaDefined) {
         throw IncorrectAppStatusException()
       }
       logInfo(s"${path.eventLog.toString} has App: ${app.appId}")

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationEventProcessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationEventProcessor.scala
@@ -33,23 +33,6 @@ class QualificationEventProcessor(app: QualificationAppInfo, perSqlOnly: Boolean
 
   type T = QualificationAppInfo
 
-  override def doSparkListenerApplicationStart(
-      app: QualificationAppInfo,
-      event: SparkListenerApplicationStart): Unit = {
-    logDebug("Processing event: " + event.getClass)
-    val thisAppInfo = QualApplicationInfo(
-      event.appName,
-      event.appId,
-      event.time,
-      event.sparkUser,
-      None,
-      None,
-      endDurationEstimated = false
-    )
-    app.appInfo = Some(thisAppInfo)
-    app.appId = event.appId.getOrElse("")
-  }
-
   override def doSparkListenerTaskEnd(
       app: QualificationAppInfo,
       event: SparkListenerTaskEnd): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/RunningQualificationEventProcessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/RunningQualificationEventProcessor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ class RunningQualificationEventProcessor(sparkConf: SparkConf) extends SparkList
   private val maxNumFiles: Int =
     sparkConf.get("spark.rapids.qualification.output.maxNumFiles", "100").toInt
   private val outputFileFromConfig = sparkConf.get("spark.rapids.qualification.outputDir", "")
-  private lazy val appName = qualApp.appInfo.map(_.appName).getOrElse("")
+  private lazy val appName = qualApp.getAppName
   private var fileWriter: Option[RunningQualOutputWriter] = None
   private var currentFileNum = 0
   private var currentSQLQueriesWritten = 0

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
@@ -70,13 +70,13 @@ class StageModel private(var sInfo: StageInfo) {
     sInfo.accumulables.keySet
   }
 
-
-  @Calculated
-  @WallClock
   /**
    * Duration won't be defined when neither submitted/completion-Time is defined.
+   *
    * @return the WallClock duration of the stage in milliseconds if defined, or 0L otherwise.
    */
+  @Calculated
+  @WallClock
   def getDuration: Long = {
     duration.getOrElse(0L)
   }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AnalysisSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AnalysisSuite.scala
@@ -146,7 +146,7 @@ class AnalysisSuite extends FunSuite {
 
     val apps = ToolTestUtils.processProfileApps(logs, sparkSession)
     apps.foreach { app =>
-      app.appInfo = null
+      app.appMetaData = None
     }
     val analysis = new Analysis(apps)
     val metrics = analysis.sqlMetricsAggregationDurationAndCpuTime()

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -134,7 +134,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
     assert(rapidsJarResults.filter(_.jar.contains("rapids-4-spark_2.12-0.5.0.jar")).size === 1)
     assert(rapidsJarResults.filter(_.jar.contains("cudf-0.19.2-cuda11.jar")).size === 1)
 
-    assert(apps.head.eventLogPath == (s"file:$logDir/rapids_join_eventlog.zstd"))
+    assert(apps.head.getEventLogPath == s"file:$logDir/rapids_join_eventlog.zstd")
   }
 
   test("test sql and resourceprofile eventlog") {


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Contributes to #980

- this code change aims at using common logic to create and update the application info inside Tools.

**Changes**

- No changes in unit tests was needed.
- Created a new class AppMetaData that holds the basic information of a spark application: startTime, user, appId, appName, endTime, duration and flag to indicate whether duration is estimated.
- Handling ApplicationStart became common between the EventParser classes: this means that the following functionswere removed:
  - `QualificationEventProcessor.doSparkListenerApplicationStart` 
  - `EventsProcessor.doSparkListenerApplicationStart`
  - `EventsProcessor.doSparkListenerApplicationEnd`
  - `EventsProcessor.doSparkListenerTaskStart`
- Removed unused case classes 
  - `case class ApplicationCase`
  - `case class PlanNodeAccumCase` 
  - `case QualSQLExecutionInfo` and 
  - `case QualApplicationInfo` 
- Moved the ML flags `mlEventLogType` and `pysparkLogFlag` to the trait. This goes along having all the predicates in one place such as "isHive, isGpu...etc"
- For AppBase:
  - added `appMetaData` field
  - `appId` becomes a method. thevalue can be retrieved from the AppMetadata  
  - removed `appEndTime` because it is redundant as we hold the endTime inside `appMetaData`
  - Created `estimateAppEndTime` which is used between Qualification and Profiling to estimate the endTime if it is missing.
  - Temporary, I moved `checkMLOps` to the QualificationAppInfo because it is not being used by the profiling and we need to reconsider how to etract ML anyway.
  - There is a bunch of methods defined inside AppBase but they do not have anything to do with  its fields or methods. I moved those to the object for now until we find a btter class member for them.
    - `getPlanMetaWithSchema`
    - `getPlanInfoWithHiveScan`
    - `trimSchema`