### PR TITLE
[FEA] Support custom XGBoost model file via user tools CLI

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -1042,7 +1042,7 @@ class Qualification(RapidsJarTool):
         output_info = self.__build_prediction_output_files_info()
         predictions_df = predict(platform=model_name, qual=qual_output_dir,
                                  output_info=output_info,
-                                 custom_model_file=estimation_model_args['customModelFile'])
+                                 model=estimation_model_args['customModelFile'])
 
         if predictions_df.empty:
             return all_apps

--- a/user_tools/src/spark_rapids_pytools/rapids/qualx/prediction.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualx/prediction.py
@@ -60,8 +60,15 @@ class Prediction(QualXTool):
         """
         try:
             output_info = self.__prepare_prediction_output_info()
-            df = predict(platform=self.platform_type.map_to_java_arg(), qual=self.qual_output,
-                         output_info=output_info)
+            estimation_model_args = self.wrapper_options.get('estimationModelArgs')
+            if estimation_model_args is not None and estimation_model_args:
+                custom_model_file = estimation_model_args['customModelFile']
+            else:
+                custom_model_file = None
+            df = predict(platform=self.platform_type.map_to_java_arg(),
+                         qual=self.qual_output,
+                         output_info=output_info,
+                         model=custom_model_file)
             if not df.empty:
                 print_summary(df)
                 print_speedup_summary(df)

--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -336,10 +336,8 @@ class EstimationModelArgProcessor(AbsToolUserArgModel):
         return ArgValueCase.UNDEFINED
 
     def build_tools_args(self) -> dict:
-        if self.p_args['toolArgs']['estimationModel'] == QualEstimationModel.XGBOOST:
-            self.p_args['toolArgs']['xgboostEnabled'] = True
-        else:
-            self.p_args['toolArgs']['xgboostEnabled'] = False
+        xgboost_enabled = self.p_args['toolArgs']['estimationModel'] == QualEstimationModel.XGBOOST
+        self.p_args['toolArgs']['xgboostEnabled'] = xgboost_enabled
         return self.p_args['toolArgs']
 
 
@@ -721,11 +719,17 @@ class PredictUserArgModel(AbsToolUserArgModel):
     estimation_model_args: Optional[Dict] = dataclasses.field(default_factory=dict)
 
     def build_tools_args(self) -> dict:
+        if self.estimation_model_args is None or not self.estimation_model_args:
+            def_model = QualEstimationModel.XGBOOST
+            self.p_args['toolArgs']['estimationModelArgs'] = QualEstimationModel.create_default_model_args(def_model)
+        else:
+            self.p_args['toolArgs']['estimationModelArgs'] = self.estimation_model_args
         return {
             'runtimePlatform': self.platform,
             'qual_output': self.qual_output,
             'prof_output': self.prof_output,
             'output_folder': self.output_folder,
+            'estimationModelArgs': self.p_args['toolArgs']['estimationModelArgs'],
             'platformOpts': {}
         }
 

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -18,7 +18,7 @@
 import fire
 
 from spark_rapids_tools.cmdli.argprocessor import AbsToolUserArgModel
-from spark_rapids_tools.enums import QualGpuClusterReshapeType, CspEnv
+from spark_rapids_tools.enums import QualGpuClusterReshapeType, CspEnv, QualEstimationModel
 from spark_rapids_tools.utils.util import gen_app_banner, init_environment
 from spark_rapids_pytools.common.utilities import Utils, ToolLogging
 from spark_rapids_pytools.rapids.qualx.prediction import Prediction
@@ -43,6 +43,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                       output_folder: str = None,
                       filter_apps: str = None,
                       estimation_model: str = None,
+                      custom_model_file: str = None,
                       tools_jar: str = None,
                       cpu_cluster_price: float = None,
                       estimated_gpu_cluster_price: float = None,
@@ -54,7 +55,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                       jvm_heap_size: int = None,
                       jvm_threads: int = None,
                       verbose: bool = None,
-                      **rapids_options):
+                      **rapids_options) -> None:
         """The Qualification cmd provides estimated running costs and speedups by migrating Apache
         Spark applications to GPU accelerated clusters.
 
@@ -97,6 +98,9 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                It accepts one of the following:
                "xgboost": An XGBoost model for GPU duration estimation. Set by default
                "speedups": It uses a simple static estimated speedup per operator.
