### PR TITLE
Disable creating StageInfo object

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
@@ -35,12 +35,13 @@ class StageModel private(sInfo: StageInfo) {
   updateInfo(sInfo)
 
   /**
-   * Creates a new StageInfo object by extractingand copying
+   * Creates a new StageInfo object by extracting and copying
    * only the necessary fields from the given StageInfo object.
    * @param newStageInfo
    * @return a new StageInfo object with the necessary fields.
+   * TODO: https://github.com/NVIDIA/spark-rapids-tools/issues/1260
    */
-  private def initStageInfo(newStageInfo: StageInfo): StageInfo = {
+/*  private def initStageInfo(newStageInfo: StageInfo): StageInfo = {
     val stubStage = new StageInfo(
       stageId = newStageInfo.stageId,
       attemptId = newStageInfo.attemptNumber(),
@@ -54,7 +55,7 @@ class StageModel private(sInfo: StageInfo) {
     stubStage.submissionTime = newStageInfo.submissionTime
     stubStage.failureReason = newStageInfo.failureReason
     stubStage
-  }
+  }*/
 
   @WallClock
   @Calculated("Calculated as (submissionTime - completionTime)")
@@ -67,7 +68,10 @@ class StageModel private(sInfo: StageInfo) {
    * @param newStageInfo Spark's StageInfo loaded from StageSubmitted/StageCompleted events.
    */
   private def updateInfo(newStageInfo: StageInfo): Unit = {
-    stageInfo = initStageInfo(newStageInfo)
+    // TODO: initStageInfo(newStageInfo) fails with Spark-3.1.1 and Spark-3.2.1.
+    //  issue: https://github.com/NVIDIA/spark-rapids-tools/issues/1260
+    //  We will assign the newStageInfo to the stageInfo directly for now.
+    stageInfo = newStageInfo
     calculateDuration()
   }
 
@@ -129,5 +133,3 @@ object StageModel {
     sModel
   }
 }
-
-


### PR DESCRIPTION
This contributes to https://github.com/NVIDIA/spark-rapids-tools/issues/1260

In this PR, we disable the call to initStageInfo which creates the new StageInfo object.  Instead we directly assign the value of newStageInfo to stageInfo. 

<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
