### PR TITLE
Add PartitionFilters and DataFilters to the dataSourceInfo table

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/HiveParseHelper.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/HiveParseHelper.scala
@@ -25,7 +25,7 @@ case class HiveScanSerdeClasses(className: String, format: String) extends Loggi
   def parseReadNode(node: SparkPlanGraphNode): ReadMetaData = {
     logDebug(s"Parsing node as ScanHiveTable: ${node.desc}")
     // Schema, pushedFilters empty for now as we cannot extract them yet from eventlogs
-    ReadMetaData("", "HiveTableRelation", "unknown", format)
+    ReadMetaData("", "HiveTableRelation", format)
   }
   def accepts(str: String): Boolean = {
     str.equals(className)
@@ -75,7 +75,8 @@ object HiveParseHelper extends Logging {
   // If the SerDe class does not match the lookups, it returns an "unknown" format.
   def parseReadNode(node: SparkPlanGraphNode): ReadMetaData = {
     LOADED_SERDE_CLASSES.find(k => node.desc.contains(k.className)).map(
-      _.parseReadNode(node)).getOrElse(ReadMetaData("", "HiveTableRelation", "unknown", "unknown"))
+      _.parseReadNode(node)).getOrElse(
+      ReadMetaData("", "HiveTableRelation", ReadParser.UNKNOWN_METAFIELD))
   }
 
   // Given a "scan hive" NodeGraph, construct the MetaData of the write operation based on the

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ReadParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ReadParser.scala
@@ -107,6 +107,17 @@ object ReadParser extends Logging {
     result
   }
 
+  // Extracts the tag from SparkPlanInfo.metadata Map[String, String].
+  def extractTagFromV1ReadMeta(tag: String, metadata: Map[String, String]): String = {
+    tag match {
+      case METAFIELD_TAG_DATA_FILTERS | METAFIELD_TAG_PUSHED_FILTERS |
+           METAFIELD_TAG_PARTITION_FILTERS =>
+        // Strip off opening and closing brackets to be consistent with other ReadParser methods
+        metadata.getOrElse(tag, UNKNOWN_METAFIELD).stripPrefix("[").stripSuffix("]")
+      case _ => metadata.getOrElse(tag, UNKNOWN_METAFIELD)
+    }
+  }
+
   def parseReadNode(node: SparkPlanGraphNode): ReadMetaData = {
     if (HiveParseHelper.isHiveTableScanNode(node)) {
       HiveParseHelper.parseReadNode(node)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -136,22 +136,25 @@ case class RapidsJarProfileResult(appIndex: Int, jar: String)  extends ProfileRe
 
 case class DataSourceProfileResult(appIndex: Int, sqlID: Long, nodeId: Long,
     format: String, buffer_time: Long, scan_time: Long, data_size: Long,
-    decode_time: Long, location: String, pushedFilters: String, schema: String)
+    decode_time: Long, location: String, pushedFilters: String, schema: String,
+    dataFilters: String, partitionFilters: String)
 extends ProfileResult {
   override val outputHeaders =
     Seq("appIndex", "sqlID", "nodeId", "format", "buffer_time", "scan_time", "data_size",
-      "decode_time", "location", "pushedFilters", "schema")
+      "decode_time", "location", "pushedFilters", "schema", "data_filters", "partition_filters")
 
   override def convertToSeq: Seq[String] = {
     Seq(appIndex.toString, sqlID.toString, nodeId.toString, format, buffer_time.toString,
       scan_time.toString, data_size.toString, decode_time.toString,
-      location, pushedFilters, schema)
+      location, pushedFilters, schema, dataFilters, partitionFilters)
   }
   override def convertToCSVSeq: Seq[String] = {
     Seq(appIndex.toString, sqlID.toString, nodeId.toString, StringUtils.reformatCSVString(format),
       buffer_time.toString, scan_time.toString, data_size.toString, decode_time.toString,
       StringUtils.reformatCSVString(location), StringUtils.reformatCSVString(pushedFilters),
-      StringUtils.reformatCSVString(schema))
+      StringUtils.reformatCSVString(schema),
+      StringUtils.reformatCSVString(dataFilters),
+      StringUtils.reformatCSVString(partitionFilters))
   }
 }
 
