### PR TITLE
Add footnotes for config recommendations and speedup category in top candidate view

### DIFF
--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -137,7 +137,6 @@ local:
             outputComment: "Heuristics information"
       configRecommendations:
         name: 'rapids_4_spark_qualification_output/tuning'
-        outputComment: "*Cluster config recommendations"
         columns:
           - 'Full Cluster Config Recommendations*'
           - 'GPU Config Recommendation Breakdown*'


### PR DESCRIPTION
Fixes #1240. This PR adds the footnotes for config recommendations and speedup category in the top candidate view.

## Output

### Filter: Top Candidates:
```
+----+---------------+--------------------------------+-----------------+------------------+-------------------------------------+------------------------------------+
|    | App Name      | App ID                         | Estimated GPU   | Qualified Node   | Full Cluster                        | GPU Config                         |
|    |               |                                | Speedup         | Recommendation   | Config                              | Recommendation                     |
|    |               |                                | Category**      |                  | Recommendations*                    | Breakdown*                         |
|----+---------------+--------------------------------+-----------------+------------------+-------------------------------------+------------------------------------|
|  0 | NDS - query72 | application_1686676198636_0002 | Large           | n1-standard-32   | application_1686676198636_0002.conf | application_1686676198636_0002.log |
+----+---------------+--------------------------------+-----------------+------------------+-------------------------------------+------------------------------------+
* Config Recommendations can be found in /Users/psarthi/Work/tools-run/qual_20240731161621_B804dA0F/rapids_4_spark_qualification_output/tuning.
** Estimated GPU Speedup Category assumes the user is using the node type recommended and config recommendations with the same size cluster as was used with the CPU side.

Report Summary:
----------------------  -
Total applications      1
Processed applications  1
Top candidates          1
----------------------  -
```


### Filter: ALL
```
+----+--------------------------------+---------------+----------------------+---------------+-----------------+-----------------+
|    | App ID                         | App Name      | Speedup Based        |           App |   Estimated GPU |   Estimated GPU |
|    |                                |               | Recommendation       |   Duration(s) |     Duration(s) |         Speedup |
|----+--------------------------------+---------------+----------------------+---------------+-----------------+-----------------|
|  0 | application_1686676198636_0002 | NDS - query72 | Strongly Recommended |        887.62 |          146.65 |            6.05 |
+----+--------------------------------+---------------+----------------------+---------------+-----------------+-----------------+

Report Summary:
-------------------------  ----
Total applications            1
Processed applications        1
Recommended applications      1
Overall estimated speedup  6.05
-------------------------  ----
```