### PR TITLE
[FEA] Remove gcloud CLI dependency for Dataproc platform

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -56,7 +56,7 @@ class DataprocPlatform(PlatformBase):
                                                           'confProperties',
                                                           'propertiesMap')
         if properties_map_arr:
-            # We support multiple CLI configurations, the following two dictionaries map
+            # We support multiple gcloud CLI configurations, the following two dictionaries map
             # config sections to the corresponding property keys to be set, and config file name respectively
             config_section_keys = defaultdict(list)  # config section: keys
             config_section_file = {}  # config section: config file

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -28,7 +28,7 @@ from spark_rapids_pytools.cloud_api.sp_types import PlatformBase, CMDDriverBase,
     NodeHWInfo, ClusterGetAccessor
 from spark_rapids_pytools.common.prop_manager import JSONPropertiesContainer, is_valid_gpu_device
 from spark_rapids_pytools.common.sys_storage import FSUtil
-from spark_rapids_pytools.common.utilities import SysCmd, Utils
+from spark_rapids_pytools.common.utilities import Utils
 from spark_rapids_pytools.pricing.dataproc_pricing import DataprocPriceProvider
 from spark_rapids_pytools.pricing.price_provider import SavingsEstimator
 

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -43,7 +43,7 @@
     "//description": "Define the metadata related to the system, prerequisites, and configurations",
     "envParams": ["credentialFile", "deployMode"],
     "//initialConfigList": "represents the list of the configurations that need to be loaded first",