+        :param custom_model_file: An optional Path to a custom XGBoost model file. The path is a local filesystem,
+                or remote cloud storage url.
+                Requires that "estimation_model" is set to "xgboost".
         :param cpu_cluster_price: the CPU cluster hourly price provided by the user.
         :param estimated_gpu_cluster_price: the GPU cluster hourly price provided by the user.
         :param cpu_discount: A percent discount for the cpu cluster cost in the form of an integer value
@@ -131,6 +135,15 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         if verbose:
             ToolLogging.enable_debug_mode()
         init_environment('qual')
+        estimation_arg_valid = {
+            'toolName': 'qualification',
+            'validatorName': 'estimation_model_args'
+        }
+        estimation_model_args = AbsToolUserArgModel.create_tool_args(estimation_arg_valid,
+                                                                     estimation_model=estimation_model,
+                                                                     custom_model_file=custom_model_file)
+        if estimation_model_args is None:
+            return None
         qual_args = AbsToolUserArgModel.create_tool_args('qualification',
                                                          eventlogs=eventlogs,
                                                          cluster=cluster,
@@ -141,7 +154,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                                          jvm_heap_size=jvm_heap_size,
                                                          jvm_threads=jvm_threads,
                                                          filter_apps=filter_apps,
-                                                         estimation_model=estimation_model,
+                                                         estimation_model_args=estimation_model_args,
                                                          cpu_cluster_price=cpu_cluster_price,
                                                          estimated_gpu_cluster_price=estimated_gpu_cluster_price,
                                                          cpu_discount=cpu_discount,
@@ -154,6 +167,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                             wrapper_options=qual_args,
                                             rapids_options=rapids_options)
             tool_obj.launch()
+        return None
 
     def profiling(self,
                   eventlogs: str = None,
@@ -226,14 +240,17 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
     def prediction(self,
                    qual_output: str = None,
                    output_folder: str = None,
-                   platform: str = 'onprem'):
+                   custom_model_file: str = None,
+                   platform: str = 'onprem') -> None:
         """The prediction cmd takes existing qualification tool output and runs the
         estimation model in the qualification tools for GPU speedups.
 
-        :param qual_output: path to the directory which contains the qualification tool output. E.g. user should
+        :param qual_output: path to the directory, which contains the qualification tool output. E.g. user should
                             specify the parent directory $WORK_DIR where $WORK_DIR/rapids_4_spark_qualification_output
                             exists.
         :param output_folder: path to store the output.
+        :param custom_model_file: An optional Path to a custom XGBoost model file. The path is a local filesystem,
+                or remote cloud storage url.
         :param platform: defines one of the following "onprem", "dataproc", "databricks-aws",
                          and "databricks-azure", default to "onprem".
         """
@@ -241,11 +258,20 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         ToolLogging.enable_debug_mode()
 
         init_environment('pred')
-
+        estimation_arg_valid = {
+            'toolName': 'prediction',
+            'validatorName': 'estimation_model_args'
+        }
+        estimation_model_args = AbsToolUserArgModel.create_tool_args(estimation_arg_valid,
+                                                                     estimation_model=QualEstimationModel.XGBOOST,
+                                                                     custom_model_file=custom_model_file)
+        if estimation_model_args is None:
+            return None
         predict_args = AbsToolUserArgModel.create_tool_args('prediction',
                                                             platform=platform,
                                                             qual_output=qual_output,
-                                                            output_folder=output_folder)
+                                                            output_folder=output_folder,
+                                                            estimation_model_args=estimation_model_args)
 
         if predict_args:
             tool_obj = Prediction(platform_type=predict_args['runtimePlatform'],
@@ -253,6 +279,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                   output_folder=predict_args['output_folder'],
                                   wrapper_options=predict_args)
             tool_obj.launch()
