### PR TITLE
user-tools:Update --help for cluster argument

### DIFF
--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -69,7 +69,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
 
                 Skipping this argument requires that the cluster argument points to a valid
                 cluster name on the CSP.
-        :param cluster: Name or ID (for databricks platforms) of cluster or path to cluster-properties.
+        :param cluster: The CPU cluster on which the Spark applications were executed.
+               Name or ID (for databricks platforms) of cluster or path to cluster-properties.
         :param platform: defines one of the following "onprem", "emr", "dataproc", "dataproc-gke",
                "databricks-aws", and "databricks-azure".
         :param target_platform: Cost savings and speedup recommendation for comparable cluster in

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -69,7 +69,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
 
                 Skipping this argument requires that the cluster argument points to a valid
                 cluster name on the CSP.
-        :param cluster: The CPU cluster on which the Spark applications were executed.
+        :param cluster: The CPU cluster on which the Spark application(s) were executed.
                Name or ID (for databricks platforms) of cluster or path to cluster-properties.
         :param platform: defines one of the following "onprem", "emr", "dataproc", "dataproc-gke",
                "databricks-aws", and "databricks-azure".


### PR DESCRIPTION
This contributes to https://github.com/NVIDIA/spark-rapids-tools/issues/1144

This is a minor PR where --help returns better explanation for --cluster argument. Earlier it wasn't clear if the cluster is the target cluster or CPU cluster that the Spark applications were run.

 spark_rapids qualification  --help 

Earlier output:
```
  --cluster=CLUSTER
        Type: Optional[str]
        Default: None
        Name or ID (for databricks platforms) of cluster or path to cluster-properties.
```

In this PR:


```
--cluster=CLUSTER
        Type: Optional[str]
        Default: None
        The CPU cluster on which the Spark applications were executed. Name or ID (for databricks platforms) of cluster or path to cluster-properties.
```

Pending: Create MR to update it in documentation.


<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
