### PR TITLE
Fix stage level metrics output csv file

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
@@ -373,17 +373,18 @@ class AppSQLPlanAnalyzer(app: AppBase, appIndex: Int) extends AppAnalysisBase(ap
 
     // Process taskStageAccumMap to get all the accumulators
     val stageLevelAccums = app.taskStageAccumMap.values.flatten
-    val groupedByAccumulatorId = stageLevelAccums.groupBy(_.accumulatorId)
-    groupedByAccumulatorId.flatMap { case (accumulatorId, accums) =>
-      // Extract and sort the update values, defaulting to 0 if not present
-      val sortedUpdates = accums.flatMap(_.update).toSeq.sorted
+    val groupedByStageAndAccumulatorId = stageLevelAccums.groupBy(
+      task => (task.stageId, task.accumulatorId))
+    // Extract and sort the update values, defaulting to 0 if not present
+    groupedByStageAndAccumulatorId.flatMap { case ((stageId, accumulatorId), accums) =>
+    val sortedUpdates = accums.flatMap(_.update).toSeq.sorted
 
       // Compute the statistics for the accumulator if applicable
       computeStatistics(sortedUpdates).map { stats =>
         val sampleAccum = accums.head
         AccumProfileResults(
           appIndex = appIndex,
-          stageId = sampleAccum.stageId.toString,
+          stageId = stageId.toString,
           accumulatorId = accumulatorId,
           name = sampleAccum.name.getOrElse("Unknown"),
           min = stats.min,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
@@ -384,7 +384,7 @@ class AppSQLPlanAnalyzer(app: AppBase, appIndex: Int) extends AppAnalysisBase(ap
         val sampleAccum = accums.head
         AccumProfileResults(
           appIndex = appIndex,
-          stageId = stageId.toString,
+          stageId = stageId,
           accumulatorId = accumulatorId,
           name = sampleAccum.name.getOrElse("Unknown"),
           min = stats.min,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -221,16 +221,16 @@ case class SQLAccumProfileResults(appIndex: Int, sqlID: Long, nodeID: Long,
 
 case class AccumProfileResults(appIndex: Int, stageId: String, accumulatorId: Long,  name: String,
     min: Long, median: Long, max: Long, total: Long) extends ProfileResult {
-  override val outputHeaders = Seq("appIndex", "stageId", "accumulatorId", "name", "min",
+  override val outputHeaders = Seq("appIndex",  "accumulatorId", "stageId","name", "min",
     "median", "max", "total")
 
   override def convertToSeq: Seq[String] = {
-    Seq(appIndex.toString, stageId, accumulatorId.toString, name, min.toString, median.toString,
+    Seq(appIndex.toString, accumulatorId.toString, stageId, name, min.toString, median.toString,
       max.toString, total.toString)
   }
 
   override def convertToCSVSeq: Seq[String] = {
-    Seq(appIndex.toString, StringUtils.reformatCSVString(stageId), accumulatorId.toString,
+    Seq(appIndex.toString, accumulatorId.toString, StringUtils.reformatCSVString(stageId),
       StringUtils.reformatCSVString(name), min.toString, median.toString, max.toString,
       total.toString)
   }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -219,18 +219,18 @@ case class SQLAccumProfileResults(appIndex: Int, sqlID: Long, nodeID: Long,
   }
 }
 
-case class AccumProfileResults(appIndex: Int, stageId: String, accumulatorId: Long,  name: String,
+case class AccumProfileResults(appIndex: Int, stageId: Int, accumulatorId: Long,  name: String,
     min: Long, median: Long, max: Long, total: Long) extends ProfileResult {
-  override val outputHeaders = Seq("appIndex",  "accumulatorId", "stageId","name", "min",
+  override val outputHeaders = Seq("appIndex", "stageId", "accumulatorId", "name", "min",
     "median", "max", "total")
 
   override def convertToSeq: Seq[String] = {
-    Seq(appIndex.toString, accumulatorId.toString, stageId, name, min.toString, median.toString,
-      max.toString, total.toString)
+    Seq(appIndex.toString, stageId.toString, accumulatorId.toString, name, min.toString,
+      median.toString, max.toString, total.toString)
   }
 
   override def convertToCSVSeq: Seq[String] = {
-    Seq(appIndex.toString, accumulatorId.toString, StringUtils.reformatCSVString(stageId),
+    Seq(appIndex.toString, stageId.toString, accumulatorId.toString,
       StringUtils.reformatCSVString(name), min.toString, median.toString, max.toString,
       total.toString)
   }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/AppStageMetricsView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/AppStageMetricsView.scala
@@ -29,7 +29,7 @@ trait AppStageMetricsViewTrait extends ViewableTrait[AccumProfileResults] {
 
   override def sortView(
       rows: Seq[AccumProfileResults]): Seq[AccumProfileResults] = {
-    rows.sortBy(cols => (cols.stageId, cols.appIndex, cols.accumulatorId))
+    rows.sortBy(cols => (cols.appIndex, cols.accumulatorId, cols.stageId))
   }
 }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/AppStageMetricsView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/AppStageMetricsView.scala
@@ -29,7 +29,7 @@ trait AppStageMetricsViewTrait extends ViewableTrait[AccumProfileResults] {
 
   override def sortView(
       rows: Seq[AccumProfileResults]): Seq[AccumProfileResults] = {
-    rows.sortBy(cols => (cols.appIndex, cols.accumulatorId, cols.stageId))
+    rows.sortBy(cols => (cols.appIndex, cols.stageId, cols.accumulatorId))
   }
 }
 


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids-tools/issues/1250.
This bug is because of grouping the metrics only on accumId. This PR fixes the bug by grouping it both on accumId and stageId such that the result is metrics per stage.
Changed the unit test such that the same accumId is updated in 2 stages and the output will show it in 2 different rows.

Also tested it on custom eventlog where the accumulator updates the value in 2 stages.

Before this PR:
```
appIndex,stageId,accumulatorId,name,min,median,max,total
1,"0",0,"My Accumulator",1,2,4,300
1,"0",1,"internal.metrics.executorDeserializeTime",626,629,631,40238
```
With this PR:
```
appIndex,stageId,accumulatorId,name,min,median,max,total
1,0,0,"My Accumulator",1,2,2,100
1,0,1,"internal.metrics.executorDeserializeTime",626,629,631,40238
1,1,0,"My Accumulator",2,4,4,200
```

<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
