### PR TITLE
Allow spark dependency to be configured dynamically

### DIFF
--- a/user_tools/src/spark_rapids_pytools/__init__.py
+++ b/user_tools/src/spark_rapids_pytools/__init__.py
@@ -14,10 +14,10 @@
 
 """init file of the spark_rapids_pytools package."""
 
-from spark_rapids_pytools.build import get_version, get_runtime_buildver
+from spark_rapids_pytools.build import get_version, get_spark_dep_version
 
 VERSION = '24.08.2'
 # defines the default runtime build version for the user tools environment
-RUNTIME_BUILDVER = '350'
+SPARK_DEP_VERSION = '350'
 __version__ = get_version(VERSION)
-__runtime_buildver__ = get_runtime_buildver()
+__spark_dep_version__ = get_spark_dep_version()

--- a/user_tools/src/spark_rapids_pytools/__init__.py
+++ b/user_tools/src/spark_rapids_pytools/__init__.py
@@ -14,7 +14,10 @@
 
 """init file of the spark_rapids_pytools package."""
 
-from spark_rapids_pytools.build import get_version
+from spark_rapids_pytools.build import get_version, get_runtime_buildver
 
 VERSION = '24.08.1'
+# defines the default runtime build version for the user tools environment
+RUNTIME_BUILDVER = '350'
 __version__ = get_version(VERSION)
+__runtime_buildver__ = get_runtime_buildver()

--- a/user_tools/src/spark_rapids_pytools/build.py
+++ b/user_tools/src/spark_rapids_pytools/build.py
@@ -32,12 +32,16 @@ def get_version(main: str = None) -> str:
 def get_runtime_buildver(buildver_arg: str = None) -> str:
     """
     Get the runtime SPARK build_version for the user tools environment.
+    Note that the env_var always have precedence over the input argument and the default values
     :param buildver_arg: optional argument to specify the build version
-    :return: returns the input argument if it is set.
-       Otherwise, it returns ${RAPIDS_USER_TOOLS_RUNTIME_BUILDVER:-RUNTIME_BUILDVER}.
+    :return: the first value set in the following order:
+       1- env_var RAPIDS_USER_TOOLS_RUNTIME_BUILDVER
+       2- the input buildver_arg
+       3- default value RUNTIME_BUILDVER
     """
     if buildver_arg is None:
         # pylint: disable=import-outside-toplevel
         from spark_rapids_pytools import RUNTIME_BUILDVER
-        return os.environ.get('RAPIDS_USER_TOOLS_RUNTIME_BUILDVER', RUNTIME_BUILDVER)
-    return buildver_arg
+        buildver_arg = RUNTIME_BUILDVER
+    # the env_var should have precedence because this is the way user can override the default configs
+    return os.environ.get('RAPIDS_USER_TOOLS_RUNTIME_BUILDVER', buildver_arg)

--- a/user_tools/src/spark_rapids_pytools/build.py
+++ b/user_tools/src/spark_rapids_pytools/build.py
@@ -35,7 +35,7 @@ def get_runtime_buildver(buildver_arg: str = None) -> str:
     Note that the env_var always have precedence over the input argument and the default values
     :param buildver_arg: optional argument to specify the build version
     :return: the first value set in the following order:
-       1- env_var RAPIDS_USER_TOOLS_RUNTIME_BUILDVER
+       1- env_var RAPIDS_USER_TOOLS_SPARK_DEP_VERSION
        2- the input buildver_arg
        3- default value RUNTIME_BUILDVER
     """
@@ -44,4 +44,4 @@ def get_runtime_buildver(buildver_arg: str = None) -> str:
         from spark_rapids_pytools import RUNTIME_BUILDVER
         buildver_arg = RUNTIME_BUILDVER
     # the env_var should have precedence because this is the way user can override the default configs
-    return os.environ.get('RAPIDS_USER_TOOLS_RUNTIME_BUILDVER', buildver_arg)
+    return os.environ.get('RAPIDS_USER_TOOLS_SPARK_DEP_VERSION', buildver_arg)

--- a/user_tools/src/spark_rapids_pytools/build.py
+++ b/user_tools/src/spark_rapids_pytools/build.py
@@ -29,19 +29,19 @@ def get_version(main: str = None) -> str:
     return main + suffix
 
 
-def get_runtime_buildver(buildver_arg: str = None) -> str:
+def get_spark_dep_version(spark_dep_arg: str = None) -> str:
     """
     Get the runtime SPARK build_version for the user tools environment.
     Note that the env_var always have precedence over the input argument and the default values
