### PR TITLE
Fix Python runtime error caused by numpy 2.0.0 release

### DIFF
--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v4

--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "A simple wrapper process around cloud service providers to run tools for the RAPIDS Accelerator for Apache Spark."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.8,<3.12"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",

--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -12,6 +12,10 @@ readme = "README.md"
 requires-python = ">=3.8,<3.12"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]

--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -16,6 +16,8 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    # numpy-1.24.4 is the latest version to support python3.8. P.S: does not support python-3.12+
+    "numpy<=1.24.4",
     "chevron==0.14.0",
     "fastprogress==1.0.3",
     "fastcore==1.5.29",
@@ -36,8 +38,8 @@ dependencies = [
     # used to help pylint understand pydantic
     "pylint-pydantic==0.3.0",
     # used for common API to access remote filesystems like local/s3/gcs/hdfs
-    # this will include numpy
-    "pyarrow==14.0.1",
+    # pin to 16.1.0 which works for both numpy-1.0 and numpy-2.0
+    "pyarrow==16.1.0",
     # used for ADLS filesystem implementation
     # Issue-568: use 12.17.0 as the new 12.18.0 causes an error in runtime
     "azure-storage-blob==12.17.0",

--- a/user_tools/tests/mock_cluster.py
+++ b/user_tools/tests/mock_cluster.py
@@ -28,20 +28,20 @@ mock_live_cluster = {
                     "instanceNames": [
                         "test-master",
                     ],
-                    "machineTypeUri": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-a/"\
+                    "machineTypeUri": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-a/"
                                       "machineTypes/n1-standard-2",
                 },
                 "workerConfig": {
                     "numInstances": 1,
                     "accelerators": [{
-                        "acceleratorTypeUri": "https://www.googleapis.com/compute/beta/projects/project-id/zones/"\
+                        "acceleratorTypeUri": "https://www.googleapis.com/compute/beta/projects/project-id/zones/"
                                               "us-central1-a/acceleratorTypes/nvidia-tesla-t4",
                         "acceleratorCount": 1,
                     }],
                     "instanceNames": [
                         "test-worker-0",
                     ],
-                    "machineTypeUri": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-a/"\
+                    "machineTypeUri": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-a/"
                                       "machineTypes/n1-standard-8",
                 },
             },

--- a/user_tools/tox.ini
+++ b/user_tools/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 envlist =
-    python{3.8,3.9,3.10,3.11,3.12}
+    python{3.8,3.9,3.10,3.11}
     coverage
     pylint
     flake8
@@ -17,7 +17,6 @@ python =
     3.9: python3.9, pylint, flake8
     3.10: python3.10, pylint, flake8
     3.11: python3.11, pylint, flake8
-    3.12: python3.12, pylint, flake8
 
 [testenv]
 deps =
@@ -46,7 +45,7 @@ commands =
     coverage combine
     coverage report
 depends =
-    python{3.8,3.9,3.10,3.11,3.12}
+    python{3.8,3.9,3.10,3.11}
 
 [coverage:paths]
 source = src/spark_rapids_pytools


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1127

This code change fixes a runtime error caused by pandas loading numpy2.1+ which conflicts with pyArrow requiring numpy1+ In this commit, the fix is to:

- pin numpy to 1.24.4 which is the latest version to support python3.8. This implies that we drop support to python 3.12
- pin pyArrow to 16.1.0 which works for both numpy 1.0 and 2.0
- Drop python 3.12 from tox and github workflows

