### PR TITLE
Raise error for enum creation from invalid string values

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -157,7 +157,7 @@ class DataprocPlatform(PlatformBase):
                 # create gpu_info
                 gpu_cnt = calc_num_gpus(gpu_count_criteria, num_cpu)
                 # default memory
-                gpu_device = GpuDevice.get_default_gpu()
+                gpu_device = GpuDevice.get_default()
                 gpu_mem = gpu_device.get_gpu_mem()[0]
                 gpu_info_obj = GpuHWInfo(num_gpus=gpu_cnt, gpu_mem=gpu_mem, gpu_device=gpu_device)
                 gpu_scopes[prof_name] = NodeHWInfo(sys_info=sys_info_obj, gpu_info=gpu_info_obj)
@@ -378,7 +378,7 @@ class DataprocNode(ClusterNode):
 
     def _pull_gpu_hw_info(self, cli=None) -> Optional[GpuHWInfo]:
         # gcloud GPU machines: https://cloud.google.com/compute/docs/gpus
-        def get_gpu_device(accelerator_name: str) -> GpuDevice:
+        def get_gpu_device(accelerator_name: str) -> Optional[GpuDevice]:
             """
             return the GPU device given a accelerator full name (e.g. nvidia-tesla-t4)
             """

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -384,8 +384,11 @@ class DataprocNode(ClusterNode):
             """
             accelerator_name_arr = accelerator_name.split('-')
             for elem in accelerator_name_arr:
-                if GpuDevice.fromstring(elem) is not None:
+                try:
                     return GpuDevice.fromstring(elem)
+                except ValueError:
+                    # Continue to next entry if the accelerator name is not a valid GPU device
+                    continue
             return None
 
         # check if GPU info is already set

--- a/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
@@ -302,7 +302,7 @@ class EMRNode(ClusterNode):
         raw_gpu = raw_gpus[0]
         gpu_device = GpuDevice.fromstring(raw_gpu['Name'])
         gpu_cnt = raw_gpu['Count'][0]  # gpu count is a list
-        gpu_mem = GpuDevice.get_gpu_mem(gpu_device)
+        gpu_mem = GpuDevice.get_gpu_mem(gpu_device)[0]  # gpu memory is a list, picking the first one
         return GpuHWInfo(num_gpus=gpu_cnt,
                          gpu_device=gpu_device,
                          gpu_mem=gpu_mem)
@@ -390,7 +390,7 @@ class EMRCluster(ClusterBase):
                         count=curr_group.count,
                         market=curr_group.market,
                         group_type=curr_group.group_type,
-                        state=ClusterState.UNKNOWN)
+                        state=ClusterState.get_default())
                 group_cache.update({new_inst_grp.id: new_inst_grp})
             self.instance_groups.append(new_inst_grp)
         # convert the instances
@@ -434,11 +434,12 @@ class EMRCluster(ClusterBase):
         def process_cluster_group_list(inst_groups: list) -> list:
             instance_group_list = []
             for inst_grp in inst_groups:
-                parsed_state = ClusterState.UNKNOWN
                 try:
                     parsed_state = ClusterState.fromstring(inst_grp['Status']['State'])
-                except Exception:  # pylint: disable=broad-except
-                    self.logger.info('Unable to get cluster state, setting to \'UNKNOWN\'.')
+                except ValueError:
+                    parsed_state = ClusterState.get_default()
+                    self.logger.info(f'Unable to get cluster state, setting to '
+                                     f'\'{ClusterState.tostring(parsed_state)}\'.')
                 inst_group = InstanceGroup(
                     id=inst_grp['Id'],
                     instance_type=inst_grp['InstanceType'],

--- a/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
@@ -436,7 +436,7 @@ class EMRCluster(ClusterBase):
             for inst_grp in inst_groups:
                 try:
                     parsed_state = ClusterState.fromstring(inst_grp['Status']['State'])
-                except ValueError:
+                except (KeyError, ValueError):
                     parsed_state = ClusterState.get_default()
                     self.logger.info(f'Unable to get cluster state, setting to '
                                      f'\'{ClusterState.tostring(parsed_state)}\'.')

--- a/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
@@ -134,7 +134,7 @@ class OnPremPlatform(PlatformBase):
                 # create gpu_info
                 gpu_cnt = calc_num_gpus(gpu_count_criteria, num_cpu)
                 # default memory
-                gpu_device = GpuDevice.get_default_gpu()
+                gpu_device = GpuDevice.get_default()
                 gpu_mem = gpu_device.get_gpu_mem()[0]
                 gpu_info_obj = GpuHWInfo(num_gpus=gpu_cnt, gpu_mem=gpu_mem, gpu_device=gpu_device)
                 gpu_scopes[prof_name] = NodeHWInfo(sys_info=sys_info_obj, gpu_info=gpu_info_obj)

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -53,7 +53,7 @@ class GpuDevice(EnumeratedType):
     A10G = 'a10g'
 
     @classmethod
-    def get_default_gpu(cls):
+    def get_default(cls):
         return cls.T4
 
     def get_gpu_mem(self) -> list:
@@ -86,6 +86,10 @@ class ClusterState(EnumeratedType):
     OFFLINE = 'offline'
     UNKNOWN = 'unknown'
 
+    @classmethod
+    def get_default(cls) -> 'ClusterState':
+        return cls.UNKNOWN
+
 
 class SparkNodeType(EnumeratedType):
     """
