### PR TITLE
Include entry points for internal usage

### DIFF
--- a/user_tools/docs/qualx.md
+++ b/user_tools/docs/qualx.md
@@ -21,7 +21,12 @@ spark_rapids prediction --qual_output </path/to/qual_output> --prof_output </pat
 
 To train an XGBoost model on the specific dataset, follow these steps below. Refer to [Getting Started](../README.md#getting-started) section for installing the required dependencies for training.
 
-Set the following environment variables:
+#### Data Preparation
+TODO
+
+#### Environment Setup
+
+Training requires the following environment variables to be set:
 ```bash
 export SPARK_HOME=/path/to/spark
 export SPARK_RAPIDS_TOOL_JAR=/path/to/rapids-4-spark-tools-0.1.0-SNAPSHOT.jar
@@ -29,7 +34,7 @@ export QUALX_DATA_DIR=/path/to/qualx/datasets
 export QUALX_CACHE_DIR=/path/to/qualx/cache
 ```
 
-Run the following command to train the model:
+#### Command
 ```bash
 spark_rapids train --dataset </path/to/dataset/files(s)> --model </path/to/save/trained/model> --output_folder </path/to/save/csv/files> --n_trials <number_of_trials>
 ```
@@ -41,5 +46,5 @@ spark_rapids train --dataset </path/to/dataset/files(s)> --model </path/to/save/
 - n_trials: Number of trials for hyperparameter search.
 
 ## Notes
-- `QUALX_DATA_DIR` should be a valid path containing the training data (e.g., from SwiftStack).
+- `QUALX_DATA_DIR` should be a valid local path containing the training data.
 - `QUALX_CACHE_DIR` stores intermediate files generated during processing (e.g., profiling output). It will be created automatically if it does not exist.

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -18,7 +18,7 @@
 import fire
 
 from spark_rapids_tools.cmdli.argprocessor import AbsToolUserArgModel
-from spark_rapids_tools.enums import QualGpuClusterReshapeType
+from spark_rapids_tools.enums import QualGpuClusterReshapeType, CspEnv
 from spark_rapids_tools.utils.util import gen_app_banner, init_environment
 from spark_rapids_pytools.common.utilities import Utils, ToolLogging
 from spark_rapids_pytools.rapids.bootstrap import Bootstrap
@@ -299,8 +299,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
               dataset: str = None,
               model: str = None,
               output_folder: str = None,
-              n_trials: int = 200,
-              platform: str = 'onprem'):
+              n_trials: int = 200):
         """The train cmd trains an XGBoost model on the input data to estimate the speedup of a
          Spark CPU application.
 
@@ -308,15 +307,13 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         :param model: Path to save the trained XGBoost model.
         :param output_folder: Path to store the output.
         :param n_trials: Number of trials for hyperparameter search.
-        :param platform: Defines one of the following "onprem", "dataproc", "databricks-aws",
-                         and "databricks-azure", default to "onprem".
         """
         # Since train is an internal tool with frequent output, we enable debug mode by default
         ToolLogging.enable_debug_mode()
         init_environment('train')
 
         train_args = AbsToolUserArgModel.create_tool_args('train',
-                                                          platform=platform,
+                                                          platform=CspEnv.get_default(),
                                                           dataset=dataset,
                                                           model=model,
                                                           output_folder=output_folder,

--- a/user_tools/src/spark_rapids_tools/tools/qualx/model.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/model.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, List, Tuple
+from typing import Callable, Optional, List, Tuple
 import numpy as np
 import pandas as pd
 import random
@@ -122,7 +122,7 @@ def predict(
     cpu_aug_tbl: pd.DataFrame,
     feature_cols: List[str],
     label_col: str,
-    output_info: dict
+    output_info: Optional[dict] = None,
 ) -> pd.DataFrame:
     """Use model to predict on feature data."""
     model_features = xgb_model.feature_names
@@ -141,8 +141,9 @@ def predict(
     y_pred = xgb_model.predict(dmat)
 
     # compute SHAPley values for the model
-    shap_values_output_file = output_info['shapValues']['path']
-    compute_shapley_values(xgb_model, X, feature_cols, shap_values_output_file)
+    if output_info:
+        shap_values_output_file = output_info['shapValues']['path']
+        compute_shapley_values(xgb_model, X, feature_cols, shap_values_output_file)
 
     if LOG_LABEL:
         y_pred = np.exp(y_pred)


### PR DESCRIPTION
This PR adds remaining add-ons as part of QualX migrations.

## Changes
1. Add internal CLI for evaluate, compare
2. Add a wrapper around predict to be used by the internal CLI
3. Remove platform argument from external train CMD.
4. Minor changes in docs.

## Test
Following CMDs have been tested:


### Public Interface:
```
spark_rapids qualification --platform <platform>  --eventlogs </path/to/logs> --estimation_model xgboost --tools_jar $SPARK_RAPIDS_TOOLS_JAR --verbose
spark_rapids prediction --qual_output </path/to/qual_2024xxx> --prof_output </path/to/qual_2024xxx> --output_folder qualx_runs
spark_rapids train --dataset </path/dataset.json> --model my_model.json --output_folder qualx_runs --n_trials 20
```

### Internal Usage:
```
python qualx_main.py train --dataset </path/dataset.json> --model my_model.json --output_dir qualx_runs --n_trials 20
python qualx_main.py predict --platform onprem --profile </path/to/qual_2024xxx> --output_dir qualx_runs
```