-    :param buildver_arg: optional argument to specify the build version
+    :param spark_dep_arg: optional argument to specify the build version
     :return: the first value set in the following order:
        1- env_var RAPIDS_USER_TOOLS_SPARK_DEP_VERSION
        2- the input buildver_arg
-       3- default value RUNTIME_BUILDVER
+       3- default value SPARK_DEV_VERSION
     """
-    if buildver_arg is None:
+    if spark_dep_arg is None:
         # pylint: disable=import-outside-toplevel
-        from spark_rapids_pytools import RUNTIME_BUILDVER
-        buildver_arg = RUNTIME_BUILDVER
+        from spark_rapids_pytools import SPARK_DEP_VERSION
+        spark_dep_arg = SPARK_DEP_VERSION
     # the env_var should have precedence because this is the way user can override the default configs
-    return os.environ.get('RAPIDS_USER_TOOLS_SPARK_DEP_VERSION', buildver_arg)
+    return os.environ.get('RAPIDS_USER_TOOLS_SPARK_DEP_VERSION', spark_dep_arg)

--- a/user_tools/src/spark_rapids_pytools/build.py
+++ b/user_tools/src/spark_rapids_pytools/build.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import datetime
 import os
 
 
-def get_version(main=None):
+def get_version(main: str = None) -> str:
     if main is None:
         # pylint: disable=import-outside-toplevel
         from spark_rapids_pytools import VERSION as main
@@ -27,3 +27,17 @@ def get_version(main=None):
     if nightly == '1':
         suffix = '.dev' + datetime.datetime.utcnow().strftime('%Y%m%d%H%M%S')
     return main + suffix
+
+
+def get_runtime_buildver(buildver_arg: str = None) -> str:
+    """
+    Get the runtime SPARK build_version for the user tools environment.
+    :param buildver_arg: optional argument to specify the build version
+    :return: returns the input argument if it is set.
+       Otherwise, it returns ${RAPIDS_USER_TOOLS_RUNTIME_BUILDVER:-RUNTIME_BUILDVER}.
+    """
+    if buildver_arg is None:
+        # pylint: disable=import-outside-toplevel
+        from spark_rapids_pytools import RUNTIME_BUILDVER
+        return os.environ.get('RAPIDS_USER_TOOLS_RUNTIME_BUILDVER', RUNTIME_BUILDVER)
+    return buildver_arg

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -30,7 +30,7 @@ from typing import Any, Callable, Dict, List, Optional
 import yaml
 
 import spark_rapids_pytools
-from spark_rapids_pytools import get_runtime_buildver
+from spark_rapids_pytools import get_spark_dep_version
 from spark_rapids_pytools.cloud_api.sp_types import get_platform, \
     ClusterBase, DeployMode, NodeHWInfo
 from spark_rapids_pytools.common.prop_manager import YAMLPropertiesContainer, AbstractPropertiesContainer
@@ -397,7 +397,7 @@ class RapidsTool(object):
         """
         # allow defining default buildver per platform
         buildver_from_conf = json_props.get_value_silent('dependencies', 'deployMode', deploy_mode, 'activeBuildVer')
