### PR TITLE
Fix parsing App IDs inside metrics directory in QualX

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -907,8 +907,8 @@ class Qualification(RapidsJarTool):
             try:
                 df = self.__update_apps_with_prediction_info(df)
             except Exception as e:  # pylint: disable=broad-except
-                self.logger.warning('Unable to use XGBoost estimation model for speed ups. '
-                                    'Falling-back to default model. Reason - %s:%s', type(e).__name__, e)
+                self.logger.error('Unable to use XGBoost estimation model for speed ups. '
+                                  'Falling-back to default model. Reason - %s:%s', type(e).__name__, e)
         estimation_model_col = self.ctxt.get_value('local', 'output', 'predictionModel',
                                                    'updateResult', 'estimationModelColumn')
         if estimation_model_col not in df:

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -442,22 +442,19 @@ def predict(
                 'app_meta': {},
                 'platform': platform,
             }
-            # search sub directories for appIds
-            appIds = find_paths(
-                metrics_dir, lambda x: RegexPattern.appId.match(x), return_directories=True
-            )
-            appIds = [Path(p).name for p in appIds]
-            if len(appIds) == 0:
+            # search sub directories for App IDs
+            app_ids = [p.name for p in Path(metrics_dir).iterdir() if p.is_dir()]
+            if len(app_ids) == 0:
                 logger.warning(f'Skipping empty metrics directory: {metrics_dir}')
             else:
                 try:
-                    for appId in appIds:
+                    for app_id in app_ids:
                         # create dummy app_meta, assuming CPU and scale factor of 1 (for inference)
                         datasets[dataset_name]['app_meta'].update(
-                            {appId: {'runType': 'CPU', 'scaleFactor': 1}}
+                            {app_id: {'runType': 'CPU', 'scaleFactor': 1}}
                         )
-                        # update the dataset_name for each appId
-                        default_preds_df.loc[default_preds_df['appId'] == appId, 'dataset_name'] = dataset_name
+                        # update the dataset_name for each App ID
+                        default_preds_df.loc[default_preds_df['appId'] == app_id, 'dataset_name'] = dataset_name
                     logger.info(f'Loading dataset {dataset_name}')
                     metrics_df = load_profiles(
                         datasets=datasets,


### PR DESCRIPTION
Fixes #1163. QualX assumes App IDs start with `app*` and uses this regex pattern to fetch profiling metrics. However, App IDs can be any alphanumeric string. 

This PR fixes the parsing to read all subdirectories and create the list. We are guaranteed that all sub directories within `raw_metrics` contain individual app metrics so we do not need a regex matching and can safely read all of them.

 