### PR TITLE
Disable `too-many-positional-arguments` in pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -56,6 +56,8 @@ disable=
         # R0913: Too many arguments
         too-many-arguments,
         # R0914: Too many local variables
+        too-many-positional-arguments,
+        # R0917: Too many positional arguments
         too-many-locals,
         # R0801: Similar lines in 2 files
         duplicate-code,


### PR DESCRIPTION
Fixes #1352. This PR disables `too-many-positional-arguments` in pylintrc. This is needed as `pylint=3.3.0` introduced this check and many sections in our python code are failing this check. 