### PR TITLE
Mark decimalsum as supported in Qualification tool

### DIFF
--- a/core/src/main/resources/operatorsScore-databricks-aws-a10G.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws-a10G.csv
@@ -301,3 +301,4 @@ ArrayFilter,1.5
 BoundReference,1.5
 HiveHash,1.5
 MapFromArrays,1.5
+DecimalSum,1.5

--- a/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
@@ -301,3 +301,4 @@ ArrayFilter,1.5
 BoundReference,1.5
 HiveHash,1.5
 MapFromArrays,1.5
+DecimalSum,1.5

--- a/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
@@ -289,3 +289,4 @@ ArrayFilter,1.5
 BoundReference,1.5
 HiveHash,1.5
 MapFromArrays,1.5
+DecimalSum,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
@@ -283,3 +283,4 @@ ArrayFilter,1.5
 BoundReference,1.5
 HiveHash,1.5
 MapFromArrays,1.5
+DecimalSum,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
@@ -283,3 +283,4 @@ ArrayFilter,1.5
 BoundReference,1.5
 HiveHash,1.5
 MapFromArrays,1.5
+DecimalSum,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-l4.csv
@@ -289,3 +289,4 @@ ArrayFilter,1.5
 BoundReference,1.5
 HiveHash,1.5
 MapFromArrays,1.5
+DecimalSum,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
@@ -283,3 +283,4 @@ ArrayFilter,1.5
 BoundReference,1.5
 HiveHash,1.5
 MapFromArrays,1.5
+DecimalSum,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-t4.csv
@@ -289,3 +289,4 @@ ArrayFilter,1.5
 BoundReference,1.5
 HiveHash,1.5
 MapFromArrays,1.5
+DecimalSum,1.5

--- a/core/src/main/resources/operatorsScore-emr-a10.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10.csv
@@ -289,3 +289,4 @@ ArrayFilter,1.5
 BoundReference,1.5
 HiveHash,1.5
 MapFromArrays,1.5
+DecimalSum,1.5

--- a/core/src/main/resources/operatorsScore-emr-a10G.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10G.csv
@@ -289,3 +289,4 @@ ArrayFilter,1.5
 BoundReference,1.5
 HiveHash,1.5
 MapFromArrays,1.5
+DecimalSum,1.5

--- a/core/src/main/resources/operatorsScore-emr-t4.csv
+++ b/core/src/main/resources/operatorsScore-emr-t4.csv
@@ -289,3 +289,4 @@ ArrayFilter,1.5
 BoundReference,1.5
 HiveHash,1.5
 MapFromArrays,1.5
+DecimalSum,1.5

--- a/core/src/main/resources/operatorsScore-onprem-a100.csv
+++ b/core/src/main/resources/operatorsScore-onprem-a100.csv
@@ -301,3 +301,4 @@ ArrayFilter,1.5
 BoundReference,1.5
 HiveHash,1.5
 MapFromArrays,1.5
+DecimalSum,1.5

--- a/core/src/main/resources/supportedExprs.csv
+++ b/core/src/main/resources/supportedExprs.csv
@@ -788,3 +788,5 @@ EphemeralSubstring,S,`substr`; `substring`,None,project,str,NA,NA,NA,NA,NA,NA,NA
 EphemeralSubstring,S,`substr`; `substring`,None,project,pos,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
 EphemeralSubstring,S,`substr`; `substring`,None,project,len,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
 EphemeralSubstring,S,`substr`; `substring`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NS,NA,NA,NA,NA,NA,NS,NS
+DecimalSum,S,`decimalsum`,None,project,input,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NS,NS
+DecimalSum,S,`decimalsum`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA,NA,NA,NS,NS


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein <ahussein@nvidia.com>

Fixes #1322

This code change marks `decimalsum` as supported in the Qualification tool.
`decimalsum` is a new operator specific to EMR and the RAPIDS plugin converts it to `gpudecimal128sum`

**Changes**

- update the supportedExprs.csv
- update the score sheets. Eventhough, this is only specific to EMR, it is preferred to add it to other CSPs in case the platform was not defined correctly by the user (which is a common case)
- added a new UT.
