### PR TITLE
Generate summary metadata file and fix node recommendation in python 

### DIFF
--- a/user_tools/src/spark_rapids_pytools/common/prop_manager.py
+++ b/user_tools/src/spark_rapids_pytools/common/prop_manager.py
@@ -18,14 +18,14 @@ import json
 from dataclasses import field, dataclass
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Union
 
 import yaml
 
 from spark_rapids_tools import get_elem_from_dict, get_elem_non_safe
 
 
-def convert_dict_to_camel_case(dic: dict | list, delim: str = '_') -> object:
+def convert_dict_to_camel_case(dic: Union[dict, list], delim: str = '_') -> object:
     """
     Given a dictionary with underscore keys. This method converts the keys to a camelcase.
     Example, gce_cluster_config -> gceClusterConfig

--- a/user_tools/src/spark_rapids_pytools/common/prop_manager.py
+++ b/user_tools/src/spark_rapids_pytools/common/prop_manager.py
@@ -25,22 +25,23 @@ import yaml
 from spark_rapids_tools import get_elem_from_dict, get_elem_non_safe
 
 
-def convert_dict_to_camel_case(dic: dict):
+def convert_dict_to_camel_case(dic: dict | list, delim: str = '_') -> object:
     """
     Given a dictionary with underscore keys. This method converts the keys to a camelcase.
     Example, gce_cluster_config -> gceClusterConfig
     :param dic: the dictionary to be converted
