### PR TITLE
Ensure UTF-8 encoding for reading non-english characters

### DIFF
--- a/core/scalastyle-config.xml
+++ b/core/scalastyle-config.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2023, NVIDIA CORPORATION. All Rights Reserved.
+  Copyright (c) 2023-2024, NVIDIA CORPORATION. All Rights Reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -102,6 +102,14 @@ You can also disable only one rule, by specifying its rule id, as specified in:
             <parameter name="regex">(?m)^(\s*)/[*][*].*$(\r|)\n^\1  [*]</parameter>
         </parameters>
         <customMessage>Use Javadoc style indentation for multiline comments</customMessage>
+    </check>
+
+    <check customId="regex.source.from" level="error" class="org.scalastyle.file.RegexChecker"
+           enabled="true">
+        <parameters>
+            <parameter name="regex">(?&lt;!UTF8)Source\.from</parameter>
+        </parameters>
+        <customMessage>Use UTF8Source.from instead of Source.from</customMessage>
     </check>
 
     <!-- ================================================================================ -->

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/DriverLogProcessor.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/DriverLogProcessor.scala
@@ -16,9 +16,8 @@
 
 package com.nvidia.spark.rapids.tool.profiling
 
-import scala.io.Source
-
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.rapids.tool.util.UTF8Source
 
 trait DriverLogInfoProvider {
   def getUnsupportedOperators: Seq[DriverLogUnsupportedOperators] = Seq.empty
@@ -40,7 +39,7 @@ class DriverLogProcessor(logPath: String)
   lazy val unsupportedOps = processDriverLog()
   override def getUnsupportedOperators = unsupportedOps
   private def processDriverLog(): Seq[DriverLogUnsupportedOperators] = {
-    val source = Source.fromFile(logPath)
+    val source = UTF8Source.fromFile(logPath)
     // Create a map to store the counts for each operator and reason
     var countsMap = Map[(String, String), Int]().withDefaultValue(0)
     try {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -17,7 +17,7 @@
 package com.nvidia.spark.rapids.tool.qualification
 
 import scala.collection.mutable.{ArrayBuffer, HashMap}
-import scala.io.{BufferedSource, Source}
+import scala.io.BufferedSource
 import scala.util.control.NonFatal
 
 import com.nvidia.spark.rapids.tool.{Platform, PlatformFactory}
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.rapids.tool.UnsupportedExpr
+import org.apache.spark.sql.rapids.tool.util.UTF8Source
 
 object OpSuppLevel extends Enumeration {
   case class OpSuppLevelVal(label: String, support: Boolean,
@@ -107,14 +108,14 @@ class PluginTypeChecker(val platform: Platform = PlatformFactory.createInstance(
 
   // for testing purposes only
   def setPluginDataSourceFile(filePath: String): Unit = {
-    val source = Source.fromFile(filePath)
+    val source = UTF8Source.fromFile(filePath)
     val (readFormatsAndTypesTest, writeFormatsTest) = readSupportedTypesForPlugin(source)
     readFormatsAndTypes = readFormatsAndTypesTest
     writeFormats = writeFormatsTest
   }
 
   def setOperatorScore(filePath: String): Unit = {
-    val source = Source.fromFile(filePath)
+    val source = UTF8Source.fromFile(filePath)
     supportedOperatorsScore = readOperators(source, "score", true).map(x => (x._1, x._2.toDouble))
   }
 
@@ -126,14 +127,14 @@ class PluginTypeChecker(val platform: Platform = PlatformFactory.createInstance(
         logInfo(s"Trying to read operators scores with platform: $platform")
         val file = platform.getOperatorScoreFile
         try {
-          val source = Source.fromResource(file)
+          val source = UTF8Source.fromResource(file)
           readOperators(source, "score", true).map(x => (x._1, x._2.toDouble))
         } catch {
           case NonFatal(_) =>
             val defaultFile = platform.getDefaultOperatorScoreFile
             logWarning(s"Unable to read operator scores from file: $file. " +
                 s"Using default operator scores file: $defaultFile.")
-            val source = Source.fromResource(defaultFile)
+            val source = UTF8Source.fromResource(defaultFile)
             readOperators(source, "score", true).map(x => (x._1, x._2.toDouble))
         }
       case Some(file) =>
@@ -152,12 +153,12 @@ class PluginTypeChecker(val platform: Platform = PlatformFactory.createInstance(
   }
 
   private def readSupportedExecs: Map[String, String] = {
-    val source = Source.fromResource(SUPPORTED_EXECS_FILE)
+    val source = UTF8Source.fromResource(SUPPORTED_EXECS_FILE)
     readOperators(source, "execs", true)
   }
 
   private def readSupportedExprs: Map[String, String] = {
-    val source = Source.fromResource(SUPPORTED_EXPRS_FILE)
+    val source = UTF8Source.fromResource(SUPPORTED_EXPRS_FILE)
     // Some SQL function names have backquotes(`) around their names,
     // so we remove them before saving.
     readOperators(source, "exprs", true).map(
@@ -165,9 +166,9 @@ class PluginTypeChecker(val platform: Platform = PlatformFactory.createInstance(
   }
 
   def readUnsupportedOpsByDefaultReasons: Map[String, String] = {
-    val execsSource = Source.fromResource(SUPPORTED_EXECS_FILE)
+    val execsSource = UTF8Source.fromResource(SUPPORTED_EXECS_FILE)
     val unsupportedExecsBydefault = readOperators(execsSource, "execs", false)
-    val exprsSource = Source.fromResource(SUPPORTED_EXPRS_FILE)
+    val exprsSource = UTF8Source.fromResource(SUPPORTED_EXPRS_FILE)
     val unsupportedExprsByDefault = readOperators(exprsSource, "exprs", false).map(
       x => (x._1.toLowerCase.replaceAll("\\`", "").replaceAll(" ",""), x._2))
     unsupportedExecsBydefault ++ unsupportedExprsByDefault
@@ -175,7 +176,7 @@ class PluginTypeChecker(val platform: Platform = PlatformFactory.createInstance(
 
   private def readSupportedTypesForPlugin: (
       Map[String, Map[String, Seq[String]]], ArrayBuffer[String]) = {
-    val source = Source.fromResource(DEFAULT_DS_FILE)
+    val source = UTF8Source.fromResource(DEFAULT_DS_FILE)
     readSupportedTypesForPlugin(source)
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -20,7 +20,6 @@ import java.io.InputStream
 import java.util.zip.GZIPInputStream
 
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, LinkedHashSet, Map, SortedMap}
-import scala.io.{Codec, Source}
 
 import com.nvidia.spark.rapids.tool.{DatabricksEventLog, DatabricksRollingEventLogFilesFileReader, EventLogInfo}
 import com.nvidia.spark.rapids.tool.planparser.{HiveParseHelper, ReadParser}
@@ -35,7 +34,7 @@ import org.apache.spark.scheduler.{SparkListenerEvent, StageInfo}
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
 import org.apache.spark.sql.rapids.tool.store.{StageModel, StageModelManager, TaskModelManager}
-import org.apache.spark.sql.rapids.tool.util.{EventUtils, RapidsToolsConfUtil, ToolsPlanGraph}
+import org.apache.spark.sql.rapids.tool.util.{EventUtils, RapidsToolsConfUtil, ToolsPlanGraph, UTF8Source}
 import org.apache.spark.util.Utils
 
 abstract class AppBase(
@@ -261,7 +260,7 @@ abstract class AppBase(
           val runtimeGetFromJsonMethod = EventUtils.getEventFromJsonMethod
           reader.listEventLogFiles.foreach { file =>
             Utils.tryWithResource(openEventLogInternal(file.getPath, fs)) { in =>
-              Source.fromInputStream(in)(Codec.UTF8).getLines().find { line =>
+              UTF8Source.fromInputStream(in).getLines().find { line =>
                 // Using find as foreach with conditional to exit early if we are done.
                 // Do NOT use a while loop as it is much much slower.
                 totalNumEvents += 1

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/FSUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/FSUtils.scala
@@ -16,8 +16,10 @@
 
 package org.apache.spark.sql.rapids.tool.util
 
-import java.io.{BufferedWriter, FileOutputStream, OutputStreamWriter}
+import java.io.{BufferedWriter, File, FileOutputStream, InputStream, OutputStreamWriter}
 import java.nio.charset.StandardCharsets
+
+import scala.io.{BufferedSource, Source}
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, FSDataOutputStream, LocalFileSystem, Path}
@@ -68,4 +70,53 @@ object FSUtils {
     val outStream = getOutputStream(outputLoc, hadoopConf.getOrElse(new Configuration()))
     new BufferedWriter(new OutputStreamWriter(outStream, StandardCharsets.UTF_8))
   }
+
+  /**
+   * Reads the content of a file as UTF-8 and closes the resources.
+   */
+  def readFileContentAsUTF8(filePath: String, delim: String = "\n"): String = {
+    val source = UTF8Source.fromFile(filePath)
+    try {
+      source.getLines().mkString(delim)
+    } finally {
+      source.close()
+    }
+  }
 }
+
+// scalastyle:off regex.source.from
+/**
+ * Wrapper object for creating a BufferedSource object for reading a file as UTF-8.
+ * Any additional methods for reading files using the `Source` class should be implemented
+ * in this object to avoid encoding issues. This is also enforced by the scalastyle rule.
+ */
+object UTF8Source {
+  /**
+   * Creates a BufferedSource object for reading a file as UTF-8.
+   */
+  def fromFile(filePath: String): BufferedSource = {
+    Source.fromFile(filePath)(StandardCharsets.UTF_8)
+  }
+
+  /**
+   * Creates a BufferedSource object for reading a file as UTF-8 from a java.io.File.
+   */
+  def fromFile(file: File): BufferedSource = {
+    Source.fromFile(file)(StandardCharsets.UTF_8)
+  }
+
+  /**
+   * Creates a BufferedSource object for reading a file as UTF-8 from the resources.
+   */
+  def fromResource(filePath: String): BufferedSource = {
+    Source.fromResource(filePath)(StandardCharsets.UTF_8)
+  }
+
+  /**
+   * Creates a BufferedSource object for reading a file as UTF-8 from an InputStream.
+   */
+  def fromInputStream(inputStream: InputStream): BufferedSource = {
+    Source.fromInputStream(inputStream)(StandardCharsets.UTF_8)
+  }
+}
+// scalastyle:on regex.source.from

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/RapidsToolsConfUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/RapidsToolsConfUtil.scala
@@ -19,8 +19,6 @@ package org.apache.spark.sql.rapids.tool.util
 import java.io.FileNotFoundException
 import java.util.Properties
 
-import scala.io.Source
-
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.internal.Logging
@@ -95,7 +93,7 @@ object RapidsToolsConfUtil extends Logging {
       case null => // return empty properties if the file cannot be loaded
         logError("Cannot load properties from file", new FileNotFoundException(fileName))
       case stream =>
-        props.load(Source.fromInputStream(stream).bufferedReader())
+        props.load(UTF8Source.fromInputStream(stream).bufferedReader())
     }
     props
   }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -19,7 +19,6 @@ package com.nvidia.spark.rapids.tool.planparser
 import java.io.{File, PrintWriter}
 
 import scala.collection.mutable
-import scala.io.Source
 import scala.util.control.NonFatal
 
 import com.nvidia.spark.rapids.BaseTestSuite
@@ -34,7 +33,7 @@ import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.rapids.tool.ToolUtils
 import org.apache.spark.sql.rapids.tool.qualification.QualificationAppInfo
-import org.apache.spark.sql.rapids.tool.util.{RapidsToolsConfUtil, ToolsPlanGraph}
+import org.apache.spark.sql.rapids.tool.util.{RapidsToolsConfUtil, ToolsPlanGraph, UTF8Source}
 
 class SQLPlanParserSuite extends BaseTestSuite {
 
@@ -118,7 +117,7 @@ class SQLPlanParserSuite extends BaseTestSuite {
       // create a temporary file to write the modified events
       val faultyEventlog = new File(s"$eventLogDir/faulty_eventlog")
       val pWriter = new PrintWriter(faultyEventlog)
-      val bufferedSource = Source.fromFile(eventLog)
+      val bufferedSource = UTF8Source.fromFile(eventLog)
       try {
         bufferedSource.getLines.map( l =>
           if (l.contains("SparkListenerSQLExecutionStart")) {

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDotSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDotSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import java.io.File
 import java.security.SecureRandom
 
 import scala.collection.mutable
-import scala.io.Source
 
 import com.nvidia.spark.rapids.tool.ToolTestUtils
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
@@ -27,6 +26,7 @@ import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{SparkSession, TrampolineUtil}
 import org.apache.spark.sql.rapids.tool.ToolUtils
+import org.apache.spark.sql.rapids.tool.util.FSUtils
 
 class GenerateDotSuite extends FunSuite with BeforeAndAfterAll with Logging {
 
@@ -71,9 +71,7 @@ class GenerateDotSuite extends FunSuite with BeforeAndAfterAll with Logging {
         var stageCount = 0
         for (file <- dotDirs) {
           assert(file.getAbsolutePath.endsWith(".dot"))
-          val source = Source.fromFile(file)
-          val dotFileStr = source.mkString
-          source.close()
+          val dotFileStr = FSUtils.readFileContentAsUTF8(file.getAbsolutePath)
           assert(dotFileStr.startsWith("digraph G {"))
           assert(dotFileStr.endsWith("}"))
           val hashAggr = "HashAggregate"

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimelineSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimelineSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,12 @@ package com.nvidia.spark.rapids.tool.profiling
 
 import java.io.File
 
-import scala.io.Source
-
 import com.nvidia.spark.rapids.tool.ToolTestUtils
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{SparkSession, TrampolineUtil}
+import org.apache.spark.sql.rapids.tool.util.UTF8Source
 
 class GenerateTimelineSuite extends FunSuite with BeforeAndAfterAll with Logging {
 
@@ -71,7 +70,7 @@ class GenerateTimelineSuite extends FunSuite with BeforeAndAfterAll with Logging
         // with each test
         for (file <- outputDirs) {
           assert(file.getAbsolutePath.endsWith(".svg"))
-          val source = Source.fromFile(file)
+          val source = UTF8Source.fromFile(file)
           try {
             val lines = source.getLines().toArray
             stageZeroCount += lines.count(_.contains("STAGE 0"))

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
@@ -23,7 +23,6 @@ import java.util.Calendar
 
 import scala.concurrent.duration._
 import scala.io.Source
-import scala.util.Using
 import scala.xml.XML
 
 import com.nvidia.spark.rapids.tool.profiling.{ProfileOutputWriter, ProfileResult}
@@ -207,8 +206,11 @@ class ToolUtilsSuite extends FunSuite with Logging {
    * @return Content of the file as a string
    */
   private def readFileContentAsUtf8(filePath: String): String = {
-    Using.resource(Source.fromFile(filePath)(StandardCharsets.UTF_8)) {
-      source => source.getLines().mkString("\n")
+    val source = Source.fromFile(filePath)(StandardCharsets.UTF_8)
+    try {
+      source.getLines().mkString("\n")
+    } finally {
+      source.close()
     }
   }
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
@@ -17,12 +17,10 @@
 package com.nvidia.spark.rapids.tool.util
 
 import java.io.File
-import java.nio.charset.StandardCharsets
 import java.text.SimpleDateFormat
 import java.util.Calendar
 
 import scala.concurrent.duration._
-import scala.io.Source
 import scala.xml.XML
 
 import com.nvidia.spark.rapids.tool.profiling.{ProfileOutputWriter, ProfileResult}
@@ -32,7 +30,7 @@ import org.scalatest.Matchers.{contain, convertToAnyShouldWrapper, equal, not}
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.AccumulableInfo
 import org.apache.spark.sql.TrampolineUtil
-import org.apache.spark.sql.rapids.tool.util.{EventUtils, RapidsToolsConfUtil, StringUtils, WebCrawlerUtil}
+import org.apache.spark.sql.rapids.tool.util.{EventUtils, FSUtils, RapidsToolsConfUtil, StringUtils, WebCrawlerUtil}
 
 
 class ToolUtilsSuite extends FunSuite with Logging {
@@ -200,20 +198,6 @@ class ToolUtilsSuite extends FunSuite with Logging {
     result.value.get shouldBe (59 * 1000 + 200)
   }
 
-  /**
-   * Reads the content of a file as UTF-8 and closes the resources.
-   * @param filePath Path to the file
-   * @return Content of the file as a string
-   */
-  private def readFileContentAsUtf8(filePath: String): String = {
-    val source = Source.fromFile(filePath)(StandardCharsets.UTF_8)
-    try {
-      source.getLines().mkString("\n")
-    } finally {
-      source.close()
-    }
-  }
-
   test("output non-english characters") {
     val nonEnglishString = "你好"
     TrampolineUtil.withTempDir { tempDir =>
@@ -246,9 +230,8 @@ class ToolUtilsSuite extends FunSuite with Logging {
            |+-------+--------+---------------+---------+
            ||appID-0|1       |你好           |1,2,3    |
            |+-------+--------+---------------+---------+""".stripMargin
-      // Reading the content with UTF-8 encoding and ensuring resources are closed
-      val actualCSVContent = readFileContentAsUtf8(csvFilePath)
-      val actualTXTContent = readFileContentAsUtf8(textFilePath)
+      val actualCSVContent = FSUtils.readFileContentAsUTF8(csvFilePath)
+      val actualTXTContent = FSUtils.readFileContentAsUTF8(textFilePath)
       actualCSVContent should equal (expectedCSVFileContent)
       actualTXTContent should equal (expectedTXTContent)
     }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
@@ -17,11 +17,13 @@
 package com.nvidia.spark.rapids.tool.util
 
 import java.io.File
+import java.nio.charset.StandardCharsets
 import java.text.SimpleDateFormat
 import java.util.Calendar
 
 import scala.concurrent.duration._
 import scala.io.Source
+import scala.util.Using
 import scala.xml.XML
 
 import com.nvidia.spark.rapids.tool.profiling.{ProfileOutputWriter, ProfileResult}
@@ -199,6 +201,17 @@ class ToolUtilsSuite extends FunSuite with Logging {
     result.value.get shouldBe (59 * 1000 + 200)
   }
 
+  /**
+   * Reads the content of a file as UTF-8 and closes the resources.
+   * @param filePath Path to the file
+   * @return Content of the file as a string
+   */
+  private def readFileContentAsUtf8(filePath: String): String = {
+    Using.resource(Source.fromFile(filePath)(StandardCharsets.UTF_8)) {
+      source => source.getLines().mkString("\n")
+    }
+  }
+
   test("output non-english characters") {
     val nonEnglishString = "你好"
     TrampolineUtil.withTempDir { tempDir =>
@@ -231,8 +244,9 @@ class ToolUtilsSuite extends FunSuite with Logging {
            |+-------+--------+---------------+---------+
            ||appID-0|1       |你好           |1,2,3    |
            |+-------+--------+---------------+---------+""".stripMargin
-      val actualCSVContent: String = Source.fromFile(csvFilePath).getLines.mkString("\n")
-      val actualTXTContent: String = Source.fromFile(textFilePath).getLines.mkString("\n")
+      // Reading the content with UTF-8 encoding and ensuring resources are closed
+      val actualCSVContent = readFileContentAsUtf8(csvFilePath)
+      val actualTXTContent = readFileContentAsUtf8(textFilePath)
       actualCSVContent should equal (expectedCSVFileContent)
       actualTXTContent should equal (expectedTXTContent)
     }


### PR DESCRIPTION
Fixes #1209. This PR fixes an issue where unit tests fail due to encoding errors when reading non-English characters.


### Changes
- Added a wrapper object `UTF8Source` around `Source` with  charset set as `UTF8`
- Added a check in `scalastyle_config.xml` that disables usage of any `Source.from` related methods.
- Included a helper method `FSUtils.readFileContentAsUTF8()` to read file as UTF8 and close resources.

### Scalastyle Output
Verified the scalastyle check in `dev` branch. 28 occurrences of `Source.from` are detected.

<details>
<summary>Scalastyle Output</summary>
<pre>
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala message=Use UTF8Source.from instead of Source.from line=234 column=37
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala message=Use UTF8Source.from instead of Source.from line=235 column=37
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimelineSuite.scala message=Use UTF8Source.from instead of Source.from line=74 column=23
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDotSuite.scala message=Use UTF8Source.from instead of Source.from line=74 column=23
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala message=Use UTF8Source.from instead of Source.from line=291 column=24
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala message=Use UTF8Source.from instead of Source.from line=328 column=24
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala message=Use UTF8Source.from instead of Source.from line=341 column=30
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala message=Use UTF8Source.from instead of Source.from line=380 column=24
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala message=Use UTF8Source.from instead of Source.from line=390 column=30
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala message=Use UTF8Source.from instead of Source.from line=416 column=24
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala message=Use UTF8Source.from instead of Source.from line=450 column=24
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala message=Use UTF8Source.from instead of Source.from line=498 column=27
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala message=Use UTF8Source.from instead of Source.from line=1249 column=28
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala message=Use UTF8Source.from instead of Source.from line=1389 column=19
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala message=Use UTF8Source.from instead of Source.from line=1558 column=28
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala message=Use UTF8Source.from instead of Source.from line=121 column=27
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/RapidsToolsConfUtil.scala message=Use UTF8Source.from instead of Source.from line=98 column=19
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala message=Use UTF8Source.from instead of Source.from line=264 column=14
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/DriverLogProcessor.scala message=Use UTF8Source.from instead of Source.from line=43 column=17
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala message=Use UTF8Source.from instead of Source.from line=110 column=17
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala message=Use UTF8Source.from instead of Source.from line=117 column=17
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala message=Use UTF8Source.from instead of Source.from line=129 column=23
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala message=Use UTF8Source.from instead of Source.from line=136 column=25
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala message=Use UTF8Source.from instead of Source.from line=155 column=17
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala message=Use UTF8Source.from instead of Source.from line=160 column=17
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala message=Use UTF8Source.from instead of Source.from line=168 column=22
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala message=Use UTF8Source.from instead of Source.from line=170 column=22
error file=/Users/psarthi/Work/spark-rapids-tools/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala message=Use UTF8Source.from instead of Source.from line=178 column=17
Processed 164 file(s)
Found 28 errors
</pre>
</details>

### Testing
Tested the changes in a CICD job.

### Note
- The scalastyle check has been kept broad i.e. `Source.from` instead of specifics (i.e. `Source.fromFile`) so that in future if anyone uses a new method (eg. `Source.fromURI`), it will be automatically be caught.