### PR TITLE
[FEA] Add total core seconds into top candidate view

### DIFF
--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     # used for retrieving available memory on the host
     "psutil==5.9.8"
 ]
-dynamic=["entry-points", "version"]
+dynamic=["version"]
 
 [project.scripts]
 spark_rapids_user_tools = "spark_rapids_pytools.wrapper:main"

--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     # used for retrieving available memory on the host
     "psutil==5.9.8"
 ]
-dynamic=["version"]
+dynamic=["entry-points", "version"]
 
 [project.scripts]
 spark_rapids_user_tools = "spark_rapids_pytools.wrapper:main"

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -14,7 +14,6 @@
 
 """Implementation class representing wrapper around the RAPIDS acceleration Qualification tool."""
 
-import os
 import json
 import re
 from dataclasses import dataclass, field

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -354,7 +354,6 @@ class Qualification(RapidsJarTool):
         qual_summary_file = self.ctxt.get_value('toolOutput', 'csv', 'summaryReport', 'fileName')
         qual_summary_pd = pd.read_csv(os.path.join(self.ctxt.get_rapids_output_folder(), qual_summary_file))
 
-
         def create_stdout_table_pprinter(total_apps: pd.DataFrame,
                                          tools_processed_apps: pd.DataFrame) -> TopCandidates:
             """

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -229,7 +229,7 @@ local:
         - 'Qualified Cluster Recommendation'
         - 'Full Cluster Config Recommendations*'
         - 'GPU Config Recommendation Breakdown*'
-      noneligibleCategory:
+      ineligibleCategory:
         - 'Not Recommended'
       eligibleCategories:
         - 'Small'

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -236,6 +236,7 @@ local:
       sortingColumns:
         - 'Speedup Category Order'
         - 'Total Core Seconds'
+        - 'Unsupported Operators Stage Duration Percent'
       joinColumns:
         - 'App ID'
         - 'App Name'

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -233,8 +233,8 @@ local:
         - 'Medium'
         - 'Large'
       sortingColumns:
-        - 'Estimated GPU Speedup'
-        - 'Unsupported Operators Stage Duration Percent'
+        - 'Speedup Category Order'
+        - 'Total Core Seconds'
       joinColumns:
         - 'App ID'
         - 'App Name'
@@ -275,6 +275,8 @@ local:
         - 'App ID'
         - 'Skip by Heuristics'
         - 'Reason'
+      totalCoreSecBased:
+        totalCoreSecThreshold: 691200
       spillBased:
         stageAggMetrics:
           fileName: 'stage_level_aggregated_task_metrics.csv'

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -32,6 +32,7 @@ toolOutput:
         - SQL Stage Durations Sum
         - Unsupported Operators Stage Duration
         - Unsupported Operators Stage Duration Percent
+        - Total Core Seconds
       mapColumns:
       groupColumns:
          enabled: false
@@ -276,6 +277,7 @@ local:
         - 'Skip by Heuristics'
         - 'Reason'
       totalCoreSecBased:
+        # This is total core seconds of an 8-core machine running for 24 hours
         totalCoreSecThreshold: 691200
       spillBased:
         stageAggMetrics:

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -229,6 +229,8 @@ local:
         - 'Qualified Cluster Recommendation'
         - 'Full Cluster Config Recommendations*'
         - 'GPU Config Recommendation Breakdown*'
+      noneligibleCategory:
+        - 'Not Recommended'
       eligibleCategories:
         - 'Small'
         - 'Medium'

--- a/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
+++ b/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
@@ -100,7 +100,7 @@ class AdditionalHeuristics:
         # Load app total core seconds from qualidication summary dataframe
         app_qual_output = self.qual_summary[self.qual_summary['App ID'] == app_id]
         total_core_seconds = app_qual_output['Total Core Seconds'].astype(int).iloc[0]
-        # Threshold is total core seconds of an n1-standard-8 machine running one day
+        # Threshold is total core seconds of an n1-standard-8 instance running for one day
         total_core_seconds_threshold = self.props.get_value('totalCoreSecBased', 'totalCoreSecThreshold')
         if total_core_seconds <= total_core_seconds_threshold:
             return True, f'Skipping due to total core seconds = {total_core_seconds} lower than ' + \

--- a/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
+++ b/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
@@ -84,7 +84,8 @@ class AdditionalHeuristics:
                     should_skip = should_skip or should_skip_spill
                     reason = reason + reason_spill
                 except Exception as e:  # pylint: disable=broad-except
-                    reason = reason + f' Cannot apply spill heuristics for qualification. Reason - {type(e).__name__}:{e}.'
+                    reason = reason + ' Cannot apply spill heuristics for qualification. Reason - ' + \
+                        f'{type(e).__name__}:{e}.'
                     self.logger.error(reason)
                 result_arr.append([app_id, should_skip, reason])
 
@@ -100,7 +101,8 @@ class AdditionalHeuristics:
         # Threshold is total core seconds of an n1-standard-8 machine running one day
         total_core_seconds_threshold = self.props.get_value('totalCoreSecBased', 'totalCoreSecThreshold')
         if total_core_seconds <= total_core_seconds_threshold:
-            return True, f'Skipping due to total core seconds = {total_core_seconds} lower than {total_core_seconds_threshold}.'
+            return True, f'Skipping due to total core seconds = {total_core_seconds} lower than ' + \
+                f'{total_core_seconds_threshold}.'
         return False, ''
 
     def heuristics_based_on_spills(self, app_id_path: str) -> (bool, str):

--- a/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
+++ b/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
@@ -73,12 +73,14 @@ class AdditionalHeuristics:
                 # Apply heuristics and determine if the application should be skipped.
                 # Note: `should_skip` flag can be a combination of multiple heuristic checks.
                 should_skip = False
+                # 1. Apply heristics based on total core seconds
                 try:
                     should_skip, reason = self.heuristics_based_on_total_core_seconds(app_id)
                 except Exception as e:  # pylint: disable=broad-except
                     reason = ' Cannot apply total core seconds heuristics for qualification. Reason - ' + \
                         f'{type(e).__name__}:{e}.'
                     self.logger.error(reason)
+                # 2. Apply heristics based on spilling
                 try:
                     should_skip_spill, reason_spill = self.heuristics_based_on_spills(app_id_path)
                     should_skip = should_skip or should_skip_spill
@@ -95,7 +97,7 @@ class AdditionalHeuristics:
         """
         Apply heuristics based on total core seconds to determine if the app can be accelerated on GPU.
         """
-        # Load app output from qualidication summary dataframe
+        # Load app total core seconds from qualidication summary dataframe
         app_qual_output = self.qual_summary[self.qual_summary['App ID'] == app_id]
         total_core_seconds = app_qual_output['Total Core Seconds'].astype(int).iloc[0]
         # Threshold is total core seconds of an n1-standard-8 machine running one day

--- a/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
+++ b/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
@@ -22,6 +22,7 @@ from logging import Logger
 import pandas as pd
 
 from spark_rapids_pytools.common.prop_manager import JSONPropertiesContainer
+from spark_rapids_pytools.common.sys_storage import FSUtil
 from spark_rapids_pytools.common.utilities import ToolLogging
 from spark_rapids_tools.tools.qualx.util import find_paths, RegexPattern
 from spark_rapids_tools.utils import Utilities
@@ -96,8 +97,8 @@ class AdditionalHeuristics:
         """
         Apply heuristics based on total core seconds to determine if the app can be accelerated on GPU.
         """
-        # Load app total core seconds from qualidication summary dataframe
-        app_id = app_id_path.split('/')[-1]
+        # Load app total core seconds from qualification summary dataframe
+        app_id = FSUtil.get_resource_name(app_id_path)
         app_qual_output = self.all_apps[self.all_apps['App ID'] == app_id]  # type: ignore
         total_core_seconds = app_qual_output['Total Core Seconds'].astype(int).iloc[0]
         total_core_seconds_threshold = self.props.get_value('totalCoreSecBased', 'totalCoreSecThreshold')

--- a/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
+++ b/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
@@ -36,11 +36,13 @@ class AdditionalHeuristics:
     props: JSONPropertiesContainer = field(default=None, init=False)
     tools_output_dir: str = field(default=None, init=False)
     output_file: str = field(default=None, init=False)
+    qual_summary: pd.DataFrame = field(default=None, init=False)  # Processed apps with total core seconds
 
-    def __init__(self, props: dict, tools_output_dir: str, output_file: str):
+    def __init__(self, props: dict, tools_output_dir: str, output_file: str, qual_summary: pd.DataFrame):
         self.props = JSONPropertiesContainer(props, file_load=False)
         self.tools_output_dir = tools_output_dir
         self.output_file = output_file
+        self.qual_summary = qual_summary
         self.logger = ToolLogging.get_and_setup_logger(f'rapids.tools.{self.__class__.__name__}')
 
     def _apply_heuristics(self, app_ids: list) -> pd.DataFrame:
@@ -68,17 +70,38 @@ class AdditionalHeuristics:
         else:
             for app_id in app_ids:
                 app_id_path = os.path.join(metrics_path, app_id)
+                # Apply heuristics and determine if the application should be skipped.
+                # Note: `should_skip` flag can be a combination of multiple heuristic checks.
+                should_skip = False
                 try:
-                    # Apply heuristics and determine if the application should be skipped.
-                    # Note: `should_skip` flag can be a combination of multiple heuristic checks.
-                    should_skip, reason = self.heuristics_based_on_spills(app_id_path)
+                    should_skip, reason = self.heuristics_based_on_total_core_seconds(app_id)
                 except Exception as e:  # pylint: disable=broad-except
-                    should_skip = False
-                    reason = f'Cannot apply heuristics for qualification. Reason - {type(e).__name__}:{e}'
+                    reason = ' Cannot apply total core seconds heuristics for qualification. Reason - ' + \
+                        f'{type(e).__name__}:{e}.'
+                    self.logger.error(reason)
+                try:
+                    should_skip_spill, reason_spill = self.heuristics_based_on_spills(app_id_path)
+                    should_skip = should_skip or should_skip_spill
+                    reason = reason + reason_spill
+                except Exception as e:  # pylint: disable=broad-except
+                    reason = reason + f' Cannot apply spill heuristics for qualification. Reason - {type(e).__name__}:{e}.'
                     self.logger.error(reason)
                 result_arr.append([app_id, should_skip, reason])
 
         return pd.DataFrame(result_arr, columns=self.props.get_value('resultCols'))
+
+    def heuristics_based_on_total_core_seconds(self, app_id: str) -> (bool, str):
+        """
+        Apply heuristics based on total core seconds to determine if the app can be accelerated on GPU.
+        """
+        # Load app output from qualidication summary dataframe
+        app_qual_output = self.qual_summary[self.qual_summary['App ID'] == app_id]
+        total_core_seconds = app_qual_output['Total Core Seconds'].astype(int).iloc[0]
+        # Threshold is total core seconds of an n1-standard-8 machine running one day
+        total_core_seconds_threshold = self.props.get_value('totalCoreSecBased', 'totalCoreSecThreshold')
+        if total_core_seconds <= total_core_seconds_threshold:
+            return True, f'Skipping due to total core seconds = {total_core_seconds} lower than {total_core_seconds_threshold}.'
+        return False, ''
 
     def heuristics_based_on_spills(self, app_id_path: str) -> (bool, str):
         """
