### PR TITLE
[BUG] Catch Profiler error when app info is empty

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
@@ -336,6 +336,11 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
 
     val collect = new CollectInformation(apps)
     val appInfo = collect.getAppInfo
+    // Fail early to skip further processing
+    if (appInfo.isEmpty) {
+      throw new RuntimeException("Failed to process application because the " +
+        "eventlog does not contain any SparkListenerApplicationStart event")
+    }
     val appLogPath = collect.getAppLogPath
     val dsInfo = collect.getDataSourceInfo
     val execInfo = collect.getExecutorInfo


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/947

The Profiler could fail when: it successfully creates an `ApplicationInfo` in `createApp`, when processing this app in `processApps`, the Profiler found that it is unable to collect information from this app in `getAppInfo`. This leads to an empty `appInfo` in https://github.com/NVIDIA/spark-rapids-tools/blob/f163fccc8b57a62ba5e4c6658ab6455f75f59553/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala#L338 which fails https://github.com/NVIDIA/spark-rapids-tools/blob/f163fccc8b57a62ba5e4c6658ab6455f75f59553/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala#L410

This PR catches the error early and prints a more helpful message.