### PR TITLE
Skip generating timeline for stages that do not have completion time

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimeline.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimeline.scala
@@ -333,14 +333,18 @@ object GenerateTimeline {
         new TimelineStageInfo(stageId, start, end, end-start)
     }
 
-    val stageInfo = app.stageManager.getAllStages.map { case sm =>
-      val stageId = sm.stageInfo.stageId
-      val submissionTime = sm.stageInfo.submissionTime.get
-      val completionTime = sm.stageInfo.completionTime.get
-      val duration = sm.getDuration
-      minStartTime = Math.min(minStartTime, submissionTime)
-      maxEndTime = Math.max(maxEndTime, completionTime)
-      new TimelineStageInfo(stageId, submissionTime, completionTime, duration)
+    val stageInfo = app.stageManager.getAllStages.flatMap { case sm =>
+      if (sm.stageInfo.completionTime.isDefined) {
+        val stageId = sm.stageInfo.stageId
+        val submissionTime = sm.stageInfo.submissionTime.get
+        val completionTime = sm.stageInfo.completionTime.get
+        val duration = sm.getDuration
+        minStartTime = Math.min(minStartTime, submissionTime)
+        maxEndTime = Math.max(maxEndTime, completionTime)
+        Some(new TimelineStageInfo(stageId, submissionTime, completionTime, duration))
+      } else {
+        None
+      }
     }
 
     val execHostToSlots = execHostToTaskList.map {


### PR DESCRIPTION
This fixes a small bug when the tools is run with --generate-timeline argument on an incomplete eventlog.
The issue is that the completionTime of a stage can be None for inprogess eventlogs and we see error message as below. The fix is to generate timeline only for completed stages.
In this function, we already do similar checks for `jobIdToInfo` and `sqlIdToInfo`.

**Error without this fix:**
```
24/08/14 17:59:18 INFO ToolTextFileWriter: Profile summary output location: ./rapids_4_spark_profile/application_1723001058316_0011/profile.log
24/08/14 17:59:18 WARN FailureAppResult: File: file:/home/nartal/nvbug/eventlogs/history_spark-events_application_1723001058316_0011.inprogress, Message: Unexpected exception processing log, skipping!
java.lang.Exception: None.get
	at com.nvidia.spark.rapids.tool.profiling.Profiler.com$nvidia$spark$rapids$tool$profiling$Profiler$$profileApp(Profiler.scala:189)
	at com.nvidia.spark.rapids.tool.profiling.Profiler$ProfileProcessThread$1.run(Profiler.scala:263)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.util.NoSuchElementException: None.get
	at scala.None$.get(Option.scala:529)
	at scala.None$.get(Option.scala:527)
	at com.nvidia.spark.rapids.tool.profiling.GenerateTimeline$.$anonfun$generateFor$20(GenerateTimeline.scala:341)
	at scala.collection.TraversableLike.$anonfun$flatMap$1(TraversableLike.scala:293)
	at scala.collection.immutable.List.foreach(List.scala:431)
	at scala.collection.TraversableLike.flatMap(TraversableLike.scala:293)
	at scala.collection.TraversableLike.flatMap$(TraversableLike.scala:290)
```

**With this PR:**
```
24/08/14 18:00:21 INFO ToolTextFileWriter: Profile summary output location: ./rapids_4_spark_profile/application_1723001058316_0011/profile.log
24/08/14 18:00:21 INFO SuccessAppResult: File: file:/home/nartal/nvbug/eventlogs/history_spark-events_application_1723001058316_0011.inprogress, Message: Took 1298ms to process
24/08/14 18:00:21 INFO ToolTextFileWriter: Profiling Status CSV: output location: ./rapids_4_spark_profile/profiling_status.csv
```



<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
