### PR TITLE
Remove CLI dependency in Dataproc `_pull_gpu_hw_info` implementation

### DIFF
--- a/user_tools/tests/mock_cluster.py
+++ b/user_tools/tests/mock_cluster.py
@@ -45,10 +45,6 @@ mock_live_cluster = {
             "status": {
                 "state": "RUNNING",
             },
-        }),
-        # gcloud compute accelerator-types describe nvidia-tesla-t4 --format json --zone us-central1-a
-        json.dumps({
-            "description": "NVIDIA T4",
         })
     ],
 

--- a/user_tools/tests/test_diagnostic.py
+++ b/user_tools/tests/test_diagnostic.py
@@ -52,7 +52,7 @@ class TestInfoCollect:
     def test_info_collect(self, build_mock, cloud, capsys):
         return_values = mock_live_cluster[cloud].copy()
         expected_syscmd_calls = {
-            'dataproc': 8,
+            'dataproc': 7,
             'emr': 10,
             'databricks-aws': 7,
             'databricks-azure': 7
@@ -76,7 +76,7 @@ class TestInfoCollect:
     def test_thread_num(self, build_mock, cloud, capsys):
         return_values = mock_live_cluster[cloud].copy()
         expected_syscmd_calls = {
-            'dataproc': 8,
+            'dataproc': 7,
             'emr': 10,
             'databricks-aws': 7,
             'databricks-azure': 7
@@ -103,7 +103,7 @@ class TestInfoCollect:
     def test_invalid_thread_num(self, build_mock, cloud, thread_num, capsys):
         return_values = mock_live_cluster[cloud].copy()
         expected_syscmd_calls = {
-            'dataproc': 2,
+            'dataproc': 1,
             'emr': 4,
             'databricks-aws': 1,
             'databricks-azure': 1
@@ -160,7 +160,7 @@ class TestInfoCollect:
     def test_download_failed(self, build_mock, cloud, capsys):
         return_values = mock_live_cluster[cloud].copy()
         expected_syscmd_calls = {
-            'dataproc': 8,
+            'dataproc': 7,
             'emr': 10,
             'databricks-aws': 7,
             'databricks-azure': 7
@@ -195,7 +195,7 @@ class TestInfoCollect:
     def test_auto_confirm(self, build_mock, cloud, user_input, capsys):
         return_values = mock_live_cluster[cloud].copy()
         expected_syscmd_calls = {
-            'dataproc': 8,
+            'dataproc': 7,
             'emr': 10,
             'databricks-aws': 7,
             'databricks-azure': 7


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids-tools/issues/1191

**Changes**

- Refactor function `_pull_gpu_hw_info` to remove `gcloud` CLI calls
- Update existing tests

**Testing**

- Use a Dataproc GPU cluster properties file to invoke `_pull_gpu_hw_info`

```
spark_rapids qualification --eventlogs <my-event-logs> --platform dataproc --cluster <gpu-cluster-props-file> --verbose
```

Before PR:
```
2024-07-31 14:56:33,025 INFO rapids.tools.qualification: Loading CPU cluster properties from file <gpu-cluster-props-file>
2024-07-31 14:56:33,027 DEBUG rapids.tools.cmd: submitting system command: <gcloud compute accelerator-types describe nvidia-tesla-a100 --format json --zone us-central1-a>
2024-07-31 14:56:34,069 INFO rapids.tools.cmd_driver: Could not pull GPU info for WORKER node xxxxxx-w-0: 'NoneType' object has no attribute 'get_gpu_mem'
2024-07-31 14:56:34,070 DEBUG rapids.tools.cmd: submitting system command: <gcloud compute accelerator-types describe nvidia-tesla-a100 --format json --zone us-central1-a>
2024-07-31 14:56:35,219 INFO rapids.tools.cmd_driver: Could not pull GPU info for WORKER node xxxxxx-w-1: 'NoneType' object has no attribute 'get_gpu_mem'
2024-07-31 14:56:35,219 INFO rapids.tools.qualification: Creating GPU cluster by converting the CPU cluster instances to GPU supported types
```

After PR:
```
2024-07-31 14:58:01,858 INFO rapids.tools.qualification: Loading CPU cluster properties from file <gpu-cluster-props-file>
2024-07-31 14:58:01,859 INFO rapids.tools.qualification: Creating GPU cluster by converting the CPU cluster instances to GPU supported types
```