### PR TITLE
Update tools with latest qualx and add CLI for train

### DIFF
--- a/user_tools/README.md
+++ b/user_tools/README.md
@@ -12,6 +12,9 @@ The wrapper improves end-user experience within the following dimensions:
    shows recommended per-app RAPIDS Accelerator for Apache Spark config settings.
 4. **Diagnostics**: Run diagnostic functions to validate the Dataproc with RAPIDS Accelerator for Apache Spark environment to
    make sure the cluster is healthy and ready for Spark jobs.
+5. **Prediction**: Predict the speedup of running a Spark application with Spark RAPIDS on GPUs.
+6. **Train**: Train a model to predict the performance of a Spark job on RAPIDS Accelerator for Apache Spark. The output shows
+   the model file that can be used to predict the performance of a Spark job.
 
 
 ## Getting started
@@ -36,8 +39,9 @@ Set up a Python environment with a version between 3.8 and 3.10
       $ pip install -e .
       ```
       
-      Note that you can also use optional `test` to install dependencies required to run the unit-tests
-      `pip install -e '.[test]'`
+      Note:
+      - To install dependencies required for running unit tests, use the optional `test` parameter: `pip install -e '.[test]'`
+      - To install dependencies required for QualX training, use the optional `qualx` parameter `pip install -e '.[qualx]'`
 
     - Using wheel package built from the repo (see the build steps below).
 
@@ -77,6 +81,8 @@ Set up a Python environment similar to the steps above.
 
 Please refer to [spark-rapids-user-tools guide](https://github.com/NVIDIA/spark-rapids-tools/blob/main/user_tools/docs/index.md) for details on how to use the tools
 and the platform.
+
+Please refer to [qualx guide](docs/qualx.md) for details on how to use the QualX tool for prediction and training.
 
 ## What's new
 

--- a/user_tools/docs/qualx.md
+++ b/user_tools/docs/qualx.md
@@ -41,5 +41,5 @@ spark_rapids train --dataset </path/to/dataset/files(s)> --model </path/to/save/
 - n_trials: Number of trials for hyperparameter search.
 
 ## Notes
-- `QUALX_DATA_DIR` should already exist and must contain the dataset files (e.g., from SwiftStack).
-- `QUALX_CACHE_DIR` will be created automatically if it does not already exist and will store intermediate files generated during processing (e.g., profiling output).
+- `QUALX_DATA_DIR` should be a valid path containing the training data (e.g., from SwiftStack).
+- `QUALX_CACHE_DIR` stores intermediate files generated during processing (e.g., profiling output). It will be created automatically if it does not exist.

--- a/user_tools/docs/qualx.md
+++ b/user_tools/docs/qualx.md
@@ -1,0 +1,45 @@
+# QualX: Spark RAPIDS Qualification Tool using XGBoost
+
+Tool to qualify Spark applications for GPU acceleration, based on XGBoost.
+
+## Usage
+
+### Prediction
+
+To predict the speedup of running a Spark application with Spark RAPIDS on GPUs, use the cmd below. It uses an XGBoost model trained on matching CPU and GPU runs of various Spark applications.
+
+```bash
+spark_rapids prediction --qual_output </path/to/qual_output> --prof_output </path/to/prof_output> --output_folder </path/to/save/csv/files>
+```
+
+#### Arguments:
+- qual_output: Path to a directory containing qualification tool output.
+- prof_output: Path to a directory containing profiling tool output.
+- output_folder: Path to store the output.
+
+### Training
+
+To train an XGBoost model on the specific dataset, follow these steps below. Refer to [Getting Started](../README.md#getting-started) section for installing the required dependencies for training.
+
+Set the following environment variables:
+```bash
+export SPARK_HOME=/path/to/spark
+export SPARK_RAPIDS_TOOL_JAR=/path/to/rapids-4-spark-tools-0.1.0-SNAPSHOT.jar
+export QUALX_DATA_DIR=/path/to/qualx/datasets
+export QUALX_CACHE_DIR=/path/to/qualx/cache
+```
+
+Run the following command to train the model:
+```bash
+spark_rapids train --dataset </path/to/dataset/files(s)> --model </path/to/save/trained/model> --output_folder </path/to/save/csv/files> --n_trials <number_of_trials>
+```
+
+#### Arguments:
+- dataset: Path to a folder containing one or more dataset JSON files.
+- model: Path to save the trained XGBoost model.
+- output_folder: Path to store the output.
+- n_trials: Number of trials for hyperparameter search.
+
+## Notes
+- `QUALX_DATA_DIR` should already exist and must contain the dataset files (e.g., from SwiftStack).
+- `QUALX_CACHE_DIR` will be created automatically if it does not already exist and will store intermediate files generated during processing (e.g., profiling output).

--- a/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
@@ -114,9 +114,6 @@ class EMRPlatform(PlatformBase):
     def create_local_submission_job(self, job_prop, ctxt) -> Any:
         return EmrLocalRapidsJob(prop_container=job_prop, exec_ctxt=ctxt)
 
-    def _get_prediction_model_name(self) -> str:
-        return CspEnv.pretty_print(CspEnv.get_default())
-
     def generate_cluster_configuration(self, render_args: dict):
         image_version = self.configs.get_value_silent('clusterInference', 'defaultImage')
         render_args['IMAGE'] = f'"{image_version}"'

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -31,7 +31,7 @@ from spark_rapids_pytools.pricing.price_provider import SavingsEstimator
 from spark_rapids_pytools.rapids.rapids_job import RapidsJobPropContainer
 from spark_rapids_pytools.rapids.rapids_tool import RapidsJarTool
 from spark_rapids_tools.enums import QualFilterApp, QualGpuClusterReshapeType, QualEstimationModel
-from spark_rapids_tools.tools.model_xgboost import predict
+from spark_rapids_tools.tools.qualx.qualx_main import predict
 from spark_rapids_tools.tools.additional_heuristics import AdditionalHeuristics
 from spark_rapids_tools.tools.speedup_category import SpeedupCategory
 from spark_rapids_tools.tools.top_candidates import TopCandidates

--- a/user_tools/src/spark_rapids_pytools/rapids/qualx/prediction.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualx/prediction.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation class representing wrapper around the RAPIDS acceleration Prediction tool."""
+
+from dataclasses import dataclass
+
+from spark_rapids_pytools.common.sys_storage import FSUtil
+from spark_rapids_pytools.rapids.qualx.qualx_tool import QualXTool
+from spark_rapids_tools.tools.qualx.qualx_main import predict
+from spark_rapids_tools.tools.qualx.util import print_summary, print_speedup_summary
+
+
+@dataclass
+class Prediction(QualXTool):
+    """
+    Wrapper layer around Prediction Tool.
+
+    Attributes
+    ----------
+    qual_output: str
+        Path to a directory containing qualification tool output.
+    prof_output: str
+        Path to a directory containing profiling tool output.
+    """
+    qual_output: str = None
+    prof_output: str = None
+
+    name = 'prediction'
+
+    def __prepare_prediction_output_info(self) -> dict:
+        """
+        Prepares the output information for the prediction results.
+        :return: Dictionary with the full paths to the output files.
+        """
+        # build the full output path for the predictions output files
+        predictions_info = self.ctxt.get_value('local', 'output', 'predictionModel')
+        output_dir = FSUtil.build_path(self.ctxt.get_output_folder(), predictions_info['outputDirectory'])
+        FSUtil.make_dirs(output_dir)
+
+        files_info = predictions_info['files']
+        # update files_info dictionary with full file paths
+        for entry in files_info:
+            file_name = files_info[entry]['name']
+            file_path = FSUtil.build_path(output_dir, file_name)
+            files_info[entry]['path'] = file_path
+        return files_info
+
+    def _run_rapids_tool(self):
+        """
+        Runs the QualX prediction tool, prints the summary and saves the output to a csv file.
+        """
+        try:
+            output_info = self.__prepare_prediction_output_info()
+            df = predict(platform=self.platform_type.map_to_java_arg(), qual=self.qual_output,
+                         profile=self.prof_output, output_info=output_info)
+            print_summary(df)
+            print_speedup_summary(df)
+            df.to_csv(f'{self.output_folder}/prediction.csv', float_format='%.2f')
+            self.logger.info('Prediction completed successfully.')
+            self.logger.info('Prediction results are generated at: %s', self.output_folder)
+        except Exception as e:  # pylint: disable=broad-except
+            self.logger.error('Prediction failed with error: %s', e)
+            raise e

--- a/user_tools/src/spark_rapids_pytools/rapids/qualx/train.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualx/train.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation class representing wrapper around the RAPIDS acceleration QualX training tool."""
+
+from dataclasses import dataclass
+
+from spark_rapids_pytools.rapids.qualx.qualx_tool import QualXTool
+from spark_rapids_tools.tools.qualx.qualx_main import train
+
+
+@dataclass
+class Train(QualXTool):
+    """
+    Wrapper layer around Training tool.
+
+    Attributes
+    ----------
+    dataset:
+        Path to a folder containing one or more dataset JSON files.
+    model:
+        Path to save the trained XGBoost model.
+    n_trials:
+        Number of trials for hyperparameter search.
+    """
+    dataset: str = None
+    model: str = None
+    n_trials: int = None
+
+    name = 'train'
+
+    def _run_rapids_tool(self):
+        """
+        Runs the QualX train tool, saves the trained model and training results.
+        """
+        try:
+            train(dataset=self.dataset, model=self.model, output_dir=self.output_folder, n_trials=self.n_trials)
+            self.logger.info('Training completed successfully.')
+            self.logger.info('Trained XGBoost model is saved at: %s', self.model)
+            self.logger.info('Training results are generated at: %s', self.output_folder)
+        except Exception as e:  # pylint: disable=broad-except
+            self.logger.error('Training failed with error: %s', e)
+            raise e

--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -672,3 +672,25 @@ class PredictUserArgModel(AbsToolUserArgModel):
             'output_folder': self.output_folder,
             'platformOpts': {}
         }
+
+
+@dataclass
+@register_tool_arg_validator('train')
+class TrainUserArgModel(AbsToolUserArgModel):
+    """
+    Represents the arguments collected by the user to run the training tool.
+    """
+    dataset: str = None
+    model: Optional[str] = None
+    n_trials: Optional[int] = None
+
+    def build_tools_args(self) -> dict:
+        runtime_platform = CspEnv.fromstring(self.platform)
+        return {
+            'runtimePlatform': runtime_platform,
+            'dataset': self.dataset,
+            'model': self.model,
+            'output_folder': self.output_folder,
+            'n_trials': self.n_trials,
+            'platformOpts': {},
+        }

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -22,9 +22,10 @@ from spark_rapids_tools.enums import QualGpuClusterReshapeType
 from spark_rapids_tools.utils.util import gen_app_banner, init_environment
 from spark_rapids_pytools.common.utilities import Utils, ToolLogging
 from spark_rapids_pytools.rapids.bootstrap import Bootstrap
-from spark_rapids_pytools.rapids.prediction import Prediction
+from spark_rapids_pytools.rapids.qualx.prediction import Prediction
 from spark_rapids_pytools.rapids.profiling import ProfilingAsLocal
 from spark_rapids_pytools.rapids.qualification import QualificationAsLocal
+from spark_rapids_pytools.rapids.qualx.train import Train
 
 
 class ToolsCLI(object):  # pylint: disable=too-few-public-methods
@@ -262,8 +263,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                    qual_output: str = None,
                    prof_output: str = None,
                    output_folder: str = None,
-                   platform: str = 'onprem',
-                   verbose: bool = False):
+                   platform: str = 'onprem'):
         """The prediction cmd takes existing qualification and profiling tool output and runs the
         estimation model in the qualification tools for GPU speedups.
 
@@ -276,8 +276,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         :param platform: defines one of the following "onprem", "dataproc", "databricks-aws",
                          and "databricks-azure", default to "onprem".
         """
-        if verbose:
-            ToolLogging.enable_debug_mode()
+        # Since prediction is an internal tool with frequent output, we enable debug mode by default
+        ToolLogging.enable_debug_mode()
 
         init_environment('pred')
 
@@ -294,6 +294,41 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                   output_folder=predict_args['output_folder'],
                                   wrapper_options=predict_args)
             tool_obj.launch()
+
+    def train(self,
+              dataset: str = None,
+              model: str = None,
+              output_folder: str = None,
+              n_trials: int = 200,
+              platform: str = 'onprem'):
+        """The train cmd trains an XGBoost model on the input data to estimate the speedup of a
+         Spark CPU application.
+
+        :param dataset: Path to a folder containing one or more dataset JSON files.
+        :param model: Path to save the trained XGBoost model.
+        :param output_folder: Path to store the output.
+        :param n_trials: Number of trials for hyperparameter search.
+        :param platform: Defines one of the following "onprem", "dataproc", "databricks-aws",
+                         and "databricks-azure", default to "onprem".
+        """
+        # Since train is an internal tool with frequent output, we enable debug mode by default
+        ToolLogging.enable_debug_mode()
+        init_environment('train')
+
+        train_args = AbsToolUserArgModel.create_tool_args('train',
+                                                          platform=platform,
+                                                          dataset=dataset,
+                                                          model=model,
+                                                          output_folder=output_folder,
+                                                          n_trials=n_trials)
+
+        tool_obj = Train(platform_type=train_args['runtimePlatform'],
+                         dataset=dataset,
+                         model=model,
+                         output_folder=output_folder,
+                         n_trials=n_trials,
+                         wrapper_options=train_args)
+        tool_obj.launch()
 
 
 def main():

--- a/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
+++ b/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
@@ -23,7 +23,7 @@ import pandas as pd
 
 from spark_rapids_pytools.common.prop_manager import JSONPropertiesContainer
 from spark_rapids_pytools.common.utilities import ToolLogging
-from spark_rapids_tools.tools.model_xgboost import find_paths, RegexPattern
+from spark_rapids_tools.tools.qualx.util import find_paths, RegexPattern
 from spark_rapids_tools.utils import Utilities
 
 
@@ -49,7 +49,7 @@ class AdditionalHeuristics:
         """
         profile_list = find_paths(
             self.tools_output_dir,
-            RegexPattern.rapids_profile.match,
+            RegexPattern.rapidsProfile.match,
             return_directories=True,
         )
         if len(profile_list) == 0:

--- a/user_tools/src/spark_rapids_tools/tools/model_xgboost.py
+++ b/user_tools/src/spark_rapids_tools/tools/model_xgboost.py
@@ -20,6 +20,7 @@ import logging
 import os
 import re
 import traceback
+import warnings
 from pathlib import Path
 from typing import Optional, Mapping, List, Dict, Callable, Tuple
 
@@ -31,6 +32,13 @@ from tabulate import tabulate
 from xgboost.core import XGBoostError
 
 from spark_rapids_pytools.common.utilities import Utils
+
+warnings.simplefilter('always', DeprecationWarning)
+warnings.warn(
+    f"Module '{__name__}' is deprecated and will be removed in a future version.",
+    DeprecationWarning,
+    stacklevel=2
+)
 
 logger = logging.getLogger(__name__)
 FILTER_SPILLS = False  # remove queries with any disk/mem spills

--- a/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
@@ -1065,7 +1065,7 @@ def load_csv_files(
     return out
 
 
-def load_qtool_execs(qtool_execs: list[str]) -> Optional[pd.DataFrame]:
+def load_qtool_execs(qtool_execs: List[str]) -> Optional[pd.DataFrame]:
     """
     Load supported stage info from qtool output in a form that can be merged with profiler data
     to aggregate features and durations only over supported stages.
@@ -1089,7 +1089,7 @@ def load_qtool_execs(qtool_execs: list[str]) -> Optional[pd.DataFrame]:
 
 
 def load_qual_csv(
-    qual_dirs: list[str], csv_filename: str, cols: Optional[list[str]] = None
+    qual_dirs: List[str], csv_filename: str, cols: Optional[List[str]] = None
 ) -> Optional[pd.DataFrame]:
     """
     Load CSV file from qual tool output as pandas DataFrame.

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Optional
+from typing import Callable, List, Optional
 import glob
 import json
 import os
@@ -251,7 +251,7 @@ def _read_dataset_scores(
 
 
 def _read_platform_scores(
-    eval_dir: str, score: str, split: str, dataset_filter: list[str] = []
+    eval_dir: str, score: str, split: str, dataset_filter: List[str] = []
 ) -> pd.DataFrame:
     """Load accuracy scores per platform.
 

--- a/user_tools/src/spark_rapids_tools/tools/qualx/util.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/util.py
@@ -17,7 +17,7 @@ import glob
 import logging
 import os
 import re
-from typing import Tuple
+from typing import Dict, List, Tuple
 import secrets
 import string
 import subprocess
@@ -86,7 +86,7 @@ def find_paths(dir, filter_fn=None, return_directories=False):
     return paths
 
 
-def find_eventlogs(path) -> list[str]:
+def find_eventlogs(path) -> List[str]:
     """Find all eventlogs given a root directory."""
     if '*' in path:
         # handle paths w/ glob patterns
@@ -113,7 +113,7 @@ def get_cache_dir():
     return os.environ.get('QUALX_CACHE_DIR', 'qualx_cache')
 
 
-def get_dataset_platforms(dataset: str) -> Tuple[list[str], str]:
+def get_dataset_platforms(dataset: str) -> Tuple[List[str], str]:
     """Return list of platforms and dataset parent directory from a string path.
 
     Parameters
@@ -139,7 +139,7 @@ def get_dataset_platforms(dataset: str) -> Tuple[list[str], str]:
 
 
 def compute_accuracy(
-    results: pd.DataFrame, y: str, y_preds: dict[str, str], weight: str = None
+    results: pd.DataFrame, y: str, y_preds: Dict[str, str], weight: str = None
 ):
     """Compute accuracy scores on a pandas DataFrame.
 
@@ -149,7 +149,7 @@ def compute_accuracy(
         Pandas dataframe containing the label column and one or more prediction columns.
     y: str
         Label column name.
-    y_preds: dict[str, str]
+    y_preds: Dict[str, str]
         Dictionary of display name of metric -> prediction column name.
     weight: str
         Name of column to use as weight, e.g. 'Duration' or 'appDuration'.
@@ -238,7 +238,7 @@ def run_qualification_tool(platform: str, eventlog: str, output_dir: str):
     run_commands(cmds)
 
 
-def run_commands(commands: list[str], workers: int = 8):
+def run_commands(commands: List[str], workers: int = 8):
     """Run a list of commands using a thread pool."""
     if not commands:
         return

--- a/user_tools/tox.ini
+++ b/user_tools/tox.ini
@@ -28,7 +28,6 @@ commands =
     pytest -vv \
     --cov "{envsitepackagesdir}/spark_rapids_pytools" \
     --cov-config "{toxinidir}/tox.ini" \
-    --ignore="{envsitepackagesdir}/spark_rapids_tools/tools/qualx" \
     {posargs:tests}
 
 [testenv:pylint]

--- a/user_tools/tox.ini
+++ b/user_tools/tox.ini
@@ -28,6 +28,7 @@ commands =
     pytest -vv \
     --cov "{envsitepackagesdir}/spark_rapids_pytools" \
     --cov-config "{toxinidir}/tox.ini" \
+    --ignore="{envsitepackagesdir}/spark_rapids_tools/tools/qualx" \
     {posargs:tests}
 
 [testenv:pylint]


### PR DESCRIPTION
Fixes  #1049.

We want to import the training module from QualX and update the prediction code with latest changes. This will be done in four steps.

## Steps
1. Import the source code and pretrained models as it as. Exclude these from pytest and flake8 linters.
1. Make changes in the **qualx** files to connect them with tools.
1. Make changes in the **tools** to use the latest changes in qualx.
1. Add entry point for `train` by adding a new CMD for training. 
 
## Changes
- Step 1 and 2 were completed in #1060.
- This PR implements step 3 and 4.
- We introduce a base class `QualXTool` that extends `RapidsTool` for all qualx CMDs.


## How to test/run?
We have three entry points with qualx

### 1. Python Qualification CMD:
```bash
spark_rapids qualification --platform <platform> --eventlogs </path/to/eventlogs> --estimation_model xgboost
```
### 2. Python Prediction CMD:
```bash
spark_rapids prediction --qual_output </path/to/qual_202406xxx> --prof_output </path/to/qual_202406xx> --output_folder </path/to/save/csv/files>
```

### 3. Python Train CMD (**new**):
Install optional dependencies for qualx training
```bash
cd user_tools
pip install -e .[qualx]
```

#### Train CMD:
```bash
spark_rapids train --dataset </path/to/dataset/files(s)> --model </path/to/save/trained/model> --output_folder </path/to/save/csv/files>
```

#### Note:
- More details on usage can be found in [QualX docs](https://github.com/parthosa/spark-rapids-tools/blob/spark-rapids-tools-1049-update-tools/user_tools/docs/qualx.md).
- Instructions on how to download training dataset will be shared offline.