### PR TITLE
Disable the spark_rapids bootstrap command

### DIFF
--- a/user_tools/README.md
+++ b/user_tools/README.md
@@ -6,14 +6,12 @@ The wrapper improves end-user experience within the following dimensions:
 1. **Qualification**: Educate the CPU customer on the cost savings and acceleration potential of RAPIDS Accelerator for
    Apache Spark. The output shows a list of apps recommended for RAPIDS Accelerator for Apache Spark with estimated savings
    and speed-up.
-2. **Bootstrap**: Provide optimized RAPIDS Accelerator for Apache Spark configs based on GPU cluster shape. The output
-   shows updated Spark config settings on driver node.
-3. **Tuning**: Tune RAPIDS Accelerator for Apache Spark configs based on initial job run leveraging Spark event logs. The output
+2. **Tuning**: Tune RAPIDS Accelerator for Apache Spark configs based on initial job run leveraging Spark event logs. The output
    shows recommended per-app RAPIDS Accelerator for Apache Spark config settings.
-4. **Diagnostics**: Run diagnostic functions to validate the Dataproc with RAPIDS Accelerator for Apache Spark environment to
+3. **Diagnostics**: Run diagnostic functions to validate the Dataproc with RAPIDS Accelerator for Apache Spark environment to
    make sure the cluster is healthy and ready for Spark jobs.
-5. **Prediction**: Predict the speedup of running a Spark application with Spark RAPIDS on GPUs.
-6. **Train**: Train a model to predict the performance of a Spark job on RAPIDS Accelerator for Apache Spark. The output shows
+4. **Prediction**: Predict the speedup of running a Spark application with Spark RAPIDS on GPUs.
+5. **Train**: Train a model to predict the performance of a Spark job on RAPIDS Accelerator for Apache Spark. The output shows
    the model file that can be used to predict the performance of a Spark job.
 
 

