### PR TITLE
Handle missing pricing info for user qual tool on Databricks platforms

### DIFF
--- a/user_tools/src/spark_rapids_pytools/pricing/databricks_azure_pricing.py
+++ b/user_tools/src/spark_rapids_pytools/pricing/databricks_azure_pricing.py
@@ -79,5 +79,4 @@ class DatabricksAzurePriceProvider(PriceProvider):
             rate_per_hour = instance_conf.get('TotalPricePerHour')
             return rate_per_hour
         except Exception as ex:  # pylint: disable=broad-except
-            self.logger.error('Could not find price for instance type \'%s\': %s', instance, ex)
-            raise ex
+            raise RuntimeError(f'Could not find pricing info for instance type \'{instance}\'') from ex

--- a/user_tools/src/spark_rapids_pytools/pricing/databricks_pricing.py
+++ b/user_tools/src/spark_rapids_pytools/pricing/databricks_pricing.py
@@ -85,5 +85,7 @@ class DatabricksPriceProvider(EMREc2PriceProvider):
         job_type_conf = self.catalogs[self.plan].get_value(compute_type)
         rate_per_hour = job_type_conf.get('RatePerHour')
         instance_conf = job_type_conf.get('Instances').get(instance)
+        if instance_conf is None:
+            raise RuntimeError(f'Could not find pricing info for instance type \'{instance}\'')
         instance_dbu = instance_conf.get('DBU')
         return instance_dbu * rate_per_hour

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -676,19 +676,22 @@ class Qualification(RapidsJarTool):
             return cost_pd_series
 
         cost_cols = self.ctxt.get_value('local', 'output', 'costColumns')
-        if not cost_per_row:
-            # initialize the savings estimator only once
-            reshaped_gpu_cluster = ClusterReshape(self.ctxt.get_ctxt('gpuClusterProxy'))
-            savings_estimator = self.ctxt.platform.create_saving_estimator(self.ctxt.get_ctxt('cpuClusterProxy'),
-                                                                           reshaped_gpu_cluster,
-                                                                           self.ctxt.get_ctxt('target_cost'),
-                                                                           self.ctxt.get_ctxt('source_cost'))
-            app_df_set[cost_cols] = app_df_set.apply(
-                lambda row: get_costs_for_single_app(row, estimator=savings_estimator), axis=1)
-        else:
-            # this is per row calculation and saving estimator should be created for each row
-            app_df_set[cost_cols] = app_df_set.apply(
-                lambda row: get_cost_per_row(row, shape_col), axis=1)
+        try:
+            if not cost_per_row:
+                # initialize the savings estimator only once
+                reshaped_gpu_cluster = ClusterReshape(self.ctxt.get_ctxt('gpuClusterProxy'))
+                savings_estimator = self.ctxt.platform.create_saving_estimator(self.ctxt.get_ctxt('cpuClusterProxy'),
+                                                                               reshaped_gpu_cluster,
+                                                                               self.ctxt.get_ctxt('target_cost'),
+                                                                               self.ctxt.get_ctxt('source_cost'))
+                app_df_set[cost_cols] = app_df_set.apply(
+                    lambda row: get_costs_for_single_app(row, estimator=savings_estimator), axis=1)
+            else:
+                # this is per row calculation and saving estimator should be created for each row
+                app_df_set[cost_cols] = app_df_set.apply(
+                    lambda row: get_cost_per_row(row, shape_col), axis=1)
+        except Exception as e:  # pylint: disable=broad-except
+            self.logger.error('Error computing cost savings. Reason - %s: %s. Skipping!', type(e).__name__, e)
         return app_df_set
 
     def __generate_cluster_recommendation_report(self):


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/1051

**Changes**

- Add try catch block to handle case when tool cannot find pricing info for instance types for Databricks platforms

`Testing`
Running the following command with cluster properties files which contain instance types that do not have pricing info in tools:

```
spark_rapids qualification--eventlogs <my_event_logs> --cluster <my_cluster_properties_file>
```

Databricks AWS

<details> 
<summary> Before this PR </summary>
<pre>
2024-05-30 16:02:55,269 ERROR root: Qualification. Raised an error in phase [Collecting-Results]
Traceback (most recent call last):
...
  File "~/spark-rapids-tools/user_tools/src/spark_rapids_pytools/pricing/databricks_pricing.py", line 88, in get_instance_price
    instance_dbu = instance_conf.get('DBU')
AttributeError: 'NoneType' object has no attribute 'get'
</pre>
</details>

<details> 
<summary> After this PR </summary>
<pre>
2024-05-30 16:56:51,448 ERROR rapids.tools.qualification: Error computing cost savings. Reason - RuntimeError: Could not find pricing info for instance type 'm7gd.8xlarge'. Skipping!
</pre>
</details>

Databricks Azure

<details> 
<summary> Before this PR </summary>
<pre>
2024-05-30 18:06:15,339 ERROR rapids.tools.price.Databricks-Azure: Could not find price for instance type 'Standard_D4s_v3': 'NoneType' object has no attribute 'get'
2024-05-30 18:06:15,339 ERROR root: Qualification. Raised an error in phase [Collecting-Results]
Traceback (most recent call last):
...
  File "~/spark-rapids-tools/user_tools/src/spark_rapids_pytools/pricing/databricks_azure_pricing.py", line 79, in get_instance_price
    rate_per_hour = instance_conf.get('TotalPricePerHour')
AttributeError: 'NoneType' object has no attribute 'get'
</pre>
</details>

<details> 
<summary> After this PR </summary>
<pre>
2024-05-30 18:07:47,401 ERROR rapids.tools.qualification: Error computing cost savings. Reason - RuntimeError: Could not find pricing info for instance type 'Standard_D4s_v3'. Skipping!
</pre>
</details>