### PR TITLE
Fix header check script to exclude files

### DIFF
--- a/scripts/header-check.sh
+++ b/scripts/header-check.sh
@@ -25,14 +25,13 @@ if [ -n "$NEW_FILES" ]
 then
     for f in $NEW_FILES; do
         echo "Checking new file: $f"
-	INVALID_FILES+=($(grep -L --exclude={ \
-            core/src/main/resources/*,\
-            core/src/test/resources/*,\
-	    user_tools/src/spark_rapids_pytools/resources/*,\
-	    user_tools/docs/resources/*,\
-	    user_tools/tests/spark_rapids_tools_ut/resources/*,\
-	    *.csv \
-	} "Copyright (c) $YEAR" $f))
+	INVALID_FILES+=($(grep -L \
+	    --exclude=core/src/main/resources/* \
+	    --exclude=core/src/test/resources/* \
+	    --exclude=user_tools/src/spark_rapids_pytools/resources/* \
+	    --exclude=user_tools/docs/resources/* \
+	    --exclude=user_tools/tests/spark_rapids_tools_ut/resources/* \
+	    --exclude=*.csv "Copyright (c) $YEAR" $f))
     done
 fi
 

--- a/scripts/header-check.sh
+++ b/scripts/header-check.sh
@@ -19,19 +19,27 @@
 readonly NEW_FILES=$(git diff --diff-filter=ACRTU --cached --name-only)
 readonly YEAR=$(date +%Y)
 INVALID_FILES=()
+GREP_EXCLUDE_OPTIONS=()
 IFS=$'\n'
 
-if [ -n "$NEW_FILES" ]
-then
+EXCLUDE_PATTERNS=(
+    "core/src/main/resources/*"
+    "core/src/test/resources/*"
+    "user_tools/src/spark_rapids_pytools/resources/*"
+    "user_tools/docs/resources/*"
+    "user_tools/tests/spark_rapids_tools_ut/resources/*"
+    "*.csv"
+    )
+
+# Create the grep exclude options (--exclude=*csv --exclude=core/src/test/resources/*)
+for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+    GREP_EXCLUDE_OPTIONS+=("--exclude=$pattern")
+done
+
+if [ -n "$NEW_FILES" ]; then
     for f in $NEW_FILES; do
         echo "Checking new file: $f"
-	INVALID_FILES+=($(grep -L \
-	    --exclude=core/src/main/resources/* \
-	    --exclude=core/src/test/resources/* \
-	    --exclude=user_tools/src/spark_rapids_pytools/resources/* \
-	    --exclude=user_tools/docs/resources/* \
-	    --exclude=user_tools/tests/spark_rapids_tools_ut/resources/* \
-	    --exclude=*.csv "Copyright (c) $YEAR" $f))
+        INVALID_FILES+=($(grep -L "${GREP_EXCLUDE_OPTIONS[@]}" "Copyright (c) $YEAR" "$f"))
     done
 fi
 


### PR DESCRIPTION
This is  a bug fix in the script where the directories were not excluded correctly. This bug is from my previous PR  https://github.com/NVIDIA/spark-rapids-tools/pull/1219 where I had not checked if it excludes all the directories correctly.
The error was as below:
```
Checking new file: scripts/header-check.sh
grep: core/src/test/resources/*,: No such file or directory
grep: user_tools/src/spark_rapids_pytools/resources/*,: No such file or directory
```

This PR fixes above issue. Verified this locally. 
<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