-        active_buildver = get_runtime_buildver(buildver_from_conf)
+        active_buildver = get_spark_dep_version(buildver_from_conf)
         depend_arr = json_props.get_value_silent('dependencies', 'deployMode', deploy_mode, active_buildver)
         if depend_arr is None:
             raise ValueError(f'Invalid SPARK dependency version [{active_buildver}]')

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -399,6 +399,8 @@ class RapidsTool(object):
         buildver_from_conf = json_props.get_value_silent('dependencies', 'deployMode', deploy_mode, 'activeBuildVer')
         active_buildver = get_runtime_buildver(buildver_from_conf)
         depend_arr = json_props.get_value_silent('dependencies', 'deployMode', deploy_mode, active_buildver)
+        if depend_arr is None:
+            raise ValueError(f'Invalid SPARK dependency version [{active_buildver}]')
         return depend_arr
 
 
@@ -602,8 +604,6 @@ class RapidsJarTool(RapidsTool):
                              Utils.gen_joined_str(join_elem='; ',
                                                   items=dep_list))
             self.ctxt.add_rapids_args('javaDependencies', dep_list)
-        else:
-            self.logger.warning('Dependencies were not found for the current deployment mode')
 
     def _process_rapids_args(self):
         # add a dictionary to hold the rapids arguments

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
@@ -1,58 +1,61 @@
 {
   "dependencies": {
       "deployMode": {
-        "LOCAL": [
-          {
-            "name": "Apache Spark",
-            "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
-            "type": "archive",
-            "relativePath": "jars/*",
-            "sha512": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319",
-            "size": 400395283
-          },
-          {
-            "name": "Hadoop AWS",
-            "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
-            "type": "jar",
-            "md5": "59907e790ce713441955015d79f670bc",
-            "sha1": "a65839fbf1869f81a1632e09f415e586922e4f80",
-            "size": 962685
-          },
-          {
-            "name": "AWS Java SDK Bundled",
-            "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
-            "type": "jar",
-            "md5": "8a22f2d30b7e8eee9ea44f04fb13b35a",
-            "sha1": "02deec3a0ad83d13d032b1812421b23d7a961eea",
-            "size": 280645251
-          }
-        ],
-        "SPARK333-LOCAL": [
-          {
-            "name": "Apache Spark",
-            "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
-            "type": "archive",
-            "relativePath": "jars/*",
-            "sha512": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9",
-            "size": 299426263
-          },
-          {
-            "name": "Hadoop AWS",
-            "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
-            "type": "jar",
-            "md5": "59907e790ce713441955015d79f670bc",
-            "sha1": "a65839fbf1869f81a1632e09f415e586922e4f80",
-            "size": 962685
-          },
-          {
-            "name": "AWS Java SDK Bundled",
-            "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
-            "type": "jar",
-            "md5": "8a22f2d30b7e8eee9ea44f04fb13b35a",
-            "sha1": "02deec3a0ad83d13d032b1812421b23d7a961eea",
-            "size": 280645251
-          }
-        ]
+        "LOCAL": {
+          "//activeBuildVer": "Define this key in order to set the default buildVer for that platform",
+          "350": [
+            {
+              "name": "Apache Spark",
+              "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
+              "type": "archive",
+              "relativePath": "jars/*",
+              "sha512": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319",
+              "size": 400395283
+            },
+            {
+              "name": "Hadoop AWS",
+              "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
+              "type": "jar",
+              "md5": "59907e790ce713441955015d79f670bc",
+              "sha1": "a65839fbf1869f81a1632e09f415e586922e4f80",
+              "size": 962685
+            },
+            {
+              "name": "AWS Java SDK Bundled",
+              "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
+              "type": "jar",
+              "md5": "8a22f2d30b7e8eee9ea44f04fb13b35a",
+              "sha1": "02deec3a0ad83d13d032b1812421b23d7a961eea",
+              "size": 280645251
+            }
+          ],
+          "333": [
+            {
+              "name": "Apache Spark",
+              "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
+              "type": "archive",
+              "relativePath": "jars/*",
+              "sha512": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9",
+              "size": 299426263
+            },
+            {
+              "name": "Hadoop AWS",
+              "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
+              "type": "jar",
+              "md5": "59907e790ce713441955015d79f670bc",
+              "sha1": "a65839fbf1869f81a1632e09f415e586922e4f80",
+              "size": 962685
+            },
+            {
+              "name": "AWS Java SDK Bundled",
+              "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
+              "type": "jar",
+              "md5": "8a22f2d30b7e8eee9ea44f04fb13b35a",
+              "sha1": "02deec3a0ad83d13d032b1812421b23d7a961eea",
+              "size": 280645251
+            }
+          ]
+        }
       }
     },
   "environment": {

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_azure-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_azure-configs.json
@@ -1,42 +1,45 @@
 {
   "dependencies": {
       "deployMode": {
-        "LOCAL": [
-          {
-            "name": "Apache Spark",
-            "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
-            "type": "archive",
-            "relativePath": "jars/*",
-            "sha512": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319",
-            "size": 400395283
-          },
-          {
-            "name": "Hadoop Azure",
-            "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/3.3.4/hadoop-azure-3.3.4.jar",
-            "type": "jar",
-            "md5": "1ec4cbd59548412010fe1515070eef73",
-            "sha1": "a23f621bca9b2100554150f6b0b521f94b8b419e",
-            "size": 574116
-          }
-        ],
-        "SPARK333-LOCAL": [
-          {
-            "name": "Apache Spark",
-            "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
-            "type": "archive",
-            "relativePath": "jars/*",
-            "sha512": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9",
-            "size": 299426263
-          },
-          {
-            "name": "Hadoop Azure",
-            "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/3.3.4/hadoop-azure-3.3.4.jar",
-            "type": "jar",
-            "md5": "1ec4cbd59548412010fe1515070eef73",
-            "sha1": "a23f621bca9b2100554150f6b0b521f94b8b419e",
-            "size": 574116
-          }
-        ]
+        "LOCAL": {
+          "//activeBuildVer": "Define this key in order to set the default buildVer for that platform",
+          "350": [
+            {
+              "name": "Apache Spark",
+              "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
+              "type": "archive",
+              "relativePath": "jars/*",
+              "sha512": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319",
+              "size": 400395283
+            },
+            {
+              "name": "Hadoop Azure",
+              "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/3.3.4/hadoop-azure-3.3.4.jar",
+              "type": "jar",
+              "md5": "1ec4cbd59548412010fe1515070eef73",
+              "sha1": "a23f621bca9b2100554150f6b0b521f94b8b419e",
+              "size": 574116
+            }
+          ],
+          "333": [
+            {
+              "name": "Apache Spark",
+              "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
+              "type": "archive",
+              "relativePath": "jars/*",
+              "sha512": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9",
+              "size": 299426263
+            },
+            {
+              "name": "Hadoop Azure",
+              "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/3.3.4/hadoop-azure-3.3.4.jar",
+              "type": "jar",
+              "md5": "1ec4cbd59548412010fe1515070eef73",
+              "sha1": "a23f621bca9b2100554150f6b0b521f94b8b419e",
+              "size": 574116
+            }
+          ]
+        }
       }
     },
   "environment": {
@@ -370,4 +373,3 @@
     "minWorkerNodes": 2
   }
 }
-  

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -1,42 +1,45 @@
 {
   "dependencies": {
     "deployMode": {
-      "LOCAL": [
-        {
-          "name": "Apache Spark",
-          "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
-          "type": "archive",
-          "relativePath": "jars/*",
-          "sha512": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319",
-          "size": 400395283
-        },
-        {
-          "name": "GCS Connector Hadoop3",
-          "uri": "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.19/gcs-connector-hadoop3-2.2.19-shaded.jar",
-          "type": "jar",
-          "md5": "2ee6ad7215304cf5da8e731afb36ad72",
-          "sha1": "3bea6d5e62663a2a5c03d8ca44dff4921aeb3170",
-          "size": 39359477
-        }
-      ],
-      "SPARK333-LOCAL": [
-        {
-          "name": "Apache Spark",
-          "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
-          "type": "archive",
-          "relativePath": "jars/*",
-          "sha512": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9",
-          "size": 299426263
-        },
-        {
-          "name": "GCS Connector Hadoop3",
-          "uri": "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.17/gcs-connector-hadoop3-2.2.17-shaded.jar",
-          "type": "jar",
-          "md5": "41aea3add826dfbf3384a2c638148709",
-          "sha1": "06438f562692ff8fae5e8555eba2b9f95cb74f66",
-          "size": 38413466
-        }
-      ]
+      "LOCAL": {
+        "//activeBuildVer": "Define this key in order to set the default buildVer for that platform",
+        "350": [
+          {
+            "name": "Apache Spark",
+            "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
+            "type": "archive",
+            "relativePath": "jars/*",
+            "sha512": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319",
+            "size": 400395283
+          },
+          {
+            "name": "GCS Connector Hadoop3",
+            "uri": "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.19/gcs-connector-hadoop3-2.2.19-shaded.jar",
+            "type": "jar",
+            "md5": "2ee6ad7215304cf5da8e731afb36ad72",
+            "sha1": "3bea6d5e62663a2a5c03d8ca44dff4921aeb3170",
+            "size": 39359477
+          }
+        ],
+        "333": [
+          {
+            "name": "Apache Spark",
+            "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
+            "type": "archive",
+            "relativePath": "jars/*",
+            "sha512": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9",
+            "size": 299426263
+          },
+          {
+            "name": "GCS Connector Hadoop3",
+            "uri": "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.17/gcs-connector-hadoop3-2.2.17-shaded.jar",
+            "type": "jar",
+            "md5": "41aea3add826dfbf3384a2c638148709",
+            "sha1": "06438f562692ff8fae5e8555eba2b9f95cb74f66",
+            "size": 38413466
+          }
+        ]
+      }
     }
   },
   "environment": {

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc_gke-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc_gke-configs.json
@@ -1,42 +1,45 @@
 {
   "dependencies": {
     "deployMode": {
-      "LOCAL": [
-        {
-          "name": "Apache Spark",
-          "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
-          "type": "archive",
-          "relativePath": "jars/*",
-          "sha512": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319",
-          "size": 400395283
-        },
-        {
-          "name": "GCS Connector Hadoop3",
-          "uri": "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.19/gcs-connector-hadoop3-2.2.19-shaded.jar",
-          "type": "jar",
-          "md5": "2ee6ad7215304cf5da8e731afb36ad72",
-          "sha1": "3bea6d5e62663a2a5c03d8ca44dff4921aeb3170",
-          "size": 39359477
-        }
-      ],
-      "SPARK333-LOCAL": [
-        {
-          "name": "Apache Spark",
-          "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
-          "type": "archive",
-          "relativePath": "jars/*",
-          "sha512": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9",
-          "size": 299426263
-        },
-        {
-          "name": "GCS Connector Hadoop3",
-          "uri": "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.17/gcs-connector-hadoop3-2.2.17-shaded.jar",
-          "type": "jar",
-          "md5": "41aea3add826dfbf3384a2c638148709",
-          "sha1": "06438f562692ff8fae5e8555eba2b9f95cb74f66",
-          "size": 38413466
-        }
-      ]
+      "LOCAL": {
+        "//activeBuildVer": "Define this key in order to set the default buildVer for that platform",
+        "350": [
+          {
+            "name": "Apache Spark",
+            "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
+            "type": "archive",
+            "relativePath": "jars/*",
+            "sha512": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319",
+            "size": 400395283
+          },
+          {
+            "name": "GCS Connector Hadoop3",
+            "uri": "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.19/gcs-connector-hadoop3-2.2.19-shaded.jar",
+            "type": "jar",
+            "md5": "2ee6ad7215304cf5da8e731afb36ad72",
+            "sha1": "3bea6d5e62663a2a5c03d8ca44dff4921aeb3170",
+            "size": 39359477
+          }
+        ],
+        "333": [
+          {
+            "name": "Apache Spark",
+            "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
+            "type": "archive",
+            "relativePath": "jars/*",
+            "sha512": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9",
+            "size": 299426263
+          },
+          {
+            "name": "GCS Connector Hadoop3",
+            "uri": "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.17/gcs-connector-hadoop3-2.2.17-shaded.jar",
+            "type": "jar",
+            "md5": "41aea3add826dfbf3384a2c638148709",
+            "sha1": "06438f562692ff8fae5e8555eba2b9f95cb74f66",
+            "size": 38413466
+          }
+        ]
+      }
     }
   },
   "environment": {

--- a/user_tools/src/spark_rapids_pytools/resources/dev/prepackage_mgr.py
+++ b/user_tools/src/spark_rapids_pytools/resources/dev/prepackage_mgr.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import fire
 
 from spark_rapids_pytools.common.prop_manager import JSONPropertiesContainer
 from spark_rapids_pytools.common.sys_storage import FSUtil
+from spark_rapids_pytools.rapids.rapids_tool import RapidsTool
 from spark_rapids_tools import CspEnv
 from spark_rapids_tools.utils import Utilities
 
@@ -114,7 +115,8 @@ class PrepackageMgr:   # pylint: disable=too-few-public-methods
             config_file = FSUtil.build_full_path(self.resource_dir,
                                                  f'{platform}{self._configs_suffix}')  # pylint: disable=no-member
             platform_conf = JSONPropertiesContainer(config_file)
-            for dependency in platform_conf.get_value('dependencies', 'deployMode', 'LOCAL'):
+            dependency_list = RapidsTool.get_rapids_tools_dependencies('LOCAL', platform_conf)
+            for dependency in dependency_list:
                 uri = dependency.get('uri')
                 name = FSUtil.get_resource_name(uri)
                 if uri:

--- a/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
@@ -1,58 +1,61 @@
 {
   "dependencies": {
     "deployMode": {
-      "LOCAL": [
-        {
-          "name": "Apache Spark",
-          "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
-          "type": "archive",
-          "relativePath": "jars/*",
-          "sha512": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319",
-          "size": 400395283
-        },
-        {
-          "name": "Hadoop AWS",
-          "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
-          "type": "jar",
-          "md5": "59907e790ce713441955015d79f670bc",
-          "sha1": "a65839fbf1869f81a1632e09f415e586922e4f80",
-          "size": 962685
-        },
-        {
-          "name": "AWS Java SDK Bundled",
-          "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
-          "type": "jar",
-          "md5": "8a22f2d30b7e8eee9ea44f04fb13b35a",
-          "sha1": "02deec3a0ad83d13d032b1812421b23d7a961eea",
-          "size": 280645251
-        }
-      ],
-      "SPARK333-LOCAL": [
-        {
-          "name": "Apache Spark",
-          "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
-          "type": "archive",
-          "relativePath": "jars/*",
-          "sha512": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9",
-          "size": 299426263
-        },
-        {
-          "name": "Hadoop AWS",
-          "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
-          "type": "jar",
-          "md5": "59907e790ce713441955015d79f670bc",
-          "sha1": "a65839fbf1869f81a1632e09f415e586922e4f80",
-          "size": 962685
-        },
-        {
-          "name": "AWS Java SDK Bundled",
-          "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
-          "type": "jar",
-          "md5": "8a22f2d30b7e8eee9ea44f04fb13b35a",
-          "sha1": "02deec3a0ad83d13d032b1812421b23d7a961eea",
-          "size": 280645251
-        }
-      ]
+      "LOCAL": {
+        "//activeBuildVer": "Define this key in order to set the default buildVer for that platform",
+        "350": [
+          {
+            "name": "Apache Spark",
+            "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
+            "type": "archive",
+            "relativePath": "jars/*",
+            "sha512": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319",
+            "size": 400395283
+          },
+          {
+            "name": "Hadoop AWS",
+            "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
+            "type": "jar",
+            "md5": "59907e790ce713441955015d79f670bc",
+            "sha1": "a65839fbf1869f81a1632e09f415e586922e4f80",
+            "size": 962685
+          },
+          {
+            "name": "AWS Java SDK Bundled",
+            "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
+            "type": "jar",
+            "md5": "8a22f2d30b7e8eee9ea44f04fb13b35a",
+            "sha1": "02deec3a0ad83d13d032b1812421b23d7a961eea",
+            "size": 280645251
+          }
+        ],
+        "333": [
+          {
+            "name": "Apache Spark",
+            "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
+            "type": "archive",
+            "relativePath": "jars/*",
+            "sha512": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9",
+            "size": 299426263
+          },
+          {
+            "name": "Hadoop AWS",
+            "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
+            "type": "jar",
+            "md5": "59907e790ce713441955015d79f670bc",
+            "sha1": "a65839fbf1869f81a1632e09f415e586922e4f80",
+            "size": 962685
+          },
+          {
+            "name": "AWS Java SDK Bundled",
+            "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
+            "type": "jar",
+            "md5": "8a22f2d30b7e8eee9ea44f04fb13b35a",
+            "sha1": "02deec3a0ad83d13d032b1812421b23d7a961eea",
+            "size": 280645251
+          }
+        ]
+      }
     }
   },
   "environment": {

--- a/user_tools/src/spark_rapids_pytools/resources/onprem-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/onprem-configs.json
@@ -1,26 +1,30 @@
 {
   "dependencies": {
     "deployMode": {
-      "LOCAL": [
-        {
-          "name": "Apache Spark",
-          "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
-          "type": "archive",
-          "relativePath": "jars/*",
-          "sha512": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319",
-          "size": 400395283
-        }
-      ],
-      "SPARK333-LOCAL": [
-        {
-          "name": "Apache Spark",
-          "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
-          "type": "archive",
-          "relativePath": "jars/*",
-          "sha512": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9",
-          "size": 299426263
-        }
-      ]
+      "LOCAL": {
+        "//activeBuildVer": "Define this key in order to set the default buildVer for that platform",
+        "activeBuildVer": "331",
+        "350": [
+          {
+            "name": "Apache Spark",
+            "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
+            "type": "archive",
+            "relativePath": "jars/*",
+            "sha512": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319",
+            "size": 400395283
+          }
+        ],
+        "333": [
+          {
+            "name": "Apache Spark",
+            "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
+            "type": "archive",
+            "relativePath": "jars/*",
+            "sha512": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9",
+            "size": 299426263
+          }
+        ]
+      }
     }
   },
   "csp_pricing": {

--- a/user_tools/src/spark_rapids_pytools/resources/onprem-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/onprem-configs.json
@@ -3,7 +3,6 @@
     "deployMode": {
       "LOCAL": {
         "//activeBuildVer": "Define this key in order to set the default buildVer for that platform",
-        "activeBuildVer": "331",
         "350": [
           {
             "name": "Apache Spark",


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein <ahussein@nvidia.com>

Fixes #1316

Allow user-tools to pick the SPARK dependencies based on a runtime env_var. The value format follows the same format of `buildver` in the scala pom file.
Currently 333 and 350 (default) are supported.
If user specifies an invalid value, there will be a warning message, then the process fails running the java cmd.


**Changes**

- Add dependency key to the platform config-file
- A platform can define its own default dependency versions using `activeBuildVer` key
- Add a default `RUNTIME_BUILDVER` in the `__init__.py` to allow upgrades of spark release during official releases
- Read an env_var `RAPIDS_USER_TOOLS_SPARK_DEP_VERSION` to pick the correct dependency.
- If the env_var is set. it will overrides any other value defined in the platform_conf. Otherwise, there will be no way for the user to override a pre-configured platform.
- Currently, only `333` and `350` are supported. Default is `350`

**Docs changes**

- Will file an internal issue to update the documentation highlighting the usage of  `RAPIDS_USER_TOOLS_SPARK_DEP_VERSION`

**Possible followups**

- Fail early if the dependencies are not defined for the defined key
- Add more entries in the dependencies to cover more Spark releases (spark-4x, etc).