### PR TITLE
Update pre-commit hooks to check for headers and white-spaces

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,14 @@
 repos:
   - repo: local
     hooks:
+      - id: header-check
+        name: Header check
+        entry: scripts/header-check.sh
+        language: script
+        pass_filenames: true
+        verbose: true
+  - repo: local
+    hooks:
       - id: auto-copyrighter
         name: Update copyright year
         entry: scripts/auto-copyrighter.sh
@@ -27,4 +35,8 @@ repos:
       - id: check-added-large-files
         name: Check for file over 2.0MiB
         args: ['--maxkb=2000', '--enforce-all']
-
+      - id: trailing-whitespace
+        name: trim trailing white spaces preserving md files
+        args: ['--markdown-linebreak-ext=md']
+      - id: end-of-file-fixer
+        name: Ensure files end with a single newline

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,6 @@ repos:
         language: script
         pass_filenames: true
         verbose: true
-  - repo: local
-    hooks:
       - id: auto-copyrighter
         name: Update copyright year
         entry: scripts/auto-copyrighter.sh

--- a/core/README.md
+++ b/core/README.md
@@ -34,19 +34,19 @@ Run `mvn help:all-profiles` to list supported Spark versions.
 
 ### Setting up an Integrated Development Environment
 
-Before proceeding with importing spark-rapids into IDEA or switching to a different Spark release
-profile, execute the install phase with the corresponding `buildver`, e.g. for Spark 3.4.0:
+Before proceeding with importing spark-rapids-tools into IDEA or switching to a different Spark release
+profile, execute the install phase with the corresponding `buildver`, e.g. for Spark 3.5.0:
 
 ##### Manual Maven Install for a target Spark build
 
 ```bash
- mvn clean install -Dbuildver=340 -Dmaven.scaladoc.skip -DskipTests
+ mvn clean install -Dbuildver=350 -Dmaven.scaladoc.skip -DskipTests
 ```
 
 ##### Importing the project
 
 To start working with the project in IDEA is as easy as importing the project as a Maven project.
-Select the profile used in the mvn command above, e.g. `spark340` for Spark 3.4.0.
+Select the profile used in the mvn command above, e.g. `spark350` for Spark 3.5.0.
 
 The tools project follows the same coding style guidelines as the Apache Spark
 project.  For IntelliJ IDEA users, an example `idea-code-style-settings.xml` is available in the

--- a/core/README.md
+++ b/core/README.md
@@ -7,7 +7,7 @@ The Profiling tool generates information which can be used for debugging and pro
 Information such as Spark version, executor information, properties and so on. This runs on either CPU or
 GPU generated event logs.
 
-Please refer to [Qualification tool documentation](https://docs.nvidia.com/spark-rapids/user-guide/latest/qualification/overview.html) 
+Please refer to [Qualification tool documentation](https://docs.nvidia.com/spark-rapids/user-guide/latest/qualification/overview.html)
 and [Profiling tool documentation](https://docs.nvidia.com/spark-rapids/user-guide/latest/profiling/overview.html)
 for more details on how to use the tools.
 
@@ -31,3 +31,23 @@ mvn -Dbuildver=351 clean package
 ```
 
 Run `mvn help:all-profiles` to list supported Spark versions.
+
+### Setting up an Integrated Development Environment
+
+Before proceeding with importing spark-rapids into IDEA or switching to a different Spark release
+profile, execute the install phase with the corresponding `buildver`, e.g. for Spark 3.4.0:
+
+##### Manual Maven Install for a target Spark build
+
+```bash
+ mvn clean install -Dbuildver=340 -Dmaven.scaladoc.skip -DskipTests
+```
+
+##### Importing the project
+
+To start working with the project in IDEA is as easy as importing the project as a Maven project.
+Select the profile used in the mvn command above, e.g. `spark340` for Spark 3.4.0.
+
+The tools project follows the same coding style guidelines as the Apache Spark
+project.  For IntelliJ IDEA users, an example `idea-code-style-settings.xml` is available in the
+`scripts` subdirectory of the root project folder.

--- a/scripts/header-check.sh
+++ b/scripts/header-check.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Git pre-commit hook to check copyright headers for current year exists for newly added files
+
+readonly NEW_FILES=$(git diff --diff-filter=ACRTU --cached --name-only)
+readonly YEAR=$(date +%Y)
+INVALID_FILES=()
+IFS=$'\n'
+
+if [ -n "$NEW_FILES" ]
+then
+    for f in $NEW_FILES; do
+        echo "Checking new file: $f"
+        INVALID_FILES+=($(grep -L --exclude={core/src/test/resources/*,*.csv} "Copyright (c) $YEAR" $f))
+    done
+fi
+echo "$INVALID_FILES"
+
+if [ -n "$INVALID_FILES" ]; then
+    echo "Found new files with incorrect headers:"
+    for f in "${INVALID_FILES[@]}"; do
+        echo "    $f"
+    done
+    exit 1
+fi

--- a/scripts/header-check.sh
+++ b/scripts/header-check.sh
@@ -28,7 +28,6 @@ then
         INVALID_FILES+=($(grep -L --exclude={core/src/test/resources/*,*.csv} "Copyright (c) $YEAR" $f))
     done
 fi
-echo "$INVALID_FILES"
 
 if [ -n "$INVALID_FILES" ]; then
     echo "Found new files with incorrect headers:"

--- a/scripts/idea-code-style-settings.xml
+++ b/scripts/idea-code-style-settings.xml
@@ -1,0 +1,50 @@
+<!--
+  Copyright (c) 2024, NVIDIA CORPORATION.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<code_scheme name="Default" version="173">
+  <option name="SOFT_MARGINS" value="100" />
+  <JavaCodeStyleSettings>
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="10" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="10" />
+  </JavaCodeStyleSettings>
+  <ScalaCodeStyleSettings>
+    <option name="classCountToUseImportOnDemand" value="15" />
+    <option name="importLayout">
+      <array>
+        <option value="java" />
+        <option value="_______ blank line _______" />
+        <option value="scala" />
+        <option value="_______ blank line _______" />
+        <option value="all other imports" />
+        <option value="_______ blank line _______" />
+        <option value="org.apache.spark" />
+      </array>
+    </option>
+    <option name="sortAsScalastyle" value="true" />
+    <option name="USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS" value="true" />
+  </ScalaCodeStyleSettings>
+  <codeStyleSettings language="JAVA">
+    <option name="INDENT_CASE_FROM_SWITCH" value="false" />
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="Scala">
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+  </codeStyleSettings>
+</code_scheme>


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Contributes to #1158

- add trailing-whitespace check to the pre-commit hooks to avoid whitespaces at the end of lines
- add E-O-F fixer to make sure that only a single newline is at the end of each committed file
- added a script to check that newly added files have the header.
- pulled the intelli-j idea from RAPIDS plugin and update the the README file. No link is added because the markdown checker could cause the build to fail until a release is made.
