### PR TITLE
Fix duplicate records in DataSourceInfo report

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
@@ -50,6 +50,11 @@ class CollectInformation(apps: Seq[ApplicationInfo]) extends Logging {
     ProfDataSourceView.getRawView(apps)
   }
 
+  def getDataSourceInfo(
+      cachedSqlAccum: Seq[SQLAccumProfileResults]): Seq[DataSourceProfileResult] = {
+    ProfDataSourceView.getRawView(apps, cachedSqlAccum)
+  }
+
   // get executor related information
   def getExecutorInfo: Seq[ExecutorInfoProfileResult] = {
     ProfExecutorView.getRawView(apps)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
@@ -117,7 +117,7 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
       }
     }
     progressBar.foreach(_.finishAll())
-    
+
     // Write status reports for all event logs to a CSV file
     val reportResults = generateStatusResults(appStatusReporter.asScala.values.toSeq)
     ProfileOutputWriter.writeCSVTable("Profiling Status", reportResults, outputDir)
@@ -316,12 +316,12 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
     val collect = new CollectInformation(apps)
     val appInfo = collect.getAppInfo
     val appLogPath = collect.getAppLogPath
-    val dsInfo = collect.getDataSourceInfo
     val rapidsProps = collect.getRapidsProperties
     val sparkProps = collect.getSparkProperties
     val systemProps = collect.getSystemProperties
     val rapidsJar = collect.getRapidsJARInfo
     val sqlMetrics = collect.getSQLPlanMetrics
+    val dsInfo = collect.getDataSourceInfo(sqlMetrics)
     val stageMetrics = collect.getStageLevelMetrics
     val wholeStage = collect.getWholeStageCodeGenMapping
     // for compare mode we just add in extra tables for matching across applications

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/QualRawReportGenerator.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/QualRawReportGenerator.scala
@@ -17,7 +17,7 @@
 package com.nvidia.spark.rapids.tool.views
 
 import com.nvidia.spark.rapids.tool.analysis.{AggRawMetricsResult, AppSQLPlanAnalyzer, QualSparkMetricsAnalyzer}
-import com.nvidia.spark.rapids.tool.profiling.{DataSourceProfileResult, ProfileOutputWriter, ProfileResult}
+import com.nvidia.spark.rapids.tool.profiling.{DataSourceProfileResult, ProfileOutputWriter, ProfileResult, SQLAccumProfileResults}
 
 import org.apache.spark.sql.rapids.tool.qualification.QualificationAppInfo
 
@@ -47,15 +47,18 @@ object QualRawReportGenerator {
   }
 
   private def generateSQLProcessingView(
-      pWriter: ProfileOutputWriter, sqlPlanAnalyzer: AppSQLPlanAnalyzer): Unit = {
+      pWriter: ProfileOutputWriter,
+      sqlPlanAnalyzer: AppSQLPlanAnalyzer): Seq[SQLAccumProfileResults] = {
     pWriter.write(QualSQLToStageView.getLabel,
       QualSQLToStageView.getRawViewFromSqlProcessor(sqlPlanAnalyzer))
+    val sqlPlanMetrics = QualSQLPlanMetricsView.getRawViewFromSqlProcessor(sqlPlanAnalyzer)
     pWriter.write(QualSQLPlanMetricsView.getLabel,
-      QualSQLPlanMetricsView.getRawViewFromSqlProcessor(sqlPlanAnalyzer),
+      sqlPlanMetrics,
       Some(QualSQLPlanMetricsView.getDescription))
     pWriter.write(QualSQLCodeGenView.getLabel,
       QualSQLCodeGenView.getRawViewFromSqlProcessor(sqlPlanAnalyzer),
       Some(QualSQLCodeGenView.getDescription))
+    sqlPlanMetrics
   }
 
   def generateRawMetricQualViewAndGetDataSourceInfo(
@@ -64,17 +67,18 @@ object QualRawReportGenerator {
       appIndex: Int = 1): Seq[DataSourceProfileResult] = {
     val metricsDirectory = s"$rootDir/raw_metrics/${app.appId}"
     val sqlPlanAnalyzer = AppSQLPlanAnalyzer(app, appIndex)
-    val dataSourceInfo = QualDataSourceView.getRawView(Seq(app))
+    var dataSourceInfo: Seq[DataSourceProfileResult] = Seq.empty
     val pWriter =
       new ProfileOutputWriter(metricsDirectory, "profile", 10000000, outputCSV = true)
     try {
       pWriter.writeText("### A. Information Collected ###")
       pWriter.write(QualInformationView.getLabel, QualInformationView.getRawView(Seq(app)))
       pWriter.write(QualLogPathView.getLabel, QualLogPathView.getRawView(Seq(app)))
+      val sqlPlanMetricsResults = generateSQLProcessingView(pWriter, sqlPlanAnalyzer)
+      dataSourceInfo = QualDataSourceView.getRawView(Seq(app), sqlPlanMetricsResults)
       pWriter.write(QualDataSourceView.getLabel, dataSourceInfo)
       pWriter.write(QualExecutorView.getLabel, QualExecutorView.getRawView(Seq(app)))
       pWriter.write(QualAppJobView.getLabel, QualAppJobView.getRawView(Seq(app)))
-      generateSQLProcessingView(pWriter, sqlPlanAnalyzer)
       pWriter.write(QualStageMetricView.getLabel,
         QualStageMetricView.getRawViewFromSqlProcessor(sqlPlanAnalyzer),
         Some(QualStageMetricView.getDescription))


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1182

- this PR fixes duplicate records in data_source_infor.csv
- optimizes the implementation by cachine the `Seq[SQLAccumProfileResults]`

See the bug analysis in the comment https://github.com/NVIDIA/spark-rapids-tools/issues/1182#issuecomment-2248786953