### PR TITLE
Improve AQE support by capturing SQLPlan versions

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
@@ -254,7 +254,7 @@ class AppSQLPlanAnalyzer(app: AppBase, appIndex: Int) extends AppAnalysisBase(ap
         val nodeIds = sqlPlanNodeIdToStageIds.filter { case (_, v) =>
           v.contains(sModel.stageInfo.stageId)
         }.keys.toSeq
-        val nodeNames =  app.sqlManager.applyToPlanInfo(j.sqlID.get) { planInfo =>
+        val nodeNames = app.sqlManager.applyToPlanInfo(j.sqlID.get) { planInfo =>
           val nodes = ToolsPlanGraph(planInfo).allNodes
           val validNodes = nodes.filter { n =>
             nodeIds.contains((j.sqlID.get, n.id))

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.tool.analysis
 import scala.collection.mutable.{AbstractSet, ArrayBuffer, HashMap, LinkedHashSet}
 
 import com.nvidia.spark.rapids.tool.planparser.SQLPlanParser
-import com.nvidia.spark.rapids.tool.profiling.{AccumProfileResults, DataSourceCase, SQLAccumProfileResults, SQLMetricInfoCase, SQLStageInfoProfileResult, UnsupportedSQLPlan, WholeStageCodeGenResults}
+import com.nvidia.spark.rapids.tool.profiling.{AccumProfileResults, SQLAccumProfileResults, SQLMetricInfoCase, SQLStageInfoProfileResult, UnsupportedSQLPlan, WholeStageCodeGenResults}
 import com.nvidia.spark.rapids.tool.qualification.QualSQLPlanAnalyzer
 
 import org.apache.spark.sql.execution.SparkPlanInfo
@@ -27,6 +27,7 @@ import org.apache.spark.sql.execution.ui.{SparkPlanGraph, SparkPlanGraphCluster,
 import org.apache.spark.sql.rapids.tool.{AppBase, RDDCheckHelper, SqlPlanInfoGraphBuffer, SqlPlanInfoGraphEntry}
 import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
 import org.apache.spark.sql.rapids.tool.qualification.QualificationAppInfo
+import org.apache.spark.sql.rapids.tool.store.DataSourceRecord
 import org.apache.spark.sql.rapids.tool.util.ToolsPlanGraph
 
 /**
@@ -99,7 +100,7 @@ class AppSQLPlanAnalyzer(app: AppBase, appIndex: Int) extends AppAnalysisBase(ap
   // as RDD or DS.
   protected case class SQLPlanVisitorContext(
       sqlPIGEntry: SqlPlanInfoGraphEntry,
-      sqlDataSources: ArrayBuffer[DataSourceCase] = ArrayBuffer[DataSourceCase](),
+      sqlDataSources: ArrayBuffer[DataSourceRecord] = ArrayBuffer[DataSourceRecord](),
       potentialProblems: LinkedHashSet[String] = LinkedHashSet[String](),
       var sqlIsDsOrRDD: Boolean = false)
 
@@ -253,7 +254,7 @@ class AppSQLPlanAnalyzer(app: AppBase, appIndex: Int) extends AppAnalysisBase(ap
         val nodeIds = sqlPlanNodeIdToStageIds.filter { case (_, v) =>
           v.contains(sModel.stageInfo.stageId)
         }.keys.toSeq
-        val nodeNames = app.sqlPlans.get(j.sqlID.get).map { planInfo =>
+        val nodeNames =  app.sqlManager.applyToPlanInfo(j.sqlID.get) { planInfo =>
           val nodes = ToolsPlanGraph(planInfo).allNodes
           val validNodes = nodes.filter { n =>
             nodeIds.contains((j.sqlID.get, n.id))

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/SparkSQLPlanInfoVisitor.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/SparkSQLPlanInfoVisitor.scala
@@ -16,13 +16,10 @@
 
 package com.nvidia.spark.rapids.tool.analysis
 
-import scala.collection.mutable.Map
-
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
 import org.apache.spark.sql.rapids.tool.SqlPlanInfoGraphEntry
 import org.apache.spark.sql.rapids.tool.util.ToolsPlanGraph
-
 
 // Class defines the SQLPlan context by implementations that walk through the SQLPlanInfo
 class SQLPlanInfoContext(sqlPIGEntry: SqlPlanInfoGraphEntry) {
@@ -66,7 +63,7 @@ trait SparkSQLPlanInfoVisitor[R <: SQLPlanInfoContext] {
   }
 
   // Walks through all the SQLPlans in the given map
-  def walkPlans(plans: Map[Long, SparkPlanInfo]): Unit = {
+  def walkPlans(plans: collection.immutable.Map[Long, SparkPlanInfo]): Unit = {
     for ((sqlId, planInfo) <- plans) {
       val planCtxt = createPlanCtxt(sqlId, planInfo)
       walkPlan(planCtxt)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ReadParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ReadParser.scala
@@ -46,6 +46,9 @@ object ReadParser extends Logging {
   val METAFIELD_TAG_DATA_FILTERS = "DataFilters"
   val METAFIELD_TAG_PUSHED_FILTERS = "PushedFilters"
   val METAFIELD_TAG_PARTITION_FILTERS = "PartitionFilters"
+  val METAFIELD_TAG_READ_SCHEMA = "ReadSchema"
+  val METAFIELD_TAG_FORMAT = "Format"
+  val METAFIELD_TAG_LOCATION = "Location"
 
   val UNKNOWN_METAFIELD: String = "unknown"
   val DEFAULT_METAFIELD_MAP: Map[String, String] = collection.immutable.Map(

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
@@ -129,7 +129,7 @@ object CollectInformation extends Logging {
       val planFileWriter = new ToolTextFileWriter(s"$outputDir/${app.appId}",
         "planDescriptions.log", "SQL Plan")
       try {
-        for ((sqlID, planDesc) <- app.physicalPlanDescription.toSeq.sortBy(_._1)) {
+        for ((sqlID, planDesc) <- app.sqlManager.getPhysicalPlans) {
           planFileWriter.write("\n=============================\n")
           planFileWriter.write(s"Plan for SQL ID : $sqlID")
           planFileWriter.write("\n=============================\n")

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
@@ -110,17 +110,14 @@ object GenerateDot {
       list += row(1) -> row(2)
     }
 
-    val sqlPlansMap = app.sqlPlans.map { case (sqlId, sparkPlanInfo) =>
-      sqlId -> ((sparkPlanInfo, app.physicalPlanDescription(sqlId)))
-    }
-    for ((sqlID, (planInfo, physicalPlan)) <- sqlPlansMap) {
+    for (sqlPlan <- app.sqlManager.sqlPlans.values) {
       val dotFileWriter = new ToolTextFileWriter(outputDirectory,
-        s"query-$sqlID.dot", "Dot file")
+        s"query-${sqlPlan.id}.dot", "Dot file")
       try {
-        val metrics = sqlIdToMaxMetric.getOrElse(sqlID, Seq.empty).toMap
+        val metrics = sqlIdToMaxMetric.getOrElse(sqlPlan.id, Seq.empty).toMap
         GenerateDot.writeDotGraph(
-          QueryPlanWithMetrics(SparkPlanInfoWithStage(planInfo, accumIdToStageId), metrics),
-          physicalPlan, stageIdToStageMetrics, dotFileWriter, sqlID, app.appId)
+          QueryPlanWithMetrics(SparkPlanInfoWithStage(sqlPlan.planInfo, accumIdToStageId), metrics),
+          sqlPlan.physicalPlanDesc, stageIdToStageMetrics, dotFileWriter, sqlPlan.id, app.appId)
       } finally {
         dotFileWriter.close()
       }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfSQLPlanClassifier.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfSQLPlanClassifier.scala
@@ -53,8 +53,8 @@ class SQLPlanClassifier(app: ApplicationInfo)
 
   override def visitNode(sqlPlanCtxt: SQLPlanClassifierCtxt, node: ui.SparkPlanGraphNode): Unit = {
     // Check if the node is a delta metadata operation
-    val isDeltaLog = DeltaLakeHelper.isDeltaOpNode(
-      sqlPlanCtxt.sqlPIGEntry, app.physicalPlanDescription(sqlPlanCtxt.getSQLPIGEntry.sqlID), node)
+    val isDeltaLog = DeltaLakeHelper.isDeltaOpNode(sqlPlanCtxt.sqlPIGEntry,
+      app.sqlManager.getPhysicalPlanById(sqlPlanCtxt.getSQLPIGEntry.sqlID).get, node)
     if (isDeltaLog) {
       // if it is a Delta operation, add it to the list of Delta operations nodes
       sqlPlanCtxt.deltaOpsNode += node.id

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -140,9 +140,9 @@ case class DataSourceProfileResult(appIndex: Int, sqlID: Long, version: Int, nod
     dataFilters: String, partitionFilters: String, fromFinalPlan: Boolean)
 extends ProfileResult {
   override val outputHeaders =
-    Seq("appIndex", "sqlID", "version", "nodeId", "format", "buffer_time", "scan_time", "data_size",
-      "decode_time", "location", "pushedFilters", "schema", "data_filters", "partition_filters",
-      "from_final_plan")
+    Seq("appIndex", "sqlID", "sql_plan_version", "nodeId", "format", "buffer_time", "scan_time",
+      "data_size", "decode_time", "location", "pushedFilters", "schema", "data_filters",
+      "partition_filters", "from_final_plan")
 
   override def convertToSeq: Seq[String] = {
     Seq(appIndex.toString, sqlID.toString, version.toString, nodeId.toString, format,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -134,27 +134,28 @@ case class RapidsJarProfileResult(appIndex: Int, jar: String)  extends ProfileRe
   }
 }
 
-case class DataSourceProfileResult(appIndex: Int, sqlID: Long, nodeId: Long,
+case class DataSourceProfileResult(appIndex: Int, sqlID: Long, version: Int, nodeId: Long,
     format: String, buffer_time: Long, scan_time: Long, data_size: Long,
     decode_time: Long, location: String, pushedFilters: String, schema: String,
-    dataFilters: String, partitionFilters: String)
+    dataFilters: String, partitionFilters: String, fromFinalPlan: Boolean)
 extends ProfileResult {
   override val outputHeaders =
-    Seq("appIndex", "sqlID", "nodeId", "format", "buffer_time", "scan_time", "data_size",
-      "decode_time", "location", "pushedFilters", "schema", "data_filters", "partition_filters")
+    Seq("appIndex", "sqlID", "version", "nodeId", "format", "buffer_time", "scan_time", "data_size",
+      "decode_time", "location", "pushedFilters", "schema", "data_filters", "partition_filters",
+      "from_final_plan")
 
   override def convertToSeq: Seq[String] = {
-    Seq(appIndex.toString, sqlID.toString, nodeId.toString, format, buffer_time.toString,
-      scan_time.toString, data_size.toString, decode_time.toString,
-      location, pushedFilters, schema, dataFilters, partitionFilters)
+    Seq(appIndex.toString, sqlID.toString, version.toString, nodeId.toString, format,
+      buffer_time.toString, scan_time.toString, data_size.toString, decode_time.toString,
+      location, pushedFilters, schema, dataFilters, partitionFilters, fromFinalPlan.toString)
   }
   override def convertToCSVSeq: Seq[String] = {
-    Seq(appIndex.toString, sqlID.toString, nodeId.toString, StringUtils.reformatCSVString(format),
-      buffer_time.toString, scan_time.toString, data_size.toString, decode_time.toString,
-      StringUtils.reformatCSVString(location), StringUtils.reformatCSVString(pushedFilters),
-      StringUtils.reformatCSVString(schema),
-      StringUtils.reformatCSVString(dataFilters),
-      StringUtils.reformatCSVString(partitionFilters))
+    Seq(appIndex.toString, sqlID.toString, version.toString, nodeId.toString,
+      StringUtils.reformatCSVString(format), buffer_time.toString, scan_time.toString,
+      data_size.toString, decode_time.toString, StringUtils.reformatCSVString(location),
+      StringUtils.reformatCSVString(pushedFilters), StringUtils.reformatCSVString(schema),
+      StringUtils.reformatCSVString(dataFilters), StringUtils.reformatCSVString(partitionFilters),
+      fromFinalPlan.toString)
   }
 }
 
@@ -363,16 +364,6 @@ case class DriverAccumCase(
 
 case class UnsupportedSQLPlan(sqlID: Long, nodeID: Long, nodeName: String,
     nodeDesc: String, reason: String)
-
-case class DataSourceCase(
-    sqlID: Long,
-    nodeId: Long,
-    format: String,
-    location: String,
-    pushedFilters: String,
-    schema: String,
-    dataFilters: String,
-    partitionFilters: String)
 
 case class FailedTaskProfileResults(appIndex: Int, stageId: Int, stageAttemptId: Int,
     taskId: Long, taskAttemptId: Int, endReason: String) extends ProfileResult {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -20,13 +20,13 @@ import java.io.InputStream
 import java.util.zip.GZIPInputStream
 
 import scala.collection.immutable
-import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, LinkedHashSet, Map, SortedMap}
+import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, LinkedHashSet, Map}
 
 import com.nvidia.spark.rapids.SparkRapidsBuildInfoEvent
 import com.nvidia.spark.rapids.tool.{DatabricksEventLog, DatabricksRollingEventLogFilesFileReader, EventLogInfo}
 import com.nvidia.spark.rapids.tool.planparser.{HiveParseHelper, ReadParser}
 import com.nvidia.spark.rapids.tool.planparser.HiveParseHelper.isHiveTableScanNode
-import com.nvidia.spark.rapids.tool.profiling.{BlockManagerRemovedCase, DataSourceCase, DriverAccumCase, JobInfoClass, ResourceProfileInfoCase, SQLExecutionInfoClass, SQLPlanMetricsCase}
+import com.nvidia.spark.rapids.tool.profiling.{BlockManagerRemovedCase, DriverAccumCase, JobInfoClass, ResourceProfileInfoCase, SQLExecutionInfoClass, SQLPlanMetricsCase}
 import com.nvidia.spark.rapids.tool.qualification.AppSubscriber
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -36,7 +36,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.{SparkListenerEvent, StageInfo}
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
-import org.apache.spark.sql.rapids.tool.store.{AccumManager, StageModel, StageModelManager, TaskModelManager}
+import org.apache.spark.sql.rapids.tool.store.{AccumManager, DataSourceRecord, SQLPlanModelManager, StageModel, StageModelManager, TaskModelManager}
 import org.apache.spark.sql.rapids.tool.util.{EventUtils, RapidsToolsConfUtil, ToolsPlanGraph, UTF8Source}
 import org.apache.spark.util.Utils
 
@@ -63,11 +63,13 @@ abstract class AppBase(
   var blockManagersRemoved: ArrayBuffer[BlockManagerRemovedCase] =
     ArrayBuffer[BlockManagerRemovedCase]()
   // The data source information
-  val dataSourceInfo: ArrayBuffer[DataSourceCase] = ArrayBuffer[DataSourceCase]()
+  val dataSourceInfo: ArrayBuffer[DataSourceRecord] = ArrayBuffer[DataSourceRecord]()
 
   // jobId to job info
   val jobIdToInfo = new HashMap[Int, JobInfoClass]()
   val jobIdToSqlID: HashMap[Int, Long] = HashMap.empty[Int, Long]
+
+  lazy val sqlManager = new SQLPlanModelManager()
 
   // SQL containing any Dataset operation or RDD to DataSet/DataFrame operation
   val sqlIDToDataSetOrRDDCase: HashSet[Long] = HashSet[Long]()
@@ -78,9 +80,6 @@ abstract class AppBase(
   // sqlId to sql info
   val sqlIdToInfo = new HashMap[Long, SQLExecutionInfoClass]()
   val sqlIdToStages = new HashMap[Long, ArrayBuffer[Int]]()
-  // sqlPlans stores HashMap (sqlID <-> SparkPlanInfo)
-  // SortedMap is used to keep the order of the sqlPlans since AQEs can overrides the existing ones
-  var sqlPlans: Map[Long, SparkPlanInfo] = SortedMap[Long, SparkPlanInfo]()
   var sqlPlanMetricsAdaptive: ArrayBuffer[SQLPlanMetricsCase] = ArrayBuffer[SQLPlanMetricsCase]()
 
   // accum id to task stage accum info
@@ -96,6 +95,8 @@ abstract class AppBase(
 
   var sparkRapidsBuildInfo: SparkRapidsBuildInfoEvent = SparkRapidsBuildInfoEvent(immutable.Map(),
     immutable.Map(), immutable.Map(), immutable.Map())
+
+  def sqlPlans: immutable.Map[Long, SparkPlanInfo] = sqlManager.getPlanInfos
 
   // Returns the String value of the eventlog or empty if it is not defined. Note that the eventlog
   // won't be defined for running applications
@@ -225,7 +226,7 @@ abstract class AppBase(
     sqlIDToDataSetOrRDDCase.remove(sqlID)
     sqlIDtoProblematic.remove(sqlID)
     sqlIdToInfo.remove(sqlID)
-    sqlPlans.remove(sqlID)
+    sqlManager.remove(sqlID)
     val dsToRemove = dataSourceInfo.filter(_.sqlID == sqlID)
     dsToRemove.foreach(dataSourceInfo -= _)
 
@@ -336,11 +337,11 @@ abstract class AppBase(
 
   // The ReadSchema metadata is only in the eventlog for DataSource V1 readers
   def checkMetadataForReadSchema(
-      sqlPlanInfoGraph: SqlPlanInfoGraphEntry): ArrayBuffer[DataSourceCase] = {
+      sqlPlanInfoGraph: SqlPlanInfoGraphEntry): ArrayBuffer[DataSourceRecord] = {
     // check if planInfo has ReadSchema
     val allMetaWithSchema = AppBase.getPlanMetaWithSchema(sqlPlanInfoGraph.planInfo)
     val allNodes = sqlPlanInfoGraph.sparkPlanGraph.allNodes
-    val results = ArrayBuffer[DataSourceCase]()
+    val results = ArrayBuffer[DataSourceRecord]()
 
     allMetaWithSchema.foreach { plan =>
       val meta = plan.metadata
@@ -355,8 +356,9 @@ abstract class AppBase(
       // add it to the dataSourceInfo
       // Processing Photon eventlogs issue: https://github.com/NVIDIA/spark-rapids-tools/issues/251
       if (scanNode.nonEmpty) {
-        results += DataSourceCase(
+        results += DataSourceRecord(
           sqlPlanInfoGraph.sqlID,
+          sqlManager.getPlanById(sqlPlanInfoGraph.sqlID).get.plan.version,
           scanNode.head.id,
           ReadParser.extractTagFromV1ReadMeta("Format", meta),
           ReadParser.extractTagFromV1ReadMeta("Location", meta),
@@ -375,8 +377,9 @@ abstract class AppBase(
         val sqlGraph = ToolsPlanGraph(hiveReadPlan)
         val hiveScanNode = sqlGraph.allNodes.head
         val scanHiveMeta = HiveParseHelper.parseReadNode(hiveScanNode)
-        results += DataSourceCase(
+        results += DataSourceRecord(
           sqlPlanInfoGraph.sqlID,
+          sqlManager.getPlanById(sqlPlanInfoGraph.sqlID).get.plan.version,
           hiveScanNode.id,
           scanHiveMeta.format,
           scanHiveMeta.location,
@@ -394,11 +397,12 @@ abstract class AppBase(
   // This will find scans for DataSource V2, if the schema is very large it
   // will likely be incomplete and have ... at the end.
   def checkGraphNodeForReads(
-      sqlID: Long, node: SparkPlanGraphNode): Option[DataSourceCase] = {
+      sqlID: Long, node: SparkPlanGraphNode): Option[DataSourceRecord] = {
     if (ReadParser.isDataSourceV2Node(node)) {
       val res = ReadParser.parseReadNode(node)
-      val dsCase = DataSourceCase(
+      val dsCase = DataSourceRecord(
         sqlID,
+        sqlManager.getPlanById(sqlID).get.plan.version,
         node.id,
         res.format,
         res.location,
@@ -547,7 +551,7 @@ object AppBase {
     (complexTypes.filter(_.nonEmpty), nestedComplexTypes.filter(_.nonEmpty))
   }
 
-  private def trimSchema(str: String): String = {
+  def trimSchema(str: String): String = {
     val index = str.lastIndexOf(",")
     if (index != -1 && str.contains("...")) {
       str.substring(0, index)

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
@@ -152,7 +152,8 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
       hasDatasetOrRDD = false
     )
     app.sqlIdToInfo.put(event.executionId, sqlExecution)
-    app.sqlPlans += (event.executionId -> event.sparkPlanInfo)
+    app.sqlManager.addNewExecution(event.executionId, event.sparkPlanInfo,
+      event.physicalPlanDescription)
   }
 
   def doSparkListenerSQLExecutionEnd(
@@ -183,7 +184,8 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
       app: T,
       event: SparkListenerSQLAdaptiveExecutionUpdate): Unit = {
     // AQE plan can override the ones got from SparkListenerSQLExecutionStart
-    app.sqlPlans += (event.executionId -> event.sparkPlanInfo)
+    app.sqlManager.addAQE(event.executionId, event.sparkPlanInfo,
+      event.physicalPlanDescription)
   }
 
   def doSparkListenerSQLAdaptiveSQLMetricUpdates(

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.tool.profiling
 
-import scala.collection.{mutable, Map}
+import scala.collection.Map
 
 import com.nvidia.spark.rapids.tool.EventLogInfo
 import com.nvidia.spark.rapids.tool.analysis.AppSQLPlanAnalyzer
@@ -186,9 +186,6 @@ class ApplicationInfo(
     eLogInfo: EventLogInfo,
     val index: Int)
   extends AppBase(Some(eLogInfo), Some(hadoopConf)) with Logging {
-
-  // physicalPlanDescription stores HashMap (sqlID <-> physicalPlanDescription)
-  var physicalPlanDescription: mutable.HashMap[Long, String] = mutable.HashMap.empty[Long, String]
 
   private lazy val eventProcessor =  new EventsProcessor(this)
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
@@ -22,7 +22,6 @@ import com.nvidia.spark.rapids.tool.profiling._
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler._
-import org.apache.spark.sql.execution.ui.{SparkListenerSQLAdaptiveExecutionUpdate, SparkListenerSQLExecutionStart}
 import org.apache.spark.sql.rapids.tool.EventProcessorBase
 import org.apache.spark.sql.rapids.tool.util.StringUtils
 
@@ -88,26 +87,10 @@ class EventsProcessor(app: ApplicationInfo) extends EventProcessorBase[Applicati
     logDebug(s"App's GPU Mode = ${app.gpuMode}")
   }
 
-  override def doSparkListenerSQLExecutionStart(
-      app: ApplicationInfo,
-      event: SparkListenerSQLExecutionStart): Unit = {
-    super.doSparkListenerSQLExecutionStart(app, event)
-    app.physicalPlanDescription += (event.executionId -> event.physicalPlanDescription)
-  }
-
   override def doSparkListenerTaskGettingResult(
       app: ApplicationInfo,
       event: SparkListenerTaskGettingResult): Unit = {
     logDebug("Processing event: " + event.getClass)
-  }
-
-  override def doSparkListenerSQLAdaptiveExecutionUpdate(
-      app: ApplicationInfo,
-      event: SparkListenerSQLAdaptiveExecutionUpdate): Unit = {
-    logDebug("Processing event: " + event.getClass)
-    // AQE plan can override the ones got from SparkListenerSQLExecutionStart
-    app.physicalPlanDescription += (event.executionId -> event.physicalPlanDescription)
-    super.doSparkListenerSQLAdaptiveExecutionUpdate(app, event)
   }
 
   // To process all other unknown events

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/DataSourceRecord.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/DataSourceRecord.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool.store
+
+abstract class DataSourceRecord {
+  def sqlID: Long
+  def version: Int
+  def nodeId: Long
+  def format: String
+  def location: String
+  def pushedFilters: String
+  def schema: String
+  def dataFilters: String
+  def partitionFilters: String
+  def isFromFinalPlan: Boolean
+  def comments: String
+}
+
+case class NonFinalDataSourceCase(
+    sqlID: Long,
+    version: Int,
+    nodeId: Long,
+    format: String,
+    location: String,
+    pushedFilters: String,
+    schema: String,
+    dataFilters: String,
+    partitionFilters: String) extends DataSourceRecord {
+
+  override def isFromFinalPlan: Boolean = false
+  override def comments: String =  DataSourceRecord.COMMENT_NON_FINAL_PLAN
+}
+
+case class FinalDataSourceCase(
+    sqlID: Long,
+    version: Int,
+    nodeId: Long,
+    format: String,
+    location: String,
+    pushedFilters: String,
+    schema: String,
+    dataFilters: String,
+    partitionFilters: String) extends DataSourceRecord {
+
+  override def isFromFinalPlan: Boolean = true
+  override def comments: String =  DataSourceRecord.COMMENT_FINAL_PLAN
+}
+
+object DataSourceRecord {
+  val COMMENT_NON_FINAL_PLAN="isFinalPlan=false"
+  val COMMENT_FINAL_PLAN="isFinalPlan=true"
+
+  def apply(
+      sqlID: Long,
+      version: Int,
+      nodeId: Long,
+      format: String,
+      location: String,
+      pushedFilters: String,
+      schema: String,
+      dataFilters: String,
+      partitionFilters: String,
+      fromFinalPlan: Boolean = true): DataSourceRecord = {
+    fromFinalPlan match {
+      case true => FinalDataSourceCase(
+        sqlID,
+        version,
+        nodeId,
+        format,
+        location,
+        pushedFilters,
+        schema,
+        dataFilters,
+        partitionFilters)
+      case _ => NonFinalDataSourceCase(
+        sqlID,
+        version,
+        nodeId,
+        format,
+        location,
+        pushedFilters,
+        schema,
+        dataFilters,
+        partitionFilters)
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModel.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.execution.SparkPlanInfo
  * A new instance of this class is created while handling SparkListenerSQLExecutionStart event.
  * Note that keeping track of all SQLPlanInfo versions could result in a large memory overhead.
  * See SQLPlanModelWithDSCaching for a more memory efficient version that only captures the
- * DSV1Reads of a planInfo.
+ * DataSourceRecords of a planInfo.
  * Therefore, it is recommended to:
  * 1- Use this class iff you need to keep track of all information inside all versions of a SQLPlan.
  * 2- Do some memory optimizations to reduce the overhead of storing all versions.
@@ -101,16 +101,15 @@ class SQLPlanModel(val id: Long) {
    * @return Iterable of DataSourceRecord
    */
   def getDataSources: Iterable[DataSourceRecord] = {
-    plan.getReadDSV1
+    plan.getAllReadDS
   }
 
   /**
    * Get all the DataSources from the original plans (excludes the most recent version).
-   * Currently, it only gets the DSV1Reads.
    * @return Iterable of DataSourceRecord
    */
   def getDataSourcesFromOrigAQEPlans: Iterable[DataSourceRecord] = {
     // TODO: Consider iterating on the node to add DSV2 as well.
-    planVersions.dropRight(1).flatMap(_.getReadDSV1)
+    planVersions.dropRight(1).flatMap(_.getAllReadDS)
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModel.scala
@@ -20,43 +20,97 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.execution.SparkPlanInfo
 
+/**
+ * SQLPlanModel is a class to store the information of a SQL Plan including all its versions.
+ * A new instance of this class is created while handling SparkListenerSQLExecutionStart event.
+ * Note that keeping track of all SQLPlanInfo versions could result in a large memory overhead.
+ * See SQLPlanModelWithDSCaching for a more memory efficient version that only captures the
+ * DSV1Reads of a planInfo.
+ * Therefore, it is recommended to:
+ * 1- Use this class iff you need to keep track of all information inside all versions of a SQLPlan.
+ * 2- Do some memory optimizations to reduce the overhead of storing all versions.
+ * @param id SqlId
+ */
 class SQLPlanModel(val id: Long) {
+  // TODO: common information related to the SQLPlan should be added as fields in this class.
+  //       For example, the information tracked in
+  //       AppBase.sqlIdToInfo Map[sqlId, SQLExecutionInfoClass] should belong here.
+  // List of all the versions of a SQL Plan. For each AQE event, the new version is added to this
+  // list.
   private val planVersions: ArrayBuffer[SQLPlanVersion] = new ArrayBuffer[SQLPlanVersion]()
+  // A shortcut to the most recent version added to the list.
   // This is not defined as option() because it should not happen that a SQLPlanModel is defined
   // without adding a plan. This is to cache the value of planVersions.last
   var plan: SQLPlanVersion = _
+  // Number of versions defined for this SQL Plan (i.e., 1 + [count of AQE update events])
   var versionsCount: Int = 0
 
+  /**
+   * A shortcut to the planInfo to abstract the insternal details of the SQLPlanVersion.
+   * @return SparkPlanInfo of the latest version of the plan.
+   */
   def planInfo = plan.planInfo
+
+  /**
+   * A shortcut to the physicalPlanDescription to abstract the insternal details of the
+   * SQLPlanVersion.
+   * @return physicalPlanDesc of the latest version of the plan.
+   */
   def physicalPlanDesc = plan.physicalPlanDescription
+
+  /**
+   * Public method to add a new version of the plan.
+   * @param planInfo SparkPlanInfo for the new version of the plan.
+   * @param physicalPlanDescription String representation of the physical plan for the new version.
+   */
+  def addPlan(planInfo: SparkPlanInfo, physicalPlanDescription: String): Unit = {
+    // By default, a new planVersion is defined as final.
+    val planVersion = new SQLPlanVersion(id, versionsCount, planInfo, physicalPlanDescription)
+    // Update references and shortcuts to the latest plan and cache previous one if any
+    updateVersions(planVersion)
+  }
 
   protected def updatePlanField(newPlan: SQLPlanVersion): Unit = {
     planVersions += newPlan
     plan = newPlan
   }
 
+  // After adding a new version, reset the previous plan if necessary
   protected def resetPreviousPlan(): Unit = {
     plan.resetFinalFlag()
   }
 
+  /**
+   * Update the planVersions list and the plan shortcut to the latest version. It caches the
+   * previous information if any.
+   * @param newPlan the latest version of the plan.
+   */
   private def updateVersions(newPlan: SQLPlanVersion): Unit = {
+    // increment the versionsCount
     versionsCount += 1
     if (versionsCount > 1) {
+      // reset the flag of the previous Version
       resetPreviousPlan()
     }
+    // Update the shortcuts to the latest version
     updatePlanField(newPlan)
   }
 
-  def addPlan(planInfo: SparkPlanInfo, physicalPlanDescription: String): Unit = {
-    val planVersion = new SQLPlanVersion(id, versionsCount, planInfo, physicalPlanDescription)
-    updateVersions(planVersion)
-  }
-
+  /**
+   * Get the DataSources from the most recent version of the plan.
+   * @return Iterable of DataSourceRecord
+   */
   def getDataSources: Iterable[DataSourceRecord] = {
-    plan.getDataSources
+    plan.getReadDSV1
   }
 
+  /**
+   * Get all the DataSources from the original plans (excludes the most recent version).
+   * Currently, it only gets the DSV1Reads.
+   * @return Iterable of DataSourceRecord
+   */
   def getDataSourcesFromOrigAQEPlans: Iterable[DataSourceRecord] = {
-    planVersions.dropRight(1).flatMap(_.getDataSources)
+    // TODO: Consider iterating on the node to add DSV2 as well.
+    planVersions.dropRight(1).flatMap(_.getReadDSV1)
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModel.scala
@@ -46,13 +46,13 @@ class SQLPlanModel(val id: Long) {
   var versionsCount: Int = 0
 
   /**
-   * A shortcut to the planInfo to abstract the insternal details of the SQLPlanVersion.
+   * A shortcut to the planInfo to abstract the internal details of the SQLPlanVersion.
    * @return SparkPlanInfo of the latest version of the plan.
    */
   def planInfo = plan.planInfo
 
   /**
-   * A shortcut to the physicalPlanDescription to abstract the insternal details of the
+   * A shortcut to the physicalPlanDescription to abstract the internal details of the
    * SQLPlanVersion.
    * @return physicalPlanDesc of the latest version of the plan.
    */

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModel.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool.store
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.execution.SparkPlanInfo
+
+class SQLPlanModel(val id: Long) {
+  val planVersions: ArrayBuffer[SQLPlanVersion] = new ArrayBuffer[SQLPlanVersion]()
+  // This is not defined as option() because it should not happen that a SQLPlanModel is defined
+  // without adding a plan. This is to cache the value of planVersions.last
+  var plan: SQLPlanVersion = _
+
+  def planInfo = plan.planInfo
+  def physicalPlanDesc = plan.physicalPlanDescription
+
+  private def updateCurrentPlan(newPlan: SQLPlanVersion): Unit = {
+    planVersions += newPlan
+    if (planVersions.size > 1) {
+      plan.resetFinalFlag()
+    }
+    plan = planVersions.last
+  }
+
+  def addPlan(planInfo: SparkPlanInfo, physicalPlanDescription: String): Unit = {
+    val planVersion = new SQLPlanVersion(id, planVersions.size, planInfo, physicalPlanDescription)
+    updateCurrentPlan(planVersion)
+  }
+
+  def getDataSources: Iterable[DataSourceRecord] = {
+    plan.getDataSources
+  }
+
+  def getDataSourcesFromOriAQEPlans: Iterable[DataSourceRecord] = {
+    planVersions.dropRight(1).flatMap(_.getDataSources)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManager.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManager.scala
@@ -40,7 +40,7 @@ class SQLPlanModelManager {
   }
 
   def addNewExecution(id: Long, planInfo: SparkPlanInfo, physicalDescription: String): Unit = {
-    val planModel = sqlPlans.getOrElseUpdate(id, new SQLPlanModel(id))
+    val planModel = sqlPlans.getOrElseUpdate(id, new SQLPlanModelWithDSCaching(id))
     planModel.addPlan(planInfo, physicalDescription)
   }
 
@@ -55,7 +55,7 @@ class SQLPlanModelManager {
   }
 
   def getPhysicalPlans: immutable.Map[Long, String] = {
-    immutable.SortedMap[Long, String]() ++ sqlPlans.mapValues(_.plan.physicalPlanDescription)
+    immutable.SortedMap[Long, String]() ++ sqlPlans.mapValues(_.physicalPlanDesc)
   }
 
   def remove(id: Long): Option[SQLPlanModel] = {
@@ -63,7 +63,7 @@ class SQLPlanModelManager {
   }
 
   def getDataSourcesFromOrigPlans: Iterable[DataSourceRecord] = {
-    sqlPlans.values.flatMap(_.getDataSourcesFromOriAQEPlans)
+    sqlPlans.values.flatMap(_.getDataSourcesFromOrigAQEPlans)
   }
 
   def getPlanInfos: immutable.Map[Long, SparkPlanInfo] = {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManager.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManager.scala
@@ -21,39 +21,86 @@ import scala.collection.mutable
 
 import org.apache.spark.sql.execution.SparkPlanInfo
 
+/**
+ * Container class to store the information about SqlPlans.
+ */
 class SQLPlanModelManager {
   // SortedMap is used to keep the order of the sqlPlans by Id
   val sqlPlans: mutable.SortedMap[Long, SQLPlanModel] = mutable.SortedMap[Long, SQLPlanModel]()
 
+  /**
+   * Get the SparkPlanInfo for the given executionId. This is the last plan version added to that
+   * SQLPlan.
+   * @param id executionId of the SqlPlan
+   * @return SparkPlanInfo if exists
+   */
   def getPlanInfoById(id: Long): Option[SparkPlanInfo] = {
     // returns the last plan added to that executionId if exists
     getPlanById(id).map(_.planInfo)
   }
 
+  /**
+   * Get the SQLPlanModel for the given executionId.
+   * @param id executionId of the SqlPlan
+   * @return SQLPlanModel if exists
+   */
   def getPlanById(id: Long): Option[SQLPlanModel] = {
     // returns the last plan added to that executionId if exists
     sqlPlans.get(id)
   }
 
+  /**
+   * Get the physical plan description for the given executionId. This is the last plan version.
+   * @param id executionId of the SqlPlan
+   * @return physical plan description if exists
+   */
   def getPhysicalPlanById(id: Long): Option[String] = {
     getPlanById(id).map(_.physicalPlanDesc)
   }
 
+  /**
+   * Add a new execution to the SQLPlanModelManager. This is called when a
+   * SparkListenerSQLExecutionStart is triggered.
+   * @param id executionId of the SqlPlan
+   * @param planInfo SparkPlanInfo for the new version of the plan.
+   * @param physicalDescription String representation of the physical plan for the new version.
+   */
   def addNewExecution(id: Long, planInfo: SparkPlanInfo, physicalDescription: String): Unit = {
+    //TODO: in future we should pass more arguments to this method to capture the common information
+    //      of an SqlPlan (i.e., startTime,..etc))
     val planModel = sqlPlans.getOrElseUpdate(id, new SQLPlanModelWithDSCaching(id))
     planModel.addPlan(planInfo, physicalDescription)
   }
 
+  /**
+   * Handles the AQE event by adding a new version of the plan to the SQLPlanModelManager and update
+   * the references to the last version.
+   * @param id executionId of the SqlPlan
+   * @param planInfo SparkPlanInfo for the new version of the plan.
+   * @param physicalDescription String representation of the physical plan for the new version.
+   */
   def addAQE(id: Long, planInfo: SparkPlanInfo, physicalDescription: String): Unit = {
     // TODO: we can verify that the id already exists, but we ignore that verification now as it is
     //  undefined how we should handle an AQE without the original plan.
     addNewExecution(id, planInfo, physicalDescription)
   }
 
+  /**
+   * Apply a function to the SparkPlanInfo of the given executionId if it exists.
+   * @param id executionId of the SqlPlan
+   * @param f function to be applied
+   * @tparam A Type of the result of the function
+   * @return Some(result) if the plan exists, None otherwise
+   */
   def applyToPlanInfo[A](id: Long)(f: SparkPlanInfo => A): Option[A] = {
     getPlanInfoById(id).map(f)
   }
 
+  /**
+   * Shortcuts to make the new implementation compatible with previous code that was expecting a
+   * Map[Long, String]
+   * @return map between executionId and the physical description of the last version.
+   */
   def getPhysicalPlans: immutable.Map[Long, String] = {
     immutable.SortedMap[Long, String]() ++ sqlPlans.mapValues(_.physicalPlanDesc)
   }
@@ -62,10 +109,20 @@ class SQLPlanModelManager {
     sqlPlans.remove(id)
   }
 
+  /**
+   * When AQE is enabled, this methods is used to get the DataSources that are read by old versions
+   * of the SQLPlan if any
+   * @return Iterable of DataSourceRecord representing previous versions of the SQLPlan
+   */
   def getDataSourcesFromOrigPlans: Iterable[DataSourceRecord] = {
     sqlPlans.values.flatMap(_.getDataSourcesFromOrigAQEPlans)
   }
 
+  /**
+   * Shortcut to make the new implementation compatible with previous code that was expecting a
+   * Map[Long, SparkPlanInfo]
+   * @return map between executionId and the SparkPlanVersion of the last version.
+   */
   def getPlanInfos: immutable.Map[Long, SparkPlanInfo] = {
     immutable.SortedMap[Long, SparkPlanInfo]() ++ sqlPlans.mapValues(_.planInfo)
   }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManager.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManager.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool.store
+
+import scala.collection.immutable
+import scala.collection.mutable
+
+import org.apache.spark.sql.execution.SparkPlanInfo
+
+class SQLPlanModelManager {
+  // SortedMap is used to keep the order of the sqlPlans by Id
+  val sqlPlans: mutable.SortedMap[Long, SQLPlanModel] = mutable.SortedMap[Long, SQLPlanModel]()
+
+  def getPlanInfoById(id: Long): Option[SparkPlanInfo] = {
+    // returns the last plan added to that executionId if exists
+    getPlanById(id).map(_.planInfo)
+  }
+
+  def getPlanById(id: Long): Option[SQLPlanModel] = {
+    // returns the last plan added to that executionId if exists
+    sqlPlans.get(id)
+  }
+
+  def getPhysicalPlanById(id: Long): Option[String] = {
+    getPlanById(id).map(_.physicalPlanDesc)
+  }
+
+  def addNewExecution(id: Long, planInfo: SparkPlanInfo, physicalDescription: String): Unit = {
+    val planModel = sqlPlans.getOrElseUpdate(id, new SQLPlanModel(id))
+    planModel.addPlan(planInfo, physicalDescription)
+  }
+
+  def addAQE(id: Long, planInfo: SparkPlanInfo, physicalDescription: String): Unit = {
+    // TODO: we can verify that the id already exists, but we ignore that verification now as it is
+    //  undefined how we should handle an AQE without the original plan.
+    addNewExecution(id, planInfo, physicalDescription)
+  }
+
+  def applyToPlanInfo[A](id: Long)(f: SparkPlanInfo => A): Option[A] = {
+    getPlanInfoById(id).map(f)
+  }
+
+  def getPhysicalPlans: immutable.Map[Long, String] = {
+    immutable.SortedMap[Long, String]() ++ sqlPlans.mapValues(_.plan.physicalPlanDescription)
+  }
+
+  def remove(id: Long): Option[SQLPlanModel] = {
+    sqlPlans.remove(id)
+  }
+
+  def getDataSourcesFromOrigPlans: Iterable[DataSourceRecord] = {
+    sqlPlans.values.flatMap(_.getDataSourcesFromOriAQEPlans)
+  }
+
+  def getPlanInfos: immutable.Map[Long, SparkPlanInfo] = {
+    immutable.SortedMap[Long, SparkPlanInfo]() ++ sqlPlans.mapValues(_.planInfo)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelWithDSCaching.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelWithDSCaching.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool.store
+
+import scala.collection.mutable.ArrayBuffer
+
+class SQLPlanModelWithDSCaching(sqlId: Long) extends SQLPlanModel(sqlId) {
+  private val cachedDataSources: ArrayBuffer[DataSourceRecord] = new ArrayBuffer[DataSourceRecord]()
+
+  override def updatePlanField(newPlan: SQLPlanVersion): Unit = {
+    plan = newPlan
+  }
+
+  override def resetPreviousPlan(): Unit = {
+    plan.resetFinalFlag()
+    // cache the datasource records from previous plan if any
+    cachedDataSources ++= plan.getDataSources
+  }
+  override def getDataSourcesFromOrigAQEPlans: Iterable[DataSourceRecord] = {
+    cachedDataSources
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelWithDSCaching.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelWithDSCaching.scala
@@ -34,14 +34,12 @@ class SQLPlanModelWithDSCaching(sqlId: Long) extends SQLPlanModel(sqlId) {
   override def resetPreviousPlan(): Unit = {
     // reset the final flag to initialize the dataSources correctly
     plan.resetFinalFlag()
-    // cache the datasourceV1 records from previous plan if any
-    // TODO: Consider iterating on the node to add DSV2 as well.
-    cachedDataSources ++= plan.getReadDSV1
+    // cache the datasource records from previous plan if any
+    cachedDataSources ++= plan.getAllReadDS
   }
 
   /**
    * Get all the DataSources from the original plans (excludes the most recent version).
-   * Currently, it only gets the DSV1Reads.
    * @return Iterable of DataSourceRecord
    */
   override def getDataSourcesFromOrigAQEPlans: Iterable[DataSourceRecord] = {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanVersion.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanVersion.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool.store
+
+import com.nvidia.spark.rapids.tool.planparser.ReadParser
+
+import org.apache.spark.sql.execution.SparkPlanInfo
+import org.apache.spark.sql.rapids.tool.AppBase
+import org.apache.spark.sql.rapids.tool.util.ToolsPlanGraph
+
+
+class SQLPlanVersion(
+    val sqlId: Long,
+    val version: Int,
+    val planInfo: SparkPlanInfo,
+    val physicalPlanDescription: String,
+    var isFinal: Boolean = true) {
+
+  def resetFinalFlag(): Unit = {
+    isFinal = false
+  }
+  def getPlansWithSchema: Seq[SparkPlanInfo] = {
+    SQLPlanVersion.getPlansWithSchemaRecursive(planInfo)
+  }
+  // (ReadSchema):\s(.*?)(\.\.\.|,\s|$)
+  def getDataSources: Iterable[DataSourceRecord] = {
+    val planGraph = ToolsPlanGraph(planInfo)
+    getPlansWithSchema.flatMap { plan =>
+      val meta = plan.metadata
+      val readSchema =
+        ReadParser.formatSchemaStr(meta.getOrElse(ReadParser.METAFIELD_TAG_READ_SCHEMA, ""))
+      val scanNodes = planGraph.allNodes.filter(ReadParser.isScanNode).filter(node => {
+        // Get ReadSchema of each Node and sanitize it for comparison
+        val trimmedNode = AppBase.trimSchema(ReadParser.parseReadNode(node).schema)
+        readSchema.contains(trimmedNode)
+      })
+      if (scanNodes.nonEmpty) {
+        Some(DataSourceRecord(
+          sqlId,
+          version,
+          scanNodes.head.id,
+          ReadParser.extractTagFromV1ReadMeta(ReadParser.METAFIELD_TAG_FORMAT, meta),
+          ReadParser.extractTagFromV1ReadMeta(ReadParser.METAFIELD_TAG_LOCATION, meta),
+          ReadParser.extractTagFromV1ReadMeta(ReadParser.METAFIELD_TAG_PUSHED_FILTERS, meta),
+          readSchema,
+          ReadParser.extractTagFromV1ReadMeta(ReadParser.METAFIELD_TAG_DATA_FILTERS, meta),
+          ReadParser.extractTagFromV1ReadMeta(ReadParser.METAFIELD_TAG_PARTITION_FILTERS, meta),
+          fromFinalPlan=isFinal))
+      } else {
+        None
+      }
+    }
+  }
+}
+
+object SQLPlanVersion {
+  private def getPlansWithSchemaRecursive(planInfo: SparkPlanInfo): Seq[SparkPlanInfo] = {
+    val childRes = planInfo.children.flatMap(getPlansWithSchemaRecursive)
+    if (planInfo.metadata != null &&
+      planInfo.metadata.contains(ReadParser.METAFIELD_TAG_READ_SCHEMA)) {
+      childRes :+ planInfo
+    } else {
+      childRes
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanVersion.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanVersion.scala
@@ -23,6 +23,19 @@ import org.apache.spark.sql.rapids.tool.AppBase
 import org.apache.spark.sql.rapids.tool.util.ToolsPlanGraph
 
 
+/**
+ * Represents a version of the SQLPlan holding the specific information related to that SQL plan.
+ * In an AQE event, Spark sends the new update with the updated SparkPlanInfo and
+ * PhysicalPlanDescription.
+ * @param sqlId sql plan ID. This is redundant because the SQLPlan Model has the same information.
+ *              However, storing it here makes the code easier as we don't have to build
+ *              (sqlId, SQLPLanVersion) tuples.
+ * @param version the version number of this plan. It starts at 0 and increments by 1 for each
+ *                SparkListenerSQLAdaptiveExecutionUpdate.
+ * @param planInfo The instance of SparkPlanInfo for this version of the plan.
+ * @param physicalPlanDescription The string representation of the physical plan for this version.
+ * @param isFinal Flag to indicate if this plan is the final plan for the SQLPlan
+ */
 class SQLPlanVersion(
     val sqlId: Long,
     val version: Int,
@@ -31,16 +44,32 @@ class SQLPlanVersion(
     var isFinal: Boolean = true) {
 
   def resetFinalFlag(): Unit = {
+    // This flag depends on the AQE events sequence.
+    // It does not set that field using the substring of the physicalPlanDescription
+    // (isFinalPlan=true).
+    // The consequences of this is that for incomplete eventlogs, the last PlanInfo to be precessed
+    // is considered final.
     isFinal = false
   }
+
+  /**
+   * Starting with the SparkPlanInfo for this version, recursively get all the SparkPlanInfo within
+   * the children that define a ReadSchema.
+   * @return Sequence of SparkPlanInfo that have a ReadSchema attached to it.
+   */
   def getPlansWithSchema: Seq[SparkPlanInfo] = {
     SQLPlanVersion.getPlansWithSchemaRecursive(planInfo)
   }
-  // (ReadSchema):\s(.*?)(\.\.\.|,\s|$)
-  def getDataSources: Iterable[DataSourceRecord] = {
+
+  /**
+   * This is used to extract the metadata of ReadV1 nodes in Spark Plan Info
+   * @return all the read datasources V1 recursively that are read by this plan including.
+   */
+  def getReadDSV1: Iterable[DataSourceRecord] = {
     val planGraph = ToolsPlanGraph(planInfo)
     getPlansWithSchema.flatMap { plan =>
       val meta = plan.metadata
+      // TODO: Improve the extraction of ReaSchema using RegEx (ReadSchema):\s(.*?)(\.\.\.|,\s|$)
       val readSchema =
         ReadParser.formatSchemaStr(meta.getOrElse(ReadParser.METAFIELD_TAG_READ_SCHEMA, ""))
       val scanNodes = planGraph.allNodes.filter(ReadParser.isScanNode).filter(node => {
@@ -68,6 +97,12 @@ class SQLPlanVersion(
 }
 
 object SQLPlanVersion {
+  /**
+   * Recursive call to get all the SparkPlanInfo that have a schema attached to it.
+   * This is mainly used for V1 ReadSchema
+   * @param planInfo The SparkPlanInfo to start the search from
+   * @return A list of SparkPlanInfo that have a schema attached to it.
+   */
   private def getPlansWithSchemaRecursive(planInfo: SparkPlanInfo): Seq[SparkPlanInfo] = {
     val childRes = planInfo.children.flatMap(getPlansWithSchemaRecursive)
     if (planInfo.metadata != null &&


### PR DESCRIPTION
Contributes to #1172, Fixes #1351

This issue is to change the tools structure to support multiple version of SqlPlan.
Before that PR, if AQE is enabled, only the last plan is kept in the AppBase.SqlPlans map.

For sake of memory optimization, this PR adds the full implementation that supports capturing multiple versions but only caches the DSInformation extracted from old plans.
This allows the tools to generate the metadata of ReadV1 from original plans in case the metadata has been truncated in the finalPlan.

**Change in output**

- New columns added to `data_source_information.csv`
  - `sql_plan_version`: an integer that represents the version number of the SqlPlaninfo where this row comes from.
  - `from_final_plan` : Boolean True/False to indicate whether this row comes from final plan or not.
- Impact on API:
  - If users are interested in looking into all the information (ReadV1 and ReadV2) across all the versions 
  - If users only want the datasource from finalPlan, then they should filter the rows using "from_final_plan=true"

Sample output file after the change:

[data_source_information_after_change.csv](https://github.com/user-attachments/files/17080146/data_source_information_after_change.csv)


- In this file the versions [1-5] are skipped because they have no V1 metadata
- The last 4 rows represent the final plan
- The first 4 rows show the detailed datasource from the original plan.

Headers of the new file:

```
appIndex,sqlID,sql_plan_version,nodeId,format,buffer_time,scan_time,data_size,decode_time,location,pushedFilters,schema,data_filters,partition_filters,from_final_plan
```

**Code Changes:**

- Get rid of the `AppBase.sqlPlans`, replacing it with `SqlManager` class
-  Each Sql is represented by `SqlPlanModel` that keeps track of properties related to SQLplan and the versions.
- The entity that contains the SparkPlanInfo is SqlPlanVersion.  
- For sake of memory optimization, a derived class `SQLPlanModelWithDSCaching` from `SqlPlanModel` will not keep track of all previous PlanInfo. Instead, it only caches the DataSourceRecord if any.

**Future Work:**

- When we are confident on how to map the metadata between originalPlans and finalPlan, then we can eventually replace the truncated data with the new one.
-  Do some cleanup to get rid of all the maps inside AppBase and move the fields into the new class `SQLPlanModel`
- Some cleanups related to extracting information of the readSchema and readParser.
- File an issue on Spark open source to avoid truncating this information with AQE.