### PR TITLE
Reduce the maximum number of Java threads in CLI

### DIFF
--- a/user_tools/src/spark_rapids_tools/utils/util.py
+++ b/user_tools/src/spark_rapids_tools/utils/util.py
@@ -257,7 +257,7 @@ class Utilities:
         # Maximum number of threads that can be used in the tools JVM.
         # cpu_count returns the logical number of cores. So, we take a 50% to get better representation
         # of physical cores.
-        return min(6, (psutil.cpu_count() + 1) // 2)
+        return min(3, (psutil.cpu_count() + 1) // 2)
 
     @classmethod
     def adjust_tools_resources(cls,


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1079

Changes the maximum number of java threads to 3 (it was 6 before).