### PR TITLE
clip appDuration to at least Duration

### DIFF
--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -145,6 +145,7 @@ def _compute_summary(results):
     # compute the fraction of app duration w/ supported ops
     # without qual tool output, this is the entire SQL duration
     # with qual tool output, this is the fraction of SQL w/ supported ops
+    summary['appDuration'] = summary['appDuration'].clip(lower=summary['Duration'])
     summary['fraction_supported'] = (
         summary['Duration_supported'] / summary['appDuration']
     )


### PR DESCRIPTION
This PR fixes any possible negative predictions by clipping appDuration to be no less than Duration.  This is only a corner case.

## Changes
1. clip value of appDuration to be no less than Duration.

## Test
Following CMDs have been tested:

### Internal Usage:
```
python qualx_main.py predict
python qualx_main.py evaluate
```

