### PR TITLE
Add plugin mechanism for dataset-specific preprocessing in qualx

### DIFF
--- a/user_tools/src/spark_rapids_tools/tools/qualx/model.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/model.py
@@ -77,7 +77,7 @@ def train(
         drop=True
     )
     if cpu_aug_tbl.shape[0] < original_num_rows:
-        logger.warn(
+        logger.warning(
             f'Removed {original_num_rows - cpu_aug_tbl.shape[0]} rows with NaN label values'
         )
 
@@ -142,7 +142,7 @@ def predict(
     if missing:
         raise ValueError(f'Input is missing model features: {missing}')
     if extra:
-        logger.warn(f'Input had extra features not present in model: {extra}')
+        logger.warning(f'Input had extra features not present in model: {extra}')
 
     X = cpu_aug_tbl[model_features]
     y = cpu_aug_tbl[label_col] if label_col else None
@@ -212,7 +212,7 @@ def extract_model_features(
     """Extract model features from raw features."""
     missing = expected_raw_features - set(df.columns)
     if missing:
-        logger.warn(f'Input dataframe is missing expected raw features: {missing}')
+        logger.warning(f'Input dataframe is missing expected raw features: {missing}')
 
     if FILTER_SPILLS:
         df = df[
@@ -234,7 +234,7 @@ def extract_model_features(
     gpu_aug_tbl = df[df['runType'] == 'GPU']
     if gpu_aug_tbl.shape[0] > 0:
         if gpu_aug_tbl.shape[0] != cpu_aug_tbl.shape[0]:
-            logger.warn(
+            logger.warning(
                 'Number of GPU rows ({}) does not match number of CPU rows ({})'.format(
                     gpu_aug_tbl.shape[0], cpu_aug_tbl.shape[0]
                 )
@@ -262,7 +262,7 @@ def extract_model_features(
         if (
             num_na / num_rows > 0.05
         ):  # arbitrary threshold, misaligned sqlIDs still may 'match' most of the time
-            logger.warn(
+            logger.warning(
                 f'Percentage of NaN GPU durations is high: {num_na} / {num_rows}  Per-sql actual speedups may be inaccurate.'
             )
 
@@ -299,7 +299,7 @@ def extract_model_features(
         raise ValueError(f'Input data is missing model features: {missing}')
     if extra:
         # remove extra columns
-        logger.warn(f'Input data has extra features (removed): {extra}')
+        logger.warning(f'Input data has extra features (removed): {extra}')
         feature_cols = [c for c in feature_cols if c not in extra]
 
     # add train/val/test split column, if split function provided

--- a/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
@@ -230,7 +230,7 @@ def load_datasets(
                 dataset_keys = list(datasets.keys())
                 profile_df['appName_base'] = profile_df['appName'].str.split(':').str[0]
                 profile_df = profile_df.loc[profile_df['appName_base'].isin(dataset_keys)]
-                profile_df.drop(columns='appName_base')
+                profile_df.drop(columns='appName_base', inplace=True)
         else:
             # otherwise, check for cached profiler output
             profile_dir = f'{platform_cache}/profile'
@@ -378,7 +378,7 @@ def load_profiles(
                 raw_features['appName'] = (
                     raw_features['appName'] + ':' + raw_features['jobName']
                 )
-                raw_features.drop(columns=['jobName'])
+                raw_features.drop(columns=['jobName'], inplace=True)
 
             # add platform from app_meta
             raw_features[f'platform_{platform}'] = 1

--- a/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
@@ -395,7 +395,7 @@ def load_profiles(
     for p in plugins:
         plugin = load_plugin(p)
         if plugin:
-            profile_df = plugin.load_profile_hook(profile_df)
+            profile_df = plugin.load_profiles_hook(profile_df)
 
     return profile_df
 

--- a/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
@@ -257,7 +257,7 @@ def load_datasets(
 
     # sanity check
     if ds_count != len(all_datasets):
-        logger.warn(
+        logger.warning(
             f'Duplicate dataset key detected, got {len(all_datasets)} datasets, but read {ds_count} datasets.'
         )
 
@@ -733,7 +733,7 @@ def impute(full_tbl: pd.DataFrame) -> pd.DataFrame:
         missing = sorted(expected_raw_features - actual_features)
         extra = sorted(actual_features - expected_raw_features)
         if missing:
-            logger.warn(f'Imputing missing features: {missing}')
+            logger.warning(f'Imputing missing features: {missing}')
             for col in missing:
                 if col != 'fraction_supported':
                     full_tbl[col] = 0
@@ -741,7 +741,7 @@ def impute(full_tbl: pd.DataFrame) -> pd.DataFrame:
                     full_tbl[col] = 1.0
 
         if extra:
-            logger.warn(f'Removing extra features: {extra}')
+            logger.warning(f'Removing extra features: {extra}')
             full_tbl = full_tbl.drop(columns=extra)
 
         # one last check after modifications (update expected_raw_features if needed)
@@ -775,7 +775,7 @@ def load_csv_files(
             )
         except Exception:
             if warn_on_error or abort_on_error:
-                logger.warn(f'Failed to load {tb_name} for {app_id}.')
+                logger.warning(f'Failed to load {tb_name} for {app_id}.')
             if abort_on_error:
                 raise ScanTblError()
             out = pd.DataFrame()
@@ -1011,7 +1011,7 @@ def load_csv_files(
             )
 
         if sqls_to_drop:
-            logger.warn(
+            logger.warning(
                 f'Ignoring sqlIDs {sqls_to_drop} due to excessive failed/cancelled stage duration.'
             )
 
@@ -1092,12 +1092,12 @@ def load_csv_files(
             aborted_sql_ids = set()
 
         if aborted_sql_ids:
-            logger.warn(f'Ignoring sqlIDs {aborted_sql_ids} due to aborted jobs.')
+            logger.warning(f'Ignoring sqlIDs {aborted_sql_ids} due to aborted jobs.')
 
         sqls_to_drop = sqls_to_drop.union(aborted_sql_ids)
 
         if sqls_to_drop:
-            logger.warn(
+            logger.warning(
                 f'Ignoring a total of {len(sqls_to_drop)} sqlIDs due to stage/job failures.'
             )
             app_info_mg = app_info_mg.loc[~app_info_mg.sqlID.isin(sqls_to_drop)]

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -395,8 +395,8 @@ def train(
 
     # sanity check
     if set(dataset_list) != set(profile_datasets):
-        logger.error(
-            'Training data contained datasets: {profile_datasets}, expected: {dataset_list}.'
+        logger.warn(
+            f'Training data contained datasets: {profile_datasets}, expected: {dataset_list}.'
         )
 
     features, feature_cols, label_col = extract_model_features(profile_df, split_nds)

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -248,7 +248,7 @@ def _read_dataset_scores(
             nan_df['model'] + '/' + nan_df['platform'] + '/' + nan_df['dataset']
         )
         keys = list(nan_df['key'].unique())
-        logger.warn(f'Dropped rows w/ NaN values from: {eval_dir}: {keys}')
+        logger.warning(f'Dropped rows w/ NaN values from: {eval_dir}: {keys}')
 
     return df
 
@@ -298,7 +298,7 @@ def _read_platform_scores(
             nan_df['model'] + '/' + nan_df['platform'] + '/' + nan_df['dataset']
         )
         keys = list(nan_df['key'].unique())
-        logger.warn(f'Dropped rows w/ NaN values from: {eval_dir}: {keys}')
+        logger.warning(f'Dropped rows w/ NaN values from: {eval_dir}: {keys}')
 
     # compute accuracy by platform
     scores = {}
@@ -395,7 +395,7 @@ def train(
 
     # sanity check
     if set(dataset_list) != set(profile_datasets):
-        logger.warn(
+        logger.warning(
             f'Training data contained datasets: {profile_datasets}, expected: {dataset_list}.'
         )
 
@@ -448,7 +448,7 @@ def predict(
             )
             appIds = [Path(p).name for p in appIds]
             if len(appIds) == 0:
-                logger.warn(f'Skipping empty metrics directory: {metrics_dir}')
+                logger.warning(f'Skipping empty metrics directory: {metrics_dir}')
             else:
                 try:
                     for appId in appIds:
@@ -522,7 +522,7 @@ def predict(
                 logger.error(e)
                 traceback.print_exc(e)
         else:
-            logger.warn(f'Predicted speedup will be 1.0 for dataset: {dataset}. Check logs for details.')
+            logger.warning(f'Predicted speedup will be 1.0 for dataset: {dataset}. Check logs for details.')
         # TODO: Writing CSV reports for all datasets to the same location. We should write to separate directories.
         write_csv_reports(per_sql_summary, per_app_summary, output_info)
         dataset_summaries.append(per_app_summary)
@@ -932,7 +932,7 @@ def compare(
     # warn user of any new datasets
     added = curr_datasets - prev_datasets
     if added:
-        logger.warn(f'New datasets added, comparisons may be skewed: added={added}')
+        logger.warning(f'New datasets added, comparisons may be skewed: added={added}')
 
 
 def entrypoint():

--- a/user_tools/src/spark_rapids_tools/tools/qualx/util.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/util.py
@@ -205,7 +205,7 @@ def load_plugin(plugin_path: str) -> types.ModuleType:
         logger.info(f'Successfully loaded plugin: {plugin_path}')
         return module
     else:
-        logger.warn(f'Failed to load plugin: {plugin_path}')
+        logger.warning(f'Failed to load plugin: {plugin_path}')
         return None
 
 

--- a/user_tools/src/spark_rapids_tools/tools/qualx/util.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/util.py
@@ -192,9 +192,9 @@ def load_plugin(plugin_path: str) -> types.ModuleType:
 
     Supported APIs:
 
-    def post_process(profile_df: pd.DataFrame) -> pd.DataFrame:
-        # post-process profile_df
-        return profile_df
+    def load_profiles_hook(df: pd.DataFrame) -> pd.DataFrame:
+        # add dataset-specific modifications
+        return df
     """
     plugin_path = os.path.expandvars(plugin_path)
     plugin_name = Path(plugin_path).name.split('.')[0]


### PR DESCRIPTION
This PR adds a plugin mechanism to invoke dataset-specific code to modify the pandas dataframe returned by the qualx `load_profiles()` function.  This is intended to allow custom handlers for one-off cases which shouldn't be introduced into the main codebase.

The path to the plugin module should be specified within the dataset JSON file with the "load_profiles_hook" key, e.g.
```
{
    "nds": {
        "eventlogs": [
            "/path/to/eventlogs",
        ],
        "app_meta": { ... }
        "load_profiles_hook": "/path/to/plugin/module.py"
    }
}
```

The plugin module should define a function with the following signature:
```python
def load_profiles_hook(df: pd.DataFrame) -> pd.DataFrame:
    # add dataset-specific modifications
    return df
```

## Changes
1. Add plugin mechanism for dataset-specific manipulation of the profile dataframe.
2. Moved injection of the "jobName" from the "description" field to a suffix of the "appName" field.  This allows the "description" field to retain it's original value for inferred app_meta cases, which can be useful inside the `load_profiles_hook`.
3. Strip the injected "jobName" when filtering out test sets by "appName".
4. Add `--output-sql-ids-aligned` argument to Profiler invocations (for future use).
5. Fix logger deprecation warnings.

## Test
Following CMDs have been tested:

### Internal Usage:
```
python qualx_main.py preprocess
python qualx_main.py train
python qualx_main.py evaluate
python qualx_main.py compare
```