### PR TITLE
user-tools: Update log messages

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -394,7 +394,7 @@ class RapidsJarTool(RapidsTool):
                                                                 self.ctxt.get_local_work_dir(),
                                                                 fail_ok=False,
                                                                 create_dir=True)
-        self.logger.info('RAPIDS accelerator jar is downloaded to work_dir %s', jar_path)
+        self.logger.info('RAPIDS accelerator tools jar is downloaded to work_dir %s', jar_path)
         # get the jar file name
         jar_file_name = FSUtil.get_resource_name(jar_path)
         version_match = re.search(r'\d{2}\.\d{2}\.\d+', jar_file_name)

--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -167,6 +167,7 @@ class AbsToolUserArgModel:
         ev_logs_path = CspPath(self.get_eventlogs().split(',')[0])
         storage_type = ev_logs_path.get_storage_name()
         self.p_args['toolArgs']['platform'] = map_storage_to_platform[storage_type]
+        self.logger.info('Detected platform from eventlogs prefix: %s', self.p_args['toolArgs']['platform'].name)
 
     def validate_onprem_with_cluster_name(self):
         # this field has already been populated during initialization
@@ -319,7 +320,7 @@ class ToolUserArgModel(AbsToolUserArgModel):
                 [ArgValueCase.VALUE_A, ArgValueCase.VALUE_B, ArgValueCase.UNDEFINED]
             ]
         }
-        self.rejected['Invalid Jar Argument'] = {
+        self.rejected['Jar Argument'] = {
             'valid': False,
             'callable': partial(self.validate_jar_argument_is_valid),
             'cases': [


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids-tools/issues/977

This is a small PR that updates some of the confusing log messages mentioned in the above issue. 
This PR also logs the message about detected platform based on eventlogs. 

```
 2024-06-11 19:37:47,434 INFO spark_rapids_tools.argparser: ...applying argument case: Jar Argument
2024-06-11 19:37:47,435 INFO spark_rapids_tools.argparser: ...applying argument case: Define Platform based on Eventlogs prefix
2024-06-11 19:37:55,577 INFO spark_rapids_tools.argparser: Detected platform from eventlogs prefix: EMR

```

<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