@@ -367,7 +370,9 @@ case class DataSourceCase(
     format: String,
     location: String,
     pushedFilters: String,
-    schema: String)
+    schema: String,
+    dataFilters: String,
+    partitionFilters: String)
 
 case class FailedTaskProfileResults(appIndex: Int, stageId: Int, stageAttemptId: Int,
     taskId: Long, taskAttemptId: Int, endReason: String) extends ProfileResult {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/DataSourceView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/DataSourceView.scala
@@ -38,6 +38,8 @@ object IoMetrics {
   val SCAN_TIME_LABEL = "scan time"
   val DATA_SIZE_LABEL = "size of files read"
   val DECODE_TIME_LABEL = "GPU decode time"
+
+  val EMPTY_IO_METRICS: IoMetrics = IoMetrics(0, 0, 0, 0)
 }
 
 trait AppDataSourceViewTrait extends ViewableTrait[DataSourceProfileResult] {
@@ -105,15 +107,15 @@ trait AppDataSourceViewTrait extends ViewableTrait[DataSourceProfileResult] {
     app.dataSourceInfo.map { ds =>
       val sqlIdtoDs = dataSourceMetrics.filter(
         sqlAccum => sqlAccum.sqlID == ds.sqlID && sqlAccum.nodeID == ds.nodeId)
-      if (sqlIdtoDs.nonEmpty) {
-        val ioMetrics = getIoMetrics(sqlIdtoDs)
-        DataSourceProfileResult(index, ds.sqlID, ds.nodeId,
-          ds.format, ioMetrics.bufferTime, ioMetrics.scanTime, ioMetrics.dataSize,
-          ioMetrics.decodeTime, ds.location, ds.pushedFilters, ds.schema)
+      val ioMetrics = if (sqlIdtoDs.nonEmpty) {
+        getIoMetrics(sqlIdtoDs)
       } else {
-        DataSourceProfileResult(index, ds.sqlID, ds.nodeId,
-          ds.format, 0, 0, 0, 0, ds.location, ds.pushedFilters, ds.schema)
+        IoMetrics.EMPTY_IO_METRICS
       }
+      DataSourceProfileResult(index, ds.sqlID, ds.nodeId,
+        ds.format, ioMetrics.bufferTime, ioMetrics.scanTime, ioMetrics.dataSize,
+        ioMetrics.decodeTime, ds.location, ds.pushedFilters, ds.schema, ds.dataFilters,
+        ds.partitionFilters)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -358,12 +358,12 @@ abstract class AppBase(
         results += DataSourceCase(
           sqlPlanInfoGraph.sqlID,
           scanNode.head.id,
-          meta.getOrElse("Format", ReadParser.UNKNOWN_METAFIELD),
-          meta.getOrElse("Location", ReadParser.UNKNOWN_METAFIELD),
-          meta.getOrElse("PushedFilters", ReadParser.UNKNOWN_METAFIELD),
+          ReadParser.extractTagFromV1ReadMeta("Format", meta),
+          ReadParser.extractTagFromV1ReadMeta("Location", meta),
+          ReadParser.extractTagFromV1ReadMeta(ReadParser.METAFIELD_TAG_PUSHED_FILTERS, meta),
           readSchema,
-          meta.getOrElse("DataFilters", ReadParser.UNKNOWN_METAFIELD),
-          meta.getOrElse("PartitionFilters", ReadParser.UNKNOWN_METAFIELD)
+          ReadParser.extractTagFromV1ReadMeta(ReadParser.METAFIELD_TAG_DATA_FILTERS, meta),
+          ReadParser.extractTagFromV1ReadMeta(ReadParser.METAFIELD_TAG_PARTITION_FILTERS, meta)
         )
       }
     }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -358,10 +358,12 @@ abstract class AppBase(
         results += DataSourceCase(
           sqlPlanInfoGraph.sqlID,
           scanNode.head.id,
-          meta.getOrElse("Format", "unknown"),
-          meta.getOrElse("Location", "unknown"),
-          meta.getOrElse("PushedFilters", "unknown"),
-          readSchema
+          meta.getOrElse("Format", ReadParser.UNKNOWN_METAFIELD),
+          meta.getOrElse("Location", ReadParser.UNKNOWN_METAFIELD),
+          meta.getOrElse("PushedFilters", ReadParser.UNKNOWN_METAFIELD),
+          readSchema,
+          meta.getOrElse("DataFilters", ReadParser.UNKNOWN_METAFIELD),
+          meta.getOrElse("PartitionFilters", ReadParser.UNKNOWN_METAFIELD)
         )
       }
     }
@@ -378,8 +380,10 @@ abstract class AppBase(
           hiveScanNode.id,
           scanHiveMeta.format,
           scanHiveMeta.location,
-          scanHiveMeta.filters,
-          scanHiveMeta.schema
+          scanHiveMeta.pushedFilters,
+          scanHiveMeta.schema,
+          scanHiveMeta.dataFilters,
+          scanHiveMeta.partitionFilters
         )
       }
     }
@@ -398,8 +402,10 @@ abstract class AppBase(
         node.id,
         res.format,
         res.location,
-        res.filters,
-        res.schema)
+        res.pushedFilters,
+        res.schema,
+        res.dataFilters,
+        res.partitionFilters)
       dataSourceInfo += dsCase
       Some(dsCase)
     } else {

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/ReadParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/ReadParserSuite.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.nvidia.spark.rapids.tool.planparser
+
+import com.nvidia.spark.rapids.BaseTestSuite
+import org.scalatest.Matchers.{be, convertToAnyShouldWrapper}
+
+// Tests the implementation of the ReadParser independently of end-2-end tests
+class ReadParserSuite extends BaseTestSuite {
+  // Wrapper to hold the related test cases
+  case class MetaFieldsTestCase(testDescription: String,
+      nodeDescr: String, expectedMetafields: Map[String, String]) {
+  }
+
+  test("Read Metadata fields from a graphNode (pushedFilters, dataFilters, partitionFilters)") {
+    val nodeDescrPrologue =
+      """FileScan parquet db.table[field_00#952L,label#953,field_02#954,field_03#958L,
+        |field_04#960,field_05#961L,field_06#962L,field_07#963L,field_08#964L,field_09#965L,
+        |field_10#966L,field_11#967L,field_12#968L,field_13#969L,field_14#970L,field_15#971L,
+        |field_16#972L,field_17#973L,field_18#974L,field_19#975L,field_20#976L,field_21#977L,
+        |field_22#978L,field_22#979L,... 36 more fields]""".stripMargin.replaceAll("\n", "")
+    // All metrafields exist and terminated by closing brackets
+    val allTestScenarios = Seq(
+      MetaFieldsTestCase(
+        "All the 3 MetaFields are present -- terminated by closing bracket",
+        nodeDescrPrologue + """ Batched: true,
+          | DataFilters: [isnotnull(flag_00#1013L), (flag_00#1013L = 1)],
+          | Format: Parquet,
+          | Location: InMemoryFileIndex(20 paths)[hdfs://directory/subdirectory/file_1....,
+          | PartitionFilters: [isnotnull(date_00#1014), (date_00#1014 = 20240621)],
+          | PushedFilters: [IsNotNull(flag_00), EqualTo(flag_00,1)],
+          | ReadSchema: struct<field_00:bigint,label:string,field_02:string,field_03:bigint,
+          |field_04:string,high_price...
+          |""".stripMargin.stripMargin.replaceAll("\n", ""),
+        Map(
+          ReadParser.METAFIELD_TAG_PUSHED_FILTERS ->
+            "IsNotNull(flag_00), EqualTo(flag_00,1)",
+          ReadParser.METAFIELD_TAG_DATA_FILTERS ->
+            "isnotnull(flag_00#1013L), (flag_00#1013L = 1)",
+          ReadParser.METAFIELD_TAG_PARTITION_FILTERS ->
+            "isnotnull(date_00#1014), (date_00#1014 = 20240621)")),
+      MetaFieldsTestCase(
+        "All the 3 MetaFields are present -- terminated by closing bracket -- Order is different",
+        nodeDescrPrologue + """ Batched: true,
+          | PushedFilters: [IsNotNull(flag_00), EqualTo(flag_00,1)],
+          | DataFilters: [isnotnull(flag_00#1013L), (flag_00#1013L = 1)],
+          | Format: Parquet,
+          | Location: InMemoryFileIndex(20 paths)[hdfs://directory/subdirectory/file_1....,
+          | PartitionFilters: [isnotnull(date_00#1014), (date_00#1014 = 20240621)],
+          | ReadSchema: struct<field_00:bigint,label:string,field_02:string,field_03:bigint,
+          |field_04:string,high_price...
+          |""".stripMargin.stripMargin.replaceAll("\n", ""),
+        Map(
+          ReadParser.METAFIELD_TAG_PUSHED_FILTERS ->
+            "IsNotNull(flag_00), EqualTo(flag_00,1)",
+          ReadParser.METAFIELD_TAG_DATA_FILTERS ->
+            "isnotnull(flag_00#1013L), (flag_00#1013L = 1)",
+          ReadParser.METAFIELD_TAG_PARTITION_FILTERS ->
+            "isnotnull(date_00#1014), (date_00#1014 = 20240621)")),
+      MetaFieldsTestCase(
+        "Only 1 MetaField is present -- terminated by closing bracket",
+        nodeDescrPrologue + """ Batched: true,
+          | PushedFilters: [IsNotNull(flag_00), EqualTo(flag_00,1)],
+          | Format: Parquet,
+          | Location: InMemoryFileIndex(20 paths)[hdfs://directory/subdirectory/file_1....,
+          | ReadSchema: struct<field_00:bigint,label:string,field_02:string,field_03:bigint,
+          |field_04:string,high_price...
+          |""".stripMargin.stripMargin.replaceAll("\n", ""),
+        Map(
+          ReadParser.METAFIELD_TAG_PUSHED_FILTERS ->
+            "IsNotNull(flag_00), EqualTo(flag_00,1)",
+          ReadParser.METAFIELD_TAG_DATA_FILTERS -> ReadParser.UNKNOWN_METAFIELD,
+          ReadParser.METAFIELD_TAG_PARTITION_FILTERS -> ReadParser.UNKNOWN_METAFIELD)),
+      MetaFieldsTestCase(
+        "Metafields might be truncated (not terminated by closing bracket)",
+        nodeDescrPrologue + """ Batched: true,
+          | PushedFilters: [IsNotNull(flag_00), EqualTo(flag_00,1),...,
+          | DataFilters: [isnotnull(flag_00#1013L), (flag_00#1013L = 1)...,
+          | Format: Parquet,
+          | Location: InMemoryFileIndex(20 paths)[hdfs://directory/subdirectory/file_1....,
+          | ReadSchema: struct<field_00:bigint,label:string,field_02:string,field_03:bigint,
+          |field_04:string,high_price...
+          | PartitionFilters: [isnotnull(date_00#1014), (date_00#1014 = 20240621)...
+          |""".stripMargin.stripMargin.replaceAll("\n", ""),
+        Map(
+          ReadParser.METAFIELD_TAG_PUSHED_FILTERS ->
+            "IsNotNull(flag_00), EqualTo(flag_00,1),...",
+          ReadParser.METAFIELD_TAG_DATA_FILTERS ->
+            "isnotnull(flag_00#1013L), (flag_00#1013L = 1)...",
+          ReadParser.METAFIELD_TAG_PARTITION_FILTERS ->
+            "isnotnull(date_00#1014), (date_00#1014 = 20240621)...")),
+      MetaFieldsTestCase(
+        "Metafields might be empty",
+        nodeDescrPrologue + """ Batched: true,
+          | PushedFilters: [IsNotNull(flag_00), EqualTo(flag_00,1),...,
+          | DataFilters: [],
+          | Format: Parquet,
+          | Location: InMemoryFileIndex(20 paths)[hdfs://directory/subdirectory/file_1....,
+          | ReadSchema: struct<field_00:bigint,label:string,field_02:string,field_03:bigint,
+          |field_04:string,high_price...
+          | PartitionFilters: [isnotnull(date_00#1014), (date_00#1014 = 20240621)...
+          |""".stripMargin.stripMargin.replaceAll("\n", ""),
+        Map(
+          ReadParser.METAFIELD_TAG_PUSHED_FILTERS ->
+            "IsNotNull(flag_00), EqualTo(flag_00,1),...",
+          ReadParser.METAFIELD_TAG_DATA_FILTERS -> "",
+          ReadParser.METAFIELD_TAG_PARTITION_FILTERS ->
+            "isnotnull(date_00#1014), (date_00#1014 = 20240621)..."))
+    )
+    for (scenario <- allTestScenarios) {
+      try {
+        ReadParser.extractReadTags(scenario.nodeDescr) should be (scenario.expectedMetafields)
+      } catch {
+        case e: Exception =>
+          fail(s"Failed for scenario: ${scenario.testDescription}", e)
+      }
+    }
+  }
+}

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/ReadParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/ReadParserSuite.scala
@@ -34,7 +34,6 @@ class ReadParserSuite extends BaseTestSuite {
         |field_10#966L,field_11#967L,field_12#968L,field_13#969L,field_14#970L,field_15#971L,
         |field_16#972L,field_17#973L,field_18#974L,field_19#975L,field_20#976L,field_21#977L,
         |field_22#978L,field_22#979L,... 36 more fields]""".stripMargin.replaceAll("\n", "")
-    // All metrafields exist and terminated by closing brackets
     val allTestScenarios = Seq(
       MetaFieldsTestCase(
         "All the 3 MetaFields are present -- terminated by closing bracket",


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein <ahussein@nvidia.com>

Fixes #1192

**Changes**

- Output:
  - Adds two new columns "data_filters" and "partition_filters" to datasourceInformation table `data_source_information.csv`
  - If the value is truncated, it shows ellipsis
- Logic:
  - Fixes a bug in extracting the `PushedFilters`. The legacy code used to stop on the first comma which is incorrect.
  - Fixes a bug where the tags extracted from V1Read are wrapped in brackets; while other node reads are stipped off the brackets. This would lead to inconsistent format of the columns.
- Testing:
  - Added new test class `ReadParserSuite` to make it easier to test parsing of read expression directly without dependency on Spark, or other end-2-end components