+        return None
 
     def train(self,
               dataset: str = None,

--- a/user_tools/src/spark_rapids_tools/enums.py
+++ b/user_tools/src/spark_rapids_tools/enums.py
@@ -168,3 +168,17 @@ class QualEstimationModel(EnumeratedType):
     @classmethod
     def get_default(cls):
         return cls.XGBOOST
+
+    @classmethod
+    def create_default_model_args(cls, model_type: str) -> dict:
+        """
+        Giving a estimation-model, it sets the default arguments for the model.
+        This is useful to avoid duplicating code all over the place.
+        :param model_type: the instance of the estimation-model
+        :return: a dictionary with the default arguments for the estimationModel
+        """
+        return {
+            'estimationModel': model_type,
+            'xgboostEnabled': model_type == QualEstimationModel.XGBOOST,
+            'customModelFile': None,
+        }

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -59,37 +59,39 @@ logger = get_logger(__name__)
 
 
 def _get_model(platform: str,
-               model: Optional[str] = None,
-               custom_model_file: Optional[str] = None) -> Booster:
+               model: Optional[str] = None) -> Booster:
     """
     Load the XGBoost model from the specified path or use the pre-trained model for the platform.
-    The custom_model_file has a precedence over the other input options. If it is undefined, the
-    model and finally the platform will be used to define the path of the model file.
+    The "model" has a precedence over the other input options. If it is undefined, this function checks
+    if it is a valid path or a string literal that represents a model name.
+    Finally the platform will be used to define the path of the model file if the model is not defined.
     :param platform: name of the platform used to define the path of the pre-trained model.
-                     The platform should match a JSON file in the resources directory.
-    :param model: Pretrained model. It is a JSON file name already existing in the resources directory.
-    :param custom_model_file: A custom model file path that is not defined in the resources directory.
+                     The platform should match a JSON file in the "resources" directory.
+    :param model: Either a file or a pre-trained model name. If the input is a string literal that
+                 cannot be a file path, then it is assumed that the file is located under the
+                 resources directory.
     :return: xgb.Booster loading the model file.
     """
-    model_path = None
-    if custom_model_file is not None:
-        # try custom-model file set by the user
-        if not CspPath.is_file_path(custom_model_file,
-                                    extensions=['json'],
-                                    raise_on_error=False):
-            raise ValueError(
-                f'Custom model file [{custom_model_file}] is invalid. Please specify a valid JSON file. ')
-        # TODO: If the path is remote, we need to copy it locally in order to successfully
-        #       load it with xgboost.
-        model_path = Path(CspPath(custom_model_file).no_prefix)
-    elif model is None:
-        # try pre-trained model for platform
-        model_path = Path(Utils.resource_path(f'qualx/models/xgboost/{platform}.json'))
+    if model is not None:
+        if CspPath.is_file_path(model, raise_on_error=False):
+            # "model" is actually represents a file path
+            # check that it is valid json file
+            if not CspPath.is_file_path(model,
+                                        extensions=['json'],
+                                        raise_on_error=False):
+                raise ValueError(
+                    f'Custom model file [{model}] is invalid. Please specify a valid JSON file.')
+            # TODO: If the path is remote, we need to copy it locally in order to successfully
+            #       load it with xgboost.
+            model_path = Path(CspPath(model).no_prefix)
+        else:
+            # try pre-trained model first
+            model_path = Path(Utils.resource_path(f'qualx/models/xgboost/{model}.json'))
     else:
-        # try pre-trained model first
-        model_path = Path(Utils.resource_path(f'qualx/models/xgboost/{model}.json'))
+        # use the platform to define the path of the pre-trained model
+        model_path = Path(Utils.resource_path(f'qualx/models/xgboost/{platform}.json'))
     if not model_path.exists():
-        raise ValueError(f'Platform {model_path} does not have a pre-trained model, '
+        raise ValueError(f'Platform [{model_path}] does not have a pre-trained model, '
                          'please specify --model or choose another platform.')
     logger.info(f'Loading model from: {model_path}')
     xgb_model = xgb.Booster()
@@ -468,12 +470,11 @@ def predict(
         qual: str,
         output_info: dict,
         *,
-        custom_model_file: Optional[str] = None,
         model: Optional[str] = None,
         qualtool_filter: Optional[str] = 'stage') -> pd.DataFrame:
     """Predict GPU speedup given CPU logs."""
 
-    xgb_model = _get_model(platform, model=model, custom_model_file=custom_model_file)
+    xgb_model = _get_model(platform, model=model)
     node_level_supp, qualtool_output, _, qual_metrics = _get_qual_data(qual)
     # create a DataFrame with default predictions for all app IDs.
     # this will be used for apps without predictions.


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1134

- Adds a new argument `custom_model_file` to qualification/prediction cmds
- Added validation class to the estimationModel arguments
- The input file has to be a valid json file
- If the estimation_model is set to SPEEDUPS, the validation throws an error

```
spark_rapids qualification \
  --output_folder $OUTPUT_FOLDER \
  --eventlogs $EVENTLOGS \
  --custom_model_file $WORK_DIR/dataproc.json \
  --tools_jar $WORK_DIR/jars/rapids-4-spark-tools_2.12-24.06.2-SNAPSHOT.jar
```

P.S: Filed an internal issue to update the documentation.