### PR TITLE
[Bug] Fix java Qual tool handling of `--platform` argument

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -195,6 +195,7 @@ class DataprocPlatform(gpuDevice: Option[GpuDevice]) extends Platform(gpuDevice)
 class DataprocServerlessPlatform(gpuDevice: Option[GpuDevice]) extends DataprocPlatform(gpuDevice) {
   override val platformName: String =  PlatformNames.DATAPROC_SL
   override val defaultGpuDevice: GpuDevice = L4Gpu
+  override val defaultGpuForSpeedupFactor: GpuDevice = L4Gpu
   override def isPlatformCSP: Boolean = true
 }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -123,16 +123,16 @@ class PluginTypeChecker(val platform: Platform = PlatformFactory.createInstance(
   private def readOperatorsScore: Map[String, Double] = {
     speedupFactorFile match {
       case None =>
-        logInfo(s"Reading operators scores with platform: $platform")
+        logInfo(s"Trying to read operators scores with platform: $platform")
         val file = platform.getOperatorScoreFile
         try {
           val source = Source.fromResource(file)
           readOperators(source, "score", true).map(x => (x._1, x._2.toDouble))
         } catch {
           case NonFatal(_) =>
-            logWarning(s"Unable to read operator scores from file: $file")
             val defaultFile = platform.getDefaultOperatorScoreFile
-            logInfo(s"Using default operator scores file: $defaultFile")
+            logWarning(s"Unable to read operator scores from file: $file. " +
+                s"Using default operator scores file: $defaultFile.")
             val source = Source.fromResource(defaultFile)
             readOperators(source, "score", true).map(x => (x._1, x._2.toDouble))
         }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -125,8 +125,17 @@ class PluginTypeChecker(val platform: Platform = PlatformFactory.createInstance(
       case None =>
         logInfo(s"Reading operators scores with platform: $platform")
         val file = platform.getOperatorScoreFile
-        val source = Source.fromResource(file)
-        readOperators(source, "score", true).map(x => (x._1, x._2.toDouble))
+        try {
+          val source = Source.fromResource(file)
+          readOperators(source, "score", true).map(x => (x._1, x._2.toDouble))
+        } catch {
+          case NonFatal(_) =>
+            logWarning(s"Unable to read operator scores from file: $file")
+            val defaultFile = platform.getDefaultOperatorScoreFile
+            logInfo(s"Using default operator scores file: $defaultFile")
+            val source = Source.fromResource(defaultFile)
+            readOperators(source, "score", true).map(x => (x._1, x._2.toDouble))
+        }
       case Some(file) =>
         logInfo(s"Reading operators scores from custom speedup factor file: $file")
         try {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
@@ -16,6 +16,8 @@
 
 package com.nvidia.spark.rapids.tool.qualification
 
+import scala.util.control.NonFatal
+
 import com.nvidia.spark.rapids.tool.{EventLogPathProcessor, PlatformFactory}
 import com.nvidia.spark.rapids.tool.tuning.TunerContext
 
@@ -66,8 +68,8 @@ object QualificationMain extends Logging {
     val platform = try {
       PlatformFactory.createInstance(appArgs.platform())
     } catch {
-      case ie: Exception =>
-        logError("Error creating the platform", ie)
+      case NonFatal(e) =>
+        logError("Error creating the platform", e)
         return (1, Seq[QualificationSummaryInfo]())
     }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
@@ -66,7 +66,7 @@ object QualificationMain extends Logging {
     val platform = try {
       PlatformFactory.createInstance(appArgs.platform())
     } catch {
-      case ie: IllegalStateException =>
+      case ie: Exception =>
         logError("Error creating the platform", ie)
         return (1, Seq[QualificationSummaryInfo]())
     }


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/1028

A valid platform argument consists of two parts: `Platform` name and optional `GPU` name. For example:
- 'emr-t4': Platform: emr, GPU: t4
- 'databricks-aws': Platform databricks-aws, GPU: None

In this PR, we are discussing the case where `Platform` name is valid, but `GPU` name may be corrupted, because otherwise the tool will have detected it and raised an error.

**Changes**

This PR handles different scenarios of input `--platform` argument:

**1.** Platform with unsupported GPU device, e.g. `databricks-aws-r4`

Before this PR:
The implementation will extract `r4` as the GPU device, but since it is not in the GPU device map, the tool will use `databricks-aws` as the platform to proceed with running the Qual tool.

<details>
<summary>Stdout</summary>
<pre>
24/07/02 17:08:58 INFO PlatformFactory: Using platform: databricks-aws
24/07/02 17:08:58 INFO PluginTypeChecker: Reading operators scores with platform: databricks-aws
</pre>
</details>

After this PR:
The tool will raise an error about the unsupported GPU device and skips the rest of processing.

<details>
<summary>Stdout</summary>
<pre>
24/07/02 17:04:44 ERROR QualificationMain: Error creating the platform
java.lang.IllegalArgumentException: Unsupprted GPU device: r4
	at com.nvidia.spark.rapids.tool.PlatformFactory$.createInstance(Platform.scala:290)
	at com.nvidia.spark.rapids.tool.qualification.QualificationMain$.mainInternal(QualificationMain.scala:67)
	at com.nvidia.spark.rapids.tool.qualification.QualificationMain$.main(QualificationMain.scala:35)
	at com.nvidia.spark.rapids.tool.qualification.QualificationMain.main(QualificationMain.scala)
</pre>
</details>

**2.** Platform with supported GPU device, but the combination of Platform and GPU does not have existing speedup factor files, e.g. `databricks-aws-l4`.

Before this PR:
The tool is unable to find the corresponding speedup factor file, and runs into `NullPointerException`.

<details>
<summary>Stdout</summary>
<pre>
24/07/02 17:09:33 INFO PlatformFactory: Using platform: databricks-aws-l4
24/07/02 17:09:33 INFO PluginTypeChecker: Reading operators scores with platform: databricks-aws-l4
Exception in thread "main" java.lang.NullPointerException
	at scala.io.Source$.$anonfun$fromInputStream$2(Source.scala:172)
	at scala.io.Source.close(Source.scala:368)
	at com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker.readOperators(PluginTypeChecker.scala:205)
	at com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker.readOperatorsScore(PluginTypeChecker.scala:129)
	at com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker.<init>(PluginTypeChecker.scala:100)
	at com.nvidia.spark.rapids.tool.qualification.QualificationMain$.mainInternal(QualificationMain.scala:77)
	at com.nvidia.spark.rapids.tool.qualification.QualificationMain$.main(QualificationMain.scala:35)
	at com.nvidia.spark.rapids.tool.qualification.QualificationMain.main(QualificationMain.scala)
</pre>
</details>

After this PR:
The tool prints a message that there is no speedup factor for this platform and will use a default speedup factor file. E.g. `databricks-aws-l4` will use `databricks-aws-t4` file.

<details>
<summary>Stdout</summary>
<pre>
24/07/02 17:06:49 INFO PluginTypeChecker: Reading operators scores with platform: databricks-aws-l4
24/07/02 17:06:49 WARN PluginTypeChecker: Unable to read operator scores from file: operatorsScore-databricks-aws-l4.csv
24/07/02 17:06:49 INFO PluginTypeChecker: Using default operator scores file: operatorsScore-databricks-aws-t4.csv
</pre>
</details>