### PR TITLE
Fix java Qual tool Autotuner output when GPU device is missing

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -39,10 +39,13 @@ object PlatformNames {
    * Return a list of all supported platform names.
    */
   def getAllNames: List[String] = List(
-    DATABRICKS_AWS, DATABRICKS_AZURE, DATAPROC, EMR, ONPREM,
-    s"$DATAPROC-$L4Gpu", s"$DATAPROC-$T4Gpu",
-    s"$DATAPROC_GKE-$L4Gpu", s"$DATAPROC_GKE-$T4Gpu",
-    s"$DATAPROC_SL-$L4Gpu", s"$EMR-$A10Gpu", s"$EMR-$T4Gpu"
+    DATABRICKS_AWS, s"$DATABRICKS_AWS-$A10GGpu", s"$DATABRICKS_AWS-$T4Gpu",
+    DATABRICKS_AZURE, s"$DATABRICKS_AZURE-$T4Gpu",
+    DATAPROC, s"$DATAPROC-$L4Gpu", s"$DATAPROC-$T4Gpu",
+    DATAPROC_GKE, s"$DATAPROC_GKE-$L4Gpu", s"$DATAPROC_GKE-$T4Gpu",
+    DATAPROC_SL, s"$DATAPROC_SL-$L4Gpu",
+    EMR, s"$EMR-$A10Gpu", s"$EMR-$A10GGpu", s"$EMR-$T4Gpu",
+    ONPREM, s"$ONPREM-$A100Gpu"
   )
 }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -73,7 +73,7 @@ class GpuWorkerProps(
   }
   def setDefaultGpuNameIfMissing(platform: Platform): Boolean = {
     if (!GpuDevice.deviceMap.contains(name)) {
-      name = platform.defaultGpuDevice.toString
+      name = platform.gpuDevice.getOrElse(platform.defaultGpuDevice).toString
       true
     } else {
       false


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/1030

**Problem**
Java Qual tool Autotuner outputs inconsistent results when GPU device is not provided in worker info file (`--worker-info`) and platform is set to `databricks-aws-t4`:
- `- GPU device is missing. Setting default to a10G.`
- `--conf spark.rapids.sql.concurrentGpuTasks=2 ` -> indicates GPU is T4

**Changes**
- When setting default GPU if name is missing, autotuner should consider the GPU device provided in the platform first
- Make platform list more exhaustive

**Testing**
```
export TOOLS_JAR
export EVENTLOGS
export WORKER_INFO_FILE
java -XX:+UseG1GC -Xmx50g -cp $TOOLS_JAR:$SPARK_HOME/jars/* com.nvidia.spark.rapids.tool.qualification.QualificationMain --platform databricks-aws-t4 --num-threads 6 --auto-tuner --worker-info $WORKER_INFO_FILE $EVENTLOGS
```

In `WORKER_INFO_FILE`:
```
system:
  numCores: 32
  memory: 131072MiB
  numWorkers: 4
softwareProperties:
  spark.scheduler.mode: FAIR
  spark.sql.cbo.enabled: 'true'
  spark.ui.port: '0'
  spark.yarn.am.memory: 640m
```