### PR TITLE
Replace split_nds with split_train_val

### DIFF
--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -39,8 +39,8 @@ from spark_rapids_tools.tools.qualx.preprocess import (
 from spark_rapids_tools.tools.qualx.model import (
     extract_model_features,
     compute_shapley_values,
-    split_nds,
     split_all_test,
+    split_train_val,
 )
 from spark_rapids_tools.tools.qualx.model import train as train_model, predict as predict_model
 from spark_rapids_tools.tools.qualx.util import (
@@ -450,7 +450,7 @@ def train(
             'Training data contained datasets: %s, expected: %s', profile_datasets, dataset_list
         )
 
-    split_functions = [split_nds]
+    split_functions = [split_train_val]
     for ds_name, ds_meta in datasets.items():
         if 'split_function' in ds_meta:
             plugin_path = ds_meta['split_function']
@@ -816,7 +816,7 @@ def evaluate(
 
     if not split_fn:
         # use default split_fn if not specified
-        split_fn = split_all_test if 'test' in dataset_name else split_nds
+        split_fn = split_all_test if 'test' in dataset_name else split_train_val
 
     # raw predictions on unfiltered data
     raw_sql, raw_app = _predict(


### PR DESCRIPTION
This PR replaces the `split_nds` function with a more generic `split_train_val` function.  This avoids having any dataset-specific split functions in the core qualx code, and pushes them to the dataset-specific plugins.

I have confirmed that this produces identical models when paired w/ a new `nds.py` plugin in the internal repo.

## Test
Following CMDs have been tested.

### Internal Usage:
```
python qualx_main.py preprocess
python qualx_main.py train
python qualx_main.py evaluate
```
