### PR TITLE
Profiler should identify the delta log ops and generate views for non-delta logs

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.rapids.tool.util.ToolsPlanGraph
  * 1- it updates dataSourceInfo with V2 and V1 data sources
  * 2- it updates sqlIDtoProblematic the map between SQL ID and potential problems
  * 3- it updates sqlIdToInfo.DsOrRdd as boolean to indicate whether a sql is an RDD/DS or not
- *
+ * TODO: this class should extend the trait SparkSQLPlanInfoVisitor[T]
  * @param app the Application info objects that contains the SQL plans to be processed
  */
 class AppSQLPlanAnalyzer(app: AppBase, appIndex: Int) extends AppAnalysisBase(app) {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/SparkSQLPlanInfoVisitor.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/SparkSQLPlanInfoVisitor.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.analysis
+
+import scala.collection.mutable.Map
+
+import org.apache.spark.sql.execution.SparkPlanInfo
+import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
+import org.apache.spark.sql.rapids.tool.SqlPlanInfoGraphEntry
+import org.apache.spark.sql.rapids.tool.util.ToolsPlanGraph
+
+
+// Class defines the SQLPlan context by implementations that walk through the SQLPlanInfo
+class SQLPlanInfoContext(sqlPIGEntry: SqlPlanInfoGraphEntry) {
+  def getSQLPIGEntry: SqlPlanInfoGraphEntry = sqlPIGEntry
+}
+
+/**
+ * A trait that defines the logic to walk through the all the nodes a SQLPlanInfo
+ * @tparam R the type of the SQLPlanInfoContext defined by teh actual implementation
+ */
+trait SparkSQLPlanInfoVisitor[R <: SQLPlanInfoContext] {
+  // Given a SparkPlanInfo and its SQLID, it builds the SparkPlanGraph and returns
+  // a SqlPlanInfoGraphEntry that holds the SQLID, SparkPlanInfo and SparkPlanGraph to be passed
+  // as argument to the visitor
+  protected def createSqlPIGEntry(sqlId: Long, info: SparkPlanInfo): SqlPlanInfoGraphEntry = {
+    val planGraph = ToolsPlanGraph(info)
+    SqlPlanInfoGraphEntry(sqlId, info, planGraph)
+  }
+  // Defines the logic to visit a single node
+  protected def visitNode(sqlPlanCtxt: R, node: SparkPlanGraphNode): Unit
+
+  // Given a SqlPlanInfoGraphEntry, it creates a context to be used by the visitor.
+  // This is specific to the logic of the SQLPlan visitor
+  protected def createPlanCtxtFromPIGEntry(sqlPIGEntry: SqlPlanInfoGraphEntry): R
+
+  // For each SQLPlan, it creates a context object to be passed down to all the nodes.
+  private def createPlanCtxt(sqlId: Long, info: SparkPlanInfo): R = {
+    val sqlPIGEntry = createSqlPIGEntry(sqlId, info)
+    createPlanCtxtFromPIGEntry(sqlPIGEntry)
+  }
+
+  protected def walkPlan(planCtxt: R): Unit = {
+    planCtxt.getSQLPIGEntry.sparkPlanGraph.allNodes.foreach(visitNode(planCtxt, _))
+  }
+
+  // After a SQLPlan is visited, this method is called to process any additional logic.
+  // Note that this extracted in a separate method to give more flexibility to extend the
+  // implementation
+  protected def postWalkPlan(planCtxt: R): Unit = {
+    // do nothing by default
+  }
+
+  // Walks through all the SQLPlans in the given map
+  def walkPlans(plans: Map[Long, SparkPlanInfo]): Unit = {
+    for ((sqlId, planInfo) <- plans) {
+      val planCtxt = createPlanCtxt(sqlId, planInfo)
+      walkPlan(planCtxt)
+      postWalkPlan(planCtxt)
+    }
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -45,7 +45,8 @@ case class ApplicationSummaryInfo(
     maxTaskInputBytesRead: Seq[SQLMaxTaskInputSizes],
     appLogPath: Seq[AppLogPathProfileResults],
     ioMetrics: Seq[IOAnalysisProfileResult],
-    sysProps: Seq[RapidsPropertyProfileResult])
+    sysProps: Seq[RapidsPropertyProfileResult],
+    sqlCleanedAlignedIds: Seq[SQLCleanAndAlignIdsProfileResult])
 
 trait AppInfoPropertyGetter {
   // returns all the properties (i.e., spark)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.tool.profiling
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 
 import com.nvidia.spark.rapids.tool.ToolTextFileWriter
-import com.nvidia.spark.rapids.tool.views.{ProfExecutorView, ProfJobsView, ProfSQLCodeGenView, ProfSQLPlanMetricsView, ProfSQLToStageView}
+import com.nvidia.spark.rapids.tool.views.{ProfExecutorView, ProfJobsView, ProfSQLCodeGenView, ProfSQLPlanAlignedView, ProfSQLPlanMetricsView, ProfSQLToStageView}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.rapids.tool.ToolUtils
@@ -212,6 +212,16 @@ class CollectInformation(apps: Seq[ApplicationInfo]) extends Logging {
   // Print SQL Plan Metrics
   def getSQLPlanMetrics: Seq[SQLAccumProfileResults] = {
     ProfSQLPlanMetricsView.getRawView(apps)
+  }
+
+  /**
+   * This function is meant to clean up Delta log execs so that you could align
+   * SQL ids between CPU and GPU eventlogs. It attempts to remove any delta log
+   * SQL ids. This includes reading checkpoints, delta_log json files,
+   * updating Delta state cache/table.
+   */
+  def getSQLCleanAndAligned: Seq[SQLCleanAndAlignIdsProfileResult] = {
+    ProfSQLPlanAlignedView.getRawView(apps)
   }
 }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfSQLPlanClassifier.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfSQLPlanClassifier.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.profiling
+
+import scala.collection.mutable
+
+import com.nvidia.spark.rapids.tool.analysis.{AppAnalysisBase, SparkSQLPlanInfoVisitor, SQLPlanInfoContext}
+import com.nvidia.spark.rapids.tool.planparser.DeltaLakeHelper
+
+import org.apache.spark.sql.execution.ui
+import org.apache.spark.sql.rapids.tool.SqlPlanInfoGraphEntry
+import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
+
+
+/**
+ * A context object that holds the classification information for a SQLPlan
+ * @param sqlPIGEntry the SqlPlanInfoGraphEntry for the SQLPlan
+ * @param deltaOpsNode the list of nodes that are classified as Delta metadata
+ */
+case class SQLPlanClassifierCtxt(
+    sqlPIGEntry: SqlPlanInfoGraphEntry,
+    deltaOpsNode: mutable.ArrayBuffer[Long] = mutable.ArrayBuffer.empty)
+  extends SQLPlanInfoContext(sqlPIGEntry)
+
+
+/**
+ * An implementation of SparkSQLPlanInfoVisitor that visits all the nodes of a SQLPlanInfo to
+ * assign classifications to each SQLPlan
+ * @param app the AppBase object to analyze
+ */
+class SQLPlanClassifier(app: ApplicationInfo)
+  extends AppAnalysisBase(app) with SparkSQLPlanInfoVisitor[SQLPlanClassifierCtxt] {
+  // A HashMap[category: String, SQLIDs Set[Long]] that holds the relation between specific
+  // category/class to the SQLID
+  // Note that for now we have only category "deltaOp", but this is subject to be extended in the
+  // future to classify the SQLPlans.
+  val sqlCategories: mutable.HashMap[String, mutable.LinkedHashSet[Long]] =
+    mutable.HashMap("deltaOp" -> mutable.LinkedHashSet.empty)
+
+  override def visitNode(sqlPlanCtxt: SQLPlanClassifierCtxt, node: ui.SparkPlanGraphNode): Unit = {
+    // Check if the node is a delta metadata operation
+    val isDeltaLog = DeltaLakeHelper.isDeltaOpNode(
+      sqlPlanCtxt.sqlPIGEntry, app.physicalPlanDescription(sqlPlanCtxt.getSQLPIGEntry.sqlID), node)
+    if (isDeltaLog) {
+      // if it is a Delta operation, add it to the list of Delta operations nodes
+      sqlPlanCtxt.deltaOpsNode += node.id
+    }
+  }
+
+  override def createPlanCtxtFromPIGEntry(
+      sqlPIGEntry: SqlPlanInfoGraphEntry): SQLPlanClassifierCtxt = {
+    SQLPlanClassifierCtxt(sqlPIGEntry)
+  }
+
+  override def postWalkPlan(planCtxt: SQLPlanClassifierCtxt): Unit = {
+    // After visiting all the nodes of a SQLPlan, decide on the classifications
+    if (planCtxt.deltaOpsNode.nonEmpty) {
+      // If at least one nodes is defined as Delta operations, then the entire SQLPlan is a Delta
+      // operation
+      // Note that we do not keep the nodes in a global variable because we do not that for now
+      sqlCategories("deltaOp") += planCtxt.getSQLPIGEntry.sqlID
+    }
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,6 +101,11 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
   val autoTuner: ScallopOption[Boolean] =
     opt[Boolean](required = false,
       descr = "Toggle AutoTuner module.",
+      default = Some(false))
+  val outputSqlIdsAligned: ScallopOption[Boolean] =
+    opt[Boolean](required = false,
+      descr = "Output the SQL Ids after being cleaned of delta log metadata operations to " +
+        "allow aligning cpu/gpu runs.",
       default = Some(false))
   val workerInfo: ScallopOption[String] =
     opt[String](required = false,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -87,6 +87,19 @@ case class JobInfoProfileResult(
   }
 }
 
+case class SQLCleanAndAlignIdsProfileResult(
+    appIndex: Int,
+    sqlID: Long) extends ProfileResult {
+  override val outputHeaders = Seq("appIndex", "sqlID")
+
+  override def convertToSeq: Seq[String] = {
+    Seq(appIndex.toString, sqlID.toString)
+  }
+  override def convertToCSVSeq: Seq[String] = {
+    Seq(appIndex.toString, sqlID.toString)
+  }
+}
+
 case class SQLStageInfoProfileResult(
     appIndex: Int,
     sqlID: Long,


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1023

Credits to @tgravescs 

This adds a new option to the profiler tool: `--output-sql-ids-aligned` that causes the tool to ouput a new table and optionally csv file, that strips out the sqlids of all the delta log related things. The table simply has appId and sqlIds in sorted order.

The idea is you run with this option on the comparable cpu and gpu event logs and then you can join those 2 tables to see which sqlIds are comparable between the cpu and gpu run.

**For testing**

- There is a couple of related issues for Qualification. then we can decide on testing methodology to evaluate the output 
- [issue 782: [FEA] Ignore all unsupported operators in Delta metadata query](https://github.com/NVIDIA/spark-rapids-tools/issues/782)

**Output**

- New CSV File output: sql_ids_cleaned_for_alignment.csv
- text format 

```
SQL Ids Cleaned For Alignment:
+--------+-----+
|appIndex|sqlID|
+--------+-----+
|1       |0    |
|1       |1    |
|1       |2    |
|1       |3    |
|1       |4    |
|1       |5    |
|1       |9    |
|1       |10   |
|1       |11   |
|1       |12   |
|1       |14   |
|1       |27   |
|1       |35   |
|1       |36   |

```

**sample output files**

- [gpu-sql_ids_cleaned_for_alignment.csv](https://github.com/NVIDIA/spark-rapids-tools/files/15408951/gpu-sql_ids_cleaned_for_alignment.csv)

- [cpu-sql_ids_cleaned_for_alignment.csv](https://github.com/NVIDIA/spark-rapids-tools/files/15408954/cpu-sql_ids_cleaned_for_alignment.csv)

