### PR TITLE
Rename cluster shape columns to use 'worker' prefix in the output files and rename metadata file

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -426,7 +426,7 @@ class AutoTuner(
    * the executor cores and instances based on that instance type.
    * Returns None if the platform doesn't support specific instance types.
    */
-  def configureGPURecommendedInstanceType: Unit = {
+  private def configureGPURecommendedInstanceType(): Unit = {
     val gpuClusterRec = platform.getGPUInstanceTypeRecommendation(getAllProperties.toMap)
     if (gpuClusterRec.isDefined) {
       appendRecommendation("spark.executor.cores", gpuClusterRec.get.coresPerExecutor)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
@@ -465,13 +465,13 @@ object QualOutputWriter {
   val RECOMMENDED_NUM_GPUS = "Recommended Num GPUs Per Node"
   val NUM_EXECS_PER_NODE = "Num Executors Per Node"
   val RECOMMENDED_NUM_EXECS = "Recommended Num Executors"
-  val NUM_EXEC_NODES = "Num Executor Nodes"
-  val RECOMMENDED_NUM_EXEC_NODES = "Recommended Num Executor Nodes"
+  val NUM_WORKER_NODES = "Num Worker Nodes"
+  val RECOMMENDED_NUM_WORKER_NODES = "Recommended Num Worker Nodes"
   val CORES_PER_EXEC = "Cores Per Executor"
   val RECOMMENDED_CORES_PER_EXEC = "Recommended Cores Per Executor"
-  val EXEC_INSTANCE = "Executor Instance"
-  val RECOMMENDED_EXEC_INSTANCE = "Recommended Executor Instance"
-  val DRIVER_INSTANCE = "Driver Instance"
+  val WORKER_NODE_TYPE = "Worker Node Type"
+  val RECOMMENDED_WORKER_NODE_TYPE = "Recommended Worker Node Type"
+  val DRIVER_NODE_TYPE = "Driver Node Type"
   // Default frequency for jobs with a single instance is 30 times every month (30 days)
   val DEFAULT_JOB_FREQUENCY = 30L
 
@@ -824,8 +824,8 @@ object QualOutputWriter {
   private def getClusterInfoHeaderStrings: mutable.LinkedHashMap[String, Int] = {
     val headersAndFields = Seq(
       APP_ID_STR, APP_NAME_STR, VENDOR, DRIVER_HOST, CLUSTER_ID_STR, CLUSTER_NAME,
-      EXEC_INSTANCE, DRIVER_INSTANCE, NUM_EXEC_NODES, NUM_EXECS_PER_NODE, CORES_PER_EXEC,
-      RECOMMENDED_EXEC_INSTANCE, RECOMMENDED_NUM_EXECS, RECOMMENDED_NUM_EXEC_NODES,
+      WORKER_NODE_TYPE, DRIVER_NODE_TYPE, NUM_WORKER_NODES, NUM_EXECS_PER_NODE, CORES_PER_EXEC,
+      RECOMMENDED_WORKER_NODE_TYPE, RECOMMENDED_NUM_EXECS, RECOMMENDED_NUM_WORKER_NODES,
       RECOMMENDED_CORES_PER_EXEC, RECOMMENDED_NUM_GPUS).map {
       key => (key, key.length)
     }
@@ -854,17 +854,17 @@ object QualOutputWriter {
       refactorCSVFuncWithOption(clusterInfo.flatMap(_.driverHost), DRIVER_HOST),
       refactorCSVFuncWithOption(clusterInfo.flatMap(_.clusterId), CLUSTER_ID_STR),
       refactorCSVFuncWithOption(clusterInfo.flatMap(_.clusterName), CLUSTER_NAME),
-      refactorCSVFuncWithOption(clusterInfo.flatMap(_.executorInstance), EXEC_INSTANCE),
-      refactorCSVFuncWithOption(clusterInfo.flatMap(_.driverInstance), DRIVER_INSTANCE),
-      refactorCSVFuncWithOption(clusterInfo.map(_.numExecutorNodes.toString), NUM_EXEC_NODES),
+      refactorCSVFuncWithOption(clusterInfo.flatMap(_.workerNodeType), WORKER_NODE_TYPE),
+      refactorCSVFuncWithOption(clusterInfo.flatMap(_.driverNodeType), DRIVER_NODE_TYPE),
+      refactorCSVFuncWithOption(clusterInfo.map(_.numWorkerNodes.toString), NUM_WORKER_NODES),
       refactorCSVFuncWithOption(clusterInfo.map(_.numExecsPerNode.toString), NUM_EXECS_PER_NODE),
       refactorCSVFuncWithOption(clusterInfo.map(_.coresPerExecutor.toString), CORES_PER_EXEC),
-      refactorCSVFuncWithOption(recClusterInfo.map(_.executorInstance.toString),
-        RECOMMENDED_EXEC_INSTANCE),
+      refactorCSVFuncWithOption(recClusterInfo.flatMap(_.workerNodeType),
+        RECOMMENDED_WORKER_NODE_TYPE),
       refactorCSVFuncWithOption(recClusterInfo.map(_.numExecutors.toString),
         RECOMMENDED_NUM_EXECS),
-      refactorCSVFuncWithOption(recClusterInfo.map(_.numExecutorNodes.toString),
-        RECOMMENDED_NUM_EXEC_NODES),
+      refactorCSVFuncWithOption(recClusterInfo.map(_.numWorkerNodes.toString),
+        RECOMMENDED_NUM_WORKER_NODES),
       refactorCSVFuncWithOption(recClusterInfo.map(_.coresPerExecutor.toString),
         RECOMMENDED_CORES_PER_EXEC),
       refactorCSVFuncWithOption(recClusterInfo.map(_.numGpus.toString), RECOMMENDED_NUM_GPUS)

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ClassWarehouse.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ClassWarehouse.scala
@@ -41,28 +41,41 @@ class ExecutorInfoClass(val executorId: String, _addTime: Long) {
     var resourceProfileId = ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID
 }
 
+sealed trait ClusterInfo {
+    def vendor: String
+    def coresPerExecutor: Int
+    def numExecsPerNode: Int
+    def numWorkerNodes: Int
+    def driverNodeType: Option[String]
+    def workerNodeType: Option[String]
+}
+
 // Information about the cluster used with to run the application we
-// are qulafying or profiling. This is compared to what we might recommend
+// are qualifying or profiling. This is compared to what we might recommend
 // for a cluster.
 case class ExistingClusterInfo(
     vendor: String,
     coresPerExecutor: Int,
     numExecsPerNode: Int,
-    numExecutorNodes: Int,
+    numWorkerNodes: Int,
     executorHeapMemory: Long,
-    executorInstance: Option[String] = None,
-    driverInstance: Option[String] = None,
+    driverNodeType: Option[String] = None,
+    workerNodeType: Option[String] = None,
     driverHost: Option[String] = None,
     clusterId: Option[String] = None,
-    clusterName: Option[String] = None)
+    clusterName: Option[String] = None) extends ClusterInfo
 
 case class RecommendedClusterInfo(
     vendor: String,
     coresPerExecutor: Int,
-    numExecutors: Int,
-    numExecutorNodes: Int,
+    numWorkerNodes: Int,
     numGpus: Int,
-    executorInstance: String)
+    numExecutors: Int,
+    driverNodeType: Option[String] = None,
+    workerNodeType: Option[String] = None) extends ClusterInfo {
+    // The number of executors per node is the same as the number of GPUs
+    def numExecsPerNode: Int = numGpus
+}
 
 case class ClusterSummary(
     appName: String,

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -1568,18 +1568,6 @@ class QualificationSuite extends BaseTestSuite {
     }
   }
 
-//  case class ExistingClusterInfo(
-  //    vendor: String,
-  //    coresPerExecutor: Int,
-  //    numExecsPerNode: Int,
-  //    numWorkerNodes: Int,
-  //    executorHeapMemory: Long,
-  //    driverNodeType: Option[String] = None,
-  //    workerNodeType: Option[String] = None,
-  //    driverHost: Option[String] = None,
-  //    clusterId: Option[String] = None,
-  //    clusterName: Option[String] = None) extends ClusterInfo
-
   // Expected results as a map of event log -> cluster info.
   // scalastyle:off line.size.limit
   val expectedClusterInfoMap: Seq[(String, Option[ExistingClusterInfo])] = Seq(
@@ -1622,33 +1610,48 @@ class QualificationSuite extends BaseTestSuite {
   // Expected results as a map of platform -> cluster info.
   val expectedPlatformClusterInfoMap: Seq[(String, ExistingClusterInfo)] = Seq(
     PlatformNames.DATABRICKS_AWS ->
-        ExistingClusterInfo(vendor = PlatformNames.DATABRICKS_AWS, coresPerExecutor = 8,
-          numExecsPerNode = 1, numWorkerNodes = 2, executorHeapMemory = 0L,
+        ExistingClusterInfo(vendor = PlatformNames.DATABRICKS_AWS,
+          coresPerExecutor = 8,
+          numExecsPerNode = 1,
+          numWorkerNodes = 2,
+          executorHeapMemory = 0L,
           driverNodeType = Some("m6gd.2xlarge"),
           workerNodeType = Some("m6gd.2xlarge"),
           driverHost = Some("10.10.10.100"),
           clusterId = Some("1212-214324-test"),
           clusterName = Some("test-db-aws-cluster")),
     PlatformNames.DATABRICKS_AZURE ->
-      ExistingClusterInfo(vendor = PlatformNames.DATABRICKS_AZURE, coresPerExecutor = 8,
-        numExecsPerNode = 1, numWorkerNodes = 2, executorHeapMemory = 0L,
+      ExistingClusterInfo(vendor = PlatformNames.DATABRICKS_AZURE,
+        coresPerExecutor = 8,
+        numExecsPerNode = 1,
+        numWorkerNodes = 2,
+        executorHeapMemory = 0L,
         driverNodeType = Some("Standard_E8ds_v4"),
         workerNodeType = Some("Standard_E8ds_v4"),
         driverHost = Some("10.10.10.100"),
         clusterId = Some("1212-214324-test"),
         clusterName = Some("test-db-azure-cluster")),
     PlatformNames.DATAPROC ->
-      ExistingClusterInfo(vendor = PlatformNames.DATAPROC, coresPerExecutor = 8,
-        numExecsPerNode = 1, numWorkerNodes = 2, executorHeapMemory = 0L,
+      ExistingClusterInfo(vendor = PlatformNames.DATAPROC,
+        coresPerExecutor = 8,
+        numExecsPerNode = 1,
+        numWorkerNodes = 2,
+        executorHeapMemory = 0L,
         driverHost = Some("dataproc-test-m.c.internal")),
     PlatformNames.EMR ->
-      ExistingClusterInfo(vendor = PlatformNames.EMR, coresPerExecutor = 8,
-        numExecsPerNode = 1, numWorkerNodes = 2, executorHeapMemory = 0L,
+      ExistingClusterInfo(vendor = PlatformNames.EMR,
+        coresPerExecutor = 8,
+        numExecsPerNode = 1,
+        numWorkerNodes = 2,
+        executorHeapMemory = 0L,
         driverHost = Some("10.10.10.100"),
         clusterId = Some("j-123AB678XY321")),
     PlatformNames.ONPREM ->
-      ExistingClusterInfo(vendor = PlatformNames.ONPREM, coresPerExecutor = 8,
-        numExecsPerNode = 1, numWorkerNodes = 2, executorHeapMemory = 0L,
+      ExistingClusterInfo(vendor = PlatformNames.ONPREM,
+        coresPerExecutor = 8,
+        numExecsPerNode = 1,
+        numWorkerNodes = 2,
+        executorHeapMemory = 0L,
         driverHost = Some("10.10.10.100"))
       )
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -1568,29 +1568,46 @@ class QualificationSuite extends BaseTestSuite {
     }
   }
 
+//  case class ExistingClusterInfo(
+  //    vendor: String,
+  //    coresPerExecutor: Int,
+  //    numExecsPerNode: Int,
+  //    numWorkerNodes: Int,
+  //    executorHeapMemory: Long,
+  //    driverNodeType: Option[String] = None,
+  //    workerNodeType: Option[String] = None,
+  //    driverHost: Option[String] = None,
+  //    clusterId: Option[String] = None,
+  //    clusterName: Option[String] = None) extends ClusterInfo
+
   // Expected results as a map of event log -> cluster info.
   // scalastyle:off line.size.limit
   val expectedClusterInfoMap: Seq[(String, Option[ExistingClusterInfo])] = Seq(
     "eventlog_2nodes_8cores" -> // 2 executor nodes with 8 cores.
-      Some(ExistingClusterInfo(PlatformNames.DEFAULT, 8, 1, 2, 0L,
-        None, None, Some("10.10.10.100"), None, None)),
+      Some(ExistingClusterInfo(vendor = PlatformNames.DEFAULT, coresPerExecutor = 8,
+        numExecsPerNode = 1, numWorkerNodes = 2, executorHeapMemory = 0L,
+        driverHost = Some("10.10.10.100"))),
     "eventlog_3nodes_12cores_multiple_executors" -> // 3 nodes, each with 2 executors having 12 cores.
-      Some(ExistingClusterInfo(PlatformNames.DEFAULT, 12, 2, 3, 0L,
-        None, None, Some("10.59.184.210"), None, None)),
+      Some(ExistingClusterInfo(vendor = PlatformNames.DEFAULT, coresPerExecutor = 12,
+        numExecsPerNode = 2, numWorkerNodes = 3, executorHeapMemory = 0L,
+        driverHost = Some("10.59.184.210"))),
     // TODO: Currently we do not handle dynamic allocation while calculating number of nodes. For
     //  calculating nodes, we look at unique active hosts at the end of application. In this test
     //  case, the application used all 4 nodes initially (8 executors total), and then 7 executors were
     //  removed. In the end, only 1 executor was active on 1 node. This test case should be updated
     //  once we handle dynamic allocation.
     "eventlog_4nodes_8cores_dynamic_alloc" -> // 4 nodes, each with 2 executor having 8 cores, with dynamic allocation.
-      Some(ExistingClusterInfo(PlatformNames.DEFAULT, 8, 2, 1, 0L,
-        None, None, Some("test-cpu-cluster-m"), None, None)),
+      Some(ExistingClusterInfo(vendor = PlatformNames.DEFAULT, coresPerExecutor = 8,
+        numExecsPerNode = 2, numWorkerNodes = 1, executorHeapMemory = 0L,
+        driverHost = Some("test-cpu-cluster-m"))),
     "eventlog_3nodes_12cores_variable_cores" -> // 3 nodes with varying cores: 8, 12, and 8, each with 1 executor.
-      Some(ExistingClusterInfo(PlatformNames.DEFAULT, 12, 1, 3, 0L,
-        None, None, Some("10.10.10.100"), None, None)),
+      Some(ExistingClusterInfo(vendor = PlatformNames.DEFAULT, coresPerExecutor = 12,
+        numExecsPerNode = 1, numWorkerNodes = 3, executorHeapMemory = 0L,
+        driverHost = Some("10.10.10.100"))),
     "eventlog_3nodes_12cores_exec_removed" -> // 2 nodes, each with 1 executor having 12 cores, 1 executor removed.
-      Some(ExistingClusterInfo(PlatformNames.DEFAULT, 12, 1, 2, 0L,
-        None, None, Some("10.10.10.100"), None, None)),
+      Some(ExistingClusterInfo(vendor = PlatformNames.DEFAULT, coresPerExecutor = 12,
+        numExecsPerNode = 1, numWorkerNodes = 2, executorHeapMemory = 0L,
+        driverHost = Some("10.10.10.100"))),
     "eventlog_driver_only" -> None // Event log with driver only
   )
   // scalastyle:on line.size.limit
@@ -1605,44 +1622,35 @@ class QualificationSuite extends BaseTestSuite {
   // Expected results as a map of platform -> cluster info.
   val expectedPlatformClusterInfoMap: Seq[(String, ExistingClusterInfo)] = Seq(
     PlatformNames.DATABRICKS_AWS ->
-      ExistingClusterInfo(PlatformNames.DATABRICKS_AWS, 8, 1, 2, 0L,
-        Some("m6gd.2xlarge"),
-        Some("m6gd.2xlarge"),
-        Some("10.10.10.100"),
-        Some("1212-214324-test"),
-        Some("test-db-aws-cluster")),
+        ExistingClusterInfo(vendor = PlatformNames.DATABRICKS_AWS, coresPerExecutor = 8,
+          numExecsPerNode = 1, numWorkerNodes = 2, executorHeapMemory = 0L,
+          driverNodeType = Some("m6gd.2xlarge"),
+          workerNodeType = Some("m6gd.2xlarge"),
+          driverHost = Some("10.10.10.100"),
+          clusterId = Some("1212-214324-test"),
+          clusterName = Some("test-db-aws-cluster")),
     PlatformNames.DATABRICKS_AZURE ->
-      ExistingClusterInfo(PlatformNames.DATABRICKS_AZURE, 8, 1, 2, 0L,
-        Some("Standard_E8ds_v4"),
-        Some("Standard_E8ds_v4"),
-        Some("10.10.10.100"),
-        Some("1212-214324-test"),
-        Some("test-db-azure-cluster")),
+      ExistingClusterInfo(vendor = PlatformNames.DATABRICKS_AZURE, coresPerExecutor = 8,
+        numExecsPerNode = 1, numWorkerNodes = 2, executorHeapMemory = 0L,
+        driverNodeType = Some("Standard_E8ds_v4"),
+        workerNodeType = Some("Standard_E8ds_v4"),
+        driverHost = Some("10.10.10.100"),
+        clusterId = Some("1212-214324-test"),
+        clusterName = Some("test-db-azure-cluster")),
     PlatformNames.DATAPROC ->
-      ExistingClusterInfo(PlatformNames.DATAPROC, 8, 1, 2,
-        0L,
-        None,
-        None,
-        Some("dataproc-test-m.c.internal"),
-        None,
-        None),
+      ExistingClusterInfo(vendor = PlatformNames.DATAPROC, coresPerExecutor = 8,
+        numExecsPerNode = 1, numWorkerNodes = 2, executorHeapMemory = 0L,
+        driverHost = Some("dataproc-test-m.c.internal")),
     PlatformNames.EMR ->
-      ExistingClusterInfo(PlatformNames.EMR, 8, 1, 2,
-        0L,
-        None,
-        None,
-        Some("10.10.10.100"),
-        Some("j-123AB678XY321"),
-        None),
+      ExistingClusterInfo(vendor = PlatformNames.EMR, coresPerExecutor = 8,
+        numExecsPerNode = 1, numWorkerNodes = 2, executorHeapMemory = 0L,
+        driverHost = Some("10.10.10.100"),
+        clusterId = Some("j-123AB678XY321")),
     PlatformNames.ONPREM ->
-      ExistingClusterInfo(PlatformNames.ONPREM, 8, 1, 2,
-        0L,
-        None,
-        None,
-        Some("10.10.10.100"),
-        None,
-        None)
-  )
+      ExistingClusterInfo(vendor = PlatformNames.ONPREM, coresPerExecutor = 8,
+        numExecsPerNode = 1, numWorkerNodes = 2, executorHeapMemory = 0L,
+        driverHost = Some("10.10.10.100"))
+      )
 
   expectedPlatformClusterInfoMap.foreach { case (platform, expectedClusterInfo) =>
     test(s"test cluster information JSON for platform - $platform ") {

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -17,7 +17,7 @@
 
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any, List, Union
+from typing import Any, List, Union, Optional
 
 from spark_rapids_tools import CspEnv
 from spark_rapids_pytools.cloud_api.dataproc_job import DataprocLocalRapidsJob
@@ -163,12 +163,12 @@ class DataprocPlatform(PlatformBase):
                 gpu_scopes[prof_name] = NodeHWInfo(sys_info=sys_info_obj, gpu_info=gpu_info_obj)
         return gpu_scopes
 
-    def get_matching_executor_instance(self, cores_per_executor):
-        executors_from_config = self.configs.get_value('clusterInference', 'defaultCpuInstances', 'executor')
+    def get_matching_worker_node_type(self, total_cores: int) -> Optional[str]:
+        node_types_from_config = self.configs.get_value('clusterInference', 'defaultCpuInstances', 'executor')
         # TODO: Currently only single series is supported. Change this to a loop when using multiple series.
-        series_name, unit_info = list(executors_from_config.items())[0]
-        if cores_per_executor in unit_info['vCPUs']:
-            return f'{series_name}-{cores_per_executor}'
+        series_name, unit_info = list(node_types_from_config.items())[0]
+        if total_cores in unit_info['vCPUs']:
+            return f'{series_name}-{total_cores}'
         return None
 
     def generate_cluster_configuration(self, render_args: dict):

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -650,10 +650,10 @@ class Qualification(RapidsJarTool):
         # Merge the total_apps with the processed_apps to get the Event Log
         df_final_result = pd.merge(df_final_result, total_apps[['Event Log', 'AppID']],
                                    left_on='App ID', right_on='AppID')
-        # Write the summary metadata
-        summary_metadata_info = output_files_info.get_value('summaryMetadata')
+        # Write the app metadata
+        app_metadata_info = output_files_info.get_value('appMetadata')
         config_recommendations_info = output_files_info.get_value('configRecommendations')
-        self._write_summary_metadata(df_final_result, summary_metadata_info, config_recommendations_info)
+        self._write_app_metadata(df_final_result, app_metadata_info, config_recommendations_info)
         return QualificationSummary(total_apps=total_apps,
                                     tools_processed_apps=df_final_result,
                                     recommended_apps=recommended_apps,
@@ -887,10 +887,10 @@ class Qualification(RapidsJarTool):
         result_df['Estimated GPU Time Saved'] = result_df['App Duration'] - result_df['Estimated GPU Duration']
         return result_df.drop(columns=result_info['subsetColumns'])
 
-    def _write_summary_metadata(self, tools_processed_apps: pd.DataFrame,
-                                metadata_file_info: dict, config_recommendations_dir_info: dict) -> None:
+    def _write_app_metadata(self, tools_processed_apps: pd.DataFrame,
+                            metadata_file_info: dict, config_recommendations_dir_info: dict) -> None:
         """
-        Write the summary metadata to a JSON file.
+        Write the metadata for apps to a JSON file.
         :param tools_processed_apps: Processed applications from tools
         :param metadata_file_info: Metadata file information
         :param config_recommendations_dir_info: Configuration recommendations directory information
@@ -898,27 +898,32 @@ class Qualification(RapidsJarTool):
         if not tools_processed_apps.empty:
             try:
                 valid_cols = Utilities.get_valid_df_columns(metadata_file_info.get('columns'), tools_processed_apps)
-                summary_metadata_df = tools_processed_apps[valid_cols].copy()
+                app_metadata_df = tools_processed_apps[valid_cols].copy()
                 # 1. Prepend parent dir to the config recommendations columns (only for the JSON file, not stdout)
                 parent_dir = config_recommendations_dir_info.get('path')
+
+                # Helper function to prepend the parent directory to the config file
+                def _prepend_parent_dir(conf_file: str) -> str:
+                    conf_file_full = FSUtil.build_path(parent_dir, conf_file)
+                    return conf_file_full if FSUtil.resource_exists(conf_file_full) else ''
+
                 for col in config_recommendations_dir_info.get('columns'):
-                    if col in summary_metadata_df.columns:
-                        summary_metadata_df[col] = summary_metadata_df[col].apply(
-                            lambda conf_file: FSUtil.build_path(parent_dir, conf_file))
+                    if col in app_metadata_df.columns:
+                        app_metadata_df[col] = app_metadata_df[col].apply(_prepend_parent_dir)
 
                 # 2. Convert column names to camel case for JSON file writing
                 # First, remove any non-alphanumeric characters from column names and convert to lowercase
-                summary_metadata_df.rename(columns=lambda x: re.sub(r'[^a-z\s]', '', x.lower()), inplace=True)
+                app_metadata_df.rename(columns=lambda x: re.sub(r'[^a-z\s]', '', x.lower()), inplace=True)
                 # Then, convert df to dict with camel case keys
-                summary_metadata_dict = convert_dict_to_camel_case(summary_metadata_df.to_dict(orient='records'),
-                                                                   delim=' ')
+                app_metadata_dict = convert_dict_to_camel_case(app_metadata_df.to_dict(orient='records'),
+                                                               delim=' ')
                 with open(metadata_file_info.get('path'), 'w', encoding='UTF-8') as f:
-                    json.dump(summary_metadata_dict, f, indent=2)
+                    json.dump(app_metadata_dict, f, indent=2)
             except Exception as e:  # pylint: disable=broad-except
-                self.logger.error('Error writing the summary metadata report. Reason - %s:%s',
+                self.logger.error('Error writing the app metadata report. Reason - %s:%s',
                                   type(e).__name__, e)
         else:
-            self.logger.warning('No applications to write to the summary metadata report.')
+            self.logger.warning('No applications to write to the metadata report.')
 
     def _read_qualification_output_file(self, report_name_key: str, file_format_key: str = 'csv') -> pd.DataFrame:
         """

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -140,15 +140,14 @@ local:
         columns:
           - 'Full Cluster Config Recommendations*'
           - 'GPU Config Recommendation Breakdown*'
-      summaryMetadata:
-        name: qualification_summary_metadata.json
+      appMetadata:
+        name: app_metadata.json
         outputComment: "Metadata file with cluster recommendation and tuning details"
         columns:
           - 'App ID'
           - 'App Name'
           - 'Event Log'
-          - 'Source Cluster'
-          - 'Recommended Cluster'
+          - 'Cluster Info'
           - 'Estimated GPU Speedup Category'
           - 'Full Cluster Config Recommendations*'
           - 'GPU Config Recommendation Breakdown*'
@@ -348,12 +347,12 @@ local:
             dstCol: 'Estimated GPU Duration'
     clusterInference:
       cpuClusterColumns:
-        - 'Num Executor Nodes'
-        - 'Executor Instance'
+        - 'Num Worker Nodes'
+        - 'Worker Node Type'
         - 'Cores Per Executor'
       gpuClusterColumns:
-        - 'Recommended Num Executor Nodes'
-        - 'Recommended Executor Instance'
+        - 'Recommended Num Worker Nodes'
+        - 'Recommended Worker Node Type'
         - 'Recommended Cores Per Executor'
 
 platform:

--- a/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/databricks_aws.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/databricks_aws.ms
@@ -1,8 +1,8 @@
 {
   "cluster_id": "1234-5678-test",
   "cluster_name": "default-cluster-name",
-  "driver_node_type_id": {{{ DRIVER_INSTANCE }}},
-  "node_type_id": {{{ EXECUTOR_INSTANCE }}},
-  "num_workers": {{ NUM_EXECUTOR_NODES }},
+  "driver_node_type_id": {{{ DRIVER_NODE_TYPE }}},
+  "node_type_id": {{{ WORKER_NODE_TYPE }}},
+  "num_workers": {{ NUM_WORKER_NODES }},
   "state": "TERMINATED"
 }

--- a/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/databricks_azure.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/databricks_azure.ms
@@ -4,8 +4,8 @@
     "node_id": "1234567890"
   },
   "cluster_name": "default-cluster-name",
-  "driver_node_type_id": {{{ DRIVER_INSTANCE }}},
-  "node_type_id": {{{ EXECUTOR_INSTANCE }}},
-  "num_workers": {{ NUM_EXECUTOR_NODES }},
+  "driver_node_type_id": {{{ DRIVER_NODE_TYPE }}},
+  "node_type_id": {{{ WORKER_NODE_TYPE }}},
+  "num_workers": {{ NUM_WORKER_NODES }},
   "state": "TERMINATED"
 }

--- a/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/dataproc.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/dataproc.ms
@@ -9,12 +9,12 @@
       "instanceNames": [
         "test-node-d"
       ],
-      "machineTypeUri": {{{ DRIVER_INSTANCE }}},
+      "machineTypeUri": {{{ DRIVER_NODE_TYPE }}},
       "numInstances": {{ NUM_DRIVER_NODES }}
     },
     "workerConfig": {
-      "machineTypeUri": {{{ EXECUTOR_INSTANCE }}},
-      "numInstances": {{ NUM_EXECUTOR_NODES }}
+      "machineTypeUri": {{{ WORKER_NODE_TYPE }}},
+      "numInstances": {{ NUM_WORKER_NODES }}
     },
     "softwareConfig": {
         "imageVersion": {{{ IMAGE }}}

--- a/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/emr.ms
+++ b/user_tools/src/spark_rapids_pytools/resources/templates/cluster_template/emr.ms
@@ -14,15 +14,15 @@
 	      "Name": "CORE",
 	      "Market": "ON_DEMAND",
 	      "InstanceGroupType": "CORE",
-	      "InstanceType": {{{ EXECUTOR_INSTANCE }}},
-	      "RequestedInstanceCount": {{ NUM_EXECUTOR_NODES }}
+	      "InstanceType": {{{ WORKER_NODE_TYPE }}},
+	      "RequestedInstanceCount": {{ NUM_WORKER_NODES }}
 	    },
 	    {
 	      "Id": "ig-123456789012d",
 	      "Name": "MASTER",
 	      "Market": "ON_DEMAND",
 	      "InstanceGroupType": "MASTER",
-	      "InstanceType": {{{ DRIVER_INSTANCE }}},
+	      "InstanceType": {{{ DRIVER_NODE_TYPE }}},
 	      "RequestedInstanceCount": {{ NUM_DRIVER_NODES }}
 	    }
 	  ],

--- a/user_tools/src/spark_rapids_tools/tools/cluster_config_recommender.py
+++ b/user_tools/src/spark_rapids_tools/tools/cluster_config_recommender.py
@@ -25,6 +25,7 @@ from spark_rapids_pytools.cloud_api.sp_types import ClusterBase
 from spark_rapids_pytools.common.sys_storage import FSUtil
 from spark_rapids_pytools.rapids.tool_ctxt import ToolContext
 from spark_rapids_pytools.common.utilities import ToolLogging
+from spark_rapids_tools import CspEnv
 
 
 @dataclass
@@ -32,12 +33,18 @@ class ClusterRecommendationInfo:
     """
     Dataclass to hold the recommended cluster and the qualified node recommendation.
     """
+    platform: str = field(default=CspEnv.get_default(), init=True)
     source_cluster_config: dict = field(default_factory=dict)
     recommended_cluster_config: dict = field(default_factory=dict)
     qualified_node_recommendation: str = 'Not Available'
 
     def _cluster_info_to_dict(self) -> Dict[str, dict]:
+        """
+        Returns the cluster info as a dictionary. Since this will be a value of a column, the keys are in
+        camelCase to match the JSON format.
+        """
         return {
+            'platform': self.platform,
             'sourceCluster': self.source_cluster_config,
             'recommendedCluster': self.recommended_cluster_config
         }
@@ -104,13 +111,14 @@ class ClusterConfigRecommender:
         recommended_cluster_config = gpu_cluster.get_cluster_configuration()
         conversion_str = gpu_instance_type
         source_cluster_config = {}
+        platform = gpu_cluster.platform.get_platform_name()
 
         if cpu_cluster:
             source_cluster_config = cpu_cluster.get_cluster_configuration()
             cpu_instance_type = cpu_cluster.get_worker_node().instance_type
             if cpu_instance_type != gpu_instance_type:
                 conversion_str = f'{cpu_instance_type} to {gpu_instance_type}'
-        return ClusterRecommendationInfo(source_cluster_config, recommended_cluster_config, conversion_str)
+        return ClusterRecommendationInfo(platform, source_cluster_config, recommended_cluster_config, conversion_str)
 
     def _get_cluster_conversion_summary(self) -> Dict[str, ClusterRecommendationInfo]:
         """

--- a/user_tools/src/spark_rapids_tools/tools/cluster_config_recommender.py
+++ b/user_tools/src/spark_rapids_tools/tools/cluster_config_recommender.py
@@ -36,10 +36,15 @@ class ClusterRecommendationInfo:
     recommended_cluster_config: dict = field(default_factory=dict)
     qualified_node_recommendation: str = 'Not Available'
 
+    def _cluster_info_to_dict(self) -> Dict[str, dict]:
+        return {
+            'sourceCluster': self.source_cluster_config,
+            'recommendedCluster': self.recommended_cluster_config
+        }
+
     def to_dict(self) -> Dict[str, Union[dict, str]]:
         return {
-            'Source Cluster': self.source_cluster_config,
-            'Recommended Cluster': self.recommended_cluster_config,
+            'Cluster Info': self._cluster_info_to_dict(),
             'Qualified Node Recommendation': self.qualified_node_recommendation
         }
 
@@ -83,11 +88,13 @@ class ClusterConfigRecommender:
         Helper method to determine the conversion summary between CPU and GPU instance types.
         Generate the cluster shape recommendation as:
         {
-          'Source Cluster': {'driverInstance': 'm6.xlarge', 'executorInstance': 'm6.xlarge', 'numExecutors': 2 }
-          'Recommended Cluster': {'driverInstance': 'm6.xlarge', 'executorInstance': 'g5.2xlarge', 'numExecutors': 2 }
+          'Cluster Info': {
+             'sourceCluster': {'driverNodeType': 'm6.xlarge', 'workerNodeType': 'm6.xlarge', 'numWorkerNodes': 2 }
+             'recommendedCluster': {'driverNodeType': 'm6.xlarge', 'workerNodeType': 'g5.2xlarge', 'numWorkerNodes': 2 }
+           },
           'Qualified Node Recommendation': 'm6.xlarge to g5.2xlarge'
         }
-        """
+        """  # pylint: disable=line-too-long
         # Return None if no GPU cluster is available.
         # If no CPU cluster is available, we can still recommend based on the inferred GPU cluster in the Scala tool.
         if not gpu_cluster:


### PR DESCRIPTION
Issue: #1239

### Changes
- Rename all cluster shape related columns/fields to use `worker` prefix instead of `executor`.  
    - Usage of `executorInstance`, `driverInstance` has been replaced by `workerNodeType` and `driverNodeType` 
    -  Going forward we should ensure `executor` term is reserved only for spark executors to avoid ambiguity.
- Renames metadata file to `app_metadata.json`
   - Add `platform` field in the metadata file

### Output

File: `qual_2024xxx/app_metadata.json`

<details>
<summary>Contents </summary>
<pre>
[
  {
    "appId": "application_1692643187882_0001",
    "appName": "NDS - Power Run",
    "eventLog": "file:/path/application_1692643187882_0001",
    "clusterInfo": {
      "platform": "emr",
      "sourceCluster": {
        "driverNodeType": "i3.2xlarge",
        "workerNodeType": "m5d.8xlarge",
        "numWorkerNodes": 8
      },
      "recommendedCluster": {
        "driverNodeType": "i3.2xlarge",
        "workerNodeType": "g5.4xlarge",
        "numWorkerNodes": 16
      }
    },
    "estimatedGpuSpeedupCategory": "Small",
    "fullClusterConfigRecommendations": "/tool_output/qual_20240805173341_9Eb76BAa/rapids_4_spark_qualification_output/tuning/application_1692643187882_0001.conf",
    "gpuConfigRecommendationBreakdown": "/tool_output/qual_20240805173341_9Eb76BAa/rapids_4_spark_qualification_output/tuning/application_1692643187882_0001.log"
  }
]
</pre>
</details>


File: `qual_2024xxx/rapids_4_spark_qualification_output/rapids_4_spark_qualification_output_cluster_information.json `

<details>
<summary>Contents </summary>
<pre>
[ {
  "appName" : "NDS - Power Run",
  "appId" : "application_1692643187882_0001",
  "eventLogPath" : "file:/path/application_1692643187882_0001",
  "clusterInfo" : {
    "vendor" : "emr",
    "coresPerExecutor" : 16,
    "numExecsPerNode" : 2,
    "numWorkerNodes" : 8,
    "executorHeapMemory" : 16384,
    "driverHost" : "ip-xxx.us-west-2.compute.internal",
    "clusterId" : "j-2xxxx"
  },
  "recommendedClusterInfo" : {
    "vendor" : "emr",
    "coresPerExecutor" : 16,
    "numWorkerNodes" : 16,
    "numGpus" : 1,
    "numExecutors" : 16,
    "workerNodeType" : "g5.4xlarge"
  }
} ]
</pre>
</details>


### Follow Up PR
- Add cluster recommendation for `onprem`
- Ensure correct `gpuPerWorker` is recommended for eligible platforms (`dataproc`, `onprem`)