### PR TITLE
[FEA] Generate Status Report for Profiling Tool

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -158,6 +158,21 @@ case class DriverLogUnsupportedOperators(
   }
 }
 
+case class StatusProfileResult(
+    path: String,
+    status: String,
+    message: String = "") extends ProfileResult {
+    override val outputHeaders: Seq[String] = Seq("Event Log", "Status", "Description")
+
+    override def convertToSeq: Seq[String] = {
+      Seq(path, status, message)
+    }
+
+    override def convertToCSVSeq: Seq[String] = {
+      Seq(path, status, message)
+    }
+  }
+
 // note that some things might not be set until after sqlMetricsAggregation called
 class SQLExecutionInfoClass(
     val sqlID: Long,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
@@ -16,19 +16,19 @@
 
 package com.nvidia.spark.rapids.tool.profiling
 
-import java.util.concurrent.{ConcurrentLinkedQueue, Executors, ThreadPoolExecutor, TimeUnit}
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentLinkedQueue, Executors, ThreadPoolExecutor, TimeUnit}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, HashMap}
-import scala.util.control.NonFatal
 
 import com.nvidia.spark.rapids.ThreadFactoryBuilder
 import com.nvidia.spark.rapids.tool.{EventLogInfo, EventLogPathProcessor, PlatformFactory}
 import org.apache.hadoop.conf.Configuration
 
+import org.apache.spark.sql.rapids.tool.{AppBase, FailureApp, IncorrectAppStatusException}
 import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
 import org.apache.spark.sql.rapids.tool.ui.ConsoleProgressBar
