### PR TITLE
Reduce memory footprint of stageInfo

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
@@ -249,7 +249,7 @@ class AppSQLPlanAnalyzer(app: AppBase, appIndex: Int) extends AppAnalysisBase(ap
       val stagesInJob = app.stageManager.getStagesByIds(stages)
       stagesInJob.map { sModel =>
         val nodeIds = sqlPlanNodeIdToStageIds.filter { case (_, v) =>
-          v.contains(sModel.getStageId)
+          v.contains(sModel.stageInfo.stageId)
         }.keys.toSeq
         val nodeNames = app.sqlPlans.get(j.sqlID.get).map { planInfo =>
           val nodes = ToolsPlanGraph(planInfo).allNodes
@@ -258,8 +258,8 @@ class AppSQLPlanAnalyzer(app: AppBase, appIndex: Int) extends AppAnalysisBase(ap
           }
           validNodes.map(n => s"${n.name}(${n.id.toString})")
         }.getOrElse(Seq.empty)
-        SQLStageInfoProfileResult(appIndex, j.sqlID.get, jobId, sModel.getStageId,
-          sModel.getStageAttemptId, sModel.getStageDuration, nodeNames)
+        SQLStageInfoProfileResult(appIndex, j.sqlID.get, jobId, sModel.stageInfo.stageId,
+          sModel.stageInfo.attemptNumber(), sModel.duration, nodeNames)
       }
     }
     sqlToStages.toSeq

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
@@ -249,7 +249,7 @@ class AppSQLPlanAnalyzer(app: AppBase, appIndex: Int) extends AppAnalysisBase(ap
       val stagesInJob = app.stageManager.getStagesByIds(stages)
       stagesInJob.map { sModel =>
         val nodeIds = sqlPlanNodeIdToStageIds.filter { case (_, v) =>
-          v.contains(sModel.sId)
+          v.contains(sModel.getStageId)
         }.keys.toSeq
         val nodeNames = app.sqlPlans.get(j.sqlID.get).map { planInfo =>
           val nodes = ToolsPlanGraph(planInfo).allNodes
@@ -258,8 +258,8 @@ class AppSQLPlanAnalyzer(app: AppBase, appIndex: Int) extends AppAnalysisBase(ap
           }
           validNodes.map(n => s"${n.name}(${n.id.toString})")
         }.getOrElse(Seq.empty)
-        SQLStageInfoProfileResult(appIndex, j.sqlID.get, jobId, sModel.sId,
-          sModel.attemptId, sModel.duration, nodeNames)
+        SQLStageInfoProfileResult(appIndex, j.sqlID.get, jobId, sModel.getStageId,
+          sModel.getStageAttemptId, sModel.getStageDuration, nodeNames)
       }
     }
     sqlToStages.toSeq

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSparkMetricsAnalyzer.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSparkMetricsAnalyzer.scala
@@ -326,14 +326,14 @@ class AppSparkMetricsAnalyzer(app: AppBase) extends AppAnalysisBase(app) {
     // TODO: this has stage attempts. we should handle different attempts
     app.stageManager.getAllStages.foreach { sm =>
       // TODO: Should we only consider successful tasks?
-      val tasksInStage = app.taskManager.getTasks(sm.sId, sm.attemptId)
+      val tasksInStage = app.taskManager.getTasks(sm.getStageId, sm.getStageAttemptId)
       // count duplicate task attempts
       val numAttempts = tasksInStage.size
       val (durSum, durMax, durMin, durAvg) = AppSparkMetricsAnalyzer.getDurations(tasksInStage)
       val stageRow = StageAggTaskMetricsProfileResult(index,
-        sm.sId,
+        sm.getStageId,
         numAttempts,  // TODO: why is this numAttempts and not numTasks?
-        sm.duration,
+        sm.getStageDuration,
         tasksInStage.map(_.diskBytesSpilled).sum,
         durSum,
         durMax,
@@ -363,7 +363,7 @@ class AppSparkMetricsAnalyzer(app: AppBase) extends AppAnalysisBase(app) {
         tasksInStage.map(_.sw_recordsWritten).sum,
         tasksInStage.map(_.sw_writeTime).sum
       )
-      stageLevelSparkMetrics(index).put(sm.sId, stageRow)
+      stageLevelSparkMetrics(index).put(sm.getStageId, stageRow)
     }
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSparkMetricsAnalyzer.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSparkMetricsAnalyzer.scala
@@ -326,14 +326,15 @@ class AppSparkMetricsAnalyzer(app: AppBase) extends AppAnalysisBase(app) {
     // TODO: this has stage attempts. we should handle different attempts
     app.stageManager.getAllStages.foreach { sm =>
       // TODO: Should we only consider successful tasks?
-      val tasksInStage = app.taskManager.getTasks(sm.getStageId, sm.getStageAttemptId)
+      val tasksInStage = app.taskManager.getTasks(sm.stageInfo.stageId,
+        sm.stageInfo.attemptNumber())
       // count duplicate task attempts
       val numAttempts = tasksInStage.size
       val (durSum, durMax, durMin, durAvg) = AppSparkMetricsAnalyzer.getDurations(tasksInStage)
       val stageRow = StageAggTaskMetricsProfileResult(index,
-        sm.getStageId,
+        sm.stageInfo.stageId,
         numAttempts,  // TODO: why is this numAttempts and not numTasks?
-        sm.getStageDuration,
+        sm.duration,
         tasksInStage.map(_.diskBytesSpilled).sum,
         durSum,
         durMax,
@@ -363,7 +364,7 @@ class AppSparkMetricsAnalyzer(app: AppBase) extends AppAnalysisBase(app) {
         tasksInStage.map(_.sw_recordsWritten).sum,
         tasksInStage.map(_.sw_writeTime).sum
       )
-      stageLevelSparkMetrics(index).put(sm.getStageId, stageRow)
+      stageLevelSparkMetrics(index).put(sm.stageInfo.stageId, stageRow)
     }
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimeline.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimeline.scala
@@ -346,10 +346,10 @@ object GenerateTimeline {
     }
 
     val stageInfo = app.stageManager.getAllStages.map { case sm =>
-      val stageId = sm.sId
-      val submissionTime = sm.sInfo.submissionTime.get
-      val completionTime = sm.sInfo.completionTime.get
-      val duration = sm.getDuration
+      val stageId = sm.getStageId
+      val submissionTime = sm.getStageSubmissionTime.get
+      val completionTime = sm.getStageCompletionTime.get
+      val duration = sm.getStageDuration.getOrElse(0L)
       minStartTime = Math.min(minStartTime, submissionTime)
       maxEndTime = Math.max(maxEndTime, completionTime)
       new TimelineStageInfo(stageId, submissionTime, completionTime, duration)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimeline.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimeline.scala
@@ -346,10 +346,10 @@ object GenerateTimeline {
     }
 
     val stageInfo = app.stageManager.getAllStages.map { case sm =>
-      val stageId = sm.getStageId
-      val submissionTime = sm.getStageSubmissionTime.get
-      val completionTime = sm.getStageCompletionTime.get
-      val duration = sm.getStageDuration.getOrElse(0L)
+      val stageId = sm.stageInfo.stageId
+      val submissionTime = sm.stageInfo.submissionTime.get
+      val completionTime = sm.stageInfo.completionTime.get
+      val duration = sm.getDuration
       minStartTime = Math.min(minStartTime, submissionTime)
       maxEndTime = Math.max(maxEndTime, completionTime)
       new TimelineStageInfo(stageId, submissionTime, completionTime, duration)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/StageView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/StageView.scala
@@ -28,8 +28,8 @@ trait AppFailedStageViewTrait extends ViewableTrait[FailedStagesProfileResults] 
 
   override def getRawView(app: AppBase, index: Int): Seq[FailedStagesProfileResults] = {
     app.stageManager.getFailedStages.map { fsm =>
-      FailedStagesProfileResults(index, fsm.sId, fsm.attemptId,
-        fsm.sInfo.name, fsm.sInfo.numTasks,
+      FailedStagesProfileResults(index, fsm.getStageId, fsm.getStageAttemptId,
+        fsm.getStageName, fsm.getStageNumTasks,
         StringUtils.renderStr(fsm.getFailureReason, doEscapeMetaCharacters = false, maxLength = 0))
     }.toSeq
   }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/StageView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/StageView.scala
@@ -28,8 +28,9 @@ trait AppFailedStageViewTrait extends ViewableTrait[FailedStagesProfileResults] 
 
   override def getRawView(app: AppBase, index: Int): Seq[FailedStagesProfileResults] = {
     app.stageManager.getFailedStages.map { fsm =>
-      FailedStagesProfileResults(index, fsm.getStageId, fsm.getStageAttemptId,
-        fsm.getStageName, fsm.getStageNumTasks,
+      FailedStagesProfileResults(index, fsm.stageInfo.stageId,
+        fsm.stageInfo.attemptNumber(),
+        fsm.stageInfo.name, fsm.stageInfo.numTasks,
         StringUtils.renderStr(fsm.getFailureReason, doEscapeMetaCharacters = false, maxLength = 0))
     }.toSeq
   }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -749,7 +749,7 @@ class QualificationAppInfo(
   }
 
   private def checkMLOps(appId: Option[String], stageModel: StageModel): Option[MLFunctions] = {
-    val stageInfoDetails = stageModel.sInfo.details
+    val stageInfoDetails = stageModel.getStageDetails
     val mlOps = if (stageInfoDetails.contains(MlOps.sparkml) ||
       stageInfoDetails.contains(MlOps.xgBoost)) {
 
@@ -783,8 +783,8 @@ class QualificationAppInfo(
     }
 
     if (mlOps.nonEmpty) {
-      Some(MLFunctions(appId, stageModel.sId, mlOps,
-        stageModel.getDuration))
+      Some(MLFunctions(appId, stageModel.getStageId, mlOps,
+        stageModel.getStageDuration.getOrElse(0L)))
     } else {
       None
     }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -749,7 +749,7 @@ class QualificationAppInfo(
   }
 
   private def checkMLOps(appId: Option[String], stageModel: StageModel): Option[MLFunctions] = {
-    val stageInfoDetails = stageModel.getStageDetails
+    val stageInfoDetails = stageModel.stageInfo.details
     val mlOps = if (stageInfoDetails.contains(MlOps.sparkml) ||
       stageInfoDetails.contains(MlOps.xgBoost)) {
 
@@ -783,8 +783,8 @@ class QualificationAppInfo(
     }
 
     if (mlOps.nonEmpty) {
-      Some(MLFunctions(appId, stageModel.getStageId, mlOps,
-        stageModel.getStageDuration.getOrElse(0L)))
+      Some(MLFunctions(appId, stageModel.stageInfo.stageId, mlOps,
+        stageModel.getDuration))
     } else {
       None
     }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
@@ -31,7 +31,8 @@ import org.apache.spark.sql.rapids.tool.annotation.{Calculated, Since, WallClock
 @Since("24.02.3")
 class StageModel private(sInfo: StageInfo) {
 
-  var stageInfo: StageInfo = initStageInfo(sInfo)
+  var stageInfo: StageInfo = _
+  updateInfo(sInfo)
 
   /**
    * This method create a new StageInfo object from the incoming StageInfo object.

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
@@ -33,6 +33,12 @@ class StageModel private(sInfo: StageInfo) {
 
   var stageInfo: StageInfo = initStageInfo(sInfo)
 
+  /**
+   * This method create a new StageInfo object from the incoming StageInfo object.
+   * after trimming it down to contain only the necessary fields.
+   * @param newStageInfo
+   * @return a new StageInfo object with the necessary fields.
+   */
   private def initStageInfo(newStageInfo: StageInfo): StageInfo = {
     val stubStage = new StageInfo(
       stageId = newStageInfo.stageId,

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
@@ -49,12 +49,12 @@ class StageModel private(sInfo: StageInfo) {
    * events
    * @param newSInfo Spark's StageInfo loaded from StageSubmitted/StageCompleted events.
    */
-  private def updateInfo(newSInfo: StageInfo): Unit = {
-    sNumTasks = newSInfo.numTasks
-    sDetails = newSInfo.details
-    sSubmissionTime = newSInfo.submissionTime
-    sCompletionTime = newSInfo.completionTime
-    sFailureReason = newSInfo.failureReason
+  private def updateInfo(newStageInfo: StageInfo): Unit = {
+    sNumTasks = newStageInfo.numTasks
+    sDetails = newStageInfo.details
+    sSubmissionTime = newStageInfo.submissionTime
+    sCompletionTime = newStageInfo.completionTime
+    sFailureReason = newStageInfo.failureReason
     calculateDuration()
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
@@ -35,8 +35,8 @@ class StageModel private(sInfo: StageInfo) {
   updateInfo(sInfo)
 
   /**
-   * This method create a new StageInfo object from the incoming StageInfo object.
-   * after trimming it down to contain only the necessary fields.
+   * Creates a new StageInfo object by extractingand copying
+   * only the necessary fields from the given StageInfo object.
    * @param newStageInfo
    * @return a new StageInfo object with the necessary fields.
    */

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
@@ -47,7 +47,7 @@ class StageModel private(sInfo: StageInfo) {
    * Updates the snapshot of Spark's stageInfo to point to the new value and recalculate the
    * duration. Typically, a new StageInfo object is created with both StageSubmitted/StageCompleted
    * events
-   * @param newSInfo Spark's StageInfo loaded from StageSubmitted/StageCompleted events.
+   * @param newStageInfo Spark's StageInfo loaded from StageSubmitted/StageCompleted events.
    */
   private def updateInfo(newStageInfo: StageInfo): Unit = {
     sNumTasks = newStageInfo.numTasks

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModelManager.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModelManager.scala
@@ -99,7 +99,7 @@ class StageModelManager extends Logging {
   @Calculated("Sum all the WallClockDuration for the given stageId")
   def getDurationById(stageId: Int): Long = {
     stageIdToInfo.get(stageId).map { attempts =>
-      attempts.values.map(_.getStageDuration.getOrElse(0L)).sum
+      attempts.values.map(_.getDuration).sum
     }.getOrElse(0L)
   }
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -98,7 +98,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
     assert(firstApp.gpuMode.equals(true))
     assert(firstApp.jobIdToInfo.keys.toSeq.contains(1))
     val stageInfo = firstApp.stageManager.getStage(0, 0)
-    assert(stageInfo.isDefined && stageInfo.get.sInfo.numTasks.equals(1))
+    assert(stageInfo.isDefined && stageInfo.get.getStageNumTasks.equals(1))
     assert(firstApp.stageManager.getStage(2, 0).isDefined)
     assert(firstApp.taskManager.getTasks(firstApp.index, 0).head.successful.equals(true))
     assert(firstApp.taskManager.getTasks(firstApp.index, 0).head.endReason.equals("Success"))
@@ -161,7 +161,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
     assert(apps.head.jobIdToInfo.keys.toSeq.contains(0))
     val stage0 = apps.head.stageManager.getStage(0, 0)
     assert(stage0.isDefined)
-    assert(stage0.get.sInfo.numTasks.equals(1))
+    assert(stage0.get.getStageNumTasks.equals(1))
   }
 
   test("test no sql eventlog") {

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -98,7 +98,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
     assert(firstApp.gpuMode.equals(true))
     assert(firstApp.jobIdToInfo.keys.toSeq.contains(1))
     val stageInfo = firstApp.stageManager.getStage(0, 0)
-    assert(stageInfo.isDefined && stageInfo.get.getStageNumTasks.equals(1))
+    assert(stageInfo.isDefined && stageInfo.get.stageInfo.numTasks.equals(1))
     assert(firstApp.stageManager.getStage(2, 0).isDefined)
     assert(firstApp.taskManager.getTasks(firstApp.index, 0).head.successful.equals(true))
     assert(firstApp.taskManager.getTasks(firstApp.index, 0).head.endReason.equals("Success"))
@@ -161,7 +161,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
     assert(apps.head.jobIdToInfo.keys.toSeq.contains(0))
     val stage0 = apps.head.stageManager.getStage(0, 0)
     assert(stage0.isDefined)
-    assert(stage0.get.getStageNumTasks.equals(1))
+    assert(stage0.get.stageInfo.numTasks.equals(1))
   }
 
   test("test no sql eventlog") {


### PR DESCRIPTION
Resolves #1206 

## Issue
- Currently the StageModel stores the StageInfo for each stage completely
- The accumulable stored here were not being used in the code anywhere
- Refactor to remove redundant data being stored

## Changes
- StageModel updated to create a new StageInfo with only required fields
- StageModelManager now updates accumulable map directly when we add stage and does not refer the internal stageIndo accumulables

## Classes Affected
- StageModel - changes for creating new class with reduced size
- StageModelManager - changes for referring acumulables directly
- Other classes- mainly updates for accessing StageInfo information

## Profiling Observations
- Because we are creating a new stageInfo, post GC the old one will be dereferenced and the new Object will be smaller in size