### PR TITLE
Handling FileNotFound exception in AutoTuner

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -1268,6 +1268,8 @@ object AutoTuner extends Logging {
       val autoT = new AutoTuner(clusterPropsOpt.getOrElse(new ClusterProperties()),
         singleAppProvider, platform, driverInfoProvider)
       if(clusterPropsOpt.isEmpty) {
+        // In case the workerInfo input path is incorrect, extra comment
+        // mentioning that recommendations were generated using default values
         autoT.appendComment(s"workerInfo file not found at $workerInfoFilePath. " +
           "Using default values.")
       }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids.tool.profiling
 
-import java.io.{BufferedReader, InputStreamReader}
+import java.io.{BufferedReader, FileNotFoundException, InputStreamReader}
 
 import scala.beans.BeanProperty
 import scala.collection.{mutable, Seq}
@@ -1215,7 +1215,14 @@ object AutoTuner extends Logging {
       val reader = new BufferedReader(new InputStreamReader(fsIs))
       val fileContent = Stream.continually(reader.readLine()).takeWhile(_ != null).mkString("\n")
       loadClusterPropertiesFromContent(fileContent)
-    } finally {
+    }
+    catch {
+      case _: FileNotFoundException =>
+        logWarning("No yaml found for input path")
+        None
+      case e: Exception => throw e
+    }
+    finally {
       if (fsIs != null) {
         fsIs.close()
       }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -1270,8 +1270,8 @@ object AutoTuner extends Logging {
       if (clusterPropsOpt.isEmpty) {
         // In case the workerInfo input path is incorrect, extra comment
         // mentioning that recommendations were generated using default values
-        autoT.appendComment(s"Exception reading workerInfo: $workerInfoFilePath. " +
-          "Recommendations are generated using default values.")
+        autoT.appendComment(s"Exception reading workerInfo: $workerInfoFilePath.\n" +
+          "  Recommendations are generated using default values.")
       }
       autoT
     } catch {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -1218,6 +1218,8 @@ object AutoTuner extends Logging {
       loadClusterPropertiesFromContent(fileContent)
     }
     catch {
+      // In case of missing file for cluster properties, default properties are used.
+      // Hence, catching and logging as a warning
       case _: FileNotFoundException =>
         logWarning(s"No file found for input workerInfo path: $filePath")
         None

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.tool.profiling
 import java.io.{BufferedReader, FileNotFoundException, InputStreamReader}
 
 import scala.beans.BeanProperty
-import scala.collection.{mutable, Seq }
+import scala.collection.{mutable, Seq}
 import scala.collection.JavaConverters.mapAsScalaMapConverter
 import scala.collection.mutable.ListBuffer
 import scala.util.control.NonFatal

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -236,7 +236,8 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |- 'spark.sql.files.maxPartitionBytes' was not set.
           |- 'spark.sql.shuffle.partitions' was not set.
           |- 'spark.task.resource.gpu.amount' should be set to Min(1, (gpuCount / numCores)).
-          |- Exception reading workerInfo: non-existing.yaml. Recommendations are generated using default values.
+          |- Exception reading workerInfo: non-existing.yaml.
+          |  Recommendations are generated using default values.
           |- RAPIDS Accelerator for Apache Spark plugin jar is missing
           |  from the classpath entries.
           |  If the Spark RAPIDS jar is being bundled with your

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -245,7 +245,6 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |  path to the Spark RAPIDS plugin jar.
           |  If the Spark RAPIDS jar is being bundled with your Spark
           |  distribution, this step is not needed.
-          |- java.io.FileNotFoundException: File non-existing.yaml does not exist
           |""".stripMargin
     assert(expectedResults == autoTunerOutput)
   }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -245,6 +245,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |  path to the Spark RAPIDS plugin jar.
           |  If the Spark RAPIDS jar is being bundled with your Spark
           |  distribution, this step is not needed.
+          |- workerInfo file not found at non-existing.yaml. Using default values.
           |""".stripMargin
     assert(expectedResults == autoTunerOutput)
   }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -236,6 +236,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |- 'spark.sql.files.maxPartitionBytes' was not set.
           |- 'spark.sql.shuffle.partitions' was not set.
           |- 'spark.task.resource.gpu.amount' should be set to Min(1, (gpuCount / numCores)).
+          |- Exception reading workerInfo: non-existing.yaml. Recommendations are generated using default values.
           |- RAPIDS Accelerator for Apache Spark plugin jar is missing
           |  from the classpath entries.
           |  If the Spark RAPIDS jar is being bundled with your
@@ -245,7 +246,6 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |  path to the Spark RAPIDS plugin jar.
           |  If the Spark RAPIDS jar is being bundled with your Spark
           |  distribution, this step is not needed.
-          |- workerInfo file not found at non-existing.yaml. Using default values.
           |""".stripMargin
     assert(expectedResults == autoTunerOutput)
   }


### PR DESCRIPTION
Fixes #978

This fix handles the AutoTuner exception when an input file passed as workerInfo arguments does not exist.

Changes -
1. Catching the FileNotFound exception and adding a warning for it.
2. As well as appending a tuner comment which conveys this
3. Minor change to handle NonFatal exception while building AutoTuner from props