@@ -113,7 +136,7 @@ class AdditionalHeuristics:
         if not relevant_stages_with_spills.empty:
             stages_str = '; '.join(relevant_stages_with_spills['stageId'].astype(str))
             spill_threshold_human_readable = Utilities.bytes_to_human_readable(spill_threshold_bytes)
-            reason = f'Skipping due to spills in stages [{stages_str}] exceeding {spill_threshold_human_readable}'
+            reason = f'Skipping due to spills in stages [{stages_str}] exceeding {spill_threshold_human_readable}.'
             return True, reason
         return False, ''
 

--- a/user_tools/src/spark_rapids_tools/tools/top_candidates.py
+++ b/user_tools/src/spark_rapids_tools/tools/top_candidates.py
@@ -87,12 +87,11 @@ class TopCandidates:
         Internal implementation to prepare the output table. This can be overridden by the child classes.
         """
         # Append 'Speedup Category Order' and 'Total Core Seconds' columns to output_df for sorting order
-        # First, we want to sort on speedup category (decs order), so larger speedup categories appear first
-        # Create and append 'Speedup Category Order' column
+        # First, sort based on speedup category (decs order). Create and append 'Speedup Category Order' column.
         speedup_category_order = ['Not Recommended', 'Small', 'Medium', 'Large']
         output_df['Speedup Category Order'] = \
             output_df['Estimated GPU Speedup Category'].map({name: i for i, name in enumerate(speedup_category_order)})
-        # Second, within each speedup category, we want to sort on total core seconds (desc order)
+        # Second, within each speedup category, sort based on total core seconds (desc order)
         output_df = pd.merge(output_df, self.qual_summary[['App ID', 'Total Core Seconds']],
                              how='left', left_on='App ID', right_on='App ID')
 

--- a/user_tools/src/spark_rapids_tools/tools/top_candidates.py
+++ b/user_tools/src/spark_rapids_tools/tools/top_candidates.py
@@ -34,6 +34,7 @@ class TopCandidates:
     tools_processed_apps: pd.DataFrame = field(init=True)  # Apps after tools processing and heuristic filtering
     filtered_apps: pd.DataFrame = field(default_factory=pd.DataFrame, init=False)  # Apps after applying filters
     filter_enabled: bool = field(default=False, init=False)
+    qual_summary: pd.DataFrame = field(init=True)  # Processed apps with total core seconds
 
     def __post_init__(self) -> None:
         # Filter applications based on categories
@@ -85,12 +86,22 @@ class TopCandidates:
         """
         Internal implementation to prepare the output table. This can be overridden by the child classes.
         """
+        # Append 'Speedup Category Order' and 'Total Core Seconds' columns to output_df for sorting order
+        # First, we want to sort on speedup category (decs order), so larger speedup categories appear first
+        # Create and append 'Speedup Category Order' column
+        speedup_category_order = ['Not Recommended', 'Small', 'Medium', 'Large']
+        output_df['Speedup Category Order'] = \
+            output_df['Estimated GPU Speedup Category'].map({name: i for i, name in enumerate(speedup_category_order)})
+        # Second, within each speedup category, we want to sort on total core seconds (desc order)
+        output_df = pd.merge(output_df, self.qual_summary[['App ID', 'Total Core Seconds']],
+                             how='left', left_on='App ID', right_on='App ID')
+
+        # Sort columns and select output columns
         output_columns = self.props.get('outputColumns')
         sorting_columns = self.props.get('sortingColumns')
         valid_output_columns = list(output_df.columns.intersection(output_columns))
-        valid_sorting_columns = list(output_df.columns.intersection(sorting_columns))
-        # Sort columns and select output columns
-        res_df = output_df.sort_values(by=valid_sorting_columns, ascending=False)[valid_output_columns]
+        res_df = output_df.sort_values(by=sorting_columns, ascending=False)[valid_output_columns]
+
         # this is a bit weird since hardcoding, but we don't want this to have ** for csv output
         if 'Estimated GPU Speedup Category' in res_df:
             res_df.rename(columns={'Estimated GPU Speedup Category': 'Estimated GPU Speedup Category**'},

--- a/user_tools/src/spark_rapids_tools/tools/top_candidates.py
+++ b/user_tools/src/spark_rapids_tools/tools/top_candidates.py
@@ -86,7 +86,7 @@ class TopCandidates:
         Internal implementation to prepare the output table. This can be overridden by the child classes.
         """
         # Creat and append 'Speedup Category Order' column to output_df for sorting order
