### PR TITLE
[FOLLOWUP-1326] Set Spark version to 3.4.2 by default for onprem environment

### DIFF
--- a/user_tools/src/spark_rapids_pytools/resources/onprem-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/onprem-configs.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "deployMode": {
       "LOCAL": {
-        "//activeBuildVer": "Define this key in order to set the default buildVer for that platform",
+        "activeBuildVer": "342",
         "350": [
           {
             "name": "Apache Spark",
@@ -11,6 +11,16 @@
             "relativePath": "jars/*",
             "sha512": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319",
             "size": 400395283
+          }
+        ],
+        "342": [
+          {
+            "name": "Apache Spark",
+            "uri": "https://archive.apache.org/dist/spark/spark-3.4.2/spark-3.4.2-bin-hadoop3.tgz",
+            "type": "archive",
+            "relativePath": "jars/*",
+            "sha512": "c9470a557c96fe899dd1c9ea8d0dda3310eaf0155b2bb972f70a6d97fee8cdaf838b425c30df3d5856b2c31fc2be933537c111db72d0427eabb76c6abd92c1f1",
+            "size": 388664780
           }
         ],
         "333": [


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Followup on #1326 to set the default spark version to 3.4.2 for onPrem to avoid the bug described in #1316 without need to do something on customer side.

I tested that the `./build.sh fat` downloads both Spark releases 3.5.0 and 3.4.2

during runtime, onPrem adds `3.4.2/jars/*` to the classpath whioch is the expected behavior.

```
# list of downloaded dependencies

Downloading spark-3.5.0-bin-hadoop3.tgz
Downloading spark-3.5.0-bin-hadoop3.tgz.asc
Downloading hadoop-aws-3.3.4.jar
Downloading hadoop-aws-3.3.4.jar.asc
Downloading aws-java-sdk-bundle-1.12.262.jar
Downloading aws-java-sdk-bundle-1.12.262.jar.asc
Downloading databricks-aws-catalog.json
Downloading hadoop-azure-3.3.4.jar
Downloading aws_ec2_catalog_ec2_us-west-2.json
Downloading hadoop-azure-3.3.4.jar.asc
Downloading gcs-connector-hadoop3-2.2.19-shaded.jar
Downloading gcs-connector-hadoop3-2.2.19-shaded.jar.asc
Downloading gcloud-catalog.json
Downloading premium-databricks-azure-catalog.json
Downloading aws_ec2_catalog_emr_us-west-2.json
Downloading spark-3.4.2-bin-hadoop3.tgz
Downloading spark-3.4.2-bin-hadoop3.tgz.asc
Creating archive.....
Created archived resources successfully

```

snippet from tools log for onprem

```
java -XX:+UseG1GC -Dlog4j.configuration=/var/folders/y1/xc14jjfx4kdgwcbhx8c8l37h0000gp/T/tmptof1by66.properties -Xmx12g -cp /output_folder/qual_20240924180248_04336fdf/work_dir/rapids-4-spark-tools_2.12-24.08.3-SNAPSHOT.jar:/output_folder/qual_20240924180248_04336fdf/work_dir/spark-3.4.2-bin-hadoop3/jars/* com.nvidia.spark.rapids.tool.qualification.QualificationMain --output-directory file:///output_folder/qual_20240924180248_04336fdf --platform onprem --per-sql --num-threads 1 --auto-tuner /cpu-logs
```

snippet from tools for dataproc

```
java -XX:+UseG1GC -Dlog4j.configuration=/var/folders/y1/xc14jjfx4kdgwcbhx8c8l37h0000gp/T/tmpfc9amctc.properties -Xmx12g -cp /output_folder/qual_20240924181021_8acaB9E2/work_dir/rapids-4-spark-tools_2.12-24.08.3-SNAPSHOT.jar:/output_folder/qual_20240924181021_8acaB9E2/work_dir/gcs-connector-hadoop3-2.2.19-shaded.jar:/output_folder/qual_20240924181021_8acaB9E2/work_dir/spark-3.5.0-bin-hadoop3/jars/* com.nvidia.spark.rapids.tool.qualification.QualificationMain --output-directory file:///output_folder/qual_20240924181021_8acaB9E2 --platform dataproc --per-sql --num-threads 1 --auto-tuner /cpu-logs
```