### PR TITLE
Qualification tool - Handle cancelled jobs and stages better and don't skip the app

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationEventProcessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationEventProcessor.scala
@@ -152,6 +152,8 @@ class QualificationEventProcessor(app: QualificationAppInfo, perSqlOnly: Boolean
         } else {
           logDebug(s"Job was cancelled so not skipping, failure reason: ${failedJob.exception}")
         }
+      } else {
+        logError("Unknown JobResult type, not checking for failure!")
       }
     }
   }


### PR DESCRIPTION


Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/1032

I ran an event log through the qualification tool and it got labelled as not applicable because it had failed stages. Those failed stages though were cancelled by AQE runs.

We should take this into account in the qual tool.

The reasons in task show up as: Stage cancelled...
The stage failure reason shows: Job 243 cancelled

tool output:
24/05/23 10:00:26 WARN QualificationEventProcessor: SQL execution id 47 had failures, skipping
24/05/23 10:00:26 WARN QualificationEventProcessor: SQL execution id 125 had failures, skipping

This PR fixes that by looking for cancelled in the failure messages ignores those as failures.

I tested on customer event log and this is working. Need to put that event log into our integration tests.