### PR TITLE
Fix handling of clusterTags and SparkVersion in Q/P Tools

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DatabricksParseHelper.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DatabricksParseHelper.scala
@@ -39,6 +39,9 @@ object DatabricksParseHelper extends Logging {
   val PROP_WORKER_TYPE_ID_KEY = "spark.databricks.workerNodeTypeId"
   val PROP_DRIVER_TYPE_ID_KEY = "spark.databricks.driverNodeTypeId"
 
+  val SUB_PROP_CLUSTER_ID = "ClusterId"
+  val SUB_PROP_JOB_ID = "JobId"
+  val SUB_PROP_RUN_NAME = "RunName"
   /**
    * Checks if the properties indicate that the application is a Photon app.
    * This ca be checked by looking for keywords in one of the keys defined in PHOTON_SPARK_PROPS
@@ -50,6 +53,10 @@ object DatabricksParseHelper extends Logging {
     PHOTON_SPARK_PROPS.exists { case (key, value) =>
       properties.get(key).exists(_.matches(value))
     }
+  }
+
+  def getSparkVersion(properties: collection.Map[String, String]): String = {
+    properties.getOrElse(PROP_TAG_CLUSTER_SPARK_VERSION_KEY, "")
   }
 
   /**

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable
 import scala.collection.mutable.{Buffer, LinkedHashMap, ListBuffer}
 
 import com.nvidia.spark.rapids.tool.ToolTextFileWriter
-import com.nvidia.spark.rapids.tool.planparser.{ExecInfo, PlanInfo, UnsupportedExecSummary}
+import com.nvidia.spark.rapids.tool.planparser.{DatabricksParseHelper, ExecInfo, PlanInfo, UnsupportedExecSummary}
 import com.nvidia.spark.rapids.tool.profiling.ProfileUtils.replaceDelimiter
 import com.nvidia.spark.rapids.tool.qualification.QualOutputWriter.{CLUSTER_ID, CLUSTER_ID_STR_SIZE, JOB_ID, JOB_ID_STR_SIZE, RUN_NAME, RUN_NAME_STR_SIZE, TEXT_DELIMITER}
 import org.apache.hadoop.conf.Configuration
@@ -437,15 +437,15 @@ object QualOutputWriter {
   val UNSUPPORTED_EXPRS = "Unsupported Expressions"
   val UNSUPPORTED_OPERATOR = "Unsupported Operator"
   val CLUSTER_TAGS = "Cluster Tags"
-  val CLUSTER_ID = "ClusterId"
-  val JOB_ID = "JobId"
+  val CLUSTER_ID = DatabricksParseHelper.SUB_PROP_CLUSTER_ID
+  val JOB_ID = DatabricksParseHelper.SUB_PROP_JOB_ID
   val UNSUPPORTED_TYPE = "Unsupported Type"
   val EXEC_ID = "ExecId"
   val DETAILS = "Details"
   val NOTES = "Notes"
   private val EXEC_ACTION = "Action"
   val IGNORE_OPERATOR = "Ignore Operator"
-  val RUN_NAME = "RunName"
+  val RUN_NAME = DatabricksParseHelper.SUB_PROP_RUN_NAME
   val ESTIMATED_FREQUENCY = "Estimated Job Frequency (monthly)"
   val ML_FUNCTIONS = "ML Functions"
   val ML_FUNCTION_NAME = "ML Function Name"

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ClusterTagPropHandler.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ClusterTagPropHandler.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool
+
+import com.nvidia.spark.rapids.tool.planparser.DatabricksParseHelper
+
+import org.apache.spark.scheduler.SparkListenerJobStart
+import org.apache.spark.sql.rapids.tool.util.CacheablePropsHandler
+
+// Maintains and handles cluster tags for a Spark application.
+trait ClusterTagPropHandler extends CacheablePropsHandler {
+  // clusterTags can be redacted so try to get ClusterId and ClusterName separately
+  var clusterTags: String = ""
+  var clusterTagClusterId: String = ""
+  var clusterTagClusterName: String = ""
+
+  // A flag to indicate whether the eventlog being processed is an eventlog from Photon.
+  var isPhoton = false
+
+  // Flag used to indicate that the App was a Databricks App.
+  def isDatabricks: Boolean = {
+    clusterTags.nonEmpty && clusterTagClusterId.nonEmpty && clusterTagClusterName.nonEmpty
+  }
+
+  private def updateClusterTagsFromSparkProperties(): Unit = {
+    // Update the clusterTags if any.
+    if (clusterTags.isEmpty) {
+      clusterTags = sparkProperties.getOrElse(DatabricksParseHelper.PROP_ALL_TAGS_KEY, "")
+    }
+    if (clusterTagClusterId.isEmpty) {
+      clusterTagClusterId =
+        sparkProperties.getOrElse(DatabricksParseHelper.PROP_TAG_CLUSTER_ID_KEY, "")
+    }
+    if (clusterTagClusterName.isEmpty) {
+      clusterTagClusterName =
+        sparkProperties.getOrElse(DatabricksParseHelper.PROP_TAG_CLUSTER_NAME_KEY, "")
+    }
+    // update the photon Flag
+    if (isDatabricks) {
+      // update photonFlag
+      isPhoton ||= DatabricksParseHelper.isPhotonApp(sparkProperties)
+      // set the spark version
+      sparkVersion = DatabricksParseHelper.getSparkVersion(sparkProperties)
+    }
+  }
+
+  override def handleJobStartForCachedProps(event: SparkListenerJobStart): Unit = {
+    super.handleJobStartForCachedProps(event)
+    // If the confs are set after SparkSession initialization, it is captured in this event.
+    val dbFlagPreprocess = isDatabricks
+    if (!isDatabricks) {
+      // Add the clusterTags to SparkProperties if any
+      Seq(DatabricksParseHelper.PROP_ALL_TAGS_KEY,
+          DatabricksParseHelper.PROP_TAG_CLUSTER_ID_KEY,
+          DatabricksParseHelper.PROP_TAG_CLUSTER_NAME_KEY
+      ).foreach { tagKey =>
+        sparkProperties += (tagKey -> event.properties.getProperty(tagKey, ""))
+      }
+    }
+
+    if (!dbFlagPreprocess && isDatabricks) {
+      updateClusterTagsFromSparkProperties()
+    }
+  }
+
+  override def updatePredicatesFromSparkProperties(): Unit = {
+    super.updatePredicatesFromSparkProperties()
+    updateClusterTagsFromSparkProperties()
+  }
+
+  protected def prepareClusterTags: Map[String, String] = {
+    val initialClusterTagsMap = if (clusterTags.nonEmpty) {
+      DatabricksParseHelper.parseClusterTags(clusterTags)
+    } else {
+      Map.empty[String, String]
+    }
+
+    val tagsMapWithClusterId =
+      if (!initialClusterTagsMap.contains(DatabricksParseHelper.SUB_PROP_CLUSTER_ID)
+          && clusterTagClusterId.nonEmpty) {
+        initialClusterTagsMap + (DatabricksParseHelper.SUB_PROP_CLUSTER_ID -> clusterTagClusterId)
+      } else {
+        initialClusterTagsMap
+      }
+
+    if(!tagsMapWithClusterId.contains(DatabricksParseHelper.SUB_PROP_JOB_ID)
+        && clusterTagClusterName.nonEmpty) {
+      val clusterTagJobId = DatabricksParseHelper.parseClusterNameForJobId(clusterTagClusterName)
+      clusterTagJobId.map { jobId =>
+        tagsMapWithClusterId + (DatabricksParseHelper.SUB_PROP_JOB_ID -> jobId)
+      }.getOrElse(tagsMapWithClusterId)
+    } else {
+      tagsMapWithClusterId
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -223,6 +223,10 @@ class ApplicationInfo(
     false
   }
 
+  override def postCompletion(): Unit = {
+    clusterInfo = buildClusterInfo
+  }
+
   /**
    * Connects Operators to Stages using AccumulatorIDs
    * @param cb function that creates a SparkPlanGraph. This can be used as a cacheHolder for the

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/CacheablePropsHandler.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/CacheablePropsHandler.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool.util
+
+import scala.collection.JavaConverters._
+
+import com.nvidia.spark.rapids.tool.planparser.HiveParseHelper
+import com.nvidia.spark.rapids.tool.profiling.ProfileUtils
+
+import org.apache.spark.scheduler.{SparkListenerEnvironmentUpdate, SparkListenerJobStart, SparkListenerLogStart}
+import org.apache.spark.sql.rapids.tool.AppEventlogProcessException
+import org.apache.spark.util.Utils.REDACTION_REPLACEMENT_TEXT
+
+// Handles updating and caching Spark Properties for a Spark application.
+// Properties stored in this container can be accessed to make decision about certain analysis
+// that depends on the context of the Spark properties.
+trait CacheablePropsHandler {
+  /**
+   * Important system properties that should be retained.
+   */
+  protected def getRetainedSystemProps: Set[String] = Set(
+    "file.encoding", "java.version", "os.arch", "os.name",
+    "os.version", "user.timezone")
+
+  // Patterns to be used to redact sensitive values from Spark Properties.
+  private val REDACTED_PROPERTIES = Set[String](
+    // S3
+    "spark.hadoop.fs.s3a.secret.key",
+    "spark.hadoop.fs.s3a.access.key",
+    "spark.hadoop.fs.s3a.session.token",
+    "spark.hadoop.fs.s3a.encryption.key",
+    "spark.hadoop.fs.s3a.bucket.nightly.access.key",
+    "spark.hadoop.fs.s3a.bucket.nightly.secret.key",
+    "spark.hadoop.fs.s3a.bucket.nightly.session.token",
+    // ABFS
+    "spark.hadoop.fs.azure.account.oauth2.client.secret",
+    "spark.hadoop.fs.azure.account.oauth2.client.id",
+    "spark.hadoop.fs.azure.account.oauth2.refresh.token",
+    "spark.hadoop.fs.azure.account.key\\..*",
+    "spark.hadoop.fs.azure.account.auth.type\\..*",
+    // GCS
+    "spark.hadoop.google.cloud.auth.service.account.json.keyfile",
+    "spark.hadoop.fs.gs.auth.client.id",
+    "spark.hadoop.fs.gs.encryption.key",
+    "spark.hadoop.fs.gs.auth.client.secret",
+    "spark.hadoop.fs.gs.auth.refresh.token",
+    "spark.hadoop.fs.gs.auth.impersonation.service.account.for.user\\..*",
+    "spark.hadoop.fs.gs.auth.impersonation.service.account.for.group\\..*",
+    "spark.hadoop.fs.gs.auth.impersonation.service.account",
+    "spark.hadoop.fs.gs.proxy.username",
+    // matches on any key that contains password in it.
+    "(?i).*password.*"
+  )
+
+  // caches the spark-version from the eventlogs
+  var sparkVersion: String = ""
+  var gpuMode = false
+  // A flag whether hive is enabled or not. Note that we assume that the
+  // property is global to the entire application once it is set. a.k.a, it cannot be disabled
+  // once it is was set to true.
+  var hiveEnabled = false
+  // Indicates the ML eventlogType (i.e., Scala or pyspark). It is set only when MLOps are detected.
+  // By default, it is empty.
+  var mlEventLogType = ""
+  // A flag to indicate that the eventlog is ML
+  var pysparkLogFlag = false
+
+  var sparkProperties = Map[String, String]()
+  var classpathEntries = Map[String, String]()
+  // set the fileEncoding to UTF-8 by default
+  var systemProperties = Map[String, String]()
+
+  private def processPropKeys(srcMap: Map[String, String]): Map[String, String] = {
+    // Redact the sensitive values in the given map.
+    val redactedKeys = REDACTED_PROPERTIES.collect {
+      case rK if srcMap.keySet.exists(_.matches(rK)) => rK -> REDACTION_REPLACEMENT_TEXT
+    }
+    srcMap ++ redactedKeys
+  }
+
+  /**
+   * Used to validate that the eventlog is allowed to be processed by the Tool
+   * @throws org.apache.spark.sql.rapids.tool.AppEventlogProcessException if the eventlog fails the
+   *                                                                      validation step
+   */
+  @throws(classOf[AppEventlogProcessException])
+  def validateAppEventlogProperties(): Unit = { }
+
+  def updatePredicatesFromSparkProperties(): Unit = {
+    gpuMode ||= ProfileUtils.isPluginEnabled(sparkProperties)
+    hiveEnabled ||= HiveParseHelper.isHiveEnabled(sparkProperties)
+  }
+
+  def handleEnvUpdateForCachedProps(event: SparkListenerEnvironmentUpdate): Unit = {
+    sparkProperties ++= processPropKeys(event.environmentDetails("Spark Properties").toMap)
+    classpathEntries ++= event.environmentDetails("Classpath Entries").toMap
+
+    updatePredicatesFromSparkProperties()
+
+    // Update the properties if system environments are set.
+    // No need to capture all the properties in memory. We only capture important ones.
+    systemProperties ++= event.environmentDetails("System Properties").toMap.filterKeys(
+      getRetainedSystemProps.contains(_))
+
+    // After setting the properties, validate the properties.
+    validateAppEventlogProperties()
+  }
+
+  def handleJobStartForCachedProps(event: SparkListenerJobStart): Unit = {
+    // TODO: we need to improve this in order to support per-job-level
+    hiveEnabled ||= HiveParseHelper.isHiveEnabled(event.properties.asScala)
+  }
+
+  def handleLogStartForCachedProps(event: SparkListenerLogStart): Unit = {
+    sparkVersion = event.sparkVersion
+  }
+
+  def isGPUModeEnabledForJob(event: SparkListenerJobStart): Boolean = {
+    gpuMode || ProfileUtils.isPluginEnabled(event.properties.asScala)
+  }
+}


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #985

- Refactors the code so that both Q/P tools can handle clusterTags correctly
- there is a new property isDatabricks that will be true if the eventlogs has clusterTags values
- This fixes a bug where the tools were not able to set the SparkVersion correctly because logStart event did not exist in DB events.