### PR TITLE
User tools fallback to default zone/region

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -72,9 +72,8 @@ class DataprocPlatform(PlatformBase):
                     self.ctxt.update({prop_entry_key: prop_cmd_res})
             for prop_entry in properties_map_arr:
                 prop_entry_key = prop_entry.get('propKey')
-                if self.ctxt.get(prop_entry_key) is None:
-                    # set it using environment variable if possible
-                    self._set_env_prop_from_env_var(prop_entry_key)
+                # set it using environment variable if possible
+                self._set_env_prop_from_env_var(prop_entry_key)
 
     def _construct_cli_object(self) -> CMDDriverBase:
         return DataprocCMDDriver(timeout=0, cloud_ctxt=self.ctxt)

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -689,7 +689,7 @@ class PlatformBase:
                     # this is a file
                     env_var_val = FSUtil.expand_path(env_var_val)
                 self.ctxt.update({prop_key: env_var_val})
-                self.logger.warning('Property %s  is not set. Setting default value %s'
+                self.logger.warning('Property %s is not set. Setting default value %s'
                                     ' from environment variable', prop_key, env_var_val)
                 break
 
@@ -729,6 +729,10 @@ class PlatformBase:
                                                         sectionKey=self.ctxt.get(config_file_section[config_file]))
                 if loaded_conf_dict:
                     self.ctxt.update(loaded_conf_dict)
+            # If the property key is not already set, below code attempts to set the property
+            # using an environment variable. This is a fallback mechanism to populate configuration
+            # properties from the environment if they are not already set in the
+            # loaded configuration.
             for prop_entry in properties_map_arr:
                 prop_entry_key = prop_entry.get('propKey')
                 if self.ctxt.get(prop_entry_key) is None:

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -689,6 +689,8 @@ class PlatformBase:
                     # this is a file
                     env_var_val = FSUtil.expand_path(env_var_val)
                 self.ctxt.update({prop_key: env_var_val})
+                self.logger.warning('Property %s  is not set. Setting default value %s'
+                                    ' from environment variable', prop_key, env_var_val)
                 break
 
     def _set_initial_configuration_list(self) -> None:
@@ -727,10 +729,11 @@ class PlatformBase:
                                                         sectionKey=self.ctxt.get(config_file_section[config_file]))
                 if loaded_conf_dict:
                     self.ctxt.update(loaded_conf_dict)
-            for prop_elem in properties_map_arr:
-                if loaded_conf_dict and prop_elem.get('propKey') not in loaded_conf_dict:
+            for prop_entry in properties_map_arr:
+                prop_entry_key = prop_entry.get('propKey')
+                if self.ctxt.get(prop_entry_key) is None:
                     # set it using environment variable if possible