-import org.apache.spark.sql.rapids.tool.util.RuntimeReporter
+import org.apache.spark.sql.rapids.tool.util._
 
 class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolean)
   extends RuntimeReporter {
@@ -49,11 +49,28 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
 
   private val useAutoTuner: Boolean = appArgs.autoTuner()
   private var progressBar: Option[ConsoleProgressBar] = None
+  // Store application status reports indexed by event log path.
+  private val appStatusReporter = new ConcurrentHashMap[String, AppResult]
 
   override val outputDir = appArgs.outputDirectory().stripSuffix("/") +
     s"/${Profiler.SUBDIR}"
 
   logInfo(s"Threadpool size is $nThreads")
+
+  /**
+   * For each app status report, generate a StatusProfileResult.
+   * @return Seq[StatusProfileResult] - Seq[(path, status, description)]
+   */
+  private def generateStatusProfResults(appStatuses: Seq[AppResult]): Seq[StatusProfileResult] = {
+    appStatuses.map {
+      case FailureAppResult(path, message) => StatusProfileResult(path, "FAILURE", message)
+      case SkippedAppResult(path, message) => StatusProfileResult(path, "SKIPPED", message)
+      case SuccessAppResult(path, _, message) => StatusProfileResult(path, "SUCCESS", message)
+      case UnknownAppResult(path, _, message) => StatusProfileResult(path, "UNKNOWN", message)
+      case profAppResult: AppResult =>
+        throw new UnsupportedOperationException(s"Invalid status for $profAppResult")
+    }
+  }
 
   /**
    * Profiles application according to the mode requested. The main difference in processing for
@@ -125,6 +142,12 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
       }
     }
     progressBar.foreach(_.finishAll())
+    
+    // Write status reports for all event logs
+    val profileOutputWriter = new ProfileOutputWriter(outputDir, Profiler.PROFILE_LOG_NAME,
+      numOutputRows, outputCSV = outputCSV)
+    val reportResults = generateStatusProfResults(appStatusReporter.asScala.values.toSeq)
+    profileOutputWriter.write("Profiling Status", reportResults)
   }
 
   def profileDriver(driverLogInfos: String, eventLogsEmpty: Boolean): Unit = {
@@ -147,17 +170,51 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
     }
   }
 
-  private def errorHandler(error: Throwable, path: EventLogInfo) = {
-    error match {
+  /**
+   * Process a created ApplicationInfo object and handles all exceptions.
+   */
+  private def profileApp(
+      path: EventLogInfo,
+      index: Int,
+      processSuccessApp: ApplicationInfo => Unit): Unit = {
+    val pathStr = path.eventLog.toString
+    try {
+      val startTime = System.currentTimeMillis()
+      val appOpt = createApp(path, index, hadoopConf)
+      val profAppResult = appOpt match {
+        case Left(FailureApp("skipped", errorMessage)) =>
+          // Case to be skipped
+          progressBar.foreach(_.reportSkippedProcess())
+          SkippedAppResult(pathStr, errorMessage)
+        case Left(FailureApp(_, errorMessage)) =>
+          // Case when other error occurred during ApplicationInfo creation
+          progressBar.foreach(_.reportUnkownStatusProcess())
+          UnknownAppResult(pathStr, "", errorMessage)
+        case Right(app: ApplicationInfo) =>
+          // Case with successful creation of ApplicationInfo
+          processSuccessApp(app)
+          progressBar.foreach(_.reportSuccessfulProcess())
+          val endTime = System.currentTimeMillis()
+          SuccessAppResult(pathStr, app.appId, s"Took ${endTime - startTime}ms to process")
+      }
+      // Log the information to the console
+      profAppResult.logMessage()
+      // Update the appStatusReporter with the result of Application processing
+      appStatusReporter.put(pathStr, profAppResult)
+    } catch {
       case oom: OutOfMemoryError =>
-        logError(s"OOM error while processing large file: ${path.eventLog.toString}." +
-            s" Increase heap size. Exiting ...", oom)
+        logError(s"OOM error while processing large file: $pathStr." +
+            s"Increase heap size.", oom)
         sys.exit(1)
-      case NonFatal(e) =>
-        logWarning(s"Exception occurred processing file: ${path.eventLog.getName}", e)
-      case o: Throwable =>
-        logError(s"Error occurred while processing file: ${path.eventLog.toString}. Exiting ...", o)
+      case o: Error =>
+        logError(s"Error occurred while processing file: $pathStr", o)
         sys.exit(1)
+      case e: Exception =>
+        progressBar.foreach(_.reportFailedProcess())
+        val failureAppResult = FailureAppResult(pathStr,
+          s"Unexpected exception processing log, skipping!")
+        failureAppResult.logMessage(Some(e))
+        appStatusReporter.put(pathStr, failureAppResult)
     }
   }
 
@@ -165,21 +222,7 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
     val allApps = new ConcurrentLinkedQueue[ApplicationInfo]()
 
     class ProfileThread(path: EventLogInfo, index: Int) extends Runnable {
-      def run: Unit = {
-        try {
-          val appOpt = createApp(path, index, hadoopConf)
-          appOpt match {
-            case Some(app) =>
-              allApps.add(app)
-            case None =>
-              progressBar.foreach(_.reportUnkownStatusProcess())
-          }
-        } catch {
-          case t: Throwable =>
-            progressBar.foreach(_.reportFailedProcess())
-            errorHandler(t, path)
-        }
-      }
+      def run: Unit = profileApp(path, index, (app => allApps.add(app)))
     }
 
     var appIndex = 1
@@ -207,30 +250,12 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
     val allApps = new ConcurrentLinkedQueue[ApplicationSummaryInfo]()
 
     class ProfileThread(path: EventLogInfo, index: Int) extends Runnable {
-      def run: Unit = {
-        try {
-          val appOpt = createApp(path, index, hadoopConf)
-          appOpt match {
-            case Some(app) =>
-              try {
-                val (s, _) = processApps(Seq(app), false, profileOutputWriter)
-                progressBar.foreach(_.reportSuccessfulProcess())
-                allApps.add(s)
-              } catch {
-                case t: Throwable =>
-                  progressBar.foreach(_.reportFailedProcess())
-                  errorHandler(t, path)
-              }
-            case None =>
-              progressBar.foreach(_.reportUnkownStatusProcess())
-          }
-        } catch {
-          case t: Throwable =>
-            progressBar.foreach(_.reportFailedProcess())
-            errorHandler(t, path)
-        }
-      }
+      def run: Unit = profileApp(path, index, { app =>
+        val (s, _) = processApps(Seq(app), false, profileOutputWriter)
+        allApps.add(s)
+      })
     }
+
     var appIndex = 1
     allPaths.foreach { path =>
       try {
@@ -255,37 +280,16 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
       allPaths: Seq[EventLogInfo],
       startIndex: Int): Unit = {
     class ProfileProcessThread(path: EventLogInfo, index: Int) extends Runnable {
-      def run: Unit = {
+      def run: Unit = profileApp(path, index, { app =>
+        val profileOutputWriter = new ProfileOutputWriter(s"$outputDir/${app.appId}",
+          Profiler.PROFILE_LOG_NAME, numOutputRows, outputCSV = outputCSV)
         try {
-          // we just skip apps that don't process cleanly and exit if heap is smaller
-          val appOpt = createApp(path, index, hadoopConf)
-          appOpt match {
-            case Some(app) =>
-              val profileOutputWriter = new ProfileOutputWriter(s"$outputDir/${app.appId}",
-                Profiler.PROFILE_LOG_NAME, numOutputRows,
-                outputCSV = outputCSV)
-              try {
-                val (sum, _) =
-                  processApps(Seq(appOpt.get), appArgs.printPlans(), profileOutputWriter)
-                progressBar.foreach(_.reportSuccessfulProcess())
-                writeSafelyToOutput(profileOutputWriter, Seq(sum), false)
-              } catch {
-                case t: Throwable =>
-                  progressBar.foreach(_.reportFailedProcess())
-                  errorHandler(t, path)
-              } finally {
-                profileOutputWriter.close()
-              }
-            case None =>
-              progressBar.foreach(_.reportUnkownStatusProcess())
-              logInfo("No application to process. Exiting")
-          }
-        } catch {
-          case t: Throwable =>
-            progressBar.foreach(_.reportFailedProcess())
-            errorHandler(t, path)
+          val (sum, _) = processApps(Seq(app), appArgs.printPlans(), profileOutputWriter)
+          writeSafelyToOutput(profileOutputWriter, Seq(sum), false)
+        } finally {
+          profileOutputWriter.close()
         }
-      }
+      })
     }
 
     allPaths.foreach { path =>
@@ -299,26 +303,21 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
   }
 
   private def createApp(path: EventLogInfo, index: Int,
-      hadoopConf: Configuration): Option[ApplicationInfo] = {
+      hadoopConf: Configuration): Either[FailureApp, ApplicationInfo] = {
     try {
       // This apps only contains 1 app in each loop.
       val startTime = System.currentTimeMillis()
       val app = new ApplicationInfo(hadoopConf, path, index)
       EventLogPathProcessor.logApplicationInfo(app)
       val endTime = System.currentTimeMillis()
+      if (!app.isAppMetaDefined) {
+        throw IncorrectAppStatusException()
+      }
       logInfo(s"Took ${endTime - startTime}ms to create App for ${path.eventLog.toString}")
-      Some(app)
+      Right(app)
     } catch {
-      case _: com.fasterxml.jackson.core.JsonParseException =>
-        logWarning(s"Error parsing JSON: $path")
-        None
-      case il: IllegalArgumentException =>
-        logWarning(s"Error parsing file: $path", il)
-        None
       case e: Exception =>
-        // catch all exceptions and skip that file
-        logWarning(s"Got unexpected exception processing file: $path", e)
-        None
+        Left(AppBase.handleException(e, path))
     }
   }
 
@@ -336,11 +335,6 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
 
     val collect = new CollectInformation(apps)
     val appInfo = collect.getAppInfo
-    // Fail early to skip further processing
-    if (appInfo.isEmpty) {
-      throw new RuntimeException("Failed to process application because the " +
-        "eventlog does not contain any SparkListenerApplicationStart event")
-    }
     val appLogPath = collect.getAppLogPath
     val dsInfo = collect.getDataSourceInfo
     val execInfo = collect.getExecutorInfo

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -525,4 +525,22 @@ object AppBase {
       childRes
     }
   }
+
+  def handleException(e: Exception, path: EventLogInfo): FailureApp = {
+    val (status, message): (String, String) = e match {
+      case incorrectStatusEx: IncorrectAppStatusException =>
+        ("unknown", incorrectStatusEx.getMessage)
+      case skippedEx: AppEventlogProcessException =>
+        ("skipped", skippedEx.getMessage)
+      case _: com.fasterxml.jackson.core.JsonParseException =>
+        ("unknown", s"Error parsing JSON: ${path.eventLog.toString}")
+      case _: IllegalArgumentException =>
+        ("unknown", s"Error parsing file: ${path.eventLog.toString}")
+      case _: Exception =>
+        // catch all exceptions and skip that file
+        ("unknown", s"Got unexpected exception processing file: ${path.eventLog.toString}")
+    }
+
+    FailureApp(status, s"${e.getClass.getSimpleName}: $message")
+  }
 }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -473,3 +473,9 @@ object SqlPlanInfoGraphBuffer {
     SqlPlanInfoGraphEntry(sqlID, planInfo, planGraph)
   }
 }