-    "initialConfigList": ["credentialFile"],
+    "initialConfigList": ["credentialFile", "cliConfigFile"],
     "//loadedConfigProps": "list of properties read by the configParser",
     "loadedConfigProps": ["region", "zone", "project"],
     "cliConfig": {
@@ -52,6 +52,11 @@
           "envVariableKey": "GOOGLE_APPLICATION_CREDENTIALS",
           "confProperty": "credentialFile",
           "defaultValue": "~/.config/gcloud/application_default_credentials.json"
+        },
+        {
+          "envVariableKey": "GCLOUD_CONFIG_FILE",
+          "confProperty": "cliConfigFile",
+          "defaultValue": "~/.config/gcloud/configurations/config_default"
         },
         {
           "envVariableKey": "CLOUDSDK_DATAPROC_REGION",

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-instance-catalog.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-instance-catalog.json
@@ -1,0 +1,1527 @@
+{
+  "a2-highgpu-1g": {
+    "VCpuCount": 12,
+    "MemoryInMB": 87040,
+    "GpuInfo": [
+      {
+        "Name": "A100",
+        "Count": [
+          1
+        ]
+      }
+    ]
+  },
+  "a2-highgpu-2g": {
+    "VCpuCount": 24,
+    "MemoryInMB": 174080,
+    "GpuInfo": [
+      {
+        "Name": "A100",
+        "Count": [
+          2
+        ]
+      }
+    ]
+  },
+  "a2-highgpu-4g": {
+    "VCpuCount": 48,
+    "MemoryInMB": 348160,
+    "GpuInfo": [
+      {
+        "Name": "A100",
+        "Count": [
+          4
+        ]
+      }
+    ]
+  },
+  "a2-highgpu-8g": {
+    "VCpuCount": 96,
+    "MemoryInMB": 696320,
+    "GpuInfo": [
+      {
+        "Name": "A100",
+        "Count": [
+          8
+        ]
+      }
+    ]
+  },
+  "a2-megagpu-16g": {
+    "VCpuCount": 96,
+    "MemoryInMB": 1392640,
+    "GpuInfo": [
+      {
+        "Name": "A100",
+        "Count": [
+          16
+        ]
+      }
+    ]
+  },
+  "a2-ultragpu-1g": {
+    "VCpuCount": 12,
+    "MemoryInMB": 174080,
+    "GpuInfo": [
+      {
+        "Name": "A100",
+        "Count": [
+          1
+        ]
+      }
+    ]
+  },
+  "a2-ultragpu-2g": {
+    "VCpuCount": 24,
+    "MemoryInMB": 348160,
+    "GpuInfo": [
+      {
+        "Name": "A100",
+        "Count": [
+          2
+        ]
+      }
+    ]
+  },
+  "a2-ultragpu-4g": {
+    "VCpuCount": 48,
+    "MemoryInMB": 696320,
+    "GpuInfo": [
+      {
+        "Name": "A100",
+        "Count": [
+          4
+        ]
+      }
+    ]
+  },
+  "a2-ultragpu-8g": {
+    "VCpuCount": 96,
+    "MemoryInMB": 1392640,
+    "GpuInfo": [
+      {
+        "Name": "A100",
+        "Count": [
+          8
+        ]
+      }
+    ]
+  },
+  "a3-highgpu-8g": {
+    "VCpuCount": 208,
+    "MemoryInMB": 1916928,
+    "GpuInfo": [
+      {
+        "Name": "H100",
+        "Count": [
+          8
+        ]
+      }
+    ]
+  },
+  "a3-megagpu-8g": {
+    "VCpuCount": 208,
+    "MemoryInMB": 1916928,
+    "GpuInfo": [
+      {
+        "Name": "H100",
+        "Count": [
+          8
+        ]
+      }
+    ]
+  },
+  "c2-standard-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 65536
+  },
+  "c2-standard-30": {
+    "VCpuCount": 30,
+    "MemoryInMB": 122880
+  },
+  "c2-standard-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 16384
+  },
+  "c2-standard-60": {
+    "VCpuCount": 60,
+    "MemoryInMB": 245760
+  },
+  "c2-standard-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 32768
+  },
+  "c2d-highcpu-112": {
+    "VCpuCount": 112,
+    "MemoryInMB": 229376
+  },
+  "c2d-highcpu-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 32768
+  },
+  "c2d-highcpu-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 4096
+  },
+  "c2d-highcpu-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 65536
+  },
+  "c2d-highcpu-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 8192
+  },
+  "c2d-highcpu-56": {
+    "VCpuCount": 56,
+    "MemoryInMB": 114688
+  },
+  "c2d-highcpu-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 16384
+  },
+  "c2d-highmem-112": {
+    "VCpuCount": 112,
+    "MemoryInMB": 917504
+  },
+  "c2d-highmem-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 131072
+  },
+  "c2d-highmem-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 16384
+  },
+  "c2d-highmem-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 262144
+  },
+  "c2d-highmem-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 32768
+  },
+  "c2d-highmem-56": {
+    "VCpuCount": 56,
+    "MemoryInMB": 458752
+  },
+  "c2d-highmem-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 65536
+  },
+  "c2d-standard-112": {
+    "VCpuCount": 112,
+    "MemoryInMB": 458752
+  },
+  "c2d-standard-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 65536
+  },
+  "c2d-standard-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 8192
+  },
+  "c2d-standard-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 131072
+  },
+  "c2d-standard-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 16384
+  },
+  "c2d-standard-56": {
+    "VCpuCount": 56,
+    "MemoryInMB": 229376
+  },
+  "c2d-standard-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 32768
+  },
+  "c3-highcpu-176": {
+    "VCpuCount": 176,
+    "MemoryInMB": 360448
+  },
+  "c3-highcpu-22": {
+    "VCpuCount": 22,
+    "MemoryInMB": 45056
+  },
+  "c3-highcpu-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 8192
+  },
+  "c3-highcpu-44": {
+    "VCpuCount": 44,
+    "MemoryInMB": 90112
+  },
+  "c3-highcpu-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 16384
+  },
+  "c3-highcpu-88": {
+    "VCpuCount": 88,
+    "MemoryInMB": 180224
+  },
+  "c3-highmem-176": {
+    "VCpuCount": 176,
+    "MemoryInMB": 1441792
+  },
+  "c3-highmem-192-metal": {
+    "VCpuCount": 192,
+    "MemoryInMB": 1572864
+  },
+  "c3-highmem-22": {
+    "VCpuCount": 22,
+    "MemoryInMB": 180224
+  },
+  "c3-highmem-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 32768
+  },
+  "c3-highmem-44": {
+    "VCpuCount": 44,
+    "MemoryInMB": 360448
+  },
+  "c3-highmem-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 65536
+  },
+  "c3-highmem-88": {
+    "VCpuCount": 88,
+    "MemoryInMB": 720896
+  },
+  "c3-standard-176": {
+    "VCpuCount": 176,
+    "MemoryInMB": 720896
+  },
+  "c3-standard-176-lssd": {
+    "VCpuCount": 176,
+    "MemoryInMB": 720896
+  },
+  "c3-standard-192-metal": {
+    "VCpuCount": 192,
+    "MemoryInMB": 786432
+  },
+  "c3-standard-22": {
+    "VCpuCount": 22,
+    "MemoryInMB": 90112
+  },
+  "c3-standard-22-lssd": {
+    "VCpuCount": 22,
+    "MemoryInMB": 90112
+  },
+  "c3-standard-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 16384
+  },
+  "c3-standard-4-lssd": {
+    "VCpuCount": 4,
+    "MemoryInMB": 16384
+  },
+  "c3-standard-44": {
+    "VCpuCount": 44,
+    "MemoryInMB": 180224
+  },
+  "c3-standard-44-lssd": {
+    "VCpuCount": 44,
+    "MemoryInMB": 180224
+  },
+  "c3-standard-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 32768
+  },
+  "c3-standard-8-lssd": {
+    "VCpuCount": 8,
+    "MemoryInMB": 32768
+  },
+  "c3-standard-88": {
+    "VCpuCount": 88,
+    "MemoryInMB": 360448
+  },
+  "c3-standard-88-lssd": {
+    "VCpuCount": 88,
+    "MemoryInMB": 360448
+  },
+  "c3d-highcpu-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 32768
+  },
+  "c3d-highcpu-180": {
+    "VCpuCount": 180,
+    "MemoryInMB": 362496
+  },
+  "c3d-highcpu-30": {
+    "VCpuCount": 30,
+    "MemoryInMB": 60416
+  },
+  "c3d-highcpu-360": {
+    "VCpuCount": 360,
+    "MemoryInMB": 724992
+  },
+  "c3d-highcpu-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 8192
+  },
+  "c3d-highcpu-60": {
+    "VCpuCount": 60,
+    "MemoryInMB": 120832
+  },
+  "c3d-highcpu-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 16384
+  },
+  "c3d-highcpu-90": {
+    "VCpuCount": 90,
+    "MemoryInMB": 181248
+  },
+  "c3d-highmem-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 131072
+  },
+  "c3d-highmem-180": {
+    "VCpuCount": 180,
+    "MemoryInMB": 1474560
+  },
+  "c3d-highmem-30": {
+    "VCpuCount": 30,
+    "MemoryInMB": 245760
+  },
+  "c3d-highmem-360": {
+    "VCpuCount": 360,
+    "MemoryInMB": 2949120
+  },
+  "c3d-highmem-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 32768
+  },
+  "c3d-highmem-60": {
+    "VCpuCount": 60,
+    "MemoryInMB": 491520
+  },
+  "c3d-highmem-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 65536
+  },
+  "c3d-highmem-90": {
+    "VCpuCount": 90,
+    "MemoryInMB": 737280
+  },
+  "c3d-standard-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 65536
+  },
+  "c3d-standard-16-lssd": {
+    "VCpuCount": 16,
+    "MemoryInMB": 65536
+  },
+  "c3d-standard-180": {
+    "VCpuCount": 180,
+    "MemoryInMB": 737280
+  },
+  "c3d-standard-180-lssd": {
+    "VCpuCount": 180,
+    "MemoryInMB": 737280
+  },
+  "c3d-standard-30": {
+    "VCpuCount": 30,
+    "MemoryInMB": 122880
+  },
+  "c3d-standard-30-lssd": {
+    "VCpuCount": 30,
+    "MemoryInMB": 122880
+  },
+  "c3d-standard-360": {
+    "VCpuCount": 360,
+    "MemoryInMB": 1474560
+  },
+  "c3d-standard-360-lssd": {
+    "VCpuCount": 360,
+    "MemoryInMB": 1474560
+  },
+  "c3d-standard-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 16384
+  },
+  "c3d-standard-60": {
+    "VCpuCount": 60,
+    "MemoryInMB": 245760
+  },
+  "c3d-standard-60-lssd": {
+    "VCpuCount": 60,
+    "MemoryInMB": 245760
+  },
+  "c3d-standard-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 32768
+  },
+  "c3d-standard-8-lssd": {
+    "VCpuCount": 8,
+    "MemoryInMB": 32768
+  },
+  "c3d-standard-90": {
+    "VCpuCount": 90,
+    "MemoryInMB": 368640
+  },
+  "c3d-standard-90-lssd": {
+    "VCpuCount": 90,
+    "MemoryInMB": 368640
+  },
+  "c4-standard-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 61440
+  },
+  "c4-standard-192": {
+    "VCpuCount": 192,
+    "MemoryInMB": 737280
+  },
+  "c4-standard-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 7168
+  },
+  "c4-standard-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 122880
+  },
+  "c4-standard-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 15360
+  },
+  "c4-standard-48": {
+    "VCpuCount": 48,
+    "MemoryInMB": 184320
+  },
+  "c4-standard-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 30720
+  },
+  "c4-standard-96": {
+    "VCpuCount": 96,
+    "MemoryInMB": 368640
+  },
+  "ct5l-hightpu-1t": {
+    "VCpuCount": 24,
+    "MemoryInMB": 49152
+  },
+  "ct5l-hightpu-4t": {
+    "VCpuCount": 112,
+    "MemoryInMB": 196608
+  },
+  "ct5l-hightpu-8t": {
+    "VCpuCount": 224,
+    "MemoryInMB": 393216
+  },
+  "ct5lp-hightpu-1t": {
+    "VCpuCount": 24,
+    "MemoryInMB": 49152
+  },
+  "ct5lp-hightpu-4t": {
+    "VCpuCount": 112,
+    "MemoryInMB": 196608
+  },
+  "ct5lp-hightpu-8t": {
+    "VCpuCount": 224,
+    "MemoryInMB": 393216
+  },
+  "e2-highcpu-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 16384
+  },
+  "e2-highcpu-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 2048
+  },
+  "e2-highcpu-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 32768
+  },
+  "e2-highcpu-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 4096
+  },
+  "e2-highcpu-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 8192
+  },
+  "e2-highmem-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 131072
+  },
+  "e2-highmem-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 16384
+  },
+  "e2-highmem-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 32768
+  },
+  "e2-highmem-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 65536
+  },
+  "e2-medium": {
+    "VCpuCount": 2,
+    "MemoryInMB": 4096
+  },
+  "e2-micro": {
+    "VCpuCount": 2,
+    "MemoryInMB": 1024
+  },
+  "e2-small": {
+    "VCpuCount": 2,
+    "MemoryInMB": 2048
+  },
+  "e2-standard-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 65536
+  },
+  "e2-standard-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 8192
+  },
+  "e2-standard-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 131072
+  },
+  "e2-standard-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 16384
+  },
+  "e2-standard-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 32768
+  },
+  "f1-micro": {
+    "VCpuCount": 1,
+    "MemoryInMB": 614
+  },
+  "g1-small": {
+    "VCpuCount": 1,
+    "MemoryInMB": 1740
+  },
+  "g2-standard-12": {
+    "VCpuCount": 12,
+    "MemoryInMB": 49152,
+    "GpuInfo": [
+      {
+        "Name": "L4",
+        "Count": [
+          1
+        ]
+      }
+    ]
+  },
+  "g2-standard-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 65536,
+    "GpuInfo": [
+      {
+        "Name": "L4",
+        "Count": [
+          1
+        ]
+      }
+    ]
+  },
+  "g2-standard-24": {
+    "VCpuCount": 24,
+    "MemoryInMB": 98304,
+    "GpuInfo": [
+      {
+        "Name": "L4",
+        "Count": [
+          2
+        ]
+      }
+    ]
+  },
+  "g2-standard-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 131072,
+    "GpuInfo": [
+      {
+        "Name": "L4",
+        "Count": [
+          1
+        ]
+      }
+    ]
+  },
+  "g2-standard-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 16384,
+    "GpuInfo": [
+      {
+        "Name": "L4",
+        "Count": [
+          1
+        ]
+      }
+    ]
+  },
+  "g2-standard-48": {
+    "VCpuCount": 48,
+    "MemoryInMB": 196608,
+    "GpuInfo": [
+      {
+        "Name": "L4",
+        "Count": [
+          4
+        ]
+      }
+    ]
+  },
+  "g2-standard-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 32768,
+    "GpuInfo": [
+      {
+        "Name": "L4",
+        "Count": [
+          1
+        ]
+      }
+    ]
+  },
+  "g2-standard-96": {
+    "VCpuCount": 96,
+    "MemoryInMB": 393216,
+    "GpuInfo": [
+      {
+        "Name": "L4",
+        "Count": [
+          8
+        ]
+      }
+    ]
+  },
+  "h3-standard-88": {
+    "VCpuCount": 88,
+    "MemoryInMB": 360448
+  },
+  "m1-megamem-96": {
+    "VCpuCount": 96,
+    "MemoryInMB": 1468006
+  },
+  "m1-ultramem-160": {
+    "VCpuCount": 160,
+    "MemoryInMB": 3936256
+  },
+  "m1-ultramem-40": {
+    "VCpuCount": 40,
+    "MemoryInMB": 984064
+  },
+  "m1-ultramem-80": {
+    "VCpuCount": 80,
+    "MemoryInMB": 1968128
+  },
+  "m2-hypermem-416": {
+    "VCpuCount": 416,
+    "MemoryInMB": 9043968
+  },
+  "m2-megamem-416": {
+    "VCpuCount": 416,
+    "MemoryInMB": 6029312
+  },
+  "m2-ultramem-208": {
+    "VCpuCount": 208,
+    "MemoryInMB": 6029312
+  },
+  "m2-ultramem-416": {
+    "VCpuCount": 416,
+    "MemoryInMB": 12058624
+  },
+  "m3-megamem-128": {
+    "VCpuCount": 128,
+    "MemoryInMB": 1998848
+  },
+  "m3-megamem-64": {
+    "VCpuCount": 64,
+    "MemoryInMB": 999424
+  },
+  "m3-ultramem-128": {
+    "VCpuCount": 128,
+    "MemoryInMB": 3997696
+  },
+  "m3-ultramem-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 999424
+  },
+  "m3-ultramem-64": {
+    "VCpuCount": 64,
+    "MemoryInMB": 1998848
+  },
+  "n1-highcpu-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 14746
+  },
+  "n1-highcpu-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 1843
+  },
+  "n1-highcpu-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 29491
+  },
+  "n1-highcpu-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 3686
+  },
+  "n1-highcpu-64": {
+    "VCpuCount": 64,
+    "MemoryInMB": 58982
+  },
+  "n1-highcpu-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 7373
+  },
+  "n1-highcpu-96": {
+    "VCpuCount": 96,
+    "MemoryInMB": 88474
+  },
+  "n1-highmem-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 106496
+  },
+  "n1-highmem-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 13312
+  },
+  "n1-highmem-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 212992
+  },
+  "n1-highmem-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 26624
+  },
+  "n1-highmem-64": {
+    "VCpuCount": 64,
+    "MemoryInMB": 425984
+  },
+  "n1-highmem-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 53248
+  },
+  "n1-highmem-96": {
+    "VCpuCount": 96,
+    "MemoryInMB": 638976
+  },
+  "n1-megamem-96": {
+    "VCpuCount": 96,
+    "MemoryInMB": 1468006
+  },
+  "n1-standard-1": {
+    "VCpuCount": 1,
+    "MemoryInMB": 3840,
+    "GpuInfo": [
+      {
+        "Name": "T4",
+        "Count": [
+          1,
+          2,
+          4
+        ]
+      },
+      {
+        "Name": "P4",
+        "Count": [
+          1,
+          2,
+          4
+        ]
+      },
+      {
+        "Name": "V100",
+        "Count": [
+          1,
+          2,
+          4,
+          8
+        ]
+      },
+      {
+        "Name": "P100",
+        "Count": [
+          1,
+          2,
+          4
+        ]
+      }
+    ]
+  },
+  "n1-standard-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 61440,
+    "GpuInfo": [
+      {
+        "Name": "T4",
+        "Count": [
+          1,
+          2,
+          4
+        ]
+      },
+      {
+        "Name": "P4",
+        "Count": [
+          1,
+          2,
+          4
+        ]
+      },
+      {
+        "Name": "V100",
+        "Count": [
+          2,
+          4,
+          8
+        ]
+      },
+      {
+        "Name": "P100",
+        "Count": [
+          1,
+          2,
+          4
+        ]
+      }
+    ]
+  },
+  "n1-standard-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 7680,
+    "GpuInfo": [
+      {
+        "Name": "T4",
+        "Count": [
+          1,
+          2,
+          4
+        ]
+      },
+      {
+        "Name": "P4",
+        "Count": [
+          1,
+          2,
+          4
+        ]
+      },
+      {
+        "Name": "V100",
+        "Count": [
+          1,
+          2,
+          4,
+          8
+        ]
+      },
+      {
+        "Name": "P100",
+        "Count": [
+          1,
+          2,
+          4
+        ]
+      }
+    ]
+  },
+  "n1-standard-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 122880,
+    "GpuInfo": [
+      {
+        "Name": "T4",
+        "Count": [
+          1,
+          2,
+          4
+        ]
+      },
+      {
+        "Name": "P4",
+        "Count": [
+          2,
+          4
+        ]
+      },
+      {
+        "Name": "V100",
+        "Count": [
+          4,
+          8
+        ]
+      },
+      {
+        "Name": "P100",
+        "Count": [
+          2,
+          4
+        ]
+      }
+    ]
+  },
+  "n1-standard-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 15360,
+    "GpuInfo": [
+      {
+        "Name": "T4",
+        "Count": [
+          1,
+          2,
+          4
+        ]
+      },
+      {
+        "Name": "P4",
+        "Count": [
+          1,
+          2,
+          4
+        ]
+      },
+      {
+        "Name": "V100",
+        "Count": [
+          1,
+          2,
+          4,
+          8
+        ]
+      },
+      {
+        "Name": "P100",
+        "Count": [
+          1,
+          2,
+          4
+        ]
+      }
+    ]
+  },
+  "n1-standard-64": {
+    "VCpuCount": 64,
+    "MemoryInMB": 245760,
+    "GpuInfo": [
+      {
+        "Name": "T4",
+        "Count": [
+          4
+        ]
+      },
+      {
+        "Name": "P4",
+        "Count": [
+          4
+        ]
+      },
+      {
+        "Name": "V100",
+        "Count": [
+          8
+        ]
+      },
+      {
+        "Name": "P100",
+        "Count": [
+          4
+        ]
+      }
+    ]
+  },
+  "n1-standard-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 30720,
+    "GpuInfo": [
+      {
+        "Name": "T4",
+        "Count": [
+          1,
+          2,
+          4
+        ]
+      },
+      {
+        "Name": "P4",
+        "Count": [
+          1,
+          2,
+          4
+        ]
+      },
+      {
+        "Name": "V100",
+        "Count": [
+          1,
+          2,
+          4,
+          8
+        ]
+      },
+      {
+        "Name": "P100",
+        "Count": [
+          1,
+          2,
+          4
+        ]
+      }
+    ]
+  },
+  "n1-standard-96": {
+    "VCpuCount": 96,
+    "MemoryInMB": 368640,
+    "GpuInfo": [
+      {
+        "Name": "T4",
+        "Count": [
+          4
+        ]
+      },
+      {
+        "Name": "P4",
+        "Count": [
+          4
+        ]
+      },
+      {
+        "Name": "V100",
+        "Count": [
+          8
+        ]
+      },
+      {
+        "Name": "P100",
+        "Count": [
+          4
+        ]
+      }
+    ]
+  },
+  "n1-ultramem-160": {
+    "VCpuCount": 160,
+    "MemoryInMB": 3936256
+  },
+  "n1-ultramem-40": {
+    "VCpuCount": 40,
+    "MemoryInMB": 984064
+  },
+  "n1-ultramem-80": {
+    "VCpuCount": 80,
+    "MemoryInMB": 1968128
+  },
+  "n2-highcpu-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 16384
+  },
+  "n2-highcpu-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 2048
+  },
+  "n2-highcpu-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 32768
+  },
+  "n2-highcpu-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 4096
+  },
+  "n2-highcpu-48": {
+    "VCpuCount": 48,
+    "MemoryInMB": 49152
+  },
+  "n2-highcpu-64": {
+    "VCpuCount": 64,
+    "MemoryInMB": 65536
+  },
+  "n2-highcpu-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 8192
+  },
+  "n2-highcpu-80": {
+    "VCpuCount": 80,
+    "MemoryInMB": 81920
+  },
+  "n2-highcpu-96": {
+    "VCpuCount": 96,
+    "MemoryInMB": 98304
+  },
+  "n2-highmem-128": {
+    "VCpuCount": 128,
+    "MemoryInMB": 884736
+  },
+  "n2-highmem-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 131072
+  },
+  "n2-highmem-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 16384
+  },
+  "n2-highmem-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 262144
+  },
+  "n2-highmem-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 32768
+  },
+  "n2-highmem-48": {
+    "VCpuCount": 48,
+    "MemoryInMB": 393216
+  },
+  "n2-highmem-64": {
+    "VCpuCount": 64,
+    "MemoryInMB": 524288
+  },
+  "n2-highmem-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 65536
+  },
+  "n2-highmem-80": {
+    "VCpuCount": 80,
+    "MemoryInMB": 655360
+  },
+  "n2-highmem-96": {
+    "VCpuCount": 96,
+    "MemoryInMB": 786432
+  },
+  "n2-standard-128": {
+    "VCpuCount": 128,
+    "MemoryInMB": 524288
+  },
+  "n2-standard-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 65536
+  },
+  "n2-standard-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 8192
+  },
+  "n2-standard-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 131072
+  },
+  "n2-standard-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 16384
+  },
+  "n2-standard-48": {
+    "VCpuCount": 48,
+    "MemoryInMB": 196608
+  },
+  "n2-standard-64": {
+    "VCpuCount": 64,
+    "MemoryInMB": 262144
+  },
+  "n2-standard-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 32768
+  },
+  "n2-standard-80": {
+    "VCpuCount": 80,
+    "MemoryInMB": 327680
+  },
+  "n2-standard-96": {
+    "VCpuCount": 96,
+    "MemoryInMB": 393216
+  },
+  "n2d-highcpu-128": {
+    "VCpuCount": 128,
+    "MemoryInMB": 131072
+  },
+  "n2d-highcpu-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 16384
+  },
+  "n2d-highcpu-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 2048
+  },
+  "n2d-highcpu-224": {
+    "VCpuCount": 224,
+    "MemoryInMB": 229376
+  },
+  "n2d-highcpu-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 32768
+  },
+  "n2d-highcpu-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 4096
+  },
+  "n2d-highcpu-48": {
+    "VCpuCount": 48,
+    "MemoryInMB": 49152
+  },
+  "n2d-highcpu-64": {
+    "VCpuCount": 64,
+    "MemoryInMB": 65536
+  },
+  "n2d-highcpu-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 8192
+  },
+  "n2d-highcpu-80": {
+    "VCpuCount": 80,
+    "MemoryInMB": 81920
+  },
+  "n2d-highcpu-96": {
+    "VCpuCount": 96,
+    "MemoryInMB": 98304
+  },
+  "n2d-highmem-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 131072
+  },
+  "n2d-highmem-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 16384
+  },
+  "n2d-highmem-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 262144
+  },
+  "n2d-highmem-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 32768
+  },
+  "n2d-highmem-48": {
+    "VCpuCount": 48,
+    "MemoryInMB": 393216
+  },
+  "n2d-highmem-64": {
+    "VCpuCount": 64,
+    "MemoryInMB": 524288
+  },
+  "n2d-highmem-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 65536
+  },
+  "n2d-highmem-80": {
+    "VCpuCount": 80,
+    "MemoryInMB": 655360
+  },
+  "n2d-highmem-96": {
+    "VCpuCount": 96,
+    "MemoryInMB": 786432
+  },
+  "n2d-standard-128": {
+    "VCpuCount": 128,
+    "MemoryInMB": 524288
+  },
+  "n2d-standard-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 65536
+  },
+  "n2d-standard-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 8192
+  },
+  "n2d-standard-224": {
+    "VCpuCount": 224,
+    "MemoryInMB": 917504
+  },
+  "n2d-standard-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 131072
+  },
+  "n2d-standard-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 16384
+  },
+  "n2d-standard-48": {
+    "VCpuCount": 48,
+    "MemoryInMB": 196608
+  },
+  "n2d-standard-64": {
+    "VCpuCount": 64,
+    "MemoryInMB": 262144
+  },
+  "n2d-standard-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 32768
+  },
+  "n2d-standard-80": {
+    "VCpuCount": 80,
+    "MemoryInMB": 327680
+  },
+  "n2d-standard-96": {
+    "VCpuCount": 96,
+    "MemoryInMB": 393216
+  },
+  "n4-highcpu-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 32768
+  },
+  "n4-highcpu-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 4096
+  },
+  "n4-highcpu-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 65536
+  },
+  "n4-highcpu-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 8192
+  },
+  "n4-highcpu-48": {
+    "VCpuCount": 48,
+    "MemoryInMB": 98304
+  },
+  "n4-highcpu-64": {
+    "VCpuCount": 64,
+    "MemoryInMB": 131072
+  },
+  "n4-highcpu-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 16384
+  },
+  "n4-highcpu-80": {
+    "VCpuCount": 80,
+    "MemoryInMB": 163840
+  },
+  "n4-highmem-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 131072
+  },
+  "n4-highmem-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 16384
+  },
+  "n4-highmem-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 262144
+  },
+  "n4-highmem-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 32768
+  },
+  "n4-highmem-48": {
+    "VCpuCount": 48,
+    "MemoryInMB": 393216
+  },
+  "n4-highmem-64": {
+    "VCpuCount": 64,
+    "MemoryInMB": 524288
+  },
+  "n4-highmem-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 65536
+  },
+  "n4-highmem-80": {
+    "VCpuCount": 80,
+    "MemoryInMB": 655360
+  },
+  "n4-standard-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 65536
+  },
+  "n4-standard-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 8192
+  },
+  "n4-standard-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 131072
+  },
+  "n4-standard-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 16384
+  },
+  "n4-standard-48": {
+    "VCpuCount": 48,
+    "MemoryInMB": 196608
+  },
+  "n4-standard-64": {
+    "VCpuCount": 64,
+    "MemoryInMB": 262144
+  },
+  "n4-standard-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 32768
+  },
+  "n4-standard-80": {
+    "VCpuCount": 80,
+    "MemoryInMB": 327680
+  },
+  "t2a-standard-1": {
+    "VCpuCount": 1,
+    "MemoryInMB": 4096
+  },
+  "t2a-standard-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 65536
+  },
+  "t2a-standard-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 8192
+  },
+  "t2a-standard-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 131072
+  },
+  "t2a-standard-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 16384
+  },
+  "t2a-standard-48": {
+    "VCpuCount": 48,
+    "MemoryInMB": 196608
+  },
+  "t2a-standard-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 32768
+  },
+  "t2d-standard-1": {
+    "VCpuCount": 1,
+    "MemoryInMB": 4096
+  },
+  "t2d-standard-16": {
+    "VCpuCount": 16,
+    "MemoryInMB": 65536
+  },
+  "t2d-standard-2": {
+    "VCpuCount": 2,
+    "MemoryInMB": 8192
+  },
+  "t2d-standard-32": {
+    "VCpuCount": 32,
+    "MemoryInMB": 131072
+  },
+  "t2d-standard-4": {
+    "VCpuCount": 4,
+    "MemoryInMB": 16384
+  },
+  "t2d-standard-48": {
+    "VCpuCount": 48,
+    "MemoryInMB": 196608
+  },
+  "t2d-standard-60": {
+    "VCpuCount": 60,
+    "MemoryInMB": 245760
+  },
+  "t2d-standard-8": {
+    "VCpuCount": 8,
+    "MemoryInMB": 32768
+  },
+  "x4-megamem-1440-metal": {
+    "VCpuCount": 1440,
+    "MemoryInMB": 25165824
+  },
+  "x4-megamem-1920-metal": {
+    "VCpuCount": 1920,
+    "MemoryInMB": 33554432
+  },
+  "x4-megamem-960-metal": {
+    "VCpuCount": 960,
+    "MemoryInMB": 16777216
+  },
+  "z3-highmem-176": {
+    "VCpuCount": 176,
+    "MemoryInMB": 1441792
+  },
+  "z3-highmem-88": {
+    "VCpuCount": 88,
+    "MemoryInMB": 720896
+  }
+}

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -59,7 +59,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         """The Qualification cmd provides estimated running costs and speedups by migrating Apache
         Spark applications to GPU accelerated clusters.
 
-        The Qualification cmd analyzes Spark eventlogs generated from  CPU based Spark applications to
+        The Qualification cmd analyzes Spark eventlogs generated from CPU based Spark applications to
         help quantify the expected acceleration and costs savings of migrating a Spark application or
         query to GPU.
         The cmd will process each app individually, but will group apps with the same name into the

--- a/user_tools/tests/mock_cluster.py
+++ b/user_tools/tests/mock_cluster.py
@@ -17,9 +17,6 @@ import json
 
 mock_live_cluster = {
     "dataproc": [
-        "us-central1",          # gcloud config get compute/region
-        "us-central1-a",        # gcloud config get compute/zone
-        "dataproc-project-id",  # gcloud config get core/project
         # gcloud dataproc clusters describe test-cluster --format json --region us-central1
         json.dumps({
             "clusterUuid": "11111111-1111-1111-1111-111111111111",
@@ -49,20 +46,10 @@ mock_live_cluster = {
                 "state": "RUNNING",
             },
         }),
-        # gcloud compute machine-types describe n1-standard-8 --format json --zone us-central1-a
-        json.dumps({
-            "guestCpus": 8,
-            "memoryMb": 30720,
-        }),
         # gcloud compute accelerator-types describe nvidia-tesla-t4 --format json --zone us-central1-a
         json.dumps({
             "description": "NVIDIA T4",
-        }),
-        # gcloud compute machine-types describe n1-standard-2 --format json --zone us-central1-a
-        json.dumps({
-            "guestCpus": 2,
-            "memoryMb": 7680,
-        }),
+        })
     ],
 
     "emr": [

--- a/user_tools/tests/test_diagnostic.py
+++ b/user_tools/tests/test_diagnostic.py
@@ -52,7 +52,7 @@ class TestInfoCollect:
     def test_info_collect(self, build_mock, cloud, capsys):
         return_values = mock_live_cluster[cloud].copy()
         expected_syscmd_calls = {
-            'dataproc': 13,
+            'dataproc': 8,
             'emr': 10,
             'databricks-aws': 7,
             'databricks-azure': 7
@@ -76,7 +76,7 @@ class TestInfoCollect:
     def test_thread_num(self, build_mock, cloud, capsys):
         return_values = mock_live_cluster[cloud].copy()
         expected_syscmd_calls = {
-            'dataproc': 13,
+            'dataproc': 8,
             'emr': 10,
             'databricks-aws': 7,
             'databricks-azure': 7
@@ -103,7 +103,7 @@ class TestInfoCollect:
     def test_invalid_thread_num(self, build_mock, cloud, thread_num, capsys):
         return_values = mock_live_cluster[cloud].copy()
         expected_syscmd_calls = {
-            'dataproc': 7,
+            'dataproc': 2,
             'emr': 4,
             'databricks-aws': 1,
             'databricks-azure': 1
@@ -130,7 +130,7 @@ class TestInfoCollect:
         return_values = mock_live_cluster[cloud].copy()
         return_values.reverse()
         expected_syscmd_calls = {
-            'dataproc': 8,
+            'dataproc': 1,
             'emr': 5,
             'databricks-aws': 2,
             'databricks-azure': 2
@@ -160,7 +160,7 @@ class TestInfoCollect:
     def test_download_failed(self, build_mock, cloud, capsys):
         return_values = mock_live_cluster[cloud].copy()
         expected_syscmd_calls = {
-            'dataproc': 13,
+            'dataproc': 8,
             'emr': 10,
             'databricks-aws': 7,
             'databricks-azure': 7
@@ -195,7 +195,7 @@ class TestInfoCollect:
     def test_auto_confirm(self, build_mock, cloud, user_input, capsys):
         return_values = mock_live_cluster[cloud].copy()
         expected_syscmd_calls = {
-            'dataproc': 13,
+            'dataproc': 8,
             'emr': 10,
             'databricks-aws': 7,
             'databricks-azure': 7
@@ -221,7 +221,7 @@ class TestInfoCollect:
     def test_cancel_confirm(self, build_mock, cloud, user_input, capsys):
         return_values = mock_live_cluster[cloud].copy()
         expected_syscmd_calls = {
-            'dataproc': 7,
+            'dataproc': 1,
             'emr': 2,
             'databricks-aws': 1,
             'databricks-azure': 1


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids-tools/issues/1191

Changes

- Dataproc Qual tool will use generated instance catalog file to pull instance type info.
- In Initialization phase, Dataproc Qual tool used to call `gcloud` CLI cmds to set configuration properties, this PR updates the tool to use the local config file.

Testing
- With cluster properties file
```
spark_rapids qualification --eventlogs <my-event-logs> --platform dataproc --cluster <my-cluster-props-file>

```
- With cluster name
```
spark_rapids qualification --eventlogs <my-event-logs> --platform dataproc --cluster <my-cluster-name>
```