-                    self._set_env_prop_from_env_var(prop_elem.get('propKey'))
+                    self._set_env_prop_from_env_var(prop_entry_key)
 
     def _set_credential_properties(self) -> None:
         properties_map_arr = self._get_config_environment('cliConfig',

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -735,9 +735,8 @@ class PlatformBase:
             # loaded configuration.
             for prop_entry in properties_map_arr:
                 prop_entry_key = prop_entry.get('propKey')
-                if self.ctxt.get(prop_entry_key) is None:
-                    # set it using environment variable if possible
-                    self._set_env_prop_from_env_var(prop_entry_key)
+                # set it using environment variable if possible
+                self._set_env_prop_from_env_var(prop_entry_key)
 
     def _set_credential_properties(self) -> None:
         properties_map_arr = self._get_config_environment('cliConfig',

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
@@ -91,11 +91,13 @@
         },
         {
           "envVariableKey": "AWS_REGION",
-          "confProperty": "region"
+          "confProperty": "region",
+          "defaultValue": "us-east-1"
         },
         {
           "envVariableKey": "AWS_DEFAULT_REGION",
-          "confProperty": "region"
+          "confProperty": "region",
+          "defaultValue": "us-east-1"
         },
         {
           "envVariableKey": "AWS_PROFILE",

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -55,7 +55,8 @@
         },
         {
           "envVariableKey": "CLOUDSDK_DATAPROC_REGION",
-          "confProperty": "region"
+          "confProperty": "region",
+          "defaultValue": "us-central1"
         },
         {
           "envVariableKey": "CLOUDSDK_COMPUTE_REGION",
@@ -63,7 +64,8 @@
         },
         {
           "envVariableKey": "CLOUDSDK_COMPUTE_ZONE",
-          "confProperty": "zone"
+          "confProperty": "zone",
+          "defaultValue": "us-central1-b"
         },
         {
           "envVariableKey": "CLOUDSDK_CORE_PROJECT",

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -60,7 +60,8 @@
         },
         {
           "envVariableKey": "CLOUDSDK_COMPUTE_REGION",
-          "confProperty": "region"
+          "confProperty": "region",
+          "defaultValue": "us-central1"
         },
         {
           "envVariableKey": "CLOUDSDK_COMPUTE_ZONE",

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc_gke-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc_gke-configs.json
@@ -55,7 +55,8 @@
         },
         {
           "envVariableKey": "CLOUDSDK_DATAPROC_REGION",
-          "confProperty": "region"
+          "confProperty": "region",
+          "defaultValue": "us-central1"
         },
         {
           "envVariableKey": "CLOUDSDK_COMPUTE_REGION",
@@ -63,7 +64,8 @@
         },
         {
           "envVariableKey": "CLOUDSDK_COMPUTE_ZONE",
-          "confProperty": "zone"
+          "confProperty": "zone",
+          "defaultValue": "us-central1-b"
         },
         {
           "envVariableKey": "CLOUDSDK_CORE_PROJECT",

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc_gke-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc_gke-configs.json
@@ -60,7 +60,8 @@
         },
         {
           "envVariableKey": "CLOUDSDK_COMPUTE_REGION",
-          "confProperty": "region"
+          "confProperty": "region",
+          "defaultValue": "us-central1"
         },
         {
           "envVariableKey": "CLOUDSDK_COMPUTE_ZONE",

--- a/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
@@ -76,11 +76,13 @@
         },
         {
           "envVariableKey": "AWS_REGION",
-          "confProperty": "region"
+          "confProperty": "region",
+          "defaultValue": "us-east-1"
         },
         {
           "envVariableKey": "AWS_DEFAULT_REGION",
-          "confProperty": "region"
+          "confProperty": "region",
+          "defaultValue": "us-east-1"
         },
         {
           "envVariableKey": "AWS_PROFILE",


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids-tools/issues/1018.

This PR fallsback to default  region/zone(where applicable)  for CLI command when Region/Zone is not set by the user.
Earlier it would throw an error which doesn't show the exact reason though. With this PR, it  continues with the default region with a warning that Region was not set and using the default values from environment variable.

In addition to it, updated the way the remaining environment variables are set in sp_types.py. Earlier condition would miss some of the environment variables.

Tested it on platform:
1. dataproc
2. emr
3. databricks-aws

databricks-azure has  already default defined.

<details>
<summary> Dataproc failure </summary>
<pre>
 spark_rapids qualification --eventlogs=gs://< PATH TO EVENTLOGS>  --platform=dataproc 
RuntimeError: Error invoking CMD <gcloud compute machine-types describe n1-standard-64 --format json --zone None>: 
        | ERROR: (gcloud.compute.machine-types.describe) Could not fetch resource:
        |  - Invalid value for field 'zone': 'None'. Must be a match of regex '[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?'
</pre>
</details>

<details>
<summary> Dataproc completion with this PR </summary>
<pre>
Initialization Scripts:
-----------------------
To create a GPU cluster, run the following script:

```bash
#!/bin/bash

export CLUSTER_NAME="default-cluster-name"

gcloud dataproc clusters create $CLUSTER_NAME \
    --image-version=2.1.41-debian11 \
    --region us-central1 \
    --zone us-central1-b \
    --master-machine-type n1-standard-16 \
    --num-workers 8 \
    --worker-machine-type n1-standard-64 \
    --num-worker-local-ssds 2 \
    --enable-component-gateway \
    --subnet=default \
    --initialization-actions=gs://goog-dataproc-initialization-actions-us-central1/spark-rapids/spark-rapids.sh \
    --worker-accelerator type=nvidia-tesla-t4,count=2 \
    --properties 'spark:spark.driver.memory=50g'

```
Processing Completed!
</pre>
</details>

<details>
<summary> EMR failure </summary>
<pre>
spark_rapids qualification --eventlogs=s3://{PATH_TO_EVENTLOGS} --platform=emr --verbose 
File "/home/test/spark-rapids-tools/user_tools/src/spark_rapids_pytools/common/utilities.py", line 333, in exec
    raise RuntimeError(f'{cmd_err_msg}')
RuntimeError: Error invoking CMD <aws emr list-clusters --query 'Clusters[?Name==`emr_perfio_on_filecache_on_us_east_1a`]'>: 
        | 
        | Could not connect to the endpoint URL: "https://elasticmapreduce.None.amazonaws.com/"
</pre>
</details>

<details>
<summary> EMR completion with this PR </summary>
<pre>
        Instance types conversions:
------------  --  ----------
m6gd.4xlarge  to  g5.4xlarge
------------  --  ----------
To support acceleration with T4 GPUs, switch the worker node instance types


Processing Completed!
</pre>
</details>





<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

4. Please ensure that you have written units tests for the changes made/features
   added.

5. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

6. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

7. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

8. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
