### PR TITLE
Fix typo in Profiler class using qual instead of prof

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
@@ -536,7 +536,7 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
       profileOutputWriter.write(skewHeader, app.skewInfo, tableDesc = Some(skewTableDesc))
 
       profileOutputWriter.writeText("\n### C. Health Check###\n")
-      profileOutputWriter.write(QualFailedTaskView.getLabel, app.failedTasks)
+      profileOutputWriter.write(ProfFailedTaskView.getLabel, app.failedTasks)
       profileOutputWriter.write(ProfFailedStageView.getLabel, app.failedStages)
       profileOutputWriter.write(ProfFailedJobsView.getLabel, app.failedJobs)
       profileOutputWriter.write(ProfRemovedBLKMgrView.getLabel, app.removedBMs)


### PR DESCRIPTION
Fixes a minor typo in the Profiler class