+    :param delim: the delimiter used in the keys
     :return: a dictionary where all the keys are camelcase.
     """
     def to_camel_case(word: str) -> str:
-        return word.split('_')[0] + ''.join(x.capitalize() or '_' for x in word.split('_')[1:])
+        return word.split(delim)[0] + ''.join(x.capitalize() or delim for x in word.split(delim)[1:])
 
     if isinstance(dic, list):
-        return [convert_dict_to_camel_case(i) if isinstance(i, (dict, list)) else i for i in dic]
+        return [convert_dict_to_camel_case(i, delim) if isinstance(i, (dict, list)) else i for i in dic]
     res = {}
     for key, value in dic.items():
         if isinstance(value, (dict, list)):
-            res[to_camel_case(key)] = convert_dict_to_camel_case(value)
+            res[to_camel_case(key)] = convert_dict_to_camel_case(value, delim)
         else:
             res[to_camel_case(key)] = value
     return res

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -131,9 +131,22 @@ local:
           heuristics:
             name: 'heuristics_info.csv'
             outputComment: "Heuristics information"
-          clusterShapeRecommendation:
-            name: cluster_shape_recommendation.json
-            outputComment: "Cluster shape recommendation report"
+      summaryMetadata:
+        name: qualification_summary_metadata.json
+        outputComment: "Metadata for the summary report"
+        columns:
+          - 'App ID'
+          - 'App Name'
+          - 'Recommended Cluster'
+          - 'Estimated GPU Speedup Category'
+          - 'Full Cluster Config Recommendations*'
+          - 'GPU Config Recommendation Breakdown*'
+      configRecommendations:
+        name: 'rapids_4_spark_qualification_output/tuning'
+        outputComment: "Config Recommendations"
+        columns:
+          - 'Full Cluster Config Recommendations*'
+          - 'GPU Config Recommendation Breakdown*'
     costColumns:
       - 'Savings Based Recommendation'
       - 'Estimated App Cost'

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -143,6 +143,7 @@ local:
         columns:
           - 'App ID'
           - 'App Name'
+          - 'Source Cluster'
           - 'Recommended Cluster'
           - 'Estimated GPU Speedup Category'
           - 'Full Cluster Config Recommendations*'

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -131,20 +131,20 @@ local:
           heuristics:
             name: 'heuristics_info.csv'
             outputComment: "Heuristics information"
+      configRecommendations:
+        name: 'rapids_4_spark_qualification_output/tuning'
+        outputComment: "Cluster config recommendations"
+        columns:
+          - 'Full Cluster Config Recommendations*'
+          - 'GPU Config Recommendation Breakdown*'
       summaryMetadata:
         name: qualification_summary_metadata.json
-        outputComment: "Metadata for the summary report"
+        outputComment: "Metadata file with cluster recommendation and tuning details"
         columns:
           - 'App ID'
           - 'App Name'
           - 'Recommended Cluster'
           - 'Estimated GPU Speedup Category'
-          - 'Full Cluster Config Recommendations*'
-          - 'GPU Config Recommendation Breakdown*'
-      configRecommendations:
-        name: 'rapids_4_spark_qualification_output/tuning'
-        outputComment: "Config Recommendations"
-        columns:
           - 'Full Cluster Config Recommendations*'
           - 'GPU Config Recommendation Breakdown*'
     costColumns:

--- a/user_tools/src/spark_rapids_tools/tools/cluster_config_recommender.py
+++ b/user_tools/src/spark_rapids_tools/tools/cluster_config_recommender.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" This module provides functionality for cluster shape recommendation """
+
+from functools import partial
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pandas as pd
+
+from spark_rapids_pytools.cloud_api.sp_types import ClusterBase
+from spark_rapids_pytools.common.sys_storage import FSUtil
+from spark_rapids_pytools.rapids.tool_ctxt import ToolContext
+
+
+@dataclass
+class ClusterRecommendationInfo:
+    """
+    Dataclass to hold the recommended cluster and the qualified node recommendation.
+    """
+    recommended_cluster_config: dict = field(default_factory=dict)
+    qualified_node_recommendation: str = 'Not Available'
+
+    def to_dict(self) -> dict:
+        return {
+            'Recommended Cluster': self.recommended_cluster_config,
+            'Qualified Node Recommendation': self.qualified_node_recommendation
+        }
+
+    @classmethod
+    def get_default_dict(cls) -> dict:
+        return cls().to_dict()
+
+
+@dataclass
+class TuningRecommendationInfo:
+    """
+    Dataclass to hold the full cluster config recommendations and the GPU config recommendation
+    """
+    cluster_config_recommendations: pd.Series
+    gpu_config_recommendation: pd.Series
+
+    def to_dict(self) -> dict:
+        return {
+            'Full Cluster Config Recommendations*': self.cluster_config_recommendations.to_list(),
+            'GPU Config Recommendation Breakdown*': self.gpu_config_recommendation.to_list()
+        }
+
+    @classmethod
+    def get_default(cls, missing_msg: str, num_apps: int = 0) -> 'TuningRecommendationInfo':
+        default_series = pd.Series([missing_msg] * num_apps)
+        return cls(cluster_config_recommendations=default_series, gpu_config_recommendation=default_series)
+
+
+@dataclass
+class ClusterConfigRecommender:
+    """
+    Class for recommending cluster shape and tuning configurations for processed apps.
+    """
+    ctxt: ToolContext = field(default=None, init=True)
+
+    @classmethod
+    def _get_instance_type_conversion(cls, cpu_cluster: ClusterBase,
+                                      gpu_cluster: ClusterBase) -> Optional[ClusterRecommendationInfo]:
+        """
+        Helper method to determine the conversion summary between CPU and GPU instance types.
+        Generate the cluster shape recommendation as:
+        {
+          'Recommended Cluster': {'driverInstance': 'm6.xlarge', 'executorInstance': 'g5.2xlarge', 'numExecutors': 2 }
+          'Qualified Node Recommendation': 'm6.xlarge to g5.2xlarge'
+        }
+        """
+        if not cpu_cluster:
+            return None
+
+        cpu_instance_type = cpu_cluster.get_worker_node().instance_type
+        recommended_cluster = cpu_cluster
+        conversion_str = cpu_instance_type
+        if gpu_cluster:
+            gpu_instance_type = gpu_cluster.get_worker_node().instance_type
+            if cpu_instance_type != gpu_instance_type:
+                recommended_cluster = gpu_cluster
+                conversion_str = f'{cpu_instance_type} to {gpu_instance_type}'
+        return ClusterRecommendationInfo(recommended_cluster.get_cluster_configuration(), conversion_str)
+
+    def _get_cluster_conversion_summary(self) -> dict:
+        """
+        Generates a summary of the cluster conversions from CPU to GPU instance types.
+        Returns a dictionary with either:
+        i. 'all' -> `ClusterRecommendationInfo`  for all instances
+        ii. '<app_id>' -> `ClusterRecommendationInfo`  for each app
+        """
+        cluster_conversion_summary = {}
+        # Summary for all instances
+        cpu_cluster_info = self.ctxt.get_ctxt('cpuClusterProxy')
+        gpu_cluster_info = self.ctxt.get_ctxt('gpuClusterProxy')
+        conversion_summary_all = self._get_instance_type_conversion(cpu_cluster_info, gpu_cluster_info)
+        if conversion_summary_all:
+            cluster_conversion_summary['all'] = conversion_summary_all.to_dict()
+
+        # Summary for each app
+        cpu_cluster_info_per_app = self.ctxt.get_ctxt('cpuClusterInfoPerApp')
+        gpu_cluster_info_per_app = self.ctxt.get_ctxt('gpuClusterInfoPerApp')
+        if cpu_cluster_info_per_app:
+            for app_id in cpu_cluster_info_per_app:
+                cpu_info = cpu_cluster_info_per_app.get(app_id)
+                gpu_info = gpu_cluster_info_per_app.get(app_id)
+                conversion_summary = self._get_instance_type_conversion(cpu_info, gpu_info)
+                if conversion_summary:
+                    cluster_conversion_summary[app_id] = conversion_summary.to_dict()
+
+        return cluster_conversion_summary
+
+    def _get_tuning_summary(self, tools_processed_apps: pd.DataFrame) -> TuningRecommendationInfo:
+        """
+        Get the tuning recommendations for the processed apps.
+        """
+        rapids_output_dir = self.ctxt.get_rapids_output_folder()
+        auto_tuning_path = FSUtil.build_path(rapids_output_dir,
+                                             self.ctxt.get_value('toolOutput', 'csv', 'tunings', 'subFolder'))
+        missing_msg = 'Does not exist, see log for errors'
+        if 'App ID' not in tools_processed_apps.columns:
+            return TuningRecommendationInfo.get_default(missing_msg, tools_processed_apps.shape[0])
+
+        full_tunings_file: pd.Series = tools_processed_apps['App ID'] + '.conf'
+        gpu_tunings_file: pd.Series = tools_processed_apps['App ID'] + '.log'
+        # check to see if the tuning are actually there, assume if one tuning file is there,
+        # the other will be as well.
+        tunings_abs_path = FSUtil.get_abs_path(auto_tuning_path)
+        if FSUtil.resource_exists(tunings_abs_path):  # check if the file exists
+            for index, file in gpu_tunings_file.items():
+                full_tunings_path = auto_tuning_path + '/' + file
+                abs_path = FSUtil.get_abs_path(full_tunings_path)
+                if not FSUtil.resource_exists(abs_path):  # check if the file exists
+                    gpu_tunings_file.at[index] = missing_msg
+                    full_tunings_file.at[index] = missing_msg
+            return TuningRecommendationInfo(full_tunings_file, gpu_tunings_file)
+        return TuningRecommendationInfo.get_default(missing_msg, tools_processed_apps.shape[0])
+
+    def add_cluster_and_tuning_recommendations(self, tools_processed_apps: pd.DataFrame):
+        """
+        Adds columns for cluster configuration recommendations and tuning configurations to the processed apps.
+        """
+        if tools_processed_apps.empty:
+            return tools_processed_apps
+
+        result_df = tools_processed_apps.copy()
+        # 1a. Add cluster conversion recommendations to apps
+        cluster_conversion_summary = self._get_cluster_conversion_summary()
+        # 'all' is a special indication that all the applications need to use this same node
+        # recommendation vs the recommendations being per application
+        if 'all' in cluster_conversion_summary:
+            # Add cluster conversion columns to all apps
+            for col, val in cluster_conversion_summary['all'].items():
+                result_df[col] = [val] * result_df.shape[0]
+        elif len(cluster_conversion_summary) > 0:
+            # Add the per-app node conversions
+            conversion_df = pd.DataFrame.from_dict(cluster_conversion_summary, orient='index').reset_index()
+            conversion_df.rename(columns={'index': 'App ID'}, inplace=True)
+            result_df = pd.merge(tools_processed_apps, conversion_df, on=['App ID'], how='left')
+
+        # 1b. Fill in the missing values of the cluster conversion columns with default values
+        for col, replacement in ClusterRecommendationInfo.get_default_dict().items():
+            # Using partial to avoid closure issues with lambda in apply()
+            fill_na_fn = partial(lambda x, def_val: def_val if pd.isna(x) else x, def_val=replacement)
+            result_df[col] = result_df.get(col, pd.Series()).apply(fill_na_fn)
+
+        # 2. Add tuning configuration recommendations to all apps
+        tuning_recommendation_summary = self._get_tuning_summary(result_df)
+        for col, val in tuning_recommendation_summary.to_dict().items():
+            result_df[col] = val
+        return result_df

