### PR TITLE
Remove calculation of gpu cluster recommendation from python tool when cluster argument is passed

### DIFF
--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -71,8 +71,6 @@ sparkRapids:
     cudaVersion: '11.5'
   cli:
     defaults:
-      gpuClusterRecommendation:
-        defaultRecommendation: 'MATCH'
       costSavingsSettings: #temporrary settings to control the code behavior until the cost savings feature is fully removed
         enabled: false
     toolOptions:

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -173,38 +173,6 @@ local:
         - 'App Duration'
         - 'Estimated GPU Duration'
         - 'Estimated GPU Speedup'
-    processDFProps:
-      minimumWorkerCount: 2
-      gpuScaleFactor: 0.80
-      savingsRecommendationsDefault: 'Not Recommended'
-      savingRecommendationsRanges:
-        nonRecommended:
-          title: 'Not Recommended'
-          lowerBound: -1000000.0
-          upperBound: 1.0
-        recommended:
-          title: 'Recommended'
-          lowerBound: 1.0
-          upperBound: 30.0
-        stronglyRecommended:
-          title: 'Strongly Recommended'
-          lowerBound: 30.0
-          upperBound: 1000000.0
-      clusterShapeCols:
-        columnName: 'Recommended Cluster Shape'
-        noteMsg: 'The GPU estimations are done with a recommended GPU cluster shape of {} worker nodes'
-        colsPerShapeType:
-          CLUSTER:
-            excludeColumns:
-              - 'Speedup Based Recommendation'
-              - 'Estimated GPU Speedup'
-          JOB:
-            excludeColumns:
-              - 'Speedup Based Recommendation'
-              - 'Estimated GPU Speedup'
-            appendColumns:
-              - columnName: 'Recommended Cluster Shape'
-                index: 4
     treeDirectory:
       enabled: true
       depthLevel: 4

