### PR TITLE
Handle QualX behaviour when Qual Tool does not generate any outputs

### DIFF
--- a/user_tools/docs/qualx.md
+++ b/user_tools/docs/qualx.md
@@ -29,7 +29,7 @@ TODO
 Training requires the following environment variables to be set:
 ```bash
 export SPARK_HOME=/path/to/spark
-export SPARK_RAPIDS_TOOL_JAR=/path/to/rapids-4-spark-tools-0.1.0-SNAPSHOT.jar
+export SPARK_RAPIDS_TOOLS_JAR=/path/to/rapids-4-spark-tools-0.1.0-SNAPSHOT.jar
 export QUALX_DATA_DIR=/path/to/qualx/datasets
 export QUALX_CACHE_DIR=/path/to/qualx/cache
 ```

--- a/user_tools/src/spark_rapids_pytools/rapids/qualx/prediction.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualx/prediction.py
@@ -62,11 +62,12 @@ class Prediction(QualXTool):
             output_info = self.__prepare_prediction_output_info()
             df = predict(platform=self.platform_type.map_to_java_arg(), qual=self.qual_output,
                          output_info=output_info)
-            print_summary(df)
-            print_speedup_summary(df)
-            df.to_csv(f'{self.output_folder}/prediction.csv', float_format='%.2f')
-            self.logger.info('Prediction completed successfully.')
-            self.logger.info('Prediction results are generated at: %s', self.output_folder)
+            if not df.empty:
+                print_summary(df)
+                print_speedup_summary(df)
+                df.to_csv(f'{self.output_folder}/prediction.csv', float_format='%.2f')
+                self.logger.info('Prediction completed successfully.')
+                self.logger.info('Prediction results are generated at: %s', self.output_folder)
         except Exception as e:  # pylint: disable=broad-except
             self.logger.error('Prediction failed with error: %s', e)
             raise e

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -434,8 +434,8 @@ def predict(
     default_preds_df['dataset_name'] = None
 
     # if qualification metrics are provided, load metrics and apply filtering
+    processed_dfs = {}
     if len(qual_metrics) > 0:
-        processed_dfs = {}
         for metrics_dir in qual_metrics:
             datasets = {}
             # add metrics directory to datasets
@@ -474,10 +474,13 @@ def predict(
                 except ScanTblError:
                     # ignore
                     logger.error(f'Skipping invalid dataset: {dataset_name}')
+    else:
+        logger.warning('Qualification tool metrics are missing. Speedup predictions will be skipped.')
+        return pd.DataFrame()
 
     if not processed_dfs:
-        # this is an error condition and we should not fall back to the default predictions.
-        raise ValueError('No data with metrics found.')
+        # this is an error condition, and we should not fall back to the default predictions.
+        raise ValueError('Data preprocessing resulted in an empty dataset. Speedup predictions will be skipped.')
 
     # predict on each input dataset
     dataset_summaries = []


### PR DESCRIPTION
Fixes #1094.

In QualX, if there are no outputs from Qualification Tool, we raise an exception. The same exception will be thrown when there is no data after preprocessing. This is not ideal and we should differentiate the two cases.

This PR changes the behaviour:
- If there are no outputs from Qual tool, showing a warning and return an empty dataset. 
- If there is no data after preprocessing, we would raise a `ValueError` in that scenario.


## Output:
### Case: Qual Tool does not generate any output
```
WARNING spark_rapids_tools.tools.qualx.qualx_main: Qualification tool metrics are missing. Speedup predictions will be skipped.
```
