### PR TITLE
Remove estimation-model column from qualification summary

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -1029,11 +1029,6 @@ class Qualification(RapidsJarTool):
             except Exception as e:  # pylint: disable=broad-except
                 self.logger.error('Unable to use XGBoost estimation model for speed ups. '
                                   'Falling-back to default model. Reason - %s:%s', type(e).__name__, e)
-        estimation_model_col = self.ctxt.get_value('local', 'output', 'predictionModel',
-                                                   'updateResult', 'estimationModelColumn')
-        if estimation_model_col not in df:
-            # Create the estimation model column as SPEEDUPS if there were no predictions or failure.
-            df[estimation_model_col] = QualEstimationModel.tostring(QualEstimationModel.SPEEDUPS)
 
         # 2. Operations related to cluster information
         try:
@@ -1211,12 +1206,6 @@ class Qualification(RapidsJarTool):
         # Merge with a left join to include all rows from all apps and relevant rows from model predictions
         result_df = pd.merge(all_apps, predictions_df[result_info['subsetColumns']],
                              how='left', left_on='App ID', right_on='appId')
-        # Create a estimation model column based on the model used for calculating speedups
-        result_df[result_info['estimationModelColumn']] = np.where(
-            result_df['speedup'].isna(),
-            QualEstimationModel.tostring(QualEstimationModel.SPEEDUPS),
-            QualEstimationModel.tostring(QualEstimationModel.XGBOOST)
-        )
         # Update columns in all apps with values from corresponding XGBoost columns,
         # falling back to existing values in all apps when XGBoost values are NA.
         for remap_column in result_info['remapColumns']:

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -28,7 +28,6 @@ toolOutput:
         - SQL Stage Durations Sum
         - Unsupported Operators Stage Duration
         - Unsupported Operators Stage Duration Percent
-        - Speed Up Estimation Model
       mapColumns:
         Recommendation: 'Speedup Based Recommendation'
       recommendations:
@@ -320,7 +319,6 @@ local:
           - 'appId'
           - 'speedup'
           - 'appDuration_pred'
-        estimationModelColumn: 'Speed Up Estimation Model'
         remapColumns:
           - srcCol: 'speedup'
             dstCol: 'Estimated GPU Speedup'


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Contributes to #1199

- removes `Speed Up Estimation Model` from qualification_summary.csv (as xgboost will be only option)