-        speedup_category_order = ['Not Recommended', 'Small', 'Medium', 'Large']
+        speedup_category_order = self.props.get('noneligibleCategory') + self.props.get('eligibleCategories')
         output_df['Speedup Category Order'] = \
             output_df['Estimated GPU Speedup Category'].map({name: i for i, name in enumerate(speedup_category_order)})
         # Sort columns and select output columns

--- a/user_tools/src/spark_rapids_tools/tools/top_candidates.py
+++ b/user_tools/src/spark_rapids_tools/tools/top_candidates.py
@@ -85,8 +85,8 @@ class TopCandidates:
         """
         Internal implementation to prepare the output table. This can be overridden by the child classes.
         """
-        # Creat and append 'Speedup Category Order' column to output_df for sorting order
-        speedup_category_order = self.props.get('noneligibleCategory') + self.props.get('eligibleCategories')
+        # Create and append 'Speedup Category Order' column to output_df for sorting order
+        speedup_category_order = self.props.get('ineligibleCategory') + self.props.get('eligibleCategories')
         output_df['Speedup Category Order'] = \
             output_df['Estimated GPU Speedup Category'].map({name: i for i, name in enumerate(speedup_category_order)})
         # Sort columns and select output columns


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids-tools/issues/1307

### PR Changes

