### PR TITLE
Append HADOOP_CONF_DIR to the tools CLASSPATH execution cmd

### DIFF
--- a/user_tools/src/spark_rapids_pytools/common/utilities.py
+++ b/user_tools/src/spark_rapids_pytools/common/utilities.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass, field
 from logging import Logger
 from shutil import make_archive, which
 import tempfile
-from typing import Callable, Any
+from typing import Callable, Any, Optional
 
 import chevron
 from packaging.version import Version
@@ -105,7 +105,7 @@ class Utils:
         return f'RAPIDS_USER_TOOLS_{actual_key}'
 
     @classmethod
-    def get_sys_env_var(cls, k: str, def_val=None):
+    def get_sys_env_var(cls, k: str, def_val=None) -> Optional[str]:
         return os.environ.get(k, def_val)
 
     @classmethod

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_job.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_job.py
@@ -65,7 +65,10 @@ class RapidsJob:
 
     def _init_fields(self):
         self.logger = ToolLogging.get_and_setup_logger(f'rapids.tools.submit.{self.job_label}')
-        self.output_path = self.prop_container.get_value_silent('outputDirectory')
+        output_directory = self.prop_container.get_value_silent('outputDirectory')
+        if output_directory is not None:
+            # use LocalPath to add the 'file://' prefix to the path
+            self.output_path = str(LocalPath(output_directory))
 
     def __post_init__(self):
         self._init_fields()

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -38,6 +38,7 @@ from spark_rapids_pytools.common.utilities import ToolLogging, Utils, ToolsSpinn
 from spark_rapids_pytools.rapids.rapids_job import RapidsJobPropContainer
 from spark_rapids_pytools.rapids.tool_ctxt import ToolContext
 from spark_rapids_tools import CspEnv
+from spark_rapids_tools.storagelib import LocalPath
 from spark_rapids_tools.utils import Utilities
 
 
@@ -135,7 +136,13 @@ class RapidsTool(object):
         # make sure that output_folder is being absolute
         if self.output_folder is None:
             self.output_folder = Utils.get_rapids_tools_env('OUTPUT_DIRECTORY', os.getcwd())
-        self.output_folder = FSUtil.get_abs_path(self.output_folder)
+        try:
+            output_folder_path = LocalPath(self.output_folder)
+            self.output_folder = output_folder_path.no_prefix
+        except Exception as ex:  # pylint: disable=broad-except
+            self.logger.error('Failed in processing output arguments. Output_folder must be a local directory')
+            raise ex
+        # self.output_folder = FSUtil.get_abs_path(self.output_folder)
         self.logger.debug('Root directory of local storage is set as: %s', self.output_folder)
         self.ctxt.set_local_workdir(self.output_folder)
         self.ctxt.load_prepackaged_resources()

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -142,7 +142,6 @@ class RapidsTool(object):
         except Exception as ex:  # pylint: disable=broad-except
             self.logger.error('Failed in processing output arguments. Output_folder must be a local directory')
             raise ex
-        # self.output_folder = FSUtil.get_abs_path(self.output_folder)
         self.logger.debug('Root directory of local storage is set as: %s', self.output_folder)
         self.ctxt.set_local_workdir(self.output_folder)
         self.ctxt.load_prepackaged_resources()

--- a/user_tools/src/spark_rapids_tools/storagelib/hdfs/hdfsfs.py
+++ b/user_tools/src/spark_rapids_tools/storagelib/hdfs/hdfsfs.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 
 """Wrapper for the Hadoop File system"""
+from typing import Any
 
-from ..cspfs import CspFs, register_fs_class
+from pyarrow.fs import HadoopFileSystem
+
+from ..cspfs import CspFs, register_fs_class, BoundedArrowFsT
 
 
 @register_fs_class("hdfs", "HadoopFileSystem")
@@ -36,3 +39,10 @@ class HdfsFs(CspFs):
     CLASSPATH: must contain the Hadoop jars.
     example to set the export CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath --glob`
     """
+
+    @classmethod
+    def create_fs_handler(cls, *args: Any, **kwargs: Any) -> BoundedArrowFsT:
+        try:
+            return HadoopFileSystem(*(args or ("default",)), **kwargs)
+        except Exception as e:  # pylint: disable=broad-except
+            raise RuntimeError(f"Failed to create HadoopFileSystem handler: {e}") from e

--- a/user_tools/src/spark_rapids_tools/storagelib/hdfs/hdfsfs.py
+++ b/user_tools/src/spark_rapids_tools/storagelib/hdfs/hdfsfs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Wrapper for the Hadoop File system"""
+
 from typing import Any
 
 from pyarrow.fs import HadoopFileSystem

--- a/user_tools/src/spark_rapids_tools/utils/util.py
+++ b/user_tools/src/spark_rapids_tools/utils/util.py
@@ -323,3 +323,17 @@ class Utilities:
             num_bytes /= 1024.0
             i += 1
         return f'{num_bytes:.2f} {size_units[i]}'
+
+    @classmethod
+    def get_hadoop_conf_dir(cls) -> Optional[str]:
+        """
+        Get Hadoop's configuration directory from the environment variables.
+        If not defined, return $HADOOP_HOME/etc/hadoop if HADOOP_HOME is defined.
+        Otherwise, returns None.
+        """
+        hadoop_conf_dir = Utils.get_sys_env_var('HADOOP_CONF_DIR')
+        if hadoop_conf_dir is None:
+            hadoop_home = Utils.get_sys_env_var('HADOOP_HOME')
+            if hadoop_home is not None:
+                hadoop_conf_dir = os.path.join(hadoop_home, 'etc', 'hadoop')
+        return hadoop_conf_dir

--- a/user_tools/src/spark_rapids_tools/utils/util.py
+++ b/user_tools/src/spark_rapids_tools/utils/util.py
@@ -323,17 +323,3 @@ class Utilities:
             num_bytes /= 1024.0
             i += 1
         return f'{num_bytes:.2f} {size_units[i]}'
-
-    @classmethod
-    def get_hadoop_conf_dir(cls) -> Optional[str]:
-        """
-        Get Hadoop's configuration directory from the environment variables.
-        If not defined, return $HADOOP_HOME/etc/hadoop if HADOOP_HOME is defined.
-        Otherwise, returns None.
-        """
-        hadoop_conf_dir = Utils.get_sys_env_var('HADOOP_CONF_DIR')
-        if hadoop_conf_dir is None:
-            hadoop_home = Utils.get_sys_env_var('HADOOP_HOME')
-            if hadoop_home is not None:
-                hadoop_conf_dir = os.path.join(hadoop_home, 'etc', 'hadoop')
-        return hadoop_conf_dir


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein <ahussein@nvidia.com>

Fixes #1253
Fixes #1283
Fixes #1302
Fixes #1303

This change includes the following:

- The wrapper gets Hadoop's configuration directory from the environment variables. The first valid directory is added to the java cmd CLASSPATH. The order of available hadoop configuration directories are:

        1. `HADOOP_CONF_DIR`
        2. `HADOOP_HOME/conf`
        3. `HADOOP_HOME/etc/hadoop`

- This PR also enforces URI to the `--output-folder` argument to the java cmd. This is required to prevent the core tools from storing the output-folder on the remote storage in case HDFS defines a default FileSystem.


