### PR TITLE
Recommended cluster should use executors_per_node and cores_per_executor

### DIFF
--- a/user_tools/README.md
+++ b/user_tools/README.md
@@ -17,7 +17,7 @@ The wrapper improves end-user experience within the following dimensions:
 
 ## Getting started
 
-Set up a Python environment with a version between 3.8 and 3.10
+Set up a Python environment with a version between 3.8 and 3.11
 
 1. Run the project in a virtual environment. Note, .venv is the directory created to put
    the virtual env in, so modify if you want a different location.
@@ -80,7 +80,7 @@ Set up a Python environment similar to the steps above.
 Please refer to [spark-rapids-user-tools guide](https://github.com/NVIDIA/spark-rapids-tools/blob/main/user_tools/docs/index.md) for details on how to use the tools
 and the platform.
 
-Please refer to [qualx guide](docs/qualx.md) for details on how to use the QualX tool for prediction and training.
+Please refer to [qualx guide](https://github.com/NVIDIA/spark-rapids-tools/blob/main/user_tools/docs/qualx.md) for details on how to use the QualX tool for prediction and training.
 
 ## What's new
 

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -163,11 +163,12 @@ class DataprocPlatform(PlatformBase):
             return f'{series_name}-{cores_per_executor}'
         # If the num-cores is not in the list, then we need to adjust the cores to the best match
         # that is greater than the input cores.
-        adjusted_cores = unit_info['vCPUs'][-1]
-        for arr_index in range(len(unit_info['vCPUs']) - 1, -1, -1):
-            # do not break the loop just in case the array is not sorted
-            if unit_info['vCPUs'][arr_index] >= cores_per_executor:
-                adjusted_cores = unit_info['vCPUs'][arr_index]
+        rev_sorted_cores = unit_info['vCPUs'].copy()
+        rev_sorted_cores.sort(reverse=True)
+        adjusted_cores = rev_sorted_cores[0]
+        for num_cpu in rev_sorted_cores[1:]:
+            if num_cpu >= cores_per_executor:
+                adjusted_cores = num_cpu
         # At this point adjusted_cores should be the best match.
         selected_machine_type = f'{series_name}-{adjusted_cores}'
         self.logger.info(

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -171,10 +171,16 @@ class DataprocPlatform(PlatformBase):
                 adjusted_cores = num_cpu
         # At this point adjusted_cores should be the best match.
         selected_machine_type = f'{series_name}-{adjusted_cores}'
-        self.logger.info(
-            'The number of cores %d is not in the list of supported cores. '
-            'Adjusting it to the nearest CSP machine with higher number of cores %s',
-            cores_per_executor, selected_machine_type)
+        self.logger.info('The number of cores %d is not in the list of supported cores.',
+                         cores_per_executor)
+        if adjusted_cores > cores_per_executor:
+            self.logger.info(
+                'Adjusting number of cores the nearest CSP machine with higher number of cores %s',
+                selected_machine_type)
+        else:
+            self.logger.info(
+                'Adjusting number of cores the CSP machine with highest number of cores %s',
+                selected_machine_type)
         return selected_machine_type
 
     def generate_cluster_configuration(self, render_args: dict):

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -162,8 +162,8 @@ class DataprocPlatform(PlatformBase):
         if cores_per_executor in unit_info['vCPUs']:
             return f'{series_name}-{cores_per_executor}'
         # If the num-cores is not in the list, then we need to adjust the cores to the best match.
-        # The loop below should always return a valid instance type. It takes the instancetype with
-        # number of cores less than or equan to the "cores_per_executor".
+        # The loop below should always return a valid instance type. It takes the instance type with
+        # number of cores less than or equal to the "cores_per_executor".
         adjusted_cores = unit_info['vCPUs'][0]
         for num_cpu in unit_info['vCPUs'][1:]:
             if num_cpu <= cores_per_executor:

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -56,7 +56,7 @@ class ClusterInference:
                 self.logger.info('Unable to infer CPU cluster. Could not read the number of executors'
                                  ' per node or cores per executor from the event logs.')
                 return None
-            cores_per_worker_node =  cores_per_executor * executors_per_node
+            cores_per_worker_node = cores_per_executor * executors_per_node
             executor_instance = self.platform.get_matching_executor_instance(cores_per_worker_node)
             if pd.isna(executor_instance):
                 self.logger.info('Unable to infer CPU cluster. No matching executor instance found for vCPUs = %s',

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -50,8 +50,14 @@ class ClusterInference:
         executor_instance = cluster_info_df.get('Executor Instance')
         if pd.isna(executor_instance):
             # If executor instance is not set, use the default value based on the number of cores
+            executors_per_node = cluster_info_df.get('Num Executors Per Node')
             cores_per_executor = cluster_info_df.get('Cores Per Executor')
-            executor_instance = self.platform.get_matching_executor_instance(cores_per_executor)
+            if executors_per_node is None or cores_per_executor is None:
+                self.logger.info('Unable to infer CPU cluster. Could not read the number of executors'
+                                 ' per node or cores per executor from the event logs.')
+                return None
+            cores_per_worker_node =  cores_per_executor * executors_per_node
+            executor_instance = self.platform.get_matching_executor_instance(cores_per_worker_node)
             if pd.isna(executor_instance):
                 self.logger.info('Unable to infer CPU cluster. No matching executor instance found for vCPUs = %s',
                                  cores_per_executor)

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -52,7 +52,7 @@ class ClusterInference:
             # If executor instance is not set, use the default value based on the number of cores
             executors_per_node = cluster_info_df.get('Num Executors Per Node')
             cores_per_executor = cluster_info_df.get('Cores Per Executor')
-            if executors_per_node is None or cores_per_executor is None:
+            if pd.isna(executors_per_node) or pd.isna(cores_per_executor):
                 self.logger.info('Unable to infer CPU cluster. Could not read the number of executors'
                                  ' per node or cores per executor from the event logs.')
                 return None


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

This is a follow-up on #1119 and Fixes #1133

This change address a bug with the Dataproc recommended cluster shape. To reproduce the use case, there should be a single eventlog and no `--cluster` argument. Example:

```
spark_rapids qualification \
  --platform dataproc \
  --output_folder ~/output_folder \
  --eventlogs ~/eventlogs/app-xyz \
  --verbose
```
The instance type will be set after multiplying `numExecutorCores` by `numExecutorsPerNode`. If the result does not match a valid machine-type, then the number-cores will be adjusted to pick the next valid higher number of cores.
The following log message indicates that the number of cores was adjusted.

```
2024-06-26 10:56:57,709 INFO rapids.tools.csp: The number of cores 80 is not in the list of supported cores. Adjusting it to the nearest CSP machine with higher number of cores n1-standard-96
```