After an offline discussion with Felix, here are the changes we want to proceed with:

1. Filter apps with total core secs less than threshold `691200`. This is the total core seconds of an n1-standard-8 instance running for one day. Running an n1-standard-8 for one day takes < $10, which is $3650 a year (not much cast savings potential).
2. In qual tool console output, the table is currently sorted based on `Estimated GPU Speedup` and `Unsupported Operators Stage Duration Percent`. This PR changes the sorting columns to 'Speedup Category Order' (Large > Medium > Small > Not Recommended) and `Total Core Seconds`, so that within each speedup category, the apps are sorted based on total core seconds.

### Output Changes

- Added `Total Core Seconds` column in `qualification_summary.csv`

Example:
```
,Vendor,Driver Host,App Name,App ID,Estimated GPU Speedup,Estimated GPU Duration,App Duration,SQL Stage Durations Sum,Unsupported Operators Stage Duration,Unsupported Operators Stage Duration Percent,Total Core Seconds,Skip by Heuristics,Estimated GPU Speedup Category
0,onprem,10.110.46.117,sanity_test,application_1673577383569_0004,1.89,35853,67725,41980,0.00,0.00,1692,False,Large
1,onprem,ip-172-31-56-248.us-west-2.compute.internal,sanity_test,application_1673577383569_0003,1.86,35759,66374,40168,0.00,0.00,1626,False,Large
2,onprem,ip-172-31-56-248.us-west-2.compute.internal,sanity_test,application_1673503196578_0001,1.76,41158,72507,41659,0.00,0.00,1718,False,Medium
3,onprem,ip-172-31-56-248.us-west-2.compute.internal,sanity_test,application_1673577383569_0001,1.76,41292,72649,41647,0.00,0.00,1675,False,Medium
```

