### PR TITLE
Handle metric names from legacy spark

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
@@ -177,8 +177,7 @@ class AppSQLPlanAnalyzer(app: AppBase, appIndex: Int) extends AppAnalysisBase(ap
       val stages =
         sqlPlanNodeIdToStageIds.getOrElse((visitor.sqlPIGEntry.sqlID, node.id), Set.empty)
       val allMetric = SQLMetricInfoCase(visitor.sqlPIGEntry.sqlID, metric.name,
-        metric.accumulatorId, metric.metricType, node.id,
-        node.name, node.desc, stages)
+        metric.accumulatorId, metric.metricType, node.id, node.name, node.desc, stages)
 
       allSQLMetrics += allMetric
       if (app.sqlPlanMetricsAdaptive.nonEmpty) {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ObjectHashAggregateExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ObjectHashAggregateExecParser.scala
@@ -32,8 +32,7 @@ case class ObjectHashAggregateExecParser(
 
   override def parse: ExecInfo = {
     // TODO - Its partial duration only. We need a way to specify it as partial.
-    val accumId = node.metrics.find(
-      _.name == "time in aggregation build total").map(_.accumulatorId)
+    val accumId = node.metrics.find(_.name == "time in aggregation build").map(_.accumulatorId)
     val maxDuration = SQLPlanParser.getTotalDuration(accumId, app)
     val exprString = node.desc.replaceFirst("ObjectHashAggregate", "")
     val expressions = SQLPlanParser.parseAggregateExpressions(exprString)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ShuffledHashJoinExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ShuffledHashJoinExecParser.scala
@@ -32,7 +32,7 @@ case class ShuffledHashJoinExecParser(
 
   override def parse: ExecInfo = {
     // TODO - Its partial duration only. We need a way to specify it as partial.
-    val accumId = node.metrics.find(_.name == "time to build hash map total").map(_.accumulatorId)
+    val accumId = node.metrics.find(_.name == "time to build hash map").map(_.accumulatorId)
     val maxDuration = SQLPlanParser.getTotalDuration(accumId, app)
     val exprString = node.desc.replaceFirst("ShuffledHashJoin ", "")
     val (expressions, supportedJoinType) = SQLPlanParser.parseEquijoinsExpressions(exprString)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SubqueryBroadcastExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SubqueryBroadcastExecParser.scala
@@ -30,7 +30,8 @@ case class SubqueryBroadcastExecParser(
   val fullExecName = node.name + "Exec"
 
   override def parse: ExecInfo = {
-    val collectTimeId = node.metrics.find(_.name == "time to collect (ms)").map(_.accumulatorId)
+    val collectTimeId =
+      node.metrics.find(_.name.contains("time to collect")).map(_.accumulatorId)
     val duration = SQLPlanParser.getDriverTotalDuration(collectTimeId, app)
     val (filterSpeedupFactor, isSupported) = if (checker.isExecSupported(fullExecName)) {
       (checker.getSpeedupFactor(fullExecName), true)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SubqueryExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SubqueryExecParser.scala
@@ -34,7 +34,8 @@ case class SubqueryExecParser(
 
   override def parse: ExecInfo = {
     // Note: the name of the metric may not be trailed by "(ms)" So, we only check for the prefix
-    val collectTimeId = node.metrics.find(_.name.contains("time to collect")).map(_.accumulatorId)
+    val collectTimeId =
+      node.metrics.find(_.name.contains("time to collect")).map(_.accumulatorId)
     // TODO: Should we also collect the "data size" metric?
     val duration = SQLPlanParser.getDriverTotalDuration(collectTimeId, app)
     // should remove is kept in 1 place. So no need to set it here.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/ViewableTrait.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/ViewableTrait.scala
@@ -19,9 +19,10 @@ package com.nvidia.spark.rapids.tool.views
 import com.nvidia.spark.rapids.tool.analysis.AppIndexMapperTrait
 import com.nvidia.spark.rapids.tool.profiling.ProfileResult
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.rapids.tool.AppBase
 
-trait ViewableTrait[R <: ProfileResult] extends AppIndexMapperTrait {
+trait ViewableTrait[R <: ProfileResult] extends AppIndexMapperTrait with Logging {
   def getLabel: String
   def getDescription: String = ""
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -448,6 +448,10 @@ case class IncorrectAppStatusException(
     message: String = "Application status is incorrect. Missing AppInfo")
     extends AppEventlogProcessException(message)
 
+case class UnsupportedMetricNameException(metricName: String)
+    extends AppEventlogProcessException(
+      s"Unsupported metric name found in the event log: $metricName")
+
 // Class used a container to hold the information of the Tuple<sqlID, PlanInfo, SparkGraph>
 // to simplify arguments of methods and caching.
 case class SqlPlanInfoGraphEntry(

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/ToolsPlanGraph.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/ToolsPlanGraph.scala
@@ -213,10 +213,11 @@ object ToolsPlanGraph {
       accumulatorId: Long,
       metricType: String): SQLPlanMetric = {
     try {
-      SQLPlanMetric(name, accumulatorId, metricType)
+      SQLPlanMetric(EventUtils.normalizeMetricName(name), accumulatorId, metricType)
     } catch {
       case _: java.lang.NoSuchMethodError =>
-        dbRuntimeReflection.constructSQLPlanMetric(name, accumulatorId, metricType)
+        dbRuntimeReflection.constructSQLPlanMetric(
+          EventUtils.normalizeMetricName(name), accumulatorId, metricType)
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1042

Running the tool on a legacy spark eventlog (2.x) caused problems because the SQL metric names are not the same

**Changes**

This PR adds a map between <legacy-metric-names, new-metric-names>

- The map is looked-up in the following parts:
  - During the construction of an AccumulableInfo: this guarantees that all metrics created in a TaskEnd/Stage are mapped to the valid names
  - During the contruction of the SQLplanGraph: this guarantees that node metrics are mapped to the most recent labels
- I added an extra match-pattern to avoid this failure from happening in the future. When the mtric-name is missing, there will be a warning message that it is not handled correctly. 
- The process to do the fix was painful because I had to look into all spark versions to spot any metric-name change. t is possible that I did not catch them all, but at least we can append more mapping in the future.

I had to change UT because the changes actually fixed a hidden bug in our code.