### PR TITLE
Enable recursive search for event logs by default and optional `--no-recursion` flag

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/EventLogPathProcessor.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/EventLogPathProcessor.scala
@@ -249,8 +249,10 @@ object EventLogPathProcessor extends Logging {
    *                                Enabled by default.
    * @param maxEventLogSize         Optional maximum event log size as a string
    * @param minEventLogSize         Optional minimum event log size as a string
-   * @param fsStartTime             Filesystem date and time for filtering event logs based on start time
-   * @param fsEndTime               Filesystem date and time for filtering event logs based on end time
+   * @param fsStartTime             Filesystem date and time for filtering event logs based on
+   *                                start time
+   * @param fsEndTime               Filesystem date and time for filtering event logs based on
+   *                                end time
    * @return (Seq[EventLogInfo], Seq[EventLogInfo]) - Tuple indicating paths of event logs in
    *         filesystem. First element contains paths of event logs after applying filters and
    *         second element contains paths of all event logs.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/EventLogPathProcessor.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/EventLogPathProcessor.scala
@@ -51,20 +51,19 @@ case class FailedEventLog(override val eventLog: Path,
 
 object EventLogPathProcessor extends Logging {
   // Apache Spark event log prefixes
-  val EVENT_LOG_DIR_NAME_PREFIX = "eventlog_v2_"
-  val EVENT_LOG_FILE_NAME_PREFIX = "events_"
-  val DB_EVENT_LOG_FILE_NAME_PREFIX = "eventlog"
+  private val EVENT_LOG_DIR_NAME_PREFIX = "eventlog_v2_"
+  private val DB_EVENT_LOG_FILE_NAME_PREFIX = "eventlog"
 
-  def isEventLogDir(status: FileStatus): Boolean = {
+  private def isEventLogDir(status: FileStatus): Boolean = {
     status.isDirectory && isEventLogDir(status.getPath.getName)
   }
 
   // This only checks the name of the path
-  def isEventLogDir(path: String): Boolean = {
+  private def isEventLogDir(path: String): Boolean = {
     path.startsWith(EVENT_LOG_DIR_NAME_PREFIX)
   }
 
-  def isDBEventLogFile(fileName: String): Boolean = {
+  private def isDBEventLogFile(fileName: String): Boolean = {
     fileName.startsWith(DB_EVENT_LOG_FILE_NAME_PREFIX)
   }
 
@@ -75,9 +74,9 @@ object EventLogPathProcessor extends Logging {
   // scalastyle:off line.size.limit
   // https://github.com/apache/spark/blob/0494dc90af48ce7da0625485a4dc6917a244d580/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala#L67
   // scalastyle:on line.size.limit
-  val SPARK_SHORT_COMPRESSION_CODEC_NAMES = Set("lz4", "lzf", "snappy", "zstd")
+  private val SPARK_SHORT_COMPRESSION_CODEC_NAMES = Set("lz4", "lzf", "snappy", "zstd")
   // Apache Spark ones plus gzip
-  val SPARK_SHORT_COMPRESSION_CODEC_NAMES_FOR_FILTER =
+  private val SPARK_SHORT_COMPRESSION_CODEC_NAMES_FOR_FILTER =
     SPARK_SHORT_COMPRESSION_CODEC_NAMES ++ Set("gz")
 
   // Files having these keywords are not considered as event logs
@@ -100,8 +99,8 @@ object EventLogPathProcessor extends Logging {
   // Databricks has the latest events in file named eventlog and then any rolled in format
   // eventlog-2021-06-14--20-00.gz, here we assume that if any files start with eventlog
   // then the directory is a Databricks event log directory.
-  def isDatabricksEventLogDir(dir: FileStatus, fs: FileSystem): Boolean = {
-    val dbLogFiles = fs.listStatus(dir.getPath, new PathFilter {
+  private def isDatabricksEventLogDir(dir: FileStatus, fs: FileSystem): Boolean = {
+    lazy val dbLogFiles = fs.listStatus(dir.getPath, new PathFilter {
       override def accept(path: Path): Boolean = {
         isDBEventLogFile(path.getName)
       }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/EventLogPathProcessor.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/EventLogPathProcessor.scala
@@ -245,8 +245,7 @@ object EventLogPathProcessor extends Logging {
    * @param eventLogsPaths          Array of event log paths
    * @param hadoopConf              Hadoop Configuration
    * @param recursiveSearchEnabled  If enabled, search for event logs in all subdirectories.
-   * @param maxEventLogSize         Maximum size of event log to be processed
-   * @param minEventLogSize         Minimum size of event log to be processed
+   *                                Enabled by default.
    *
    * @return (Seq[EventLogInfo], Seq[EventLogInfo]) - Tuple indicating paths of event logs in
    *         filesystem. First element contains paths of event logs after applying filters and

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
@@ -77,6 +77,11 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
   val generateTimeline: ScallopOption[Boolean] =
     opt[Boolean](required = false,
       descr = "Write an SVG graph out for the full application timeline.")
+  val noRecursion: ScallopOption[Boolean] =
+    opt[Boolean](required = false,
+      descr = "Set to true to disable recursive search for event logs in the provided " +
+        "directories. Default is false.",
+      default = Some(false))
   val numThreads: ScallopOption[Int] =
     opt[Int](required = false,
       descr = "Number of thread to use for parallel processing. The default is the " +

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,10 +51,11 @@ object ProfileMain extends Logging {
     val timeout = appArgs.timeout.toOption
     val nThreads = appArgs.numThreads.getOrElse(
       Math.ceil(Runtime.getRuntime.availableProcessors() / 4f).toInt)
+    val recursiveSearchEnabled = !appArgs.noRecursion()
 
     // Get the event logs required to process
     val (eventLogFsFiltered, _) = EventLogPathProcessor.processAllPaths(filterN.toOption,
-      matchEventLogs.toOption, eventlogPaths, hadoopConf)
+      matchEventLogs.toOption, eventlogPaths, hadoopConf, recursiveSearchEnabled)
 
     val filteredLogs = if (argsContainsAppFilters(appArgs)) {
       val appFilter = new AppFilterImpl(numOutputRows, hadoopConf, timeout, nThreads)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
@@ -115,6 +115,11 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
       descr = "Specify the sort order of the report. desc or asc, desc is the default. " +
         "desc (descending) would report applications most likely to be accelerated at the top " +
         "and asc (ascending) would show the least likely to be accelerated at the top.")
+  val noRecursion: ScallopOption[Boolean] =
+    opt[Boolean](required = false,
+      descr = "Set to true to disable recursive search for event logs in the provided " +
+        "directories. Default is false.",
+      default = Some(false))
   val numThreads: ScallopOption[Int] =
     opt[Int](required = false,
       descr = "Number of thread to use for parallel processing. The default is the " +

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.rapids.tool.qualification.QualificationSummaryInfo
 import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
 
 /**
- * A tool to analyze Spark event logs and determine if 
+ * A tool to analyze Spark event logs and determine if
  * they might be a good fit for running on the GPU.
  */
 object QualificationMain extends Logging {
@@ -66,6 +66,7 @@ object QualificationMain extends Logging {
     val reportSqlLevel = appArgs.perSql.getOrElse(false)
     val mlOpsEnabled = appArgs.mlFunctions.getOrElse(false)
     val penalizeTransitions = appArgs.penalizeTransitions.getOrElse(true)
+    val recursiveSearchEnabled = !appArgs.noRecursion()
 
     val hadoopConf = RapidsToolsConfUtil.newHadoopConf
     val platform = try {
@@ -88,7 +89,7 @@ object QualificationMain extends Logging {
     }
 
     val (eventLogFsFiltered, allEventLogs) = EventLogPathProcessor.processAllPaths(
-      filterN.toOption, matchEventLogs.toOption, eventlogPaths, hadoopConf,
+      filterN.toOption, matchEventLogs.toOption, eventlogPaths, hadoopConf, recursiveSearchEnabled,
       maxEventLogSize, minEventLogSize)
 
     val filteredLogs = if (argsContainsAppFilters(appArgs)) {

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -90,6 +90,7 @@ sparkRapids:
       - max-sql-desc-length
       - ml-functions
       - n
+      - no-recursion
       - num-output-rows
       - order
       - r


### PR DESCRIPTION

Fixes #1177. This PR enables recursive search for event logs recursively by default. This is useful when a user wants to process multiple cluster event logs at once.

### Example
```
test_cluster_logs/
├── 0325-072137-br2ztcsl
│   ├── driver
|   ├── eventlog
│   │   └── 0325-072137-br2ztcsl_100_64_30_156
│   │       └── 5801510396587970993
│   │           ├── eventlog
│   │           ├── eventlog-2024-03-25--07-30.gz
│   │           ├── eventlog-2024-03-25--07-40.gz
│   │           ├── eventlog-2024-03-25--07-50.gz
│   │           ├── eventlog-2024-03-25--08-00.gz
│   │           ├── eventlog-2024-03-25--08-10.gz
│   │           ├── eventlog-2024-03-25--08-20.gz
│   │           ├── eventlog-2024-03-25--08-30.gz
│   │           ├── eventlog-2024-03-25--08-40.gz
│   │           └── eventlog-2024-03-25--08-50.gz
│   ├── executor
│   └── init_scripts
└── 0325-092658-o0t9uwq4
    ├── driver
    ├── eventlog
    │   └── 0325-085253-u3t0qaxu_100_64_30_156
    │       └── 5160740748072535114
    │           ├── eventlog
    │           ├── eventlog-2024-03-25--09-00.gz
    │           ├── eventlog-2024-03-25--09-10.gz
    │           └── eventlog-2024-03-25--09-20.gz
    ├── executor
    └── init_scripts
```
### Before

Currently, to process the above two sets of Databricks event logs, users need to specify each directory level explicitly:

CMD:
```
spark_rapids qualification --eventlogs /path/to/test_cluster_logs/*/eventlog/*/*
```


### After
After the changes in this PR, a user can pass the root directory and the tool will recursively look for valid event logs (files or rolling databricks folders)

CMD:
```
spark_rapids qualification --eventlogs /path/to/test_cluster_logs
```

### Changes
- Enabled recursive search by default.
- Added a `--no-recursion` argument that both Python and Scala tools can provide to disable recursion if needed.
     - This maybe useful when using CSP storage.
- Wildcard handling:
   - First, we process wildcards to list all matching paths.
   - Then, perform a recursive search for each listed path.


### Code Changes
- Started using @tgravescs [branch](https://github.com/tgravescs/spark-rapids-tools/tree/recurseDirsEventlogs) as a reference.
- Simplified the `EventLogPathProcessor#getEventLogInfo()` method to avoid redundant checks and initialization.,
- Introduced a method `getEventLogInfoInternal()` to recursively search for valid event logs. This uses a queue to avoid stack overflow errors. 
- Introduced `EXCLUDED_EVENTLOG_NAME_KEYWORDS` to filter event logs based on their names.


### Testing
- Tested the changes manually using a mixed set of paths 
