### PR TITLE
Sync tools with plugin newly supported operators

### DIFF
--- a/core/src/main/resources/operatorsScore-databricks-aws-a10G.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws-a10G.csv
@@ -298,3 +298,4 @@ InSubqueryExec,2.45
 AQEShuffleReadExec,2.45
 CheckOverflowInTableInsert,2.45
 ArrayFilter,1.5
+BoundReference,1.5

--- a/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
@@ -298,3 +298,4 @@ InSubqueryExec,2.45
 AQEShuffleReadExec,2.45
 CheckOverflowInTableInsert,2.45
 ArrayFilter,1.5
+BoundReference,1.5

--- a/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
@@ -286,3 +286,4 @@ InSubqueryExec,2.73
 AQEShuffleReadExec,2.73
 CheckOverflowInTableInsert,2.73
 ArrayFilter,1.5
+BoundReference,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
@@ -280,3 +280,4 @@ InSubqueryExec,3.74
 AQEShuffleReadExec,3.74
 CheckOverflowInTableInsert,3.74
 ArrayFilter,1.5
+BoundReference,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
@@ -280,3 +280,4 @@ InSubqueryExec,3.65
 AQEShuffleReadExec,3.65
 CheckOverflowInTableInsert,3.65
 ArrayFilter,1.5
+BoundReference,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-l4.csv
@@ -286,3 +286,4 @@ InSubqueryExec,4.16
 AQEShuffleReadExec,4.16
 CheckOverflowInTableInsert,4.16
 ArrayFilter,1.5
+BoundReference,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
@@ -280,3 +280,4 @@ InSubqueryExec,4.25
 AQEShuffleReadExec,4.25
 CheckOverflowInTableInsert,4.25
 ArrayFilter,1.5
+BoundReference,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-t4.csv
@@ -286,3 +286,4 @@ InSubqueryExec,4.88
 AQEShuffleReadExec,4.88
 CheckOverflowInTableInsert,4.88
 ArrayFilter,1.5
+BoundReference,1.5

--- a/core/src/main/resources/operatorsScore-emr-a10.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10.csv
@@ -286,3 +286,4 @@ InSubqueryExec,2.59
 AQEShuffleReadExec,2.59
 CheckOverflowInTableInsert,2.59
 ArrayFilter,1.5
+BoundReference,1.5

--- a/core/src/main/resources/operatorsScore-emr-a10G.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10G.csv
@@ -286,3 +286,4 @@ InSubqueryExec,2.59
 AQEShuffleReadExec,2.59
 CheckOverflowInTableInsert,2.59
 ArrayFilter,1.5
+BoundReference,1.5

--- a/core/src/main/resources/operatorsScore-emr-t4.csv
+++ b/core/src/main/resources/operatorsScore-emr-t4.csv
@@ -286,3 +286,4 @@ InSubqueryExec,2.07
 AQEShuffleReadExec,2.07
 CheckOverflowInTableInsert,2.07
 ArrayFilter,1.5
+BoundReference,1.5

--- a/core/src/main/resources/operatorsScore-onprem-a100.csv
+++ b/core/src/main/resources/operatorsScore-onprem-a100.csv
@@ -298,3 +298,4 @@ InSubqueryExec,4
 AQEShuffleReadExec,4
 CheckOverflowInTableInsert,4
 ArrayFilter,1.5
+BoundReference,1.5

--- a/core/src/main/resources/supportedExprs.csv
+++ b/core/src/main/resources/supportedExprs.csv
@@ -115,6 +115,8 @@ BitwiseXor,S,`^`,None,AST,result,NA,NS,NS,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,N
 BloomFilterMightContain,S,`might_contain`,None,project,lhs,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,S,NA,NA,NA,NA,NA,NA,NA
 BloomFilterMightContain,S,`might_contain`,None,project,rhs,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA
 BloomFilterMightContain,S,`might_contain`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+BoundReference,S, ,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
+BoundReference,S, ,None,AST,result,S,S,S,S,S,S,S,S,PS,S,NS,NS,NS,NS,NS,NS,NS,NS,S,S
 CaseWhen,S,`when`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
 CaseWhen,S,`when`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,NS,NS
 CaseWhen,S,`when`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,NS,NS


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/1045

**Changes**
Plugin added a new expression `BoundReference`. This PR adds its support in tools.

**Notes**
- This PR updates support for an expression, so we don't need to add new parser.
- This PR does not add unit tests because `BoundReference` is not a sql function. After several iterations, I couldn't reproduce this expression in an eventlog.