### PR TITLE
Qual tool: Print more useful log messages when failures happen downloading dependencies

### DIFF
--- a/user_tools/src/spark_rapids_pytools/common/sys_storage.py
+++ b/user_tools/src/spark_rapids_pytools/common/sys_storage.py
@@ -24,10 +24,9 @@ import shutil
 import ssl
 import subprocess
 import urllib
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import partial
 from itertools import islice
-from logging import Logger
 from shutil import rmtree
 from typing import List
 
@@ -36,7 +35,7 @@ from fastcore.all import urlsave
 from fastprogress.fastprogress import progress_bar
 
 from spark_rapids_pytools.common.exceptions import StorageException
-from spark_rapids_pytools.common.utilities import ToolLogging, Utils, SysCmd
+from spark_rapids_pytools.common.utilities import Utils, SysCmd
 
 
 class FSUtil:
@@ -285,7 +284,6 @@ class StorageDriver:
     """
     Wrapper to interface with archiving command, such as copying/moving/listing files.
     """
-    logger: Logger = field(default=ToolLogging.get_and_setup_logger('rapids.tools.fsutil'), init=False)
 
     def resource_exists(self, src) -> bool:
         return os.path.exists(src)
@@ -303,11 +301,7 @@ class StorageDriver:
         """
         if src.startswith('http'):
             # this is url resource
-            try:
-                return FSUtil.download_from_url(src, dest)
-            except Exception as store_ex:
-                self.logger.error('Failed to download remote resource src: %s', src)
-                raise store_ex
+            return FSUtil.download_from_url(src, dest)
         # this is a folder-to-folder download
         return FSUtil.copy_resource(src, dest)
 
@@ -329,8 +323,7 @@ class StorageDriver:
             if create_dir:
                 FSUtil.make_dirs(abs_dest)
             return self._download_remote_resource(src, abs_dest)
-        except Exception as store_ex:
-            self.logger.error('Failed to download resources, src: %s', src)
+        except StorageException as store_ex:
             if not fail_ok:
                 raise store_ex
             return None

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -394,7 +394,6 @@ class RapidsJarTool(RapidsTool):
         jar_path = ''
         tools_jar_url = self.wrapper_options.get('toolsJar')
         try:
-            tools_jar_url = None
             if tools_jar_url is None:
                 tools_jar_url = self.ctxt.get_rapids_jar_url()
             # download the jar

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -161,7 +161,7 @@ class RapidsTool(object):
             # 3- process submission arguments
             self._process_job_submission_args()
         except Exception as ex:  # pylint: disable=broad-except
-            self.logger.error('Failed to download dependencies %s', ex)
+            self.logger.error('Failed in processing arguments')
             raise ex
 
     @phase_banner('Initialization')
@@ -404,7 +404,7 @@ class RapidsJarTool(RapidsTool):
                                                                     fail_ok=False,
                                                                     create_dir=True)
         except Exception as e:    # pylint: disable=broad-except
-             self.logger.exception("error processing jar %s", tools_jar_url)
+             self.logger.exception("Exception occurred downloading jar %s", tools_jar_url)
              raise e
 
         self.logger.info('RAPIDS accelerator tools jar is downloaded to work_dir %s', jar_path)

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -391,7 +391,7 @@ class RapidsJarTool(RapidsTool):
     """
 
     def _process_jar_arg(self):
-        jar_path = ""
+        jar_path = ''
         tools_jar_url = self.wrapper_options.get('toolsJar')
         try:
             tools_jar_url = None
@@ -404,8 +404,8 @@ class RapidsJarTool(RapidsTool):
                                                                     fail_ok=False,
                                                                     create_dir=True)
         except Exception as e:    # pylint: disable=broad-except
-             self.logger.exception("Exception occurred downloading jar %s", tools_jar_url)
-             raise e
+            self.logger.exception('Exception occurred downloading jar %s', tools_jar_url)
+            raise e
 
         self.logger.info('RAPIDS accelerator tools jar is downloaded to work_dir %s', jar_path)
         # get the jar file name

--- a/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
@@ -169,6 +169,7 @@ class ToolContext(YAMLPropertiesContainer):
         return self.get_local('depFolder')
 
     def get_rapids_jar_url(self) -> str:
+        self.logger.info('Fetching the Rapids Jar URL')
         # get the version from the package, instead of the yaml file
         # jar_version = self.get_value('sparkRapids', 'version')
         if self.is_fatwheel_mode():
@@ -176,6 +177,7 @@ class ToolContext(YAMLPropertiesContainer):
             matching_files = glob(offline_path_regex)
             if not matching_files:
                 raise FileNotFoundError('In Fat Mode. No matching JAR files found.')
+            self.logger.info('Using jar from wheel file %s', matching_files[0])
             return matching_files[0]
         mvn_base_url = self.get_value('sparkRapids', 'mvnUrl')
         jar_version = Utilities.get_latest_mvn_jar_from_metadata(mvn_base_url)


### PR DESCRIPTION
contributes to https://github.com/NVIDIA/spark-rapids-tools/issues/1286

Adds in some specific error handling and logging to help with errors downloading jars or not having access to external internet.  This is specifically handling a few cases mentioned in the issue.

Tested by making the mvn url go to an invalid host.

<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
