### PR TITLE
[BUG] Fix handling of non-english characters in tools output files

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/EventLogPathProcessor.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/EventLogPathProcessor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.{FileContext, FileStatus, FileSystem, Path, PathFilt
 import org.apache.spark.deploy.history.{EventLogFileReader, EventLogFileWriter}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
+import org.apache.spark.sql.rapids.tool.util.FSUtils
 
 sealed trait EventLogInfo {
   def eventLog: Path
@@ -129,7 +130,7 @@ object EventLogPathProcessor extends Logging {
     try {
       // Note that some cloud storage APIs may throw FileNotFoundException when the pathPrefix
       // (i.e., bucketName) is not visible to the current configuration instance.
-      val fs = inputPath.getFileSystem(hadoopConf)
+      val fs = FSUtils.getFSForPath(inputPath, hadoopConf)
       val fileStatus = fs.getFileStatus(inputPath)
       val filePath = fileStatus.getPath()
       val fileName = filePath.getName()

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/ToolTextFileWriter.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/ToolTextFileWriter.scala
@@ -35,19 +35,19 @@ class ToolTextFileWriter(
     finalLocationText: String,
     hadoopConf: Option[Configuration] = None) extends Logging {
 
-  private val textOutputPath = s"$finalOutputDir/$logFileName"
+  private val textOutputLoc = s"$finalOutputDir/$logFileName"
 
-  def getFileOutputPath: Path = new Path(textOutputPath)
+  def getFileOutputPath: Path = new Path(textOutputLoc)
 
   // The Hadoop LocalFileSystem (r1.0.4) has known issues with syncing (HADOOP-7844).
   // Therefore, for local files, use FileOutputStream instead.
   // this overwrites existing path
   private var utf8Writer: Option[BufferedWriter] = {
     try {
-      Some(FSUtils.getUTF8BufferedWriter(textOutputPath, hadoopConf))
+      Some(FSUtils.getUTF8BufferedWriter(textOutputLoc, hadoopConf))
     } catch {
       case NonFatal(e) =>
-        logError(s"Failed to open output path [$textOutputPath] for writing", e)
+        logError(s"Failed to open output path [$textOutputLoc] for writing", e)
         None
     }
   }
@@ -70,7 +70,8 @@ class ToolTextFileWriter(
     // No need to close the outputStream.
     // Java should handle nested streams automatically.
     utf8Writer.foreach { writer =>
-      logInfo(s"$finalLocationText output location: $textOutputPath")
+      logInfo(s"$finalLocationText output location: $textOutputLoc")
+      writer.flush()
       writer.close()
     }
     utf8Writer = None

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ui/QualificationReportGenerator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ui/QualificationReportGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,13 @@ import java.nio.file.{Files, FileSystems, Paths}
 
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 
-import org.apache.hadoop.fs.{FileSystem, FSDataOutputStream, Path}
+import org.apache.hadoop.fs.{FSDataOutputStream, Path}
 import org.json4s.DefaultFormats
 import org.json4s.jackson.Serialization
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.rapids.tool.qualification.QualificationSummaryInfo
+import org.apache.spark.sql.rapids.tool.util.FSUtils.getFSForPath
 import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
 import org.apache.spark.util.Utils
 
@@ -37,7 +38,7 @@ class QualificationReportGenerator(outputDir: String,
   implicit val formats = DefaultFormats
 
   val outputWorkPath = new Path(outputDir)
-  lazy val fs = Some(FileSystem.get(outputWorkPath.toUri, RapidsToolsConfUtil.newHadoopConf))
+  lazy val fs = Some(getFSForPath(outputWorkPath, RapidsToolsConfUtil.newHadoopConf))
 
   def launch(): Unit = {
     val uiRootPath = getPathForResource(RAPIDS_UI_ASSETS_DIR)
@@ -66,7 +67,7 @@ class QualificationReportGenerator(outputDir: String,
     // Serializing the entire list of sums may stress the memory.
     // Serializing one record at a time is slower but it would reduce the memory peak consumption.
     val outputPath = new Path(outputWorkPath, RAPIDS_UI_JS_DATA)
-    val mainIndexPath =new Path(outputWorkPath,  RAPIDS_UI_INDEX_PATH)
+    val mainIndexPath = new Path(outputWorkPath,  RAPIDS_UI_INDEX_PATH)
     logInfo(s"Generating UI data in ${mainIndexPath.toUri}")
     val fileHeader =
       s"""

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/FSUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/FSUtils.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool.util
+
+import java.io.{BufferedWriter, FileOutputStream, OutputStreamWriter}
+import java.nio.charset.StandardCharsets
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, FSDataOutputStream, LocalFileSystem, Path}
+import org.apache.hadoop.fs.permission.FsPermission
+
+/**
+ * Utility functions to interact with the file system (HDFS, local, etc).
+ */
+object FSUtils {
+  // use same as Spark event log writer
+  private val LOG_FILE_PERMISSIONS = new FsPermission(Integer.parseInt("660", 8).toShort)
+  private val LOG_FOLDER_PERMISSIONS = new FsPermission(Integer.parseInt("770", 8).toShort)
+
+  // Copied from org.apache.spark.streaming.util.HdfsUtils
+  def getFSForPath(path: Path, hadoopConf: Configuration): FileSystem = {
+    // For local file systems, return the raw local file system, such calls to flush()
+    // actually flushes the stream.
+    val fs = path.getFileSystem(hadoopConf)
+    fs match {
+      case localFs: LocalFileSystem => localFs.getRawFileSystem
+      case _ => fs
+    }
+  }
+
+  def getOutputStream(outputPath: String, hadoopConf: Configuration): FSDataOutputStream = {
+    val dfsPath = new Path(outputPath)
+    getOutputStream(dfsPath, hadoopConf)
+  }
+
+  def getOutputStream(dfsPath: Path, hadoopConf: Configuration): FSDataOutputStream = {
+    val dfs = getFSForPath(dfsPath, hadoopConf)
+    val uri = dfsPath.toUri
+    val defaultFs = FileSystem.getDefaultUri(hadoopConf).getScheme
+    val isDefaultLocal = defaultFs == null || defaultFs == "file"
+    val outputStream =
+      if ((isDefaultLocal && uri.getScheme == null) || uri.getScheme == "file") {
+        FileSystem.mkdirs(dfs, dfsPath.getParent, LOG_FOLDER_PERMISSIONS)
+        new FSDataOutputStream(new FileOutputStream(uri.getPath), null)
+      } else {
+        dfs.create(dfsPath)
+      }
+    dfs.setPermission(dfsPath, LOG_FILE_PERMISSIONS)
+    outputStream
+  }
+
+  def getUTF8BufferedWriter(outputPath: String,
+      hadoopConf: Option[Configuration]): BufferedWriter = {
+    val outStream = getOutputStream(outputPath, hadoopConf.getOrElse(new Configuration()))
+    new BufferedWriter(new OutputStreamWriter(outStream, StandardCharsets.UTF_8))
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/FSUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/FSUtils.scala
@@ -42,12 +42,12 @@ object FSUtils {
     }
   }
 
-  def getOutputStream(outputPath: String, hadoopConf: Configuration): FSDataOutputStream = {
-    val dfsPath = new Path(outputPath)
+  private def getOutputStream(outputLoc: String, hadoopConf: Configuration): FSDataOutputStream = {
+    val dfsPath = new Path(outputLoc)
     getOutputStream(dfsPath, hadoopConf)
   }
 
-  def getOutputStream(dfsPath: Path, hadoopConf: Configuration): FSDataOutputStream = {
+  private def getOutputStream(dfsPath: Path, hadoopConf: Configuration): FSDataOutputStream = {
     val dfs = getFSForPath(dfsPath, hadoopConf)
     val uri = dfsPath.toUri
     val defaultFs = FileSystem.getDefaultUri(hadoopConf).getScheme
@@ -63,9 +63,9 @@ object FSUtils {
     outputStream
   }
 
-  def getUTF8BufferedWriter(outputPath: String,
+  def getUTF8BufferedWriter(outputLoc: String,
       hadoopConf: Option[Configuration]): BufferedWriter = {
-    val outStream = getOutputStream(outputPath, hadoopConf.getOrElse(new Configuration()))
+    val outStream = getOutputStream(outputLoc, hadoopConf.getOrElse(new Configuration()))
     new BufferedWriter(new OutputStreamWriter(outStream, StandardCharsets.UTF_8))
   }
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,17 @@
 
 package com.nvidia.spark.rapids.tool.util
 
+import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Calendar
 
 import scala.concurrent.duration._
+import scala.io.Source
 import scala.xml.XML
 
+import com.nvidia.spark.rapids.tool.profiling.{ProfileOutputWriter, ProfileResult}
 import org.scalatest.FunSuite
-import org.scalatest.Matchers.{contain, convertToAnyShouldWrapper, not}
+import org.scalatest.Matchers.{contain, convertToAnyShouldWrapper, equal, not}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.AccumulableInfo
@@ -194,5 +197,59 @@ class ToolUtilsSuite extends FunSuite with Logging {
     val result = EventUtils.buildTaskStageAccumFromAccumInfo(accumWithDuration, 1, 1, None).get
     result.update.get shouldBe 100
     result.value.get shouldBe (59 * 1000 + 200)
+  }
+
+  test("output non-english characters") {
+    val nonEnglishString = "你好"
+    TrampolineUtil.withTempDir { tempDir =>
+      val filePrefix = "non-english"
+      val tableHeader = "Non-English"
+      val textFilePath = s"${tempDir.getAbsolutePath}/${filePrefix}.log"
+      val csvFilePath = s"${tempDir.getAbsolutePath}/${filePrefix}.csv"
+      val profOutputWriter =
+        new ProfileOutputWriter(tempDir.getAbsolutePath, filePrefix, 1000, outputCSV = true)
+      val profResults = Seq(
+        MockProfileResults("appID-0", 1, nonEnglishString, Seq(1, 2, 3).mkString(","))
+      )
+      try {
+        profOutputWriter.write(tableHeader, profResults)
+      } finally {
+        profOutputWriter.close()
+      }
+      val csvFile = new File(csvFilePath)
+      val textFile = new File(textFilePath)
+      assert(csvFile.exists())
+      assert(textFile.exists())
+      val expectedCSVFileContent =
+        s"""appID,appIndex,nonEnglishField,parentIDs
+           |appID-0,1,"你好","1,2,3"""".stripMargin
+      val expectedTXTContent =
+        s"""
+           |Non-English:
+           |+-------+--------+---------------+---------+
+           ||appID  |appIndex|nonEnglishField|parentIDs|
+           |+-------+--------+---------------+---------+
+           ||appID-0|1       |你好           |1,2,3    |
+           |+-------+--------+---------------+---------+""".stripMargin
+      val actualCSVContent: String = Source.fromFile(csvFilePath).getLines.mkString("\n")
+      val actualTXTContent: String = Source.fromFile(textFilePath).getLines.mkString("\n")
+      actualCSVContent should equal (expectedCSVFileContent)
+      actualTXTContent should equal (expectedTXTContent)
+    }
+  }
+
+  case class MockProfileResults(appID: String, appIndex: Int, nonEnglishField: String,
+      parentIDs: String) extends ProfileResult {
+    override val outputHeaders: Seq[String] = Seq("appID", "appIndex", "nonEnglishField",
+      "parentIDs")
+
+    override def convertToSeq: Seq[String] = {
+      Seq(appID, appIndex.toString, nonEnglishField, parentIDs)
+    }
+
+    override def convertToCSVSeq: Seq[String] = {
+      Seq(appID, appIndex.toString, StringUtils.reformatCSVString(nonEnglishField),
+        StringUtils.reformatCSVString(parentIDs))
+    }
   }
 }


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1181

The fix is to write into a buffer writer with UTF8 character-set

- Added a unit test to verify that Asian characters are written correctly to output files
- created a new object FSUtil and moved functionalities related to file systems to that object.

