### PR TITLE
Get stages from sqlId for collecting info for output writer functions

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Analysis.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Analysis.scala
@@ -172,10 +172,8 @@ class Analysis(apps: Seq[ApplicationInfo]) {
   def sqlMetricsAggregation(): Seq[SQLTaskAggMetricsProfileResult] = {
     val allRows = apps.flatMap { app =>
       app.sqlIdToInfo.map { case (sqlId, sqlCase) =>
-        val stagesInSQL = app.sqlIdToStages.getOrElse(sqlId, ArrayBuffer.empty)
-        if (stagesInSQL.isEmpty) {
-          None
-        } else {
+        if (app.sqlIdToStages.contains(sqlId)) {
+          val stagesInSQL = app.sqlIdToStages(sqlId)
           val tasksInSQL = app.taskEnd.filter { tc =>
             stagesInSQL.contains(tc.stageId)
           }
@@ -192,7 +190,7 @@ class Analysis(apps: Seq[ApplicationInfo]) {
 
             // set this here, so make sure we don't get it again until later
             sqlCase.sqlCpuTimePercent = execCPURatio
-           
+
             val (durSum, durMax, durMin, durAvg) = getDurations(tasksInSQL)
             Some(SQLTaskAggMetricsProfileResult(app.index,
               app.appId,
@@ -234,6 +232,8 @@ class Analysis(apps: Seq[ApplicationInfo]) {
               tasksInSQL.map(_.sw_writeTime).sum
             ))
           }
+        } else {
+          None
         }
       }
     }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Analysis.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Analysis.scala
@@ -172,15 +172,12 @@ class Analysis(apps: Seq[ApplicationInfo]) {
   def sqlMetricsAggregation(): Seq[SQLTaskAggMetricsProfileResult] = {
     val allRows = apps.flatMap { app =>
       app.sqlIdToInfo.map { case (sqlId, sqlCase) =>
-        val jcs = app.jobIdToInfo.filter { case (_, jc) =>
-          jc.sqlID.isDefined && jc.sqlID.get == sqlId
-        }
-        if (jcs.isEmpty) {
+        val stagesInSQL = app.sqlIdToStages.getOrElse(sqlId, ArrayBuffer.empty)
+        if (stagesInSQL.isEmpty) {
           None
         } else {
-          val stageIdsForSQL = jcs.flatMap(_._2.stageIds).toSet
           val tasksInSQL = app.taskEnd.filter { tc =>
-            stageIdsForSQL.contains(tc.stageId)
+            stagesInSQL.contains(tc.stageId)
           }
           if (tasksInSQL.isEmpty) {
             None
@@ -254,17 +251,10 @@ class Analysis(apps: Seq[ApplicationInfo]) {
 
   def ioAnalysis(): Seq[IOAnalysisProfileResult] = {
     val allRows = apps.flatMap { app =>
-      app.sqlIdToInfo.map { case (sqlId, _) =>
-        val jcs = app.jobIdToInfo.filter { case (_, jc) =>
-          jc.sqlID.isDefined && jc.sqlID.get == sqlId
-        }
-        if (jcs.isEmpty) {
-          None
-        } else {
-          val stageIdsForSQL = jcs.flatMap(_._2.stageIds).toSet
-
+      app.sqlIdToStages.map {
+        case (sqlId, stageIds) =>
           val tasksInSQL = app.taskEnd.filter { tc =>
-            stageIdsForSQL.contains(tc.stageId)
+            stageIds.contains(tc.stageId)
           }
           if (tasksInSQL.isEmpty) {
             None
@@ -283,7 +273,6 @@ class Analysis(apps: Seq[ApplicationInfo]) {
               tasksInSQL.map(_.sw_bytesWritten).sum
             ))
           }
-        }
       }
     }
     val allFiltered = allRows.flatMap(row => row)
@@ -299,23 +288,16 @@ class Analysis(apps: Seq[ApplicationInfo]) {
 
   def getMaxTaskInputSizeBytes(): Seq[SQLMaxTaskInputSizes] = {
     apps.map { app =>
-      val maxOfSqls = app.sqlIdToInfo.map { case (sqlId, _) =>
-        val jcs = app.jobIdToInfo.filter { case (_, jc) =>
-          jc.sqlID.isDefined && jc.sqlID.get == sqlId
-        }
-        if (jcs.isEmpty) {
-          0L
-        } else {
-          val stageIdsForSQL = jcs.flatMap(_._2.stageIds).toSet
+      val maxOfSqls = app.sqlIdToStages.map {
+        case (_, stageIds) =>
           val tasksInSQL = app.taskEnd.filter { tc =>
-            stageIdsForSQL.contains(tc.stageId)
+            stageIds.contains(tc.stageId)
           }
           if (tasksInSQL.isEmpty) {
             0L
           } else {
             tasksInSQL.map(_.input_bytesRead).max
           }
-        }
       }
       val maxVal = if (maxOfSqls.nonEmpty) {
         maxOfSqls.max

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -178,6 +178,7 @@ abstract class AppBase(
   val sqlIDtoProblematic: HashMap[Long, Set[String]] = HashMap[Long, Set[String]]()
   // sqlId to sql info
   val sqlIdToInfo = new HashMap[Long, SQLExecutionInfoClass]()
+  val sqlIdToStages = new HashMap[Long, ArrayBuffer[Int]]()
   // sqlPlans stores HashMap (sqlID <-> SparkPlanInfo)
   var sqlPlans: HashMap[Long, SparkPlanInfo] = HashMap.empty[Long, SparkPlanInfo]
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
@@ -364,6 +364,9 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
     app.handleJobStartForCachedProps(event)
     val sqlIDString = event.properties.getProperty("spark.sql.execution.id")
     val sqlID = StringUtils.stringToLong(sqlIDString)
+    if (sqlID.nonEmpty) {
+      app.sqlIdToStages.getOrElseUpdate(sqlID.get, ArrayBuffer.empty) ++= event.stageIds
+    }
     sqlID.foreach(app.jobIdToSqlID(event.jobId) = _)
   }
 


### PR DESCRIPTION
This fixes #989 

Prior to this PR - To get taskMetrics, the flow was:
For each sqlID -> Get the jobIds associates with it.  Get the stagesID based on the jobIds  -> Get the taskMetrics where the stageID of taskMetrics is  equal to the stages in SQL obtained.

We don't have to got through this flow and rather get the stages from SQL directly and get the taskMetrics. Since onJobStart  the job has stageId's associated with it, we capture that info and store it in a Map ( sqlID -> stagedIds).  Later it will be easier to retrieve the stageId's for each SQL.

Performance wise there is slight difference in memory consumption(increase) in the code block. 

Tested it on eventlog of size 9.8GB:

  |function| Memory Consumption PR excluded| Memory consumption PR included|
  |----|-----|-------|
  |ioAnalysis| 954MB| 960MB| 
  |sqlMetricsAggregation| 1.54GB|1.54GB


Since it refactoring the code, the current unit test should pass with this change. 

<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
