### PR TITLE
Disable UI-HTML report by default in Qualification tool

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
@@ -142,9 +142,9 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
       descr = "Applications which a particular user has submitted." )
   val htmlReport : ScallopOption[Boolean] =
     toggle("html-report",
-      default = Some(true),
+      default = Some(false),
       prefix = "no-",
-      descrYes = "Generates an HTML Report. Enabled by default.",
+      descrYes = "Generates an HTML Report. Disabled by default.",
       descrNo = "Disables generating the HTML report.")
   val perSql : ScallopOption[Boolean] =
     opt[Boolean](required = false,


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1166

The change is to set the the default value of the html-report to false. As a result the HTML files won't be generated by default when the qualification CLI cmd is executed.