--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -448,7 +448,6 @@ class QualifyUserArgModel(ToolUserArgModel):
     """
     target_platform: Optional[CspEnv] = None
     filter_apps: Optional[QualFilterApp] = None
-    gpu_cluster_recommendation: Optional[QualGpuClusterReshapeType] = None
     estimation_model_args: Optional[Dict] = dataclasses.field(default_factory=dict)
 
     def init_tool_args(self) -> None:
@@ -460,11 +459,6 @@ class QualifyUserArgModel(ToolUserArgModel):
             self.p_args['toolArgs']['filterApps'] = QualFilterApp.get_default()
         else:
             self.p_args['toolArgs']['filterApps'] = self.filter_apps
-        # check the reshapeType argument
-        if self.gpu_cluster_recommendation is None:
-            self.p_args['toolArgs']['gpuClusterRecommendation'] = QualGpuClusterReshapeType.get_default()
-        else:
-            self.p_args['toolArgs']['gpuClusterRecommendation'] = self.gpu_cluster_recommendation
         # Check the estimationModel argument
         # This assumes that the EstimationModelArgProcessor was used to process the arguments before
         # constructing this validator.
@@ -532,7 +526,6 @@ class QualifyUserArgModel(ToolUserArgModel):
             'eventlogs': self.eventlogs,
             'filterApps': QualFilterApp.fromstring(self.p_args['toolArgs']['filterApps']),
             'toolsJar': self.p_args['toolArgs']['toolsJar'],
-            'gpuClusterRecommendation': self.p_args['toolArgs']['gpuClusterRecommendation'],
             'estimationModelArgs': self.p_args['toolArgs']['estimationModelArgs']
         }
         return wrapped_args

--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -27,7 +27,6 @@ from pydantic_core import PydanticCustomError
 
 from spark_rapids_pytools.cloud_api.sp_types import DeployMode
 from spark_rapids_pytools.common.utilities import ToolLogging
-from spark_rapids_pytools.rapids.qualification import QualGpuClusterReshapeType
 from spark_rapids_tools.cloud import ClientCluster
 from spark_rapids_tools.utils import AbstractPropContainer, is_http_file
 from ..enums import QualFilterApp, CspEnv, QualEstimationModel

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -123,8 +123,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                                          jvm_heap_size=jvm_heap_size,
                                                          jvm_threads=jvm_threads,
                                                          filter_apps=filter_apps,
-                                                         estimation_model_args=estimation_model_args,
-                                                         gpu_cluster_shape=QualGpuClusterReshapeType.get_default())
+                                                         estimation_model_args=estimation_model_args)
         if qual_args:
             tool_obj = QualificationAsLocal(platform_type=qual_args['runtimePlatform'],
                                             output_folder=qual_args['outputFolder'],

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -18,7 +18,7 @@
 import fire
 
 from spark_rapids_tools.cmdli.argprocessor import AbsToolUserArgModel
-from spark_rapids_tools.enums import QualGpuClusterReshapeType, CspEnv, QualEstimationModel
+from spark_rapids_tools.enums import CspEnv, QualEstimationModel
 from spark_rapids_tools.utils.util import gen_app_banner, init_environment
 from spark_rapids_pytools.common.utilities import Utils, ToolLogging
 from spark_rapids_pytools.rapids.qualx.prediction import Prediction

--- a/user_tools/src/spark_rapids_tools/enums.py
+++ b/user_tools/src/spark_rapids_tools/enums.py
@@ -17,6 +17,8 @@
 from enum import Enum, auto
 from typing import Union, cast, Optional, Callable
 
+from spark_rapids_tools.utils.util import deprecated
+
 
 class EnumeratedType(str, Enum):
     """Abstract representation of enumerated values"""
@@ -126,6 +128,7 @@ class QualGpuClusterReshapeType(EnumeratedType):
     JOB = 'job'
 
     @classmethod
+    @deprecated
     def get_default(cls):
         return cls.MATCH
 

--- a/user_tools/src/spark_rapids_tools/enums.py
+++ b/user_tools/src/spark_rapids_tools/enums.py
@@ -17,8 +17,6 @@
 from enum import Enum, auto
 from typing import Union, cast, Optional, Callable
 
-from spark_rapids_tools.utils.util import deprecated
-
 
 class EnumeratedType(str, Enum):
     """Abstract representation of enumerated values"""
@@ -119,18 +117,6 @@ class QualFilterApp(EnumeratedType):
     @classmethod
     def get_default(cls):
         return cls.TOP_CANDIDATES
-
-
-class QualGpuClusterReshapeType(EnumeratedType):
-    """Values used to filter out the applications in the qualification report"""
-    MATCH = 'match'
-    CLUSTER = 'cluster'
-    JOB = 'job'
-
-    @classmethod
-    @deprecated
-    def get_default(cls):
-        return cls.MATCH
 
 
 class ConditionOperator(EnumeratedType):

--- a/user_tools/src/spark_rapids_tools/tools/cluster_config_recommender.py
+++ b/user_tools/src/spark_rapids_tools/tools/cluster_config_recommender.py
@@ -122,14 +122,6 @@ class ClusterConfigRecommender:
         ii. '<app_id>' -> `ClusterRecommendationInfo`  for each app
         """
         cluster_conversion_summary = {}
-        # Summary for all instances
-        cpu_cluster_info = self.ctxt.get_ctxt('cpuClusterProxy')
-        gpu_cluster_info = self.ctxt.get_ctxt('gpuClusterProxy')
-        conversion_summary_all = self._get_instance_type_conversion(cpu_cluster_info, gpu_cluster_info)
-        if conversion_summary_all:
-            cluster_conversion_summary['all'] = conversion_summary_all
-
-        # Summary for each app
         cpu_cluster_info_per_app = self.ctxt.get_ctxt('cpuClusterInfoPerApp')
         gpu_cluster_info_per_app = self.ctxt.get_ctxt('gpuClusterInfoPerApp')
         if cpu_cluster_info_per_app and gpu_cluster_info_per_app:
@@ -181,12 +173,7 @@ class ClusterConfigRecommender:
             cluster_conversion_summary = self._get_cluster_conversion_summary()
             # 'all' is a special indication that all the applications need to use this same node
             # recommendation vs the recommendations being per application