+
+// Case class to represent a failed AppInfo creation
+case class FailureApp(
+    status: String,
+    message: String
+)

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/OperationResult.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/OperationResult.scala
@@ -19,10 +19,10 @@ package org.apache.spark.sql.rapids.tool.util
 import org.apache.spark.internal.Logging
 
 /**
- *  Represents a result specific to `QualificationAppInfo` class. This is a base class for
+ *  Represents a result specific to `AppBase` class. This is a base class for
  *  Success, Failure and Unknown types.
  */
-class QualAppResult(path: String, message: String) extends Logging {
+class AppResult(path: String, message: String) extends Logging {
   /**
    * Logs the message along with an optional exception, if provided.
    */
@@ -35,20 +35,20 @@ class QualAppResult(path: String, message: String) extends Logging {
   }
 }
 
-case class SuccessQualAppResult(
+case class SuccessAppResult(
     path: String,
     appId: String,
-    message: String = "") extends QualAppResult(path, message) {
+    message: String = "") extends AppResult(path, message) {
   override def logMessage(exp: Option[Exception] = None): Unit = {
     logInfo(s"File: $path, Message: $message")
   }
 }
 
-case class FailureQualAppResult(path: String, message: String)
-  extends QualAppResult(path, message) {}
+case class FailureAppResult(path: String, message: String)
+  extends AppResult(path, message) {}
 
-case class UnknownQualAppResult(path: String, appId: String, message: String)
-  extends QualAppResult(path, message) {}
+case class UnknownAppResult(path: String, appId: String, message: String)
+  extends AppResult(path, message) {}
 
-case class SkippedQualAppResult(path: String, message: String)
-  extends QualAppResult(path, message) {}
+case class SkippedAppResult(path: String, message: String)
+  extends AppResult(path, message) {}


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/998

**Changes**

1. Generate a status report for event logs processed by Profiling Tool
2. Refactored common data structures and functions used by Q/P tool

**Testing**

`spark_rapids profiling --eventlogs <my_event_logs> --tools_jar <my_tools_jar> --verbose`

**Output**

In file `rapids_4_spark_profile/profiling_status.csv`:

```
Event Log,Status,Description
file:/xxxxxxxx,SUCCESS,Took 159ms to process
file:xxxxxxxx,UNKNOWN,IncorrectAppStatusException: Application status is incorrect. Missing AppInfo
file:/xxxxxxxx,SUCCESS,Took 1280ms to process
```