--- a/user_tools/docs/index.md
+++ b/user_tools/docs/index.md
@@ -23,16 +23,6 @@ averaging duration metrics accordingly.
 For more details, please visit the
 [Qualification Tool guide](https://docs.nvidia.com/spark-rapids/user-guide/latest/qualification/overview.html).
 
-### Bootstrap
-
-Provides optimized RAPIDS Accelerator for Apache Spark configs based on GPU cluster shape.
-This tool is supposed to be used once a cluster has been created to set the recommended configurations.  The tool
-will apply settings for the cluster assuming that jobs will run serially so that each job can use up all the
-cluster resources (CPU and GPU) when it is running.
-
-Note that the command may require `SSH` access on the cluster nodes to read the GPU settings and to update
-Apache Spark default configurations.
-
 ### Profiling
 
 Provides a wrapper to simplify the execution of [RAPIDS Profiling tool](https://docs.nvidia.com/spark-rapids/user-guide/latest/profiling/overview.html).
@@ -89,9 +79,6 @@ The following table summarizes the commands supported for each cloud platform:
 |                  | profiling     | spark_rapids_user_tools \               | 23.02.1+ |
 |                  |               |   dataproc profiling [ARGS]             |          |
 |                  +---------------+-----------------------------------------+----------+
-|                  | bootstrap     | spark_rapids_user_tools \               | 23.02.1+ |
-|                  |               |   dataproc bootstrap [ARGS]             |          |
-|                  +---------------+-----------------------------------------+----------+
 |                  | diagnostic    | spark_rapids_user_tools \               |  23.06+  |
 |                  |               |   dataproc diagnostic [ARGS]            |          |
 +------------------+---------------+-----------------------------------------+----------+
@@ -104,8 +91,6 @@ The following table summarizes the commands supported for each cloud platform:
 |                  | profiling     | spark_rapids_user_tools \               | 23.06.1+ |
 |                  |               |   databricks-aws profiling [ARGS]       |          |
 |                  +---------------+-----------------------------------------+----------+
-|                  | bootstrap     |               N/A                       |    TBD   |
-|                  +---------------+-----------------------------------------+----------+
 |                  | diagnostic    |               N/A                       |    TBD   |
 +------------------+---------------+-----------------------------------------+----------+
 | Databricks_Azure | qualification | spark_rapids_user_tools \               |  23.06+  |
@@ -114,16 +99,12 @@ The following table summarizes the commands supported for each cloud platform:
 |                  | profiling     | spark_rapids_user_tools \               | 23.06.2+ |
 |                  |               |   databricks-azure profiling [ARGS]     |          |
 |                  +---------------+-----------------------------------------+----------+
-|                  | bootstrap     |               N/A                       |    TBD   |
-|                  +---------------+-----------------------------------------+----------+
 |                  | diagnostic    |               N/A                       |    TBD   |
 +------------------+---------------+-----------------------------------------+----------+
 | OnPrem           | qualification | spark_rapids_user_tools \               |  23.06+  |
 |                  |               |   onprem qualification [ARGS]           |          |
 |                  +---------------+-----------------------------------------+----------+
 |                  | profiling     |               N/A                       |    TBD   |
-|                  +---------------+-----------------------------------------+----------+
-|                  | bootstrap     |               N/A                       |    TBD   |
 |                  +---------------+-----------------------------------------+----------+
 |                  | diagnostic    |               N/A                       |    TBD   |
 +------------------+---------------+-----------------------------------------+----------+

--- a/user_tools/docs/index.md
+++ b/user_tools/docs/index.md
@@ -67,9 +67,6 @@ The following table summarizes the commands supported for each cloud platform:
 |                  | profiling     | spark_rapids_user_tools \               |  23.08+  |
 |                  |               |   emr profiling [ARGS]                  |          |
 |                  +---------------+-----------------------------------------+----------+
-|                  | bootstrap     | spark_rapids_user_tools \               |  23.02+  |
-|                  |               |   emr bootstrap [ARGS]                  |          |
-|                  +---------------+-----------------------------------------+----------+
 |                  | diagnostic    | spark_rapids_user_tools \               |  23.06+  |
 |                  |               |   emr diagnostic [ARGS]                 |          |
 +------------------+---------------+-----------------------------------------+----------+

--- a/user_tools/docs/user-tools-aws-emr.md
+++ b/user_tools/docs/user-tools-aws-emr.md
@@ -12,7 +12,7 @@ the applications running on AWS EMR.
 - Install the AWS CLI version 2. Follow the instructions on [aws-cli-getting-started](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html)
 - Set the configuration settings and credentials of the AWS CLI by creating `credentials` and `config`
   files as described in [aws-cli-configure-files](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
-- In order to be able to run tools that require SSH on the EMR nodes (i.e., bootstrap), then:
+- In order to be able to run tools that require SSH on the EMR nodes then:
   - make sure that you have SSH access to the cluster nodes; and
   - create a key pair using Amazon EC2 through the AWS CLI command `aws ec2 create-key-pair`
     as instructed in [aws-cli-create-key-pairs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html).
@@ -44,7 +44,7 @@ Before running any command, you can set environment variables to specify configu
     caching the resources locally has an impact on the total execution time of the command.
   - `RAPIDS_USER_TOOLS_OUTPUT_DIRECTORY`: specifies the location of a local directory that the RAPIDS-cli uses to
     generate the output. The wrapper CLI arguments override that environment variable
-    (`--output_folder` and `local_folder` for Bootstrap and Qualification respectively).
+    (`local_folder` for Qualification).
 - For AWS CLI, some environment variables can be set and picked by the RAPIDS-user tools such as:
   `AWS_PROFILE`, `AWS_DEFAULT_REGION`, `AWS_CONFIG_FILE`, `AWS_SHARED_CREDENTIALS_FILE`. See the full list of variables in
   [aws-cli-configure-envvars](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).
@@ -308,69 +308,6 @@ The CLI is triggered by providing the location where the yaml file is stored `--
 
 Note that if the user does not supply a cluster or worker properties file, the autotuner will still recommend
 tuning settings based on the job event log.
-
-## Bootstrap command
-
-```
-spark_rapids_user_tools emr bootstrap [options]
-spark_rapids_user_tools emr bootstrap -- --help
-```
-
-The command generates an output with a list of properties to be applied to Spark configurations.
-In order to apply those recommendations, the cluster has to be running, and the user must have SSH
-access.
-
-### Bootstrap options
-
-| Option            | Description                                                                                                                                                                                                                 | Default                                                                                     | Required |
-|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|:--------:|
-| **cluster**       | Name of the EMR cluster running an accelerated computing instance                                                                                                                                                           | N/A                                                                                         |     Y    |
-| **profile**       | A named AWS profile that you can specify to get the settings/credentials of the AWS account.                                                                                                                                | "default" if the the env-variable `AWS_PROFILE` is not set                                  |     N    |
-| **output_folder** | Path to local directory where the final recommendations is logged                                                                                                                                                           | env variable `RAPIDS_USER_TOOLS_OUTPUT_DIRECTORY` if any; or the current working directory. |     N    |
-| **dry_run**       | True or False to update the Spark config settings on EMR master node                                                                                                                                                        | True                                                                                        |     N    |
-| **key_pair_path** | A '.pem' file path that enables to connect to EC2 instances using SSH. For more details on creating key pairs, visit [aws-create-key-pair-guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html) | env variable '`RAPIDS_USER_TOOLS_KEY_PAIR_PATH`' if any                                     |     N    |
-| **verbose**       | True or False to enable verbosity to the wrapper script                                                                                                                                                                     | False if `RAPIDS_USER_TOOLS_LOG_DEBUG` is not set                                           |     N    |
-
-### Dry-run enabled
-
-The default is to enable dry-run. This generates recommendations without any side effect. This mode helps to generate
-a map between cluster configuration and the recommended Spark properties.  
-Note that this mode:
-- does not require SSH access to the cluster
-- does not require the cluster to be active and running.
-
-1. User creates a cluster
-2. Run the following command
-
-    ```bash
-    spark_rapids_user_tools emr bootstrap \
-      --cluster my-cluster-name
-    ```
-
-### Dry-run disabled
-
-In some cases, the user may want to run this command as part of the initialization scripts.  
-The command update Sparks default-conf `/etc/spark/conf/spark-defaults.conf` requiring SSH access
-to the active cluster. The key-pair can be passed to the command through argument `key_pair_path`
-or the env-var `RAPIDS_USER_TOOLS_KEY_PAIR_PATH`.
-
-The steps to run the command:
-
-1. The user creates a cluster
-2. The user creates a key pair access "_.pem_" file as instructed in
-   [aws-create-key-pair-guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html)
-3. The user runs the following command:
-
-    ```bash
-    spark_rapids_user_tools emr bootstrap \
-      --cluster my-cluster-name \
-      --key_pair_path my-file-path \
-      --nodry_run
-    ```
-   If `key_pair_path` is missing, the user must set an ev-variable `RAPIDS_USER_TOOLS_KEY_PAIR_PATH`
-
-If the connection to EC2 instances cannot be established through SSH, the command will still
-generate an output while displaying warning that the remote changes failed. 
 
 ## Diagnostic command
 

--- a/user_tools/docs/user-tools-dataproc.md
+++ b/user_tools/docs/user-tools-dataproc.md
@@ -47,7 +47,7 @@ RAPIDS variables have a naming pattern `RAPIDS_USER_TOOLS_*`:
     Note that caching the resources locally has an impact on the total execution time of the command.
   - `RAPIDS_USER_TOOLS_OUTPUT_DIRECTORY`: specifies the location of a local directory that the RAPIDS-cli uses to
     generate the output. The wrapper CLI arguments override that environment variable
-    (`--output_folder` and `local_folder` for Bootstrap and Qualification respectively).
+    (`local_folder` for Qualification).
   
 ## Qualification command
 
@@ -325,62 +325,6 @@ The CLI is triggered by providing the location where the yaml file is stored `--
 
 Note that if the user does not supply a cluster or worker properties file, the autotuner will still recommend
 tuning settings based on the job event log.
-
-## Bootstrap command
-
-```
-spark_rapids_user_tools dataproc bootstrap [options]
-spark_rapids_user_tools dataproc bootstrap --help
-```
-
-The command generates an output with a list of properties to be applied to Spark configurations.
-In order to apply those recommendations, the cluster has to be running, and the user must have SSH
-access.
-
-### Bootstrap options
-
-| Option            | Description                                                               | Default                                                                                     | Required |
-|-------------------|---------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|:--------:|
-| **cluster**       | Name of the Dataproc cluster running an accelerated computing instance    | N/A                                                                                         |     Y    |
-| **output_folder** | Path to local directory where the final recommendations is logged         | env variable `RAPIDS_USER_TOOLS_OUTPUT_DIRECTORY` if any; or the current working directory. |     N    |
-| **dry_run**       | True or False to update the Spark config settings on Dataproc master node | True                                                                                        |     N    |
-| **verbose**       | True or False to enable verbosity to the wrapper script                   | False if `RAPIDS_USER_TOOLS_LOG_DEBUG` is not set                                           |     N    |
-
-### Dry-run enabled
-
-The default is to enable dry-run. This generates recommendations without any side effect. This mode helps to generate
-a map between cluster configuration and the recommended Spark properties.  
-Note that this mode:
-- does not require SSH access to the cluster
-- does not require the cluster to be active and running.
-
-1. User creates a cluster
-2. Run the following command
-
-    ```bash
-    spark_rapids_user_tools dataproc bootstrap \
-      --cluster my-cluster-name
-    ```
-
-### Dry-run disabled
-
-In some cases, the user may want to run this command as part of the initialization scripts.  
-The command update Sparks default-conf `/etc/spark/conf/spark-defaults.conf` SSH access
-to the active cluster.
-
-The steps to run the command:
-
-1. The user creates a cluster
-2. The user runs the following command:
-
-    ```bash
-    spark_rapids_user_tools dataproc bootstrap \
-      --cluster my-cluster-name \
-      --nodry_run
-    ```
-
-If the connection to Dataproc instances cannot be established through SSH, the command will still
-generate an output while displaying warning that the remote changes failed. 
 
 ## Diagnostic command
 

--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -624,39 +624,6 @@ class ProfileUserArgModel(ToolUserArgModel):
 
 
 @dataclass
-@register_tool_arg_validator('bootstrap')
-class BootstrapUserArgModel(AbsToolUserArgModel):
-    """
-    Represents the arguments collected by the user to run the bootstrap tool.
-    This is used as doing preliminary validation against some of the common pattern
-    """
-    dry_run: Optional[bool] = True
-
-    def build_tools_args(self) -> dict:
-        return {
-            'runtimePlatform': self.platform,
-            'outputFolder': self.output_folder,
-            'platformOpts': {},
-            'dryRun': self.dry_run
-        }
-
-    @model_validator(mode='after')
-    def validate_non_empty_args(self) -> 'BootstrapUserArgModel':
-        error_flag = 0
-        components = []
-        if self.cluster is None:
-            error_flag = 1
-            components.append('cluster')
-        if self.platform is None:
-            error_flag |= 2
-            components.append('platform')
-        if error_flag > 0:
-            missing = str.join(' and ', components)
-            raise ValueError(f'Cmd requires [{missing}] to be specified')
-        return self
-
-
-@dataclass
 @register_tool_arg_validator('prediction')
 class PredictUserArgModel(AbsToolUserArgModel):
     """

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -21,7 +21,6 @@ from spark_rapids_tools.cmdli.argprocessor import AbsToolUserArgModel
 from spark_rapids_tools.enums import QualGpuClusterReshapeType, CspEnv
 from spark_rapids_tools.utils.util import gen_app_banner, init_environment
 from spark_rapids_pytools.common.utilities import Utils, ToolLogging
-from spark_rapids_pytools.rapids.bootstrap import Bootstrap
 from spark_rapids_pytools.rapids.qualx.prediction import Prediction
 from spark_rapids_pytools.rapids.profiling import ProfilingAsLocal
 from spark_rapids_pytools.rapids.qualification import QualificationAsLocal
@@ -32,7 +31,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
     """CLI that provides a runtime environment that simplifies running cost and performance analysis
     using the RAPIDS Accelerator for Apache Spark.
 
-    A wrapper script to run RAPIDS Accelerator tools (Qualification, Profiling, and Bootstrap)
+    A wrapper script to run RAPIDS Accelerator tools (Qualification, and Profiling)
     locally on the dev machine.
     """
 
@@ -221,42 +220,6 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                         output_folder=prof_args['outputFolder'],
                                         wrapper_options=prof_args,
                                         rapids_options=rapids_options)
-            tool_obj.launch()
-
-    def bootstrap(self,
-                  cluster: str,
-                  platform: str,
-                  output_folder: str = None,
-                  dry_run: bool = True,
-                  verbose: bool = False):
-        """Provides optimized RAPIDS Accelerator for Apache Spark configs based on GPU cluster shape.
-
-        This tool is supposed to be used once a cluster has been created to set the recommended
-        configurations.
-        The tool will apply settings for the cluster assuming that jobs will run serially so that
-        each job can use up all the cluster resources (CPU and GPU) when it is running.
-
-        :param cluster: Name or ID (for databricks platforms) of the cluster running an accelerated
-                computing instance class
-        :param platform: defines one of the following "onprem", "emr", "dataproc", "databricks-aws",
-                and "databricks-azure".
-        :param output_folder: path where the final recommendations will be saved.
-        :param dry_run: True or False to update the Spark config settings on Dataproc driver node.
-        :param verbose: True or False to enable verbosity of the script.
-        """
-        if verbose:
-            ToolLogging.enable_debug_mode()
-        init_environment('boot')
-        boot_args = AbsToolUserArgModel.create_tool_args('bootstrap',
-                                                         cluster=cluster,
-                                                         platform=platform,
-                                                         output_folder=output_folder,
-                                                         dry_run=dry_run)
-        if boot_args:
-            tool_obj = Bootstrap(platform_type=boot_args['runtimePlatform'],
-                                 cluster=cluster,
-                                 output_folder=boot_args['outputFolder'],
-                                 wrapper_options=boot_args)
             tool_obj.launch()
 
     def prediction(self,


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1103

Remove the bootstrap cmd from spark_Rapids cmd line

Note that internally, we can spark_rapids_user_tools to run the boostrap cmd.
This PR removes  the cmd from spark_Rapids, and the markdown documents.
I will file an internal PR to remove the bootstrap tests from the CI/CD

