### PR TITLE
Reduce console output tree level, exclude JAR tool output files and remove incorrect logging

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -141,13 +141,6 @@ class Qualification(RapidsJarTool):
 
     def __process_filter_args(self, arg_val: str) -> None:
         selected_filter = QualFilterApp.fromstring(arg_val)
-        available_filters = [filter_enum.value for filter_enum in QualFilterApp]
-        self.logger.warning(
-            'Invalid argument filter_apps=%s.\n\t'
-            'Accepted options are: [%s].\n\t'
-            'Falling-back to default filter: %s',
-            arg_val, Utils.gen_joined_str(' | ', available_filters),
-            QualFilterApp.tostring(selected_filter))
         self.ctxt.set_ctxt('filterApps', selected_filter)
 
     def _process_estimation_model_args(self) -> None:

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -180,7 +180,7 @@ local:
         - 'Estimated GPU Speedup'
     treeDirectory:
       enabled: true
-      depthLevel: 4
+      depthLevel: 2
       indentation: '    '
       excludedPatterns:
         directories:
@@ -193,6 +193,7 @@ local:
           - '^(\.+).*'
           - '^(\$+).*'
           - '^.+(_\$folder\$)$'
+          - '^rapids_4_spark_qualification_output.*'
     unsupportedOperators:
       mask:
         - operator: 'NOT_EQUAL'

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -111,10 +111,7 @@ local:
     files:
       summary:
         name: qualification_summary.csv
-        outputComment: "Summarized savings and speedups CSV report"
-      full:
-        name: qualification_summary_full.csv
-        outputComment: "Full savings and speedups CSV report"
+        outputComment: "Summarized speedups CSV report"
       statistics:
         name: qualification_statistics.csv
         outputComment: "Statistics CSV report"


### PR DESCRIPTION
Fixes #1294
Fixes #1339 

This PR cleans up the console output by reducing the depth level of output structure in the console output. This improves the UX by minimizing excessive output and improving clarity.
- Contents of folders `raw_metrics` and `tuning`  could easily explode the console output if we are processing large number of apps
- Going forward, we want users to use output from python tool, with the JAR output files intended for internal use.

## Changes:
Issue-1294
- Reduced depth level in config file and excluded `rapids_4_spark_qualification_output.*` files
- Log file and runtime information generated from the core tool have been retained.

Issue-1339
- Remove code block that cause an incorrect warning to be shown everytime

## Console Output

<details>
<summary>  Output After this PR</summary>
</br>

```
____________________________________________________________________________________________________
                                        QUALIFICATION Report
____________________________________________________________________________________________________

Output:
--------------------
Qualification tool output: /Users/psarthi/Work/tools-run/qual_20240911151952_bA04ca5D/rapids_4_spark_qualification_output
    qual_20240911151952_bA04ca5D
    ├── xgboost_predictions
    │   ├── per_sql.csv
    │   ├── feature_importance.csv
    │   ├── per_app.csv
    │   ├── shap_values.csv
    │   └── features.csv
    ├── qualification_statistics.csv
    ├── intermediate_output
    │   └── heuristics_info.csv
    ├── qualification_summary.csv
    ├── app_metadata.json
    └── rapids_4_spark_qualification_output
        ├── raw_metrics
        ├── rapids_4_spark_qualification_stderr.log
        ├── runtime.properties
        └── tuning
    5 directories, 11 files
    - To learn more about the output details, visit https://docs.nvidia.com/spark-rapids/user-guide/latest/qualification/quickstart.html#qualification-output
    - Summarized savings and speedups CSV report: /Users/psarthi/Work/tools-run/qual_20240911151952_bA04ca5D/qualification_summary.csv
    - Statistics CSV report: /Users/psarthi/Work/tools-run/qual_20240911151952_bA04ca5D/qualification_statistics.csv
    - Intermediate output generated by tools: /Users/psarthi/Work/tools-run/qual_20240911151952_bA04ca5D/intermediate_output
    - Metadata file with cluster recommendation and tuning details: /Users/psarthi/Work/tools-run/qual_20240911151952_bA04ca5D/app_metadata.json
    - Application status report: /Users/psarthi/Work/tools-run/qual_20240911151952_bA04ca5D/rapids_4_spark_qualification_output/rapids_4_spark_qualification_output_status.csv
+----+-----------------+--------------------------------+-----------------+--------------------------------+-------------------------------------+------------------------------------+
|    | App Name        | App ID                         | Estimated GPU   | Qualified                      | Full Cluster                        | GPU Config                         |
|    |                 |                                | Speedup         | Cluster                        | Config                              | Recommendation                     |
|    |                 |                                | Category**      | Recommendation                 | Recommendations*                    | Breakdown*                         |
|----+-----------------+--------------------------------+-----------------+--------------------------------+-------------------------------------+------------------------------------|
|  0 | NDS - query72   | application_1686676198636_0002 | Large           | 2 x n1-standard-8 (1 T4 each)  | application_1686676198636_0002.conf | application_1686676198636_0002.log |
|  1 | NDS - Power Run | application_1692643187882_0001 | Medium          | 8 x n1-standard-32 (2 T4 each) | application_1692643187882_0001.conf | application_1692643187882_0001.log |
+----+-----------------+--------------------------------+-----------------+--------------------------------+-------------------------------------+------------------------------------+
* Config Recommendations can be found in /Users/psarthi/Work/tools-run/qual_20240911151952_bA04ca5D/rapids_4_spark_qualification_output/tuning.
** Estimated GPU Speedup Category assumes the user is using the node type recommended and config recommendations with the same size cluster as was used with the CPU side.

Report Summary:
----------------------  -
Total applications      5
Processed applications  5
Top candidates          2
----------------------  -

```
</details>
 

<details>
<summary> Output Before </summary>
</br>

```
__________________________________________________________________________________________
                                        QUALIFICATION Report
____________________________________________________________________________________________________

Output:
--------------------
Qualification tool output: /Users/psarthi/Work/tools-run/qual_20240911152159_aB3c0986/rapids_4_spark_qualification_output
    qual_20240911152159_aB3c0986
    ├── xgboost_predictions
    │   ├── per_sql.csv
    │   ├── feature_importance.csv
    │   ├── per_app.csv
    │   ├── shap_values.csv
    │   └── features.csv
    ├── qualification_statistics.csv
    ├── intermediate_output
    │   └── heuristics_info.csv
    ├── qualification_summary.csv
    ├── app_metadata.json
    └── rapids_4_spark_qualification_output
        ├── raw_metrics
        │   ├── app-20231212214826-0000
        │   │   ├── executor_information.csv
        │   │   ├── spark_properties.csv
        │   │   ├── job_information.csv
        │   │   ├── stage_level_all_metrics.csv
        │   │   ├── job_level_aggregated_task_metrics.csv
        │   │   ├── profile.log
        │   │   ├── application_information.csv
        │   │   ├── system_properties.csv
        │   │   ├── application_log_path_mapping.csv
        │   │   ├── spark_rapids_parameters_set_explicitly.csv
        │   │   ├── stage_level_aggregated_task_metrics.csv
        │   │   └── sql_duration_and_executor_cpu_time_percent.csv
        │   ├── application_1686676198636_0002
        │   │   ├── executor_information.csv
        │   │   ├── spark_properties.csv
        │   │   ├── job_information.csv
        │   │   ├── sql_level_aggregated_task_metrics.csv
        │   │   ├── stage_level_all_metrics.csv
        │   │   ├── job_level_aggregated_task_metrics.csv
        │   │   ├── wholestagecodegen_mapping.csv
        │   │   ├── profile.log
        │   │   ├── application_information.csv
        │   │   ├── system_properties.csv
        │   │   ├── io_metrics.csv
        │   │   ├── application_log_path_mapping.csv
        │   │   ├── sql_plan_metrics_for_application.csv
        │   │   ├── spark_rapids_parameters_set_explicitly.csv
        │   │   ├── stage_level_aggregated_task_metrics.csv
        │   │   ├── sql_to_stage_information.csv
        │   │   ├── data_source_information.csv
        │   │   └── sql_duration_and_executor_cpu_time_percent.csv
        │   ├── application_1692643187882_0001
        │   │   ├── executor_information.csv
        │   │   ├── spark_properties.csv
        │   │   ├── job_information.csv
        │   │   ├── sql_level_aggregated_task_metrics.csv
        │   │   ├── stage_level_all_metrics.csv
        │   │   ├── job_level_aggregated_task_metrics.csv
        │   │   ├── wholestagecodegen_mapping.csv
        │   │   ├── profile.log
        │   │   ├── application_information.csv
        │   │   ├── system_properties.csv
        │   │   ├── io_metrics.csv
        │   │   ├── application_log_path_mapping.csv
        │   │   ├── sql_plan_metrics_for_application.csv
        │   │   ├── spark_rapids_parameters_set_explicitly.csv
        │   │   ├── stage_level_aggregated_task_metrics.csv
        │   │   ├── sql_to_stage_information.csv
        │   │   ├── data_source_information.csv
        │   │   └── sql_duration_and_executor_cpu_time_percent.csv
        │   └── app-20231212234153-0000
        │       ├── executor_information.csv
        │       ├── spark_properties.csv
        │       ├── job_information.csv
        │       ├── sql_level_aggregated_task_metrics.csv
        │       ├── stage_level_all_metrics.csv
        │       ├── job_level_aggregated_task_metrics.csv
        │       ├── wholestagecodegen_mapping.csv
        │       ├── profile.log
        │       ├── application_information.csv
        │       ├── system_properties.csv
        │       ├── io_metrics.csv
        │       ├── application_log_path_mapping.csv
        │       ├── sql_plan_metrics_for_application.csv
        │       ├── spark_rapids_parameters_set_explicitly.csv
        │       ├── stage_level_aggregated_task_metrics.csv
        │       ├── sql_to_stage_information.csv
        │       ├── data_source_information.csv
        │       └── sql_duration_and_executor_cpu_time_percent.csv
        ├── rapids_4_spark_qualification_output_cluster_information.json
        ├── rapids_4_spark_qualification_output_status.csv
        ├── rapids_4_spark_qualification_output_stages.csv
        ├── rapids_4_spark_qualification_stderr.log
        ├── runtime.properties
        ├── rapids_4_spark_qualification_output_cluster_information.csv
        ├── rapids_4_spark_qualification_output_persql.log
        ├── tuning
        │   ├── application_1686676198636_0002.conf
        │   ├── app-20231212214826-0000.log
        │   ├── app-20231212214826-0000.conf
        │   ├── application_1686676198636_0002.log
        │   ├── application_1692643187882_0001.conf
        │   ├── app-20231212234153-0000.conf
        │   ├── app-20231212234153-0000.log
        │   └── application_1692643187882_0001.log
        ├── rapids_4_spark_qualification_output_persql.csv
        ├── rapids_4_spark_qualification_output_unsupportedOperators.csv
        ├── rapids_4_spark_qualification_output.csv
        ├── rapids_4_spark_qualification_output_execs.csv
        └── rapids_4_spark_qualification_output.log
    9 directories, 95 files
    - To learn more about the output details, visit https://docs.nvidia.com/spark-rapids/user-guide/latest/qualification/quickstart.html#qualification-output
    - Summarized savings and speedups CSV report: /Users/psarthi/Work/tools-run/qual_20240911152159_aB3c0986/qualification_summary.csv
    - Statistics CSV report: /Users/psarthi/Work/tools-run/qual_20240911152159_aB3c0986/qualification_statistics.csv
    - Intermediate output generated by tools: /Users/psarthi/Work/tools-run/qual_20240911152159_aB3c0986/intermediate_output
    - Metadata file with cluster recommendation and tuning details: /Users/psarthi/Work/tools-run/qual_20240911152159_aB3c0986/app_metadata.json
    - Application status report: /Users/psarthi/Work/tools-run/qual_20240911152159_aB3c0986/rapids_4_spark_qualification_output/rapids_4_spark_qualification_output_status.csv
+----+-----------------+--------------------------------+-----------------+--------------------------------+-------------------------------------+------------------------------------+
|    | App Name        | App ID                         | Estimated GPU   | Qualified                      | Full Cluster                        | GPU Config                         |
|    |                 |                                | Speedup         | Cluster                        | Config                              | Recommendation                     |
|    |                 |                                | Category**      | Recommendation                 | Recommendations*                    | Breakdown*                         |
|----+-----------------+--------------------------------+-----------------+--------------------------------+-------------------------------------+------------------------------------|
|  0 | NDS - query72   | application_1686676198636_0002 | Large           | 2 x n1-standard-8 (1 T4 each)  | application_1686676198636_0002.conf | application_1686676198636_0002.log |
|  1 | NDS - Power Run | application_1692643187882_0001 | Medium          | 8 x n1-standard-32 (2 T4 each) | application_1692643187882_0001.conf | application_1692643187882_0001.log |
+----+-----------------+--------------------------------+-----------------+--------------------------------+-------------------------------------+------------------------------------+
* Config Recommendations can be found in /Users/psarthi/Work/tools-run/qual_20240911152159_aB3c0986/rapids_4_spark_qualification_output/tuning.
** Estimated GPU Speedup Category assumes the user is using the node type recommended and config recommendations with the same size cluster as was used with the CPU side.

Report Summary:
----------------------  -
Total applications      5
Processed applications  5
Top candidates          2
----------------------  -


```
</details>
 
