### PR TITLE
Fix qualx app metrics

### DIFF
--- a/user_tools/src/spark_rapids_tools/tools/qualx/model.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/model.py
@@ -176,7 +176,7 @@ def predict(
     if 'y' in results_df.columns:
         # reconstruct original gpu duration for validation purposes
         results_df['gpuDuration'] = results_df['Duration'] / results_df['y']
-        results_df["gpuDuration"] = np.floor(results_df['gpuDuration'])
+        results_df['gpuDuration'] = np.floor(results_df['gpuDuration'])
 
     # adjust raw predictions with stage/sqlID filtering of unsupporteds
     results_df['Duration_pred'] = results_df['Duration'] * (
@@ -239,7 +239,7 @@ def extract_model_features(
                 'description',
             ]
         ]
-        gpu_aug_tbl = gpu_aug_tbl.rename(columns={"Duration": "xgpu_Duration"})
+        gpu_aug_tbl = gpu_aug_tbl.rename(columns={'Duration': 'xgpu_Duration'})
         cpu_aug_tbl = cpu_aug_tbl.merge(
             gpu_aug_tbl,
             on=['appName', 'scaleFactor', 'sqlID', 'description'],

--- a/user_tools/src/spark_rapids_tools/tools/qualx/model.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/model.py
@@ -176,9 +176,7 @@ def predict(
     if 'y' in results_df.columns:
         # reconstruct original gpu duration for validation purposes
         results_df['gpuDuration'] = results_df['Duration'] / results_df['y']
-        results_df["gpuDuration"] = np.floor(
-            results_df["gpuDuration"]
-        )  # .astype("long")
+        results_df["gpuDuration"] = np.floor(results_df['gpuDuration'])
 
     # adjust raw predictions with stage/sqlID filtering of unsupporteds
     results_df['Duration_pred'] = results_df['Duration'] * (

--- a/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
@@ -366,6 +366,10 @@ def load_profiles(
                     if 'description' in meta
                 }
                 raw_features['description'] = raw_features['appId'].map(app_desc)
+                # append also to appName to allow joining cpu and gpu logs at the app level
+                raw_features['appName'] = (
+                    raw_features['appName'] + '_' + raw_features['description']
+                )
 
             # add platform from app_meta
             raw_features[f'platform_{platform}'] = 1

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -126,21 +126,27 @@ def _compute_summary(results):
         'appName',
         'appId',
         'appDuration',
+        'description',
         'Duration',
         'Duration_pred',
         'Duration_supported',
-        # actual
-        'gpuDuration',
-        'xgpu_appDuration',
     ]
     cols = [col for col in result_cols if col in results.columns]
     # compute per-app stats
     group_by_cols = ['appName', 'appId', 'appDuration']
-    if 'xgpu_appDuration' in results:
-        group_by_cols.append('xgpu_appDuration')
-    summary = results[cols].groupby(group_by_cols).sum().reset_index()
-    if 'gpuDuration' in summary:
-        summary['gpuDuration'] = summary['gpuDuration'].replace(0.0, np.nan)
+    summary = (
+        results[cols]
+        .groupby(group_by_cols)
+        .agg(
+            {
+                'Duration': 'sum',
+                'Duration_pred': 'sum',
+                'Duration_supported': 'sum',
+                'description': 'first',
+            }
+        )
+        .reset_index()
+    )
 
     # compute the fraction of app duration w/ supported ops
     # without qual tool output, this is the entire SQL duration
@@ -156,15 +162,6 @@ def _compute_summary(results):
     )
     # compute the per-app speedup
     summary['speedup'] = summary['appDuration'] / summary['appDuration_pred']
-
-    # for datasets w/ labels, reconstruct actual speedup per-app
-    # TODO: get this from actual CSV file?
-    if 'y' in results:
-        assert 'xgpu_appDuration' in summary
-        summary = summary.rename({'xgpu_appDuration': 'appDuration_actual'}, axis=1)
-        summary['speedup_actual'] = (
-            summary['appDuration'] / summary['appDuration_actual']
-        )
 
     # fix dtypes
     long_cols = [
@@ -201,14 +198,11 @@ def _predict(
         try:
             results = predict_model(xgb_model, features, feature_cols, label_col)
 
-            # for evaluation purposes, impute actual GPU values if not provided
-            if 'y' not in results:
-                results['y'] = np.nan
-                results['gpuDuration'] = 0.0
-                results['xgpu_appDuration'] = 0.0
-
             # compute per-app speedups
             summary = _compute_summary(results)
+
+            if 'y' in results:
+                results = results.loc[~results.y.isna()].reset_index(drop=True)
         except XGBoostError as e:
             # ignore and continue
             logger.error(e)
@@ -679,6 +673,49 @@ def evaluate(
         split_fn=split_fn,
         qualtool_filter=qualtool_filter,
     )
+    # join raw app data with app level gpu ground truth
+    app_durations = (
+        profile_df.loc[profile_df.runType == 'GPU'][
+            ['appName', 'appDuration', 'description']
+        ]
+        .groupby(['appName', 'appDuration'])
+        .first()
+        .reset_index()
+    )
+    app_durations = app_durations.rename(columns={'appDuration': 'gpu_appDuration'})
+
+    # handle query per app and regular app differently.
+    # For the former, we need to use query description field to join cpu and gpu data
+    # since appname is the same for all queries/apps in these case.
+
+    raw_app_regular = raw_app.loc[~raw_app.appName.str.contains('query_per_app')]
+    raw_app_q_per_app = raw_app.loc[raw_app.appName.str.contains('query_per_app')]
+    app_durations_regular = app_durations.loc[
+        ~app_durations.appName.str.contains('query_per_app')
+    ][['appName', 'gpu_appDuration']]
+    app_durations_q_per_app = app_durations.loc[
+        app_durations.appName.str.contains('query_per_app')
+    ]
+
+    raw_app_regular = raw_app_regular.merge(
+        app_durations_regular[['appName', 'gpu_appDuration']],
+        on=['appName'],
+        how='left',
+    )
+    raw_app_q_per_app = raw_app_q_per_app.merge(
+        app_durations_q_per_app, on=['appName', 'description'], how='left'
+    )
+
+    raw_app = pd.concat([raw_app_regular, raw_app_q_per_app])
+
+    if not raw_app.loc[raw_app.gpu_appDuration.isna()].empty:
+        logger.error(
+            f'missing gpu apps: {raw_app.loc[raw_app.gpu_appDuration.isna()].to_markdown()}'
+        )
+        raise ValueError('Some cpu apps with no gpu ground truth.')
+
+    raw_app = raw_app.rename({'gpu_appDuration': 'appDuration_actual'}, axis=1)
+    raw_app['speedup_actual'] = raw_app['appDuration'] / raw_app['appDuration_actual']
 
     # adjusted prediction on filtered data
     filtered_sql, filtered_app = _predict(


### PR DESCRIPTION
From @eordentlich, this PR fixes per-app aggregations, specifically for QX (raw xgboost) metrics on datasets where the sqlIDs may be misaligned.

## Changes
1. defer GPU appDuration calculations to per-app aggregations post prediction vs. carrying per-sql pre-prediction.
1. add `scaleFactor` to the per-app aggregations.
2. add `description` to the `appName` when overridding descriptions to allow CPU/GPU joining.
3. fix loading model by name.

## Test
Following CMDs have been tested:

### Internal Usage:
```
python qualx_main.py predict
python qualx_main.py evaluate
```