--- a/user_tools/src/spark_rapids_tools/tools/cluster_config_recommender.py
+++ b/user_tools/src/spark_rapids_tools/tools/cluster_config_recommender.py
@@ -30,11 +30,13 @@ class ClusterRecommendationInfo:
     """
     Dataclass to hold the recommended cluster and the qualified node recommendation.
     """
+    source_cluster_config: dict = field(default_factory=dict)
     recommended_cluster_config: dict = field(default_factory=dict)
     qualified_node_recommendation: str = 'Not Available'
 
     def to_dict(self) -> dict:
         return {
+            'Source Cluster': self.source_cluster_config,
             'Recommended Cluster': self.recommended_cluster_config,
             'Qualified Node Recommendation': self.qualified_node_recommendation
         }
@@ -78,6 +80,7 @@ class ClusterConfigRecommender:
         Helper method to determine the conversion summary between CPU and GPU instance types.
         Generate the cluster shape recommendation as:
         {
+          'Source Cluster': {'driverInstance': 'm6.xlarge', 'executorInstance': 'm6.xlarge', 'numExecutors': 2 }
           'Recommended Cluster': {'driverInstance': 'm6.xlarge', 'executorInstance': 'g5.2xlarge', 'numExecutors': 2 }
           'Qualified Node Recommendation': 'm6.xlarge to g5.2xlarge'
         }