-            if 'all' in cluster_conversion_summary:
-                # Add cluster conversion columns to all apps
-                conversion_summary_flattened = cluster_conversion_summary['all'].to_dict()
-                for col, conversion_val in conversion_summary_flattened.items():  # type: str, Union[dict, str]
-                    result_df[col] = [conversion_val] * result_df.shape[0]
-            elif len(cluster_conversion_summary) > 0:
+            if len(cluster_conversion_summary) > 0:
                 # Add the per-app node conversions
                 conversion_summary_flattened = {k: v.to_dict() for k, v in cluster_conversion_summary.items()}
                 conversion_df = pd.DataFrame.from_dict(conversion_summary_flattened, orient='index').reset_index()

--- a/user_tools/src/spark_rapids_tools/utils/util.py
+++ b/user_tools/src/spark_rapids_tools/utils/util.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 """Utility and helper methods"""
-import functools
-import warnings
+
 import os
 import pathlib
 import re
@@ -25,7 +24,7 @@ import urllib
 import xml.etree.ElementTree as elem_tree
 from functools import reduce
 from operator import getitem
-from typing import Any, Optional, ClassVar, Callable
+from typing import Any, Optional, ClassVar
 
 import certifi
 import fire
@@ -172,19 +171,6 @@ def init_environment(short_name: str):
     print(Utils.gen_report_sec_header('Application Logs'))
     print(f'Location: {log_file}')
     print('In case of any errors, please share the log file with the Spark RAPIDS team.\n')
-
-
-def deprecated(func: Callable) -> Callable:
-    """
-    This is a decorator which can be used to mark functions as deprecated.
-    """
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        warn_msg = (f'WARNING: The function \'{func.__name__}\' in \'{func.__module__}\' is deprecated and '
-                    f'will be removed in future releases.')
-        warnings.warn(warn_msg, DeprecationWarning, stacklevel=2)
-        return func(*args, **kwargs)
-    return wrapper
 
 
 class Utilities:

--- a/user_tools/src/spark_rapids_tools/utils/util.py
+++ b/user_tools/src/spark_rapids_tools/utils/util.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 """Utility and helper methods"""
-
+import functools
+import warnings
 import os
 import pathlib
 import re
@@ -24,7 +25,7 @@ import urllib
 import xml.etree.ElementTree as elem_tree
 from functools import reduce
 from operator import getitem
-from typing import Any, Optional, ClassVar
+from typing import Any, Optional, ClassVar, Callable
 
 import certifi
 import fire
@@ -171,6 +172,19 @@ def init_environment(short_name: str):
     print(Utils.gen_report_sec_header('Application Logs'))
     print(f'Location: {log_file}')
     print('In case of any errors, please share the log file with the Spark RAPIDS team.\n')
+
+
+def deprecated(func: Callable) -> Callable:
+    """
+    This is a decorator which can be used to mark functions as deprecated.
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        warn_msg = (f'WARNING: The function \'{func.__name__}\' in \'{func.__module__}\' is deprecated and '
+                    f'will be removed in future releases.')
+        warnings.warn(warn_msg, DeprecationWarning, stacklevel=2)
+        return func(*args, **kwargs)
+    return wrapper
 
 
 class Utilities:


### PR DESCRIPTION
Fixes #1273. All gpu cluster shape recommendations are now made from the Scala Tool.  

This PR removes gpu cluster recommendation from the python tool when the argument `--cluster <cluster_name or cluster_conf_file>` is passed. Gpu cluster recommendation is shown in the stdout and app_metadata.json


## Output Changes
- For CSPs, this does not change anything because in scala also we recommend cluster shape based on cores
- For OnPrem, this would correctly generate the recommended cluster and tuning config based on the provided cluster

## Code Changes
- Removed the usage of `gpuClusterRecommendation`, `gpuClusterProxy`
- AutoTuner file will be created based on the system properties of cpu cluster. 


## Test
- To Test for OnPrem a `cluster_config.yaml` can be used as:
```
config:
 masterConfig:
   numCores: 2
   memory: 32768MiB
 workerConfig:
   numCores: 8
   memory: 32768MiB
   numWorkers: 2
```

CMD:
```
spark_rapids --platform onprem --eventlogs <eventlogs> --cluster cluster_config.yaml
```