### PR TITLE
Rename tag core to core_tools

### DIFF
--- a/.github/workflows/configuration.json
+++ b/.github/workflows/configuration.json
@@ -6,7 +6,7 @@
     },
     {
       "title": "### Core",
-      "labels": ["tools"]
+      "labels": ["core_tools"]
     },
     {
       "title": "### Miscellaneous",


### PR DESCRIPTION
This PR is to change the workflow configurations renaming "core" to "core_tools"
