### PR TITLE
Fix key error and cross-join error during qualx evaluate

### DIFF
--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -229,8 +229,29 @@ def _predict(
     split_fn: Callable[[pd.DataFrame], pd.DataFrame] = None,
     qual_tool_filter: Optional[str] = 'stage',
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
-    results = pd.DataFrame(columns=['appId', 'appDuration', 'sqlID', 'scaleFactor', 'Duration', 'Duration_supported', 'Duration_pred', 'speedup_pred'])
-    summary = pd.DataFrame(columns=['appId', 'appDuration', 'Duration_pred', 'Duration_supported', 'fraction_supported', 'appDuration_pred', 'speedup'])
+    results = pd.DataFrame(
+        columns=[
+            'appId',
+            'appDuration',
+            'sqlID',
+            'scaleFactor',
+            'Duration',
+            'Duration_supported',
+            'Duration_pred',
+            'speedup_pred',
+        ]
+    )
+    summary = pd.DataFrame(
+        columns=[
+            'appId',
+            'appDuration',
+            'Duration_pred',
+            'Duration_supported',
+            'fraction_supported',
+            'appDuration_pred',
+            'speedup',
+        ]
+    )
     if not input_df.empty:
         filter_str = (
             f'with {qual_tool_filter} filtering'

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -229,8 +229,8 @@ def _predict(
     split_fn: Callable[[pd.DataFrame], pd.DataFrame] = None,
     qual_tool_filter: Optional[str] = 'stage',
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
-    results = pd.DataFrame()
-    summary = pd.DataFrame()
+    results = pd.DataFrame(columns=['appId', 'appDuration', 'sqlID', 'scaleFactor', 'Duration', 'Duration_supported', 'Duration_pred', 'speedup_pred'])
+    summary = pd.DataFrame(columns=['appId', 'appDuration', 'Duration_pred', 'Duration_supported', 'fraction_supported', 'appDuration_pred', 'speedup'])
     if not input_df.empty:
         filter_str = (
             f'with {qual_tool_filter} filtering'
@@ -792,7 +792,8 @@ def evaluate(
         split_fn=split_fn,
         qual_tool_filter=qual_tool_filter,
     )
-    # join raw app data with app level gpu ground truth
+
+    # app level ground truth
     app_durations = (
         profile_df.loc[profile_df.runType == 'GPU'][
             ['appName', 'appDuration', 'description', 'scaleFactor']
@@ -803,29 +804,12 @@ def evaluate(
     )
     app_durations = app_durations.rename(columns={'appDuration': 'gpu_appDuration'})
 
-    # handle query per app and regular app differently.
-    # For the former, we need to use query description field to join cpu and gpu data
-    # since appname is the same for all queries/apps in these case.
-
-    raw_app_regular = raw_app.loc[~raw_app.appName.str.contains('query_per_app')]
-    raw_app_q_per_app = raw_app.loc[raw_app.appName.str.contains('query_per_app')]
-    app_durations_regular = app_durations.loc[
-        ~app_durations.appName.str.contains('query_per_app')
-    ][['appName', 'gpu_appDuration', 'scaleFactor']]
-    app_durations_q_per_app = app_durations.loc[
-        app_durations.appName.str.contains('query_per_app')
-    ]
-
-    raw_app_regular = raw_app_regular.merge(
-        app_durations_regular[['appName', 'gpu_appDuration', 'scaleFactor']],
-        on=['appName', 'scaleFactor'],
+    # join raw app data with app level gpu ground truth
+    raw_app = raw_app.merge(
+        app_durations[['appName', 'description', 'scaleFactor', 'gpu_appDuration']],
+        on=['appName', 'description', 'scaleFactor'],
         how='left',
     )
-    raw_app_q_per_app = raw_app_q_per_app.merge(
-        app_durations_q_per_app, on=['appName', 'description', 'scaleFactor'], how='left'
-    )
-
-    raw_app = pd.concat([raw_app_regular, raw_app_q_per_app])
 
     if not raw_app.loc[raw_app.gpu_appDuration.isna()].empty:
         logger.error(


### PR DESCRIPTION
This PR fixes some bugs with the `evaluate` command in the internal CLI:
- `key error` when all stages are unsupported.
- unexpected cross-join in per-app results under specific conditions (`appName` and `scaleFactor` are all the same, but `description` is different).

I have confirmed that the `evaluate` results match the results from before (except they fix the cross-join case).

## Changes
1. set default columns in new/empty DataFrames to avoid key error during subsequent joins.
2. use `description` field in all joins during evaluate.

## Test
Following CMDs have been tested:

### Internal Usage:
```
python qualx_main.py evaluate
```

