### PR TITLE
Refactor ProfileResult classes to implement new interface design and add CSV output to Qual Tool

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.tool.analysis
 import scala.collection.mutable.{AbstractSet, ArrayBuffer, HashMap, LinkedHashSet}
 
 import com.nvidia.spark.rapids.tool.planparser.SQLPlanParser
-import com.nvidia.spark.rapids.tool.profiling.{DataSourceCase, DataSourceProfileResult, SQLAccumProfileResults, SQLMetricInfoCase, SQLStageInfoProfileResult, UnsupportedSQLPlan, WholeStageCodeGenResults}
+import com.nvidia.spark.rapids.tool.profiling.{DataSourceCase, SQLAccumProfileResults, SQLMetricInfoCase, SQLStageInfoProfileResult, UnsupportedSQLPlan, WholeStageCodeGenResults}
 import com.nvidia.spark.rapids.tool.qualification.QualSQLPlanAnalyzer
 
 import org.apache.spark.sql.execution.SparkPlanInfo
@@ -343,67 +343,6 @@ class AppSQLPlanAnalyzer(app: AppBase, appIndex: Int) extends AppAnalysisBase(ap
       }
     }
   }
-
-  // This is copy of getDataSourceInfo in the CollectInformation
-  // get read data schema information
-  def getDataSourceInfo(appInfo: QualificationAppInfo,
-      appIndex: Int = 1): Seq[DataSourceProfileResult] = {
-    val dataSourceApps = Seq(appInfo)
-    val sqlAccums = generateSQLAccums()
-
-    // Metrics to capture from event log to the result
-    val buffer_time: String = "buffer time"
-    val scan_time = "scan time"
-    val data_size = "size of files read"
-    val decode_time = "GPU decode time"
-
-    // This is to save the metrics which will be extracted while creating the result.
-    case class IoMetrics(
-        var buffer_time: Long,
-        var scan_time: Long,
-        var data_size: Long,
-        var decode_time: Long)
-
-    def getIoMetrics(sqlAccums: Seq[SQLAccumProfileResults]): IoMetrics = {
-      val finalRes = IoMetrics(0, 0, 0, 0)
-      sqlAccums.map(accum => accum.name match {
-        case `buffer_time` => finalRes.buffer_time = accum.total
-        case `scan_time` => finalRes.scan_time = accum.total
-        case `data_size` => finalRes.data_size = accum.total
-        case `decode_time` => finalRes.decode_time = accum.total
-      })
-      finalRes
-    }
-
-    val allRows = dataSourceApps.flatMap { app =>
-      val appSqlAccums = sqlAccums.filter(sqlAccum => sqlAccum.appIndex == appIndex)
-
-      // Filter appSqlAccums to get only required metrics
-      val dataSourceMetrics = appSqlAccums.filter(sqlAccum => sqlAccum.name.contains(buffer_time)
-        || sqlAccum.name.contains(scan_time) || sqlAccum.name.contains(decode_time)
-        || sqlAccum.name.equals(data_size))
-
-      app.dataSourceInfo.map { ds =>
-        val sqlIdtoDs = dataSourceMetrics.filter(
-          sqlAccum => sqlAccum.sqlID == ds.sqlID && sqlAccum.nodeID == ds.nodeId)
-        if (!sqlIdtoDs.isEmpty) {
-          val ioMetrics = getIoMetrics(sqlIdtoDs)
-          DataSourceProfileResult(appIndex, ds.sqlID, ds.nodeId,
-            ds.format, ioMetrics.buffer_time, ioMetrics.scan_time, ioMetrics.data_size,
-            ioMetrics.decode_time, ds.location, ds.pushedFilters, ds.schema)
-        } else {
-          DataSourceProfileResult(appIndex, ds.sqlID, ds.nodeId,
-            ds.format, 0, 0, 0, 0, ds.location, ds.pushedFilters, ds.schema)
-        }
-      }
-    }
-    if (allRows.size > 0) {
-      allRows.sortBy(cols => (cols.appIndex, cols.sqlID, cols.location, cols.schema))
-    } else {
-      Seq.empty
-    }
-  }
-
 }
 
 object AppSQLPlanAnalyzer {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
@@ -19,10 +19,9 @@ package com.nvidia.spark.rapids.tool.profiling
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 
 import com.nvidia.spark.rapids.tool.ToolTextFileWriter
-import com.nvidia.spark.rapids.tool.views.{ProfExecutorView, ProfJobsView, ProfSQLCodeGenView, ProfSQLPlanAlignedView, ProfSQLPlanMetricsView, ProfSQLToStageView}
+import com.nvidia.spark.rapids.tool.views._
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.rapids.tool.ToolUtils
 import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
 
 case class StageMetrics(numTasks: Int, duration: String)
@@ -34,114 +33,21 @@ case class StageMetrics(numTasks: Int, duration: String)
 class CollectInformation(apps: Seq[ApplicationInfo]) extends Logging {
 
   def getAppInfo: Seq[AppInfoProfileResults] = {
-    val allRows = apps.collect {
-      case app if app.isAppMetaDefined =>
-        val a = app.appMetaData.get
-        AppInfoProfileResults(app.index, a.appName, a.appId,
-          a.sparkUser,  a.startTime, a.endTime, app.getAppDuration,
-          a.getDurationString, app.sparkVersion, app.gpuMode)
-    }
-    if (allRows.nonEmpty) {
-      allRows.sortBy(cols => (cols.appIndex))
-    } else {
-      Seq.empty
-    }
+    ProfInformationView.getRawView(apps)
   }
 
   def getAppLogPath: Seq[AppLogPathProfileResults] = {
-    val allRows = apps.collect {
-      case app if app.isAppMetaDefined => val a = app.appMetaData.get
-      AppLogPathProfileResults(app.index, a.appName, a.appId, app.getEventLogPath)
-    }
-    if (allRows.nonEmpty) {
-      allRows.sortBy(cols => cols.appIndex)
-    } else {
-      Seq.empty
-    }
+    ProfLogPathView.getRawView(apps)
   }
 
   // get rapids-4-spark and cuDF jar if CPU Mode is on.
   def getRapidsJARInfo: Seq[RapidsJarProfileResult] = {
-    val allRows = apps.flatMap { app =>
-      if (app.gpuMode) {
-        // Look for rapids-4-spark and cuDF jar in classPathEntries
-        val rapidsJars = app.classpathEntries.filterKeys(_ matches ToolUtils.RAPIDS_JAR_REGEX.regex)
-        if (rapidsJars.nonEmpty) {
-          val cols = rapidsJars.keys.toSeq
-          cols.map(jar => RapidsJarProfileResult(app.index, jar))
-        } else {
-          // Look for the rapids-4-spark and cuDF jars in Spark Properties
-          ToolUtils.extractRAPIDSJarsFromProps(app.sparkProperties).map {
-            jar => RapidsJarProfileResult(app.index, jar)
-          }
-        }
-      } else {
-        Seq.empty
-      }
-    }
-    if (allRows.size > 0) {
-      allRows.sortBy(cols => (cols.appIndex, cols.jar))
-    } else {
-      Seq.empty
-    }
+    ProfRapidsJarView.getRawView(apps)
   }
 
   // get read data schema information
   def getDataSourceInfo: Seq[DataSourceProfileResult] = {
-    val dataSourceApps = apps.filter(_.dataSourceInfo.nonEmpty)
-    val sqlAccums = CollectInformation.generateSQLAccums(dataSourceApps)
-
-    // Metrics to capture from event log to the result
-    val buffer_time: String = "buffer time"
-    val scan_time = "scan time"
-    val data_size = "size of files read"
-    val decode_time = "GPU decode time"
-
-    // This is to save the metrics which will be extracted while creating the result.
-    case class IoMetrics(
-        var buffer_time: Long,
-        var scan_time: Long,
-        var data_size: Long,
-        var decode_time: Long)
-
-    def getIoMetrics(sqlAccums: Seq[SQLAccumProfileResults]): IoMetrics = {
-      val finalRes = IoMetrics(0, 0, 0, 0)
-      sqlAccums.map(accum => accum.name match {
-        case `buffer_time` => finalRes.buffer_time = accum.total
-        case `scan_time` => finalRes.scan_time = accum.total
-        case `data_size` => finalRes.data_size = accum.total
-        case `decode_time` => finalRes.decode_time = accum.total
-      })
-      finalRes
-    }
-
-    val allRows = dataSourceApps.flatMap { app =>
-      val appSqlAccums = sqlAccums.filter(sqlAccum => sqlAccum.appIndex == app.index)
-
-      // Filter appSqlAccums to get only required metrics
-      val dataSourceMetrics = appSqlAccums.filter(sqlAccum => sqlAccum.name.contains(buffer_time)
-        || sqlAccum.name.contains(scan_time) || sqlAccum.name.contains(decode_time)
-        || sqlAccum.name.equals(data_size))
-
-      app.dataSourceInfo.map { ds =>
-        val sqlIdtoDs = dataSourceMetrics.filter(
-          sqlAccum => sqlAccum.sqlID == ds.sqlID && sqlAccum.nodeID == ds.nodeId)
-        if (!sqlIdtoDs.isEmpty) {
-          val ioMetrics = getIoMetrics(sqlIdtoDs)
-          DataSourceProfileResult(app.index, ds.sqlID, ds.nodeId,
-            ds.format, ioMetrics.buffer_time, ioMetrics.scan_time, ioMetrics.data_size,
-            ioMetrics.decode_time, ds.location, ds.pushedFilters, ds.schema)
-        } else {
-          DataSourceProfileResult(app.index, ds.sqlID, ds.nodeId,
-            ds.format, 0, 0, 0, 0, ds.location, ds.pushedFilters, ds.schema)
-        }
-      }
-    }
-    if (allRows.size > 0) {
-      allRows.sortBy(cols => (cols.appIndex, cols.sqlID, cols.location, cols.schema))
-    } else {
-      Seq.empty
-    }
+    ProfDataSourceView.getRawView(apps)
   }
 
   // get executor related information
@@ -158,50 +64,14 @@ class CollectInformation(apps: Seq[ApplicationInfo]) extends Logging {
     ProfSQLToStageView.getRawView(apps)
   }
 
-  /**
-   * Print RAPIDS related or all Spark Properties when the propSource is set to "rapids".
-   * Note that RAPIDS related properties are not necessarily starting with prefix 'spark.rapids'.
-   * This table is inverse of the other tables where the row keys are property keys and the columns
-   * are the application values. So column1 would be all the key values for app index 1.
-   * @param propSource defines which type of properties to be retrieved the properties from.
-   *                   It can be: rapids, spark, or system
-   * @return List of properties relevant to the source.
-   */
-  private def getProperties(propSource: String): Seq[RapidsPropertyProfileResult] = {
-    val outputHeaders = ArrayBuffer("propertyName")
-    val props = HashMap[String, ArrayBuffer[String]]()
-    var numApps = 0
-    apps.foreach { app =>
-      numApps += 1
-      outputHeaders += s"appIndex_${app.index}"
-      val propsToKeep = if (propSource.equals("rapids")) {
-        app.sparkProperties.filterKeys { ToolUtils.isRapidsPropKey(_) }
-      } else if (propSource.equals("spark")) {
-        // remove the rapids related ones
-        app.sparkProperties.filterKeys(key => !key.contains(ToolUtils.PROPS_RAPIDS_KEY_PREFIX))
-      } else {
-        // get the system properties
-        app.systemProperties
-      }
-      CollectInformation.addNewProps(propsToKeep, props, numApps)
-    }
-    val allRows = props.map { case (k, v) => Seq(k) ++ v }.toSeq
-    if (allRows.nonEmpty) {
-      val resRows = allRows.map(r => RapidsPropertyProfileResult(r(0), outputHeaders, r))
-      resRows.sortBy(cols => cols.key)
-    } else {
-      Seq.empty
-    }
-  }
-
   def getRapidsProperties: Seq[RapidsPropertyProfileResult] = {
-    getProperties("rapids")
+    RapidsProfPropertiesView.getRawView(apps)
   }
   def getSparkProperties: Seq[RapidsPropertyProfileResult] = {
-    getProperties("spark")
+    SparkProfPropertiesView.getRawView(apps)
   }
   def getSystemProperties: Seq[RapidsPropertyProfileResult] = {
-    getProperties("system")
+    SystemProfPropertiesView.getRawView(apps)
   }
 
   // Print SQL whole stage code gen mapping

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
@@ -496,20 +496,20 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
     }
     sums.foreach { app: ApplicationSummaryInfo =>
       profileOutputWriter.writeText("### A. Information Collected ###")
-      profileOutputWriter.write("Application Information", app.appInfo)
-      profileOutputWriter.write("Application Log Path Mapping", app.appLogPath)
-      profileOutputWriter.write("Data Source Information", app.dsInfo)
+      profileOutputWriter.write(ProfInformationView.getLabel, app.appInfo)
+      profileOutputWriter.write(ProfLogPathView.getLabel, app.appLogPath)
+      profileOutputWriter.write(ProfDataSourceView.getLabel, app.dsInfo)
       profileOutputWriter.write(ProfExecutorView.getLabel, app.execInfo)
       profileOutputWriter.write(ProfJobsView.getLabel, app.jobInfo)
       profileOutputWriter.write(ProfSQLToStageView.getLabel, app.sqlStageInfo)
-      profileOutputWriter.write("Spark Rapids parameters set explicitly", app.rapidsProps,
-        Some("Spark Rapids parameters"))
-      profileOutputWriter.write("Spark Properties", app.sparkProps,
-        Some("Spark Properties"))
-      profileOutputWriter.write("System Properties", app.sysProps,
-        Some("System Properties"))
-      profileOutputWriter.write("Rapids Accelerator Jar and cuDF Jar", app.rapidsJar,
-        Some("Rapids 4 Spark Jars"))
+      profileOutputWriter.write(RapidsQualPropertiesView.getLabel, app.rapidsProps,
+        Some(RapidsQualPropertiesView.getDescription))
+      profileOutputWriter.write(SparkQualPropertiesView.getLabel, app.sparkProps,
+        Some(SparkQualPropertiesView.getDescription))
+      profileOutputWriter.write(SystemQualPropertiesView.getLabel, app.sysProps,
+        Some(SystemQualPropertiesView.getDescription))
+      profileOutputWriter.write(ProfRapidsJarView.getLabel, app.rapidsJar,
+        Some(ProfRapidsJarView.getDescription))
       profileOutputWriter.write(ProfSQLPlanMetricsView.getLabel, app.sqlMetrics,
         Some(ProfSQLPlanMetricsView.getDescription))
       profileOutputWriter.write(ProfSQLCodeGenView.getLabel, app.wholeStage,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/DataSourceView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/DataSourceView.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.views
+
+import com.nvidia.spark.rapids.tool.analysis.{ProfAppIndexMapperTrait, QualAppIndexMapperTrait}
+import com.nvidia.spark.rapids.tool.profiling.{DataSourceProfileResult, SQLAccumProfileResults}
+import com.nvidia.spark.rapids.tool.qualification.QualSQLPlanAnalyzer
+
+import org.apache.spark.sql.rapids.tool.AppBase
+import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
+import org.apache.spark.sql.rapids.tool.qualification.QualificationAppInfo
+
+case class IoMetrics(
+    var buffer_time: Long,
+    var scan_time: Long,
+    var data_size: Long,
+    var decode_time: Long
+)
+
+object Metrics {
+  val bufferTime = "buffer time"
+  val scanTime = "scan time"
+  val dataSize = "size of files read"
+  val decodeTime = "GPU decode time"
+}
+
+trait AppDataSourceViewTrait extends ViewableTrait[DataSourceProfileResult] {
+  override def getLabel: String = "Data Source Information"
+
+  private def getIoMetrics(sqlAccums: Seq[SQLAccumProfileResults]): IoMetrics = {
+    val finalRes = IoMetrics(0, 0, 0, 0)
+    sqlAccums.map(accum => accum.name match {
+      case Metrics.bufferTime => finalRes.buffer_time = accum.total
+      case Metrics.scanTime => finalRes.scan_time = accum.total
+      case Metrics.dataSize => finalRes.data_size = accum.total
+      case Metrics.decodeTime => finalRes.decode_time = accum.total
+    })
+    finalRes
+  }
+
+  def getSQLAccums(app: AppBase, appIndex: Integer = 1): Seq[SQLAccumProfileResults] = {
+    app match {
+      case qApp: QualificationAppInfo =>
+        // TODO: We are currently processing SQL plan metrics twice, once in AppSQLPlanAnalyzer and
+        //       once here. We should refactor this to avoid the duplicate calculation.
+        val sqlAnalyzer = new QualSQLPlanAnalyzer(qApp, appIndex)
+        sqlAnalyzer.processSQLPlanMetrics()
+        QualSQLPlanMetricsView.getRawViewFromSqlProcessor(sqlAnalyzer)
+      case pApp: ApplicationInfo =>
+        ProfSQLPlanMetricsView.getRawView(pApp, appIndex)
+    }
+  }
+
+  def getRawView(app: AppBase, index: Int): Seq[DataSourceProfileResult] = {
+    val appSqlAccums = getSQLAccums(app, index)
+    // Filter appSqlAccums to get only required metrics
+    val dataSourceMetrics =
+      appSqlAccums.filter(sqlAccum => sqlAccum.name.contains(Metrics.bufferTime)
+      || sqlAccum.name.contains(Metrics.scanTime) || sqlAccum.name.contains(Metrics.decodeTime)
+      || sqlAccum.name.equals(Metrics.dataSize))
+
+    app.dataSourceInfo.map { ds =>
+      val sqlIdtoDs = dataSourceMetrics.filter(
+        sqlAccum => sqlAccum.sqlID == ds.sqlID && sqlAccum.nodeID == ds.nodeId)
+      if (sqlIdtoDs.nonEmpty) {
+        val ioMetrics = getIoMetrics(sqlIdtoDs)
+        DataSourceProfileResult(index, ds.sqlID, ds.nodeId,
+          ds.format, ioMetrics.buffer_time, ioMetrics.scan_time, ioMetrics.data_size,
+          ioMetrics.decode_time, ds.location, ds.pushedFilters, ds.schema)
+      } else {
+        DataSourceProfileResult(index, ds.sqlID, ds.nodeId,
+          ds.format, 0, 0, 0, 0, ds.location, ds.pushedFilters, ds.schema)
+      }
+    }
+  }
+
+  override def sortView(rows: Seq[DataSourceProfileResult]): Seq[DataSourceProfileResult] = {
+    rows.sortBy(cols => (cols.appIndex, cols.sqlID, cols.location, cols.schema))
+  }
+}
+
+
+object QualDataSourceView extends AppDataSourceViewTrait with QualAppIndexMapperTrait {
+  // Keep for the following refactor stages to customize the view based on the app type (Qual/Prof)
+}
+
+object ProfDataSourceView extends AppDataSourceViewTrait with ProfAppIndexMapperTrait {
+  // Keep for the following refactor stages to customize the view based on the app type (Qual/Prof)
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/InformationView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/InformationView.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.views
+
+import com.nvidia.spark.rapids.tool.analysis.{ProfAppIndexMapperTrait, QualAppIndexMapperTrait}
+import com.nvidia.spark.rapids.tool.profiling.{AppInfoProfileResults, AppLogPathProfileResults, RapidsJarProfileResult}
+
+import org.apache.spark.sql.rapids.tool.{AppBase, ToolUtils}
+
+
+trait AppInformationViewTrait extends ViewableTrait[AppInfoProfileResults] {
+  override def getLabel: String = "Application Information"
+
+  def getRawView(app: AppBase, index: Int): Seq[AppInfoProfileResults] = {
+    app.appMetaData.map { a =>
+      AppInfoProfileResults(index, a.appName, a.appId,
+        a.sparkUser, a.startTime, a.endTime, app.getAppDuration,
+        a.getDurationString, app.sparkVersion, app.gpuMode)
+    }.toSeq
+  }
+  override def sortView(rows: Seq[AppInfoProfileResults]): Seq[AppInfoProfileResults] = {
+    rows.sortBy(cols => cols.appIndex)
+  }
+}
+
+
+object QualInformationView extends AppInformationViewTrait with QualAppIndexMapperTrait {
+  // Keep for the following refactor stages to customize the view based on the app type (Qual/Prof)
+}
+
+object ProfInformationView extends AppInformationViewTrait with ProfAppIndexMapperTrait {
+  // Keep for the following refactor stages to customize the view based on the app type (Qual/Prof)
+}
+
+
+trait AppLogPathViewTrait extends ViewableTrait[AppLogPathProfileResults] {
+  override def getLabel: String = "Application Log Path Mapping"
+
+  def getRawView(app: AppBase, index: Int): Seq[AppLogPathProfileResults] = {
+    app.appMetaData.map { a =>
+      AppLogPathProfileResults(index, a.appName, a.appId, app.getEventLogPath)
+    }.toSeq
+  }
+
+  override def sortView(rows: Seq[AppLogPathProfileResults]): Seq[AppLogPathProfileResults] = {
+    rows.sortBy(cols => cols.appIndex)
+  }
+}
+
+
+object QualLogPathView extends AppLogPathViewTrait with QualAppIndexMapperTrait {
+  // Keep for the following refactor stages to customize the view based on the app type (Qual/Prof)
+}
+
+object ProfLogPathView extends AppLogPathViewTrait with ProfAppIndexMapperTrait {
+  // Keep for the following refactor stages to customize the view based on the app type (Qual/Prof)
+}
+
+trait AppRapidsJarViewTrait extends ViewableTrait[RapidsJarProfileResult] {
+  override def getLabel: String = "Rapids Accelerator Jar and cuDF Jar"
+
+  override def getDescription: String = "Rapids 4 Spark Jars"
+
+  def getRawView(app: AppBase, index: Int): Seq[RapidsJarProfileResult] = {
+    if (app.gpuMode) {
+      // Look for rapids-4-spark and cuDF jar in classPathEntries
+      val rapidsJars = app.classpathEntries.filterKeys(_ matches ToolUtils.RAPIDS_JAR_REGEX.regex)
+      if (rapidsJars.nonEmpty) {
+        val cols = rapidsJars.keys.toSeq
+        cols.map(jar => RapidsJarProfileResult(index, jar))
+      } else {
+        // Look for the rapids-4-spark and cuDF jars in Spark Properties
+        ToolUtils.extractRAPIDSJarsFromProps(app.sparkProperties).map {
+          jar => RapidsJarProfileResult(index, jar)
+        }.toSeq
+      }
+    } else {
+      Seq.empty
+    }
+  }
+
+  override def sortView(rows: Seq[RapidsJarProfileResult]): Seq[RapidsJarProfileResult] = {
+    rows.sortBy(cols => (cols.appIndex, cols.jar))
+  }
+}
+
+
+object QualRapidsJarView extends AppRapidsJarViewTrait with QualAppIndexMapperTrait {
+  // Keep for the following refactor stages to customize the view based on the app type (Qual/Prof)
+}
+
+object ProfRapidsJarView extends AppRapidsJarViewTrait with ProfAppIndexMapperTrait {
+  // Keep for the following refactor stages to customize the view based on the app type (Qual/Prof)
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/PropertiesView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/PropertiesView.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.views
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+import com.nvidia.spark.rapids.tool.analysis.{ProfAppIndexMapperTrait, QualAppIndexMapperTrait}
+import com.nvidia.spark.rapids.tool.profiling.RapidsPropertyProfileResult
+
+import org.apache.spark.sql.rapids.tool.{AppBase, ToolUtils}
+
+
+/**
+ * Print RAPIDS related or all Spark Properties when the propSource is set to "rapids".
+ * Note that RAPIDS related properties are not necessarily starting with prefix 'spark.rapids'.
+ * This table is inverse of the other tables where the row keys are property keys and the
+ columns
+ * are the application values. So column1 would be all the key values for app index 1.
+ * @return List of properties relevant to the source.
+ */
+trait AppPropertiesViewTrait extends ViewableTrait[RapidsPropertyProfileResult] {
+  def addNewProps(props: mutable.HashMap[String, ArrayBuffer[String]],
+                  newRapidsRelated: Map[String, String]): Unit = {
+    val inter = props.keys.toSeq.intersect(newRapidsRelated.keys.toSeq)
+    val existDiff = props.keys.toSeq.diff(inter)
+    val newDiff = newRapidsRelated.keys.toSeq.diff(inter)
+
+    inter.foreach { key =>
+      props(key) += newRapidsRelated.getOrElse(key, "null")
+    }
+
+    existDiff.foreach { key =>
+      props(key) += "null"
+    }
+
+    newDiff.foreach { key =>
+      val appVals = ArrayBuffer.fill(0)("null") += newRapidsRelated.getOrElse(key, "null")
+      props.put(key, appVals)
+    }
+  }
+
+  /**
+   * Get relevant properties for the view. This method should be implemented by the
+   * sub-classes to return the relevant properties for the view.
+   */
+  def getRelevantProperties(app: AppBase): Map[String, String]
+
+  def getRawView(app: AppBase, index: Int): Seq[RapidsPropertyProfileResult] = {
+    val outputHeaders = ArrayBuffer("propertyName", s"appIndex_$index")
+    val props = mutable.HashMap[String, ArrayBuffer[String]]()
+    val propsToKeep = getRelevantProperties(app)
+    addNewProps(props, propsToKeep)
+    val allRows = props.map { case (k, v) => Seq(k) ++ v }.toSeq
+    val resRows = allRows.map(r => RapidsPropertyProfileResult(r.head, outputHeaders, r))
+    resRows
+  }
+
+  override def sortView(rows: Seq[RapidsPropertyProfileResult])
+  : Seq[RapidsPropertyProfileResult] = {
+    rows.sortBy(cols => cols.key)
+  }
+}
+
+trait QualPropertiesView extends AppPropertiesViewTrait with QualAppIndexMapperTrait {
+  // Keep for the following refactor stages to customize the view based on the app type (Qual/Prof)
+}
+
+trait ProfPropertiesView extends AppPropertiesViewTrait with ProfAppIndexMapperTrait {
+  // Keep for the following refactor stages to customize the view based on the app type (Qual/Prof)
+}
+
+// View for Rapids specific properties
+trait RapidsPropertiesView extends AppPropertiesViewTrait {
+  override def getLabel: String = "Spark Rapids parameters set explicitly"
+  override def getDescription: String = "Spark Rapids parameters"
+  override def getRelevantProperties(app: AppBase): Map[String, String] = {
+    app.sparkProperties.filterKeys(ToolUtils.isRapidsPropKey)
+  }
+}
+
+// View for general Spark properties excluding Rapids-specific ones
+trait SparkPropertiesView extends AppPropertiesViewTrait {
+  override def getLabel: String = "Spark Properties"
+  override def getDescription: String = "Spark Properties"
+  override def getRelevantProperties(app: AppBase): Map[String, String] = {
+    app.sparkProperties.filterKeys(key => !key.contains(ToolUtils.PROPS_RAPIDS_KEY_PREFIX))
+  }
+}
+
+// View for system properties
+trait SystemPropertiesView extends AppPropertiesViewTrait {
+  override def getLabel: String = "System Properties"
+  override def getDescription: String = "System Properties"
+  override def getRelevantProperties(app: AppBase): Map[String, String] = {
+    app.systemProperties
+  }
+}
+
+// Create composite objects combining specific property views with tool type views.
+object RapidsQualPropertiesView extends RapidsPropertiesView with QualPropertiesView
+object SparkQualPropertiesView extends SparkPropertiesView with QualPropertiesView
+object SystemQualPropertiesView extends SystemPropertiesView with QualPropertiesView
+object RapidsProfPropertiesView extends RapidsPropertiesView with ProfPropertiesView
+object SparkProfPropertiesView extends SparkPropertiesView with ProfPropertiesView
+object SystemProfPropertiesView extends SystemPropertiesView with ProfPropertiesView

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/QualRawReportGenerator.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/QualRawReportGenerator.scala
@@ -64,14 +64,26 @@ object QualRawReportGenerator {
       appIndex: Int = 1): Seq[DataSourceProfileResult] = {
     val metricsDirectory = s"$rootDir/raw_metrics/${app.appId}"
     val sqlPlanAnalyzer = AppSQLPlanAnalyzer(app, appIndex)
-    val dsInfo = sqlPlanAnalyzer.getDataSourceInfo(app)
+    val dataSourceInfo = QualDataSourceView.getRawView(Seq(app))
     val pWriter =
       new ProfileOutputWriter(metricsDirectory, "profile", 10000000, outputCSV = true)
     try {
       pWriter.writeText("### A. Information Collected ###")
+      pWriter.write(QualInformationView.getLabel, QualInformationView.getRawView(Seq(app)))
+      pWriter.write(QualLogPathView.getLabel, QualLogPathView.getRawView(Seq(app)))
+      pWriter.write(QualDataSourceView.getLabel, dataSourceInfo)
       pWriter.write(QualExecutorView.getLabel, QualExecutorView.getRawView(Seq(app)))
       pWriter.write(QualAppJobView.getLabel, QualAppJobView.getRawView(Seq(app)))
       generateSQLProcessingView(pWriter, sqlPlanAnalyzer)
+      pWriter.write(RapidsQualPropertiesView.getLabel,
+        RapidsQualPropertiesView.getRawView(Seq(app)),
+        Some(RapidsQualPropertiesView.getDescription))
+      pWriter.write(SparkQualPropertiesView.getLabel,
+        SparkQualPropertiesView.getRawView(Seq(app)),
+        Some(SparkQualPropertiesView.getDescription))
+      pWriter.write(SystemQualPropertiesView.getLabel,
+        SystemQualPropertiesView.getRawView(Seq(app)),
+        Some(SystemQualPropertiesView.getDescription))
       pWriter.writeText("\n### B. Analysis ###\n")
       constructLabelsMaps(
         QualSparkMetricsAnalyzer.getAggRawMetrics(app, appIndex)).foreach { case (label, metrics) =>
@@ -91,6 +103,6 @@ object QualRawReportGenerator {
     } finally {
       pWriter.close()
     }
-    dsInfo
+    dataSourceInfo
   }
 }


### PR DESCRIPTION
Fixes #1041.  

#1000 introduced a new interface design for calculating `ProfileResults` types. This enabled qualification tools to generate these results as part of the raw_metrics folder.

This PR refactors the calculation of the remaining `ProfileResult` types to follow the same design pattern. These files are needed by the estimation model. This is a step toward using only the qualification tool for the estimation model.

## Files generated by Qual Tool
- `application_information.csv`
- `application_log_path_mapping.csv`
- `data_source_information.csv`
- Properties files: 
   - `spark_properties.csv`,
   - `system_properties.csv`
   - `spark_rapids_parameters_set_explicitly.csv`


## Changes:
Java/Core
- Refactored `CollectInformation`: Moved methods into the new framework `ViewableTrait[R <: ProfileResult]`.
- Created traits and objects for each `ProfileResult` case.

## Testing:
- Manually tested JAR on event logs to verify Qual Tool generates these files.
- Profiling unit tests are unaffected as this is an internal refactor.
- We do not have unit tests for the `raw_metrics` generated by Qual Tool.  We can create followup issue for this.