### Testing
Cmd:
`spark_rapids qualification -v -e <my-event-logs> --tools_jar <my_tools_jar>`

Console output:
```
+----+-------------+--------------------------------+-----------------+------------------------------------+-------------------------------------+------------------------------------+
|    | App Name    | App ID                         | Estimated GPU   | Qualified                          | Full Cluster                        | GPU Config                         |
|    |             |                                | Speedup         | Cluster                            | Config                              | Recommendation                     |
|    |             |                                | Category**      | Recommendation                     | Recommendations*                    | Breakdown*                         |
|----+-------------+--------------------------------+-----------------+------------------------------------+-------------------------------------+------------------------------------|
|  0 | sanity_test | application_1673577383569_0004 | Large           | 1 x Node with 64 vCPUs (1 L4 each) | Does not exist, see log for errors  | Does not exist, see log for errors |
|  1 | sanity_test | application_1673577383569_0003 | Large           | 4 x Node with 8 vCPUs (1 L4 each)  | application_1673577383569_0003.conf | application_1673577383569_0003.log |
|  2 | sanity_test | application_1673503196578_0001 | Medium          | 4 x Node with 8 vCPUs (1 L4 each)  | application_1673503196578_0001.conf | application_1673503196578_0001.log |
|  3 | sanity_test | application_1673577383569_0001 | Medium          | 4 x Node with 8 vCPUs (1 L4 each)  | application_1673577383569_0001.conf | application_1673577383569_0001.log |
+----+-------------+--------------------------------+-----------------+------------------------------------+-------------------------------------+------------------------------------+
```
The total core seconds for the apps (in order of the above table) are: `1692`, `1626`, `1718`, `1675`.