### PR TITLE
Sync supported operators with plugin changes and update default score

### DIFF
--- a/core/src/main/resources/operatorsScore-databricks-aws-a10G.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws-a10G.csv
@@ -297,3 +297,4 @@ KnownNullable,2.45
 InSubqueryExec,2.45
 AQEShuffleReadExec,2.45
 CheckOverflowInTableInsert,2.45
+ArrayFilter,1.5

--- a/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
@@ -297,3 +297,4 @@ KnownNullable,2.45
 InSubqueryExec,2.45
 AQEShuffleReadExec,2.45
 CheckOverflowInTableInsert,2.45
+ArrayFilter,1.5

--- a/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
@@ -285,3 +285,4 @@ KnownNullable,2.73
 InSubqueryExec,2.73
 AQEShuffleReadExec,2.73
 CheckOverflowInTableInsert,2.73
+ArrayFilter,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
@@ -279,3 +279,4 @@ KnownNullable,3.74
 InSubqueryExec,3.74
 AQEShuffleReadExec,3.74
 CheckOverflowInTableInsert,3.74
+ArrayFilter,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
@@ -279,3 +279,4 @@ KnownNullable,3.65
 InSubqueryExec,3.65
 AQEShuffleReadExec,3.65
 CheckOverflowInTableInsert,3.65
+ArrayFilter,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-l4.csv
@@ -285,3 +285,4 @@ KnownNullable,4.16
 InSubqueryExec,4.16
 AQEShuffleReadExec,4.16
 CheckOverflowInTableInsert,4.16
+ArrayFilter,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
@@ -279,3 +279,4 @@ KnownNullable,4.25
 InSubqueryExec,4.25
 AQEShuffleReadExec,4.25
 CheckOverflowInTableInsert,4.25
+ArrayFilter,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-t4.csv
@@ -285,3 +285,4 @@ KnownNullable,4.88
 InSubqueryExec,4.88
 AQEShuffleReadExec,4.88
 CheckOverflowInTableInsert,4.88
+ArrayFilter,1.5

--- a/core/src/main/resources/operatorsScore-emr-a10.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10.csv
@@ -285,3 +285,4 @@ KnownNullable,2.59
 InSubqueryExec,2.59
 AQEShuffleReadExec,2.59
 CheckOverflowInTableInsert,2.59
+ArrayFilter,1.5

--- a/core/src/main/resources/operatorsScore-emr-a10G.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10G.csv
@@ -285,3 +285,4 @@ KnownNullable,2.59
 InSubqueryExec,2.59
 AQEShuffleReadExec,2.59
 CheckOverflowInTableInsert,2.59
+ArrayFilter,1.5

--- a/core/src/main/resources/operatorsScore-emr-t4.csv
+++ b/core/src/main/resources/operatorsScore-emr-t4.csv
@@ -285,3 +285,4 @@ KnownNullable,2.07
 InSubqueryExec,2.07
 AQEShuffleReadExec,2.07
 CheckOverflowInTableInsert,2.07
+ArrayFilter,1.5

--- a/core/src/main/resources/operatorsScore-onprem-a100.csv
+++ b/core/src/main/resources/operatorsScore-onprem-a100.csv
@@ -297,3 +297,4 @@ KnownNullable,4
 InSubqueryExec,4
 AQEShuffleReadExec,4
 CheckOverflowInTableInsert,4
+ArrayFilter,1.5

--- a/core/src/main/resources/operatorsScore123.csv
+++ b/core/src/main/resources/operatorsScore123.csv
@@ -1,2 +1,0 @@
-CPUOperator,Score
-CoalesceExec,1.0ArrayFilter,1.5

--- a/core/src/main/resources/operatorsScore123.csv
+++ b/core/src/main/resources/operatorsScore123.csv
@@ -1,0 +1,2 @@
+CPUOperator,Score
+CoalesceExec,1.0ArrayFilter,1.5

--- a/core/src/main/resources/supportedExprs.csv
+++ b/core/src/main/resources/supportedExprs.csv
@@ -36,6 +36,9 @@ ArrayExcept,S,`array_except`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,N
 ArrayExists,S,`exists`,None,project,argument,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NS,NS
 ArrayExists,S,`exists`,None,project,function,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
 ArrayExists,S,`exists`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
+ArrayFilter,S,`filter`,None,project,argument,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NS,NS
+ArrayFilter,S,`filter`,None,project,function,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
+ArrayFilter,S,`filter`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NS,NS
 ArrayIntersect,S,`array_intersect`,None,project,array1,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NS,NS
 ArrayIntersect,S,`array_intersect`,None,project,array2,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NS,NS
 ArrayIntersect,S,`array_intersect`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NS,NS
@@ -290,9 +293,9 @@ IsNull,S,`isnull`,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S
 IsNull,S,`isnull`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
 JsonToStructs,NS,`from_json`,This is disabled by default because it is currently in beta and undergoes continuous enhancements. Please consult the [compatibility documentation](../compatibility.md#json-supporting-types) to determine whether you can enable this configuration for your use case,project,jsonStr,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
 JsonToStructs,NS,`from_json`,This is disabled by default because it is currently in beta and undergoes continuous enhancements. Please consult the [compatibility documentation](../compatibility.md#json-supporting-types) to determine whether you can enable this configuration for your use case,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NS,PS,PS,NA,NS,NS
-JsonTuple,NS,`json_tuple`,This is disabled by default because JsonTuple on the GPU does not support all of the normalization that the CPU supports.,project,json,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
-JsonTuple,NS,`json_tuple`,This is disabled by default because JsonTuple on the GPU does not support all of the normalization that the CPU supports.,project,field,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
-JsonTuple,NS,`json_tuple`,This is disabled by default because JsonTuple on the GPU does not support all of the normalization that the CPU supports.,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NS,NS
+JsonTuple,NS,`json_tuple`,This is disabled by default because Experimental feature that could be unstable or have performance issues.,project,json,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
+JsonTuple,NS,`json_tuple`,This is disabled by default because Experimental feature that could be unstable or have performance issues.,project,field,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
+JsonTuple,NS,`json_tuple`,This is disabled by default because Experimental feature that could be unstable or have performance issues.,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NS,NS
 KnownFloatingPointNormalized,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
 KnownFloatingPointNormalized,S, ,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
 KnownNotNull,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,NS,S,S,PS,PS,PS,NS,NS,NS

--- a/scripts/sync_plugin_files/README.md
+++ b/scripts/sync_plugin_files/README.md
@@ -53,4 +53,4 @@ python sync_operator_scores.py new_operators operator_score_dir [--new-score sco
 The script take three parameters:
 - `new_operators`: required, a text file of the new operators, separated by \newline
 - `operator_score_dir`: required, path to directory with operator score files
-- `--new-score`: optional, a score for the new operators, default to 1.0
+- `--new-score`: optional, a score for the new operators, default to 1.5

--- a/scripts/sync_plugin_files/sync_operator_scores.py
+++ b/scripts/sync_plugin_files/sync_operator_scores.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('new_operators_file', type=str, help='A text file with the new operators.')
     parser.add_argument('operator_score_dir', type=str, help='Path to directory with operator score files.')
-    parser.add_argument('--new-score', type=float, help='Score for the new operators.', default='1.0')
+    parser.add_argument('--new-score', type=float, help='Score for the new operators.', default='1.5')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids-tools/issues/1007

Updated the supportedExprs.csv  to include ArrayFilter and updated the notes section for json_tuple to be in sync with plugin changes.

- Ran [sync_operator_scores.py](https://github.com/NVIDIA/spark-rapids-tools/blob/dev/scripts/sync_plugin_files/sync_operator_scores.py) to update the scores for all platforms for newly added ArrayFilter operator. Increased the default score to 1.5( from the current 1.0) 
- Verified that filter in array works as intended. Did not add a test for this as it is just checking `filter` function. We have tests to check the function names.

Spark plan:

```
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- HashAggregate(keys=[], functions=[sum(size(f#4, true))])
   +- Exchange SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
      +- HashAggregate(keys=[], functions=[partial_sum(size(f#4, true))])
         +- Project [filter(array(id#0L, (id#0L + 1), (id#0L - 100), (id#0L + 3), (id#0L + 2)), lambdafunction(((lambda f#5L % 3) = 0), lambda f#5L, false)) AS f#4]
            +- Range (0, 1000, step=1, splits=64)

```

Before:
```
===================================================================================
|   App Name|             App ID|App Duration|SQL DF Duration|GPU Opportunity|Estimated GPU Duration|Estimated GPU Speedup|Estimated GPU Time Saved|      Recommendation|Unsupported Execs|Unsupported Expressions|Estimated Job Frequency (monthly)|
=====================================================================================================================================================================================================================================================
|Spark shell|local-1715892862056|       31861|           1346|           1010|              31103.44|                 1.02|                  757.55|     Not Recommended|          Project|                 filter|                               30|
=====================================================================================================================================================================================================================================================

```

After updating the supportedExprs.csv file:

```
=====================================================================================================================================================================================================================================================
|   App Name|             App ID|App Duration|SQL DF Duration|GPU Opportunity|Estimated GPU Duration|Estimated GPU Speedup|Estimated GPU Time Saved|      Recommendation|Unsupported Execs|Unsupported Expressions|Estimated Job Frequency (monthly)|
=====================================================================================================================================================================================================================================================
|Spark shell|local-1715892862056|       31861|           1346|           1346|               30831.7|                 1.03|                 1029.29|     Not Recommended|                 |                       |                               30|
=====================================================================================================================================================================================================================================================

```



<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