@@ -108,7 +112,7 @@ class SysInfo:
 class GpuHWInfo:
     num_gpus: int = None
     gpu_mem: int = None
-    gpu_device: GpuDevice = GpuDevice.get_default_gpu()
+    gpu_device: GpuDevice = GpuDevice.get_default()
 
     def get_gpu_device_name(self) -> str:
         return GpuDevice.tostring(self.gpu_device)
@@ -250,7 +254,7 @@ class ClusterGetAccessor:
         if gpu_info:
             num_gpus, gpu_device = gpu_info.num_gpus, gpu_info.gpu_device
         else:
-            num_gpus, gpu_device = 0, GpuDevice.get_default_gpu()
+            num_gpus, gpu_device = 0, GpuDevice.get_default()
         return num_gpus, GpuDevice.tostring(gpu_device)
 
     def get_node_instance_type(self, node_type: SparkNodeType) -> str:

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -87,7 +87,7 @@ class ClusterState(EnumeratedType):
     UNKNOWN = 'unknown'
 
     @classmethod
-    def get_default(cls) -> 'ClusterState':
+    def get_default(cls):
         return cls.UNKNOWN
 
 

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -141,15 +141,13 @@ class Qualification(RapidsJarTool):
 
     def __process_filter_args(self, arg_val: str) -> None:
         selected_filter = QualFilterApp.fromstring(arg_val)
-        if selected_filter is None:
-            selected_filter = QualFilterApp.get_default()
-            available_filters = [filter_enum.value for filter_enum in QualFilterApp]
-            self.logger.warning(
-                'Invalid argument filter_apps=%s.\n\t'
-                'Accepted options are: [%s].\n\t'
-                'Falling-back to default filter: %s',
-                arg_val, Utils.gen_joined_str(' | ', available_filters),
-                QualFilterApp.tostring(selected_filter))
+        available_filters = [filter_enum.value for filter_enum in QualFilterApp]
+        self.logger.warning(
+            'Invalid argument filter_apps=%s.\n\t'
+            'Accepted options are: [%s].\n\t'
+            'Falling-back to default filter: %s',
+            arg_val, Utils.gen_joined_str(' | ', available_filters),
+            QualFilterApp.tostring(selected_filter))
         self.ctxt.set_ctxt('filterApps', selected_filter)
 
     def _process_estimation_model_args(self) -> None:

--- a/user_tools/src/spark_rapids_tools/enums.py
+++ b/user_tools/src/spark_rapids_tools/enums.py
@@ -15,11 +15,15 @@
 """Enumeration types commonly used through the AS python implementations."""
 
 from enum import Enum, auto
-from typing import Union, cast, Optional, Callable
+from typing import Union, cast, Callable
 
 
 class EnumeratedType(str, Enum):
     """Abstract representation of enumerated values"""
+
+    @classmethod
+    def get_default(cls) -> 'EnumeratedType':
+        pass
 
     # Make enum case-insensitive by overriding the Enum's missing method
     @classmethod
@@ -41,13 +45,16 @@ class EnumeratedType(str, Enum):
         return str(value._value_).upper()  # pylint: disable=protected-access
 
     @classmethod
-    def fromstring(cls, value: str) -> Optional[str]:
+    def fromstring(cls, value: str) -> 'EnumeratedType':
         """Return the state object attribute that matches the given value
         :param str value: string to look up
         :return: the state object attribute that matches the string
         :rtype: str
         """
-        return getattr(cls, value.upper(), None)
+        attribute = getattr(cls, value.upper(), None)
+        if attribute is None:
+            raise ValueError(f'{value} is not a valid {cls.__name__}')
+        return attribute
 
     @classmethod
     def pretty_print(cls, value):

--- a/user_tools/src/spark_rapids_tools/enums.py
+++ b/user_tools/src/spark_rapids_tools/enums.py
@@ -49,7 +49,7 @@ class EnumeratedType(str, Enum):
         """Return the state object attribute that matches the given value
         :param str value: string to look up
         :return: the state object attribute that matches the string
-        :rtype: str
+        :rtype: EnumeratedType
         """
         attribute = getattr(cls, value.upper(), None)
         if attribute is None:


### PR DESCRIPTION
Fixes #887: This PR updates the `fromstring()` method for Enum creation to raise a `ValueError` for invalid input strings. Previously, it would silently returned None, which could lead to unexpected behaviour if not handled by the caller.

### Changes

class `EnumeratedType`: 
- `fromstring()` now raises a ValueError for invalid strings.
- Changed `fromstring()` return type to EnumeratedType.
- Added `get_default()` to return a default value. This is implemented by the subclasses.