### PR TITLE
Fix prediction CSV files for multiple qual directories

### DIFF
--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -569,6 +569,8 @@ def predict(
             qual_tool_filter=qual_tool_filter,
             qual_tool_output=qual_tool_output
         )
+        # reset appName to original
+        profile_df['appName'] = profile_df['appId'].map(app_id_name_map)
     except ScanTblError:
         # ignore
         logger.error('Skipping invalid dataset: %s', dataset_name)
@@ -611,8 +613,6 @@ def predict(
         summary = _compute_summary(per_sql_summary)
         # combine calculated summary with default predictions for missing apps
         per_app_summary = _add_entries_for_missing_apps(default_preds_df, summary)
-        # reset appName to original
-        per_app_summary['appName'] = per_app_summary['appId'].map(app_id_name_map)
         if INTERMEDIATE_DATA_ENABLED:
             print_summary(per_app_summary)
             # compute speedup for the entire dataset

--- a/user_tools/src/spark_rapids_tools/tools/qualx/util.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/util.py
@@ -369,7 +369,7 @@ def write_csv_reports(per_sql: pd.DataFrame, per_app: pd.DataFrame, output_info:
         if per_sql is not None:
             sql_predictions_path = output_info['perSql']['path']
             logger.info('Writing per-SQL predictions to: %s', sql_predictions_path)
-            per_sql.to_csv(sql_predictions_path, index=False)
+            per_sql.to_csv(sql_predictions_path)
     except Exception as e:  # pylint: disable=broad-except
         logger.error('Error writing per-SQL predictions. Reason: %s', e)
 
@@ -377,7 +377,7 @@ def write_csv_reports(per_sql: pd.DataFrame, per_app: pd.DataFrame, output_info:
         if per_app is not None:
             app_predictions_path = output_info['perApp']['path']
             logger.info('Writing per-application predictions to: %s', app_predictions_path)
-            per_app.to_csv(app_predictions_path, index=False)
+            per_app.to_csv(app_predictions_path)
     except Exception as e:  # pylint: disable=broad-except
         logger.error('Error writing per-app predictions. Reason: %s', e)
 


### PR DESCRIPTION
This PR fixes an open [TODO item](https://github.com/NVIDIA/spark-rapids-tools/blob/ec89eeda4d312ceffcc54d88bfef35b8ef884745/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py#L658).  Currently, if the path passed to `--qual_output` contains more than one qual tool output directory, the code will loop over the qual tool output directories, making predictions and saving out various CSV files (e.g. `per_app.csv`, `per_sql.csv`, `shap_values.csv`) in the `xgboost_predictions` output folder.  Unfortunately, these files will be overwritten each with each iteration of the loop.  Note, however, that the final `dataset_summaries` contains the full, concatenated results of all of the iterations, so only these CSV files were impacted.

This PR combines the qual tool output directories into a single prediction "dataset", so the various debugging files now contain data for all qual tool output directories found in `--qual_output`.  This has the side-benefit of speeding up prediction in these cases.  If the user wants individual results per qual tool output directory, they can still invoke the `spark_rapids prediction` command for each of those directories to produce one output directory per input directory.

I have confirmed that the final prediction output matches the prior version code (aside from ordering), while the CSV files now contain the full, expected data.

## Test
Following CMDs have been tested.

### External Usage:
```
spark_rapids prediction
```

### Internal Usage:
```
python qualx_main.py predict
```

