### PR TITLE
Follow-up 1189: handle non-english characters in data-output.js

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ui/QualificationReportGenerator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ui/QualificationReportGenerator.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.rapids.tool.ui
 
+import java.nio.charset.StandardCharsets
 import java.nio.file
 import java.nio.file.{Files, FileSystems, Paths}
 
@@ -98,10 +99,8 @@ class QualificationReportGenerator(outputDir: String,
 
   private def writeAppRecord(appRec: QualificationSummaryInfo,
       outStream: FSDataOutputStream, sep: String =","): Unit = {
-    val sumRec =
-      s"""|\t${Serialization.write(appRec)}$sep
-       """.stripMargin
-    outStream.writeBytes(sumRec)
+    val sumRec = "\t" + Serialization.write(appRec) + sep
+    outStream.write(sumRec.getBytes(StandardCharsets.UTF_8))
   }
 
   def tryCopyAssetFile(srcFilePath: java.nio.file.Path, dstPath: Path) : Unit = {


### PR DESCRIPTION
Signed-off-by: Leo Li <lyh-36@163.com>

Follow-up on https://github.com/NVIDIA/spark-rapids-tools/pull/1189  to handle non-english characters in data-output.js. 

Non-english characters in `data-output.js` will cause format problems, resulting in abnormal display of the UI page.
Locally test well in my dev env.
