### PR TITLE
Fix Qualification and Profiling tools CLI argument shorthands

### DIFF
--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -88,6 +88,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                 For more details on Qualification tool options, please visit
                 https://docs.nvidia.com/spark-rapids/user-guide/latest/qualification/jar-usage.html#running-the-qualification-tool-standalone-on-spark-event-logs
         """
+        eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
         platform = Utils.get_value_or_pop(platform, rapids_options, 'p')
         tools_jar = Utils.get_value_or_pop(tools_jar, rapids_options, 't')
         output_folder = Utils.get_value_or_pop(output_folder, rapids_options, 'o')
@@ -169,7 +170,9 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
         cluster = Utils.get_value_or_pop(cluster, rapids_options, 'c')
         platform = Utils.get_value_or_pop(platform, rapids_options, 'p')
+        driverlog = Utils.get_value_or_pop(driverlog, rapids_options, 'd')
         output_folder = Utils.get_value_or_pop(output_folder, rapids_options, 'o')
+        tools_jar = Utils.get_value_or_pop(tools_jar, rapids_options, 't')
         verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
         if verbose:
             ToolLogging.enable_debug_mode()


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/1301

Running `spark_rapids qualification/profiling -- --help` shows the tools options and their shorthands, if supported. For example:
```
FLAGS
    -e, --eventlogs=EVENTLOGS
        Type: Optional[str]
        Default: None
        Event log filenames or CSP storage directories containing event logs (comma separated).

        Skipping this argument requires that the cluster argument points to a valid cluster name on the CSP.
    --cluster=CLUSTER
        Type: Optional[str]
        Default: None
        The CPU cluster on which the Spark application(s) were executed. Name or ID (for databricks platforms) of cluster or path to cluster-properties.
```

However, this is inconsistent with what the tools actually support. This PR fixes this issue.