@@ -93,7 +96,10 @@ class ClusterConfigRecommender:
             if cpu_instance_type != gpu_instance_type:
                 recommended_cluster = gpu_cluster
                 conversion_str = f'{cpu_instance_type} to {gpu_instance_type}'
-        return ClusterRecommendationInfo(recommended_cluster.get_cluster_configuration(), conversion_str)
+        return ClusterRecommendationInfo(
+            cpu_cluster.get_cluster_configuration(),
+            recommended_cluster.get_cluster_configuration(),
+            conversion_str)
 
     def _get_cluster_conversion_summary(self) -> dict:
         """

--- a/user_tools/src/spark_rapids_tools/utils/util.py
+++ b/user_tools/src/spark_rapids_tools/utils/util.py
@@ -323,16 +323,3 @@ class Utilities:
             num_bytes /= 1024.0
             i += 1
         return f'{num_bytes:.2f} {size_units[i]}'
-
-    @classmethod
-    def convert_to_camel_case(cls, input_str: str) -> str:
-        """
-        Convert a string with spaces and special characters to camel case.
-        Eg,
-          'My Col Name' -> 'myColName'
-          'my col name**' -> 'myColName'
-        """
-        words = re.sub(r'[^a-zA-Z\s]', '', input_str).split()
-        if not words:
-            return ''
-        return words[0].lower() + ''.join(word.title() for word in words[1:])

--- a/user_tools/src/spark_rapids_tools/utils/util.py
+++ b/user_tools/src/spark_rapids_tools/utils/util.py
@@ -323,3 +323,16 @@ class Utilities:
             num_bytes /= 1024.0
             i += 1
         return f'{num_bytes:.2f} {size_units[i]}'
+
+    @classmethod
+    def convert_to_camel_case(cls, input_str: str) -> str:
+        """
+        Convert a string with spaces and special characters to camel case.
+        Eg,
+          'My Col Name' -> 'myColName'
+          'my col name**' -> 'myColName'
+        """
+        words = re.sub(r'[^a-zA-Z\s]', '', input_str).split()
+        if not words:
+            return ''
+        return words[0].lower() + ''.join(word.title() for word in words[1:])


### PR DESCRIPTION
Fixes #1143 , Fixes #1215. 

This PR introduces the following and some code refactoring:
1. Generates a metadata JSON file containing information such as tuning file, recommended cluster, speedup. Additionally, it fixes a bug. File: `qualification_summary_metadata.json`. 
2. Fixes a bug in python when node recommendations not generated for any apps if some apps lack node recommendations.

## Code Changes
1. Introduced a class `ClusterConfigRecommender` that cleans up the code by tying together the following:
     - Calculate the columns for cluster tuning config files and cluster recommendation
     - Add these columns to the final df processed by tools
2. Introduced a method `qualification.py::_write_summary_metadata()` (issue-1143)
    - This method will write the specified cols to metadata JSON file
    - It appends the full path to cluster tuning config files
    - Converts column names to camel case
3. In method `qualification.py::__infer_cluster_for_auto_tuning()` (issue-1215)
    - If we cannot create CPU cluster for an app, instead of returning we should continue inferring CPU cluster for the remaining apps. 


## Output

### Metadata JSON

<details>
<summary>File: `qual_20240723160911_B043Bae0/qualification_summary_metadata.json`</summary>
<pre>
[
  {
    "appId": "app-20240311074805-0000",
    "appName": "test_app_11111",
    "sourceCluster": {
      "driverInstance": "r5d.2xlarge",
      "executorInstance": "r5d.2xlarge",
      "numExecutors": 2
    },
    "recommendedCluster": {
      "driverInstance": "r5d.2xlarge",
      "executorInstance": "g5.2xlarge",
      "numExecutors": 2
    },
    "estimatedGpuSpeedupCategory": "Medium",
    "fullClusterConfigRecommendations": "/path/qual_20240723160911_B043Bae0/rapids_4_spark_qualification_output/tuning/app-20240311074805-0000.conf",
    "gpuConfigRecommendationBreakdown": "/path/qual_20240723160911_B043Bae0/rapids_4_spark_qualification_output/tuning/app-20240311074805-0000.log"
  },
  {
    "appId": "app-20240312011448-0000",
    "appName": "test_app_22222",
    "sourceCluster": {},
    "recommendedCluster": {},
    "estimatedGpuSpeedupCategory": "Not Recommended",
    "fullClusterConfigRecommendations": "/path/qual_20240723160911_B043Bae0/rapids_4_spark_qualification_output/tuning/app-20240312011448-0000.conf",
    "gpuConfigRecommendationBreakdown": "/path/qual_20240723160911_B043Bae0/rapids_4_spark_qualification_output/tuning/app-20240312011448-0000.log"
  }
]
</pre>
</details>

### Node Recommendation Fix

See [below](https://github.com/NVIDIA/spark-rapids-tools/pull/1216#issuecomment-2246213993). Added as a separate comment for readability

## To Discuss:
1. In `cluster_inference.py::get_cluster_template_args ()`
    - We are trying to read `'Recommended Executor Instance'` while creating CPU instance object.
    - This may cause an error because these are GPU instances.
    - Removed the block
2. We should not generate instance type conversion section anymore since the conversions are now per-app instead. 
    - Removed `sections_generators=[self.__generate_mc_types_conversion_report],`
    - Can also remove function all together `__generate_mc_types_conversion_report()`


## Follow Up
- In a follow up PR (show status report in console), event logs will be added as a property in the metadata file.