### PR TITLE
Fix python tool picking up wrong JAR version in Fat wheel mode

### DIFF
--- a/user_tools/build.sh
+++ b/user_tools/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -105,7 +105,7 @@ build "$build_mode"
 
 # Check build status
 if [ $? -eq 0 ]; then
-  echo "Build successful. To install, use: pip install <wheel-file>"
+  echo "Build successful. To install, use: pip install dist/<wheel-file>"
 else
   echo "Build failed."
   exit 1

--- a/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
@@ -135,7 +135,7 @@ class ToolContext(YAMLPropertiesContainer):
         self.logger.info('Dependencies are generated locally in local disk as: %s', dep_folder)
         self.logger.info('Local output folder is set as: %s', exec_root_dir)
 
-    def identify_fat_wheel_jar(self, resource_files: List[str]) -> None:
+    def _identify_fat_wheel_jar(self, resource_files: List[str]) -> None:
         """
         Identifies the tools JAR file from resource files in fat wheel mode and sets its name in the context.
         :param resource_files: List of resource files to search for the tools JAR file.
@@ -166,12 +166,12 @@ class ToolContext(YAMLPropertiesContainer):
                 if os.path.isdir(res_path):
                     # this is a directory, copy all the contents to the tmp
                     FSUtil.copy_resource(res_path, self.get_cache_folder())
-                    self.identify_fat_wheel_jar(FSUtil.get_all_files(res_path))
+                    self._identify_fat_wheel_jar(FSUtil.get_all_files(res_path))
                 else:
                     # this is an archived file
                     with tarfile.open(res_path, mode='r:*') as tar_file:
                         tar_file.extractall(self.get_cache_folder())
-                        self.identify_fat_wheel_jar(tar_file.getnames())
+                        self._identify_fat_wheel_jar(tar_file.getnames())
                         tar_file.close()
 
     def get_output_folder(self) -> str:

--- a/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
@@ -86,7 +86,7 @@ class ToolContext(YAMLPropertiesContainer):
     def get_deploy_mode(self) -> Any:
         return self.platform_opts.get('deployMode')
 
-    def is_fatwheel_mode(self) -> bool:
+    def is_fat_wheel_mode(self) -> bool:
         return self.get_ctxt('fatWheelModeEnabled')
 
     def set_ctxt(self, key: str, val: Any):
@@ -189,7 +189,7 @@ class ToolContext(YAMLPropertiesContainer):
         self.logger.info('Fetching the Rapids Jar URL')
         # get the version from the package, instead of the yaml file
         # jar_version = self.get_value('sparkRapids', 'version')
-        if self.is_fatwheel_mode():
+        if self.is_fat_wheel_mode():
             return self._get_tools_jar_in_fat_wheel_mode()
         mvn_base_url = self.get_value('sparkRapids', 'mvnUrl')
         jar_version = Utilities.get_latest_mvn_jar_from_metadata(mvn_base_url)

--- a/user_tools/src/spark_rapids_pytools/resources/profiling-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/profiling-conf.yaml
@@ -9,6 +9,7 @@ toolOutput:
 sparkRapids:
   mvnUrl: 'https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark-tools_2.12'
   repoUrl: '{}/{}/rapids-4-spark-tools_2.12-{}.jar'
+  toolsJarRegex: 'rapids-4-spark-tools_2.12-.*.jar'
   mainClass: 'com.nvidia.spark.rapids.tool.profiling.ProfileMain'
   outputDocURL: 'https://docs.nvidia.com/spark-rapids/user-guide/latest/profiling/quickstart.html#profiling-output'
   enableAutoTuner: true

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -61,6 +61,7 @@ toolOutput:
 sparkRapids:
   mvnUrl: 'https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark-tools_2.12'
   repoUrl: '{}/{}/rapids-4-spark-tools_2.12-{}.jar'
+  toolsJarRegex: 'rapids-4-spark-tools_2.12-.*.jar'
   mainClass: 'com.nvidia.spark.rapids.tool.qualification.QualificationMain'
   outputDocURL: 'https://docs.nvidia.com/spark-rapids/user-guide/latest/qualification/quickstart.html#qualification-output'
   enableAutoTuner: true


### PR DESCRIPTION
Fixes #1355.

Currently, in fat wheel mode, the python tools uses a glob search to pick the the first JAR file that matches the pattern `rapids-4-spark-tools_*.jar`. This PR fixes this bug by selecting the exact JAR file that was packaged during the fat build.

## Changes
- Extract the tools JAR file name that was packaged during the fat build and set it as a context variable `fatWheelModeJarFileName`
- Use the above the file name to get the correct tools JAR from the cache folder.

## Testing

- Reproduced the case using steps provided in the issue description
   - Build fat wheel for `24.08.2` and then for `24.08.3-SNAPSHOT`
   - `24.08.3-SNAPSHOT` was picking up `24.08.2` JAR.
- Manually tested before and after the changes. 

Before:
```
INFO rapids.tools.qualification: Using Spark RAPIDS user tools version 24.08.3
...
INFO rapids.tools.qualification.ctxt: Using jar from wheel file /var/tmp/spark_rapids_user_tools_cache/rapids-4-spark-tools_2.12-24.08.2.jar
INFO rapids.tools.qualification: Downloading the tools jars /var/tmp/spark_rapids_user_tools_cache/rapids-4-spark-tools_2.12-24.08.2.jar
INFO rapids.tools.qualification: RAPIDS accelerator tools jar is downloaded to work_dir /tools_run/qual_20240923210702_cB71064C/work_dir/rapids-4-spark-tools_2.12-24.08.2.jar
INFO rapids.tools.qualification: Using Spark RAPIDS Accelerator Tools jar version 24.08.2
```

After:
```
INFO rapids.tools.qualification: Using Spark RAPIDS user tools version 24.08.3
...
INFO rapids.tools.qualification.ctxt: Using jar from wheel file /var/tmp/spark_rapids_user_tools_cache/rapids-4-spark-tools_2.12-24.08.3-SNAPSHOT.jar
INFO rapids.tools.qualification: Downloading the tools jars /var/tmp/spark_rapids_user_tools_cache/rapids-4-spark-tools_2.12-24.08.3-SNAPSHOT.jar
INFO rapids.tools.qualification: RAPIDS accelerator tools jar is downloaded to work_dir /tools_run/qual_20240923222802_18fA0d42/work_dir/rapids-4-spark-tools_2.12-24.08.3-SNAPSHOT.jar
INFO rapids.tools.qualification: Using Spark RAPIDS Accelerator Tools jar version 24.08.3
```


## Notes:
- We could have simplified this by getting the Tools JAR version from python and using it as a regex in fat wheel mode.
- However, being explicit with the packaged JAR avoids any confusion.
- This approach also allows for future enhancements, such as enabling `build.sh` to accept a custom JAR.