### PR TITLE
Update QualX to return default speedups and fix App Duration for incomplete apps

### DIFF
--- a/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
@@ -413,7 +413,7 @@ def extract_raw_features(
     if empty_tables:
         empty_tables_str = ', '.join(empty_tables)
         log_fallback(logger, unique_app_ids,
-                     fallback_reason=f'Empty feature tables found: {empty_tables_str}')
+                     fallback_reason=f'Empty feature tables found after preprocessing: {empty_tables_str}')
         return pd.DataFrame()
 
     # normalize dtypes

--- a/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
@@ -265,6 +265,7 @@ def load_profiles(
     profile_dir: Optional[str] = None,
     node_level_supp: Optional[pd.DataFrame] = None,
     qualtool_filter: Optional[str] = None,
+    qualtool_output: Optional[pd.DataFrame] = None,
 ) -> pd.DataFrame:
     """Load dataset profiler CSV files as a pd.DataFrame."""
 
@@ -337,7 +338,7 @@ def load_profiles(
             raise ValueError(f'No CSV files found for: {ds_name}')
         else:
             toc = pd.concat(toc_list)
-            raw_features = extract_raw_features(toc, node_level_supp, qualtool_filter)
+            raw_features = extract_raw_features(toc, node_level_supp, qualtool_filter, qualtool_output)
             if raw_features.empty:
                 continue
             # add scaleFactor from toc or from sqlID ordering within queries grouped by query name and app
@@ -381,12 +382,13 @@ def extract_raw_features(
     toc: pd.DataFrame,
     node_level_supp: Optional[pd.DataFrame],
     qualtool_filter: Optional[str],
+    qualtool_output: Optional[pd.DataFrame] = None,
 ) -> pd.DataFrame:
     """Given a pandas dataframe of CSV files, extract raw features into a single dataframe keyed by (appId, sqlID)."""
     # read all tables per appId
     unique_app_ids = toc['appId'].unique()
     appId_tables = [
-        load_csv_files(toc, appId, node_level_supp, qualtool_filter)
+        load_csv_files(toc, appId, node_level_supp, qualtool_filter, qualtool_output)
         for appId in unique_app_ids
     ]
 
@@ -735,6 +737,7 @@ def load_csv_files(
     app_id: str,
     node_level_supp: Optional[pd.DataFrame],
     qualtool_filter: Optional[str],
+    qualtool_output: Optional[pd.DataFrame],
 ) -> List[Mapping[str, pd.DataFrame]]:
     """
     Load profiler CSV files into memory.
@@ -759,8 +762,18 @@ def load_csv_files(
     # Merge summary tables within each appId:
     sgl_app = toc[toc['appId'] == app_id]
 
+    qual_tool_app_duration = pd.DataFrame()
+    # CSV metrics from the profiling tool does not have app duration for incomplete applications.
+    # Qualification tool provides an estimated app duration for these. We should replace the app
+    # duration from CSV metrics with the estimated app duration from the qualification tool output.
+    if qualtool_output is not None:
+        qual_tool_app_duration = qualtool_output.loc[qualtool_output['App ID'] == app_id, 'App Duration']
+
     # Load summary tables:
     app_info = scan_tbl('application_information')
+    if not app_info.empty and not qual_tool_app_duration.empty:
+        # TODO: Update 'durationStr' if it is included as a model feature in the future.
+        app_info['duration'] = qual_tool_app_duration.iloc[0]
 
     # Allow user-provided 'test_name' as 'appName'
     # appName = app_info['appName'].iloc[0]
@@ -803,6 +816,9 @@ def load_csv_files(
 
     sql_duration = scan_tbl('sql_duration_and_executor_cpu_time_percent')
     if not sql_duration.empty:
+        # Replace app duration with the app duration from the qualification tool output. See details above.
+        if not qual_tool_app_duration.empty:
+            sql_duration['App Duration'] = qual_tool_app_duration.iloc[0]
         sql_duration = sql_duration.rename(
             {
                 'App Duration': 'appDuration',

--- a/user_tools/src/spark_rapids_tools/tools/qualx/util.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/util.py
@@ -308,3 +308,50 @@ def print_speedup_summary(dataset_summary: pd.DataFrame):
     print("\nReport Summary:")
     print(tabulate(summary_df, colalign=("left", "right")))
     print()
+
+
+def create_row_with_default_speedup(app: pd.Series) -> pd.Series:
+    """
+    Create a default row for an app with no speedup prediction.
+    """
+    return pd.Series({
+        'appName': app['App Name'],
+        'appId': app['App ID'],
+        'appDuration': app['App Duration'],
+        'Duration': 0,
+        'Duration_pred': 0,
+        'Duration_supported': 0,
+        'fraction_supported': 0.0,
+        'appDuration_pred': app['App Duration'],
+        'speedup': 1.0,
+    })
+
+
+def write_csv_reports(per_sql: pd.DataFrame, per_app: pd.DataFrame, output_info: dict):
+    """
+    Write per-SQL and per-application predictions to CSV files
+    """
+    try:
+        if per_sql is not None:
+            sql_predictions_path = output_info['perSql']['path']
+            logger.info(f'Writing per-SQL predictions to: {sql_predictions_path}')
+            per_sql.to_csv(sql_predictions_path, index=False)
+    except Exception as e:
+        logger.error(f'Error writing per-SQL predictions. Reason: {e}')
+
+    try:
+        if per_app is not None:
+            app_predictions_path = output_info['perApp']['path']
+            logger.info(f'Writing per-application predictions to: {app_predictions_path}')
+            per_app.to_csv(app_predictions_path, index=False)
+    except Exception as e:
+        logger.error(f'Error writing per-app predictions. Reason: {e}')
+
+
+def log_fallback(logger_obj: logging.Logger, app_ids: List[str], fallback_reason: str):
+    """
+    Log a warning message for a fallback during preprocessing.
+    This function expects logger object to log the source module of the warning.
+    """
+    app_id_str = ', '.join(app_ids)
+    logger_obj.warning(f'Predicted speedup will be 1.0 for {app_id_str}. Reason: {fallback_reason}.')


### PR DESCRIPTION
Fixes #1058, 

## Issues

### Issue 1:

In QualX, we fallback to legacy speedups if the metrics are unavailable (file not found or empty after preprocessing). This PR updates the prediction code to return a speedup of 1 for such apps and logs the reason for missing metrics.

We also introduce a column `wasPredicted` in `per_app.csv` as marker for apps that could not be predicted.

#### Affects: 
predict()

### Issue 2:

In QualX, CSV metrics from the profiling tool does not have app duration for incomplete applications. Qualification tool provides an estimated app duration for these. 

This PR updates QuaX to replace the incorrect app duration in CSV metrics with the estimated duration from the qualification tool output.

#### Affects: 
train(), compare() and predict()


## Output:
<br/>

CASE 1: No supported stages for all apps in the dataset(in this case, single eventlog)
```
WARNING spark_rapids_tools.tools.qualx.preprocess: Predicted speedup will be 1.0 for application_171615xxxx. Reason: No fully supported stages found.
WARNING spark_rapids_tools.tools.qualx.qualx_main: Predicted speedup will be 1.0 for dataset: qual_20240607xxxx. Check logs for details.
```
<br/>

CASE 2: Metrics unavailable for all apps in the dataset(in this case, single eventlog)
```
WARNING spark_rapids_tools.tools.qualx.preprocess: Predicted speedup will be 1.0 for application_1715312822xxx. Reason: Empty feature tables found after preprocessing: application_information, sql_plan_metrics_for_application, job_+_stage_level_aggregated_task_metrics.
WARNING spark_rapids_tools.tools.qualx.qualx_main: Predicted speedup will be 1.0 for dataset: qual_202406071648xxx. Check logs for details.
```
<br/>

CASE 3: Metrics unavailable for some apps in the dataset (cannot calculate exact reason, showing a broad reason):
```
WARNING spark_rapids_tools.tools.qualx.preprocess: Predicted speedup will be 1.0 for application_1715312822xxx, application_1715312822xxx. Reason: Missing features after preprocessing.
```


### Predicted CSV File:

`per_app.csv`

```
|------------------------------|----------------------------|-------------|----------|---------------|--------------------|--------------------|------------------|-------------------|--------------|
| appName                      | appId                      | appDuration | Duration | Duration_pred | Duration_supported | fraction_supported | appDuration_pred | speedup           | wasPredicted |
|------------------------------|----------------------------|-------------|----------|---------------|--------------------|--------------------|------------------|-------------------|--------------|
| qual_20240607155643_e91fB6D3 | application_1686676198xxxx |      887621 |   820739 |        116175 |             820739 | 0.9246502730331977 |           183057 | 4.848855613929893 | True         |
|------------------------------|----------------------------|-------------|----------|---------------|--------------------|--------------------|------------------|-------------------|--------------|
| NDS - Power Run              | application_1715312822xxxx |       46911 |        0 |             0 |                  0 |                0.0 |            46911 |               1.0 | False        |
|------------------------------|----------------------------|-------------|----------|---------------|--------------------|--------------------|------------------|-------------------|--------------|
| NDS - Power Run              | application_1715312822xxxx |       30507 |        0 |             0 |                  0 |                0.0 |            30507 |               1.0 | False        |
|------------------------------|----------------------------|-------------|----------|---------------|--------------------|--------------------|------------------|-------------------|--------------|
```
