### PR TITLE
Sync-up the support of parse_url in qualification tool

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -650,43 +650,14 @@ object SQLPlanParser extends Logging {
     funcName
   }
 
-  // This method aims at doing some common processing to an expression before
-  // we start parsing it. For example, some special handling is required for some functions.
-  private def processSpecialFunctions(expr: String): String = {
-    // For parse_url, we only support parse_url(*,Host,*); parse_url(*,Protocol,*)
-    // So we want to be able to define that parse_url(*,QUERY,*) is not supported.
-
-    // The following regex uses forward references to find matches for parse_url(*)
-    // we need to use forward references because otherwise multiple occurrences will be matched
-    // only once.
-    // https://stackoverflow.com/questions/47162098/is-it-possible-to-match-nested-brackets-with-a-
-    // regex-without-using-recursion-or/47162099#47162099
-    // example parse_url:
-    // Project [url_col#7, parse_url(url_col#7, HOST, false) AS HOST#9,
-    //          parse_url(url_col#7, QUERY, false) AS QUERY#10]
-    val parseURLPattern = ("parse_url(?=\\()(?:(?=.*?\\((?!.*?\\1)(.*\\)(?!.*\\2).*))(?=.*?\\)" +
-      "(?!.*?\\2)(.*)).)+?.*?(?=\\1)[^(]*(?=\\2$)").r
-    var newExpr = expr
-    parseURLPattern.findAllMatchIn(expr).foreach { parse_call =>
-      // iterate on all matches replacing parse_url by parse_url_query
-      // note that we do replaceFirst because we want to map 1-to-1 and the order does
-      // not matter here.
-      if (parse_call.matched.matches("parse_url\\(.*,\\s*(?i)query\\s*,.*\\)")) {
-        newExpr = newExpr.replaceFirst("parse_url\\(", "parse_url_query(")
-      }
-    }
-    newExpr
-  }
-
   private def getAllFunctionNames(regPattern: Regex, expr: String,
       groupInd: Int = 1, isAggr: Boolean = true): Set[String] = {
     // Returns all matches in an expression. This can be used when the SQL expression is not
     // tokenized.
-    val newExpr = processSpecialFunctions(expr)
 
     // first get all the functionNames
     val exprss =
-      regPattern.findAllMatchIn(newExpr).map(_.group(groupInd)).toSet
+      regPattern.findAllMatchIn(expr).map(_.group(groupInd)).toSet
 
     // For aggregate expressions we want to process the results to remove the prefix
     // DB: remove the "^partial_" and "^finalmerge_" prefixes

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -25,7 +25,7 @@ import scala.util.control.NonFatal
 import com.nvidia.spark.rapids.BaseTestSuite
 import com.nvidia.spark.rapids.tool.{EventLogPathProcessor, ToolTestUtils}
 import com.nvidia.spark.rapids.tool.qualification._
-import org.scalatest.Matchers.{be, convertToAnyShouldWrapper}
+import org.scalatest.Matchers.{be, contain, convertToAnyShouldWrapper}
 import org.scalatest.exceptions.TestFailedException
 
 import org.apache.spark.sql.{DataFrame, TrampolineUtil}
@@ -1193,6 +1193,34 @@ class SQLPlanParserSuite extends BaseTestSuite {
   }
 
   test("ParseUrl is supported") {
+    // Verify that each partToExtract expression causes the parse_url to be renamed.
+    SQLPlanParser.unsupportedParseURLParts.foreach { part =>
+      val partLC = part.toLowerCase
+      val a1 = SQLPlanParser.processSpecialFunctions(s"parse_url(test1, $part, cast(test))")
+      val a2 = SQLPlanParser.processSpecialFunctions(s"parse_url(test1, $partLC, cast(test))")
+      val a3 = SQLPlanParser.processSpecialFunctions(s"parse_url(test1, $part)")
+      val a4 = SQLPlanParser.processSpecialFunctions(s"parse_url(test1, $partLC)")
+      a1 shouldEqual s"parse_url_$partLC(test1, $part, cast(test))"
+      a2 shouldEqual s"parse_url_$partLC(test1, $partLC, cast(test))"
+      a3 shouldEqual s"parse_url_$partLC(test1, $part)"
+      a4 shouldEqual s"parse_url_$partLC(test1, $partLC)"
+    }
+    // verify that having the keywords in different argument does not affect the correctness
+    val a5 = SQLPlanParser.processSpecialFunctions("parse_url(AUTHORITY, ANY_PART, query)")
+    a5 shouldEqual "parse_url(AUTHORITY, ANY_PART, query)"
+    // verify multiple calls
+    val a6 = SQLPlanParser.processSpecialFunctions(
+      "parse_url(AUTHORITY, ANY_PART, query), parse_url(AUTHORITY, REF, query), " +
+        "parse_url(AUTHORITY, FILE, query)")
+    a6 shouldEqual "parse_url(AUTHORITY, ANY_PART, query), parse_url_ref(AUTHORITY, REF, query), " +
+      "parse_url_file(AUTHORITY, FILE, query)"
+    // verify nested. Note it does not matter the order as long as we get it right
+    val a7 = SQLPlanParser.processSpecialFunctions(
+      "parse_url(parse_url(AUTHORITY, ANY_PART, query), REF, query)")
+    val a8 = SQLPlanParser.processSpecialFunctions(
+      "parse_url(parse_url(AUTHORITY, REF, query), ANY_PART, query)")
+    a7 shouldEqual "parse_url_ref(parse_url(AUTHORITY, ANY_PART, query), REF, query)"
+    a8 shouldEqual "parse_url_ref(parse_url(AUTHORITY, REF, query), ANY_PART, query)"
     TrampolineUtil.withTempDir { parquetoutputLoc =>
       TrampolineUtil.withTempDir { eventLogDir =>
         val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
@@ -1205,7 +1233,8 @@ class SQLPlanParserSuite extends BaseTestSuite {
           df1.write.parquet(s"$parquetoutputLoc/testparse")
           val df2 = spark.read.parquet(s"$parquetoutputLoc/testparse")
           df2.selectExpr("*", "parse_url(`url_col`, 'HOST') as HOST",
-            "parse_url(`url_col`,'QUERY') as QUERY")
+            "parse_url(`url_col`,'QUERY') as QUERY", "parse_url(`url_col`, 'REF') as REF",
+            "parse_url(`url_col`,'USERINFO') as NOT_QUERY")
         }
         val pluginTypeChecker = new PluginTypeChecker()
         val app = createAppFromEventlog(eventLog)
@@ -1216,7 +1245,9 @@ class SQLPlanParserSuite extends BaseTestSuite {
         }
         val allExecInfo = getAllExecsFromPlan(parsedPlans.toSeq)
         val projects = allExecInfo.filter(_.exec.contains("Project"))
-        assertSizeAndSupported(1, projects)
+        assertSizeAndNotSupported(1, projects)
+        val expectedExprss = Seq("parse_url_ref", "parse_url_userinfo")
+        projects(0).unsupportedExprs.map(_.exprName) should contain theSameElementsAs expectedExprss
       }
     }
   }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -1192,9 +1192,7 @@ class SQLPlanParserSuite extends BaseTestSuite {
     }
   }
 
-  test("ParseUrl is supported except that for parse_url_query") {
-    // parse_url(*,QUERY,*) should cause the project to be unsupported
-    // the expression will appear in the unsupportedExpression summary
+  test("ParseUrl is supported") {
     TrampolineUtil.withTempDir { parquetoutputLoc =>
       TrampolineUtil.withTempDir { eventLogDir =>
         val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
@@ -1218,7 +1216,7 @@ class SQLPlanParserSuite extends BaseTestSuite {
         }
         val allExecInfo = getAllExecsFromPlan(parsedPlans.toSeq)
         val projects = allExecInfo.filter(_.exec.contains("Project"))
-        assertSizeAndNotSupported(1, projects)
+        assertSizeAndSupported(1, projects)
       }
     }
   }


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1190

- parse_url(*,query[,*]) should be treated as supported
- parse_url(*, ref|authority|file|userinfo[,*]) shuld be treated as unsupported
- Q tool will convert parse_url(ref|authority|file|userinfo) to parse_url_* to distinguish between different cases. This is a work around since the SQlPlanParser does not support arguments within expressions.
- fix the unit-test