### PR TITLE
Fix nan label issue in training

### DIFF
--- a/user_tools/src/spark_rapids_tools/tools/qualx/model.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/model.py
@@ -71,6 +71,16 @@ def train(
         cpu_aug_tbl = cpu_aug_tbl.copy()
         cpu_aug_tbl[label_col] = np.log(cpu_aug_tbl[label_col])
 
+    # remove nan label entries
+    original_num_rows = cpu_aug_tbl.shape[0]
+    cpu_aug_tbl = cpu_aug_tbl.loc[~cpu_aug_tbl[label_col].isna()].reset_index(
+        drop=True
+    )
+    if cpu_aug_tbl.shape[0] < original_num_rows:
+        logger.warn(
+            f'Removed {original_num_rows - cpu_aug_tbl.shape[0]} rows with NaN label values'
+        )
+
     # split into train/val/test sets
     X_train = cpu_aug_tbl.loc[cpu_aug_tbl['split'] == 'train', feature_cols]
     y_train = cpu_aug_tbl.loc[cpu_aug_tbl['split'] == 'train', label_col]


### PR DESCRIPTION
This PR fixes a regression in training introduced in #1102.

## Changes
1. Add back code to remove rows w/ NaN labels (but relocated inside the `train()` method).

## Test
Following CMDs have been tested:

### Internal Usage:
```
python qualx_main.py preprocess
python qualx_main.py predict
python qualx_main.py train
python qualx_main.py evaluate
python qualx_main.py compare
```