### PR TITLE
Isolate dataset for qualx plugin invocations

### DIFF
--- a/user_tools/docs/qualx.md
+++ b/user_tools/docs/qualx.md
@@ -189,16 +189,27 @@ any of the following functions:
 import pandas as pd
 
 def load_profiles_hook(profile_df: pd.DataFrame) -> pd.DataFrame:
-    """Custom post processing on the load_profiles dataframe."""
+    """Custom post processing on the load_profiles dataframe.
+
+    Notes:
+    - profile_df contains "raw" features for the target dataset, extracted from the Profiler tool's output CSV files.
+    - profile_df is a slice of the original dataframe, so the original indices must be preserved,
+      and any new columns will be ignored/dropped.
+    """
     # Insert custom code to modify the profile_df as needed.
-    # Note: profile_df contains "raw" features extracted from the Profiler tool's output CSV files.
     return profile_df
 
 
 def split_function(cpu_aug_tbl: pd.DataFrame) -> pd.DataFrame:
-    """Custom train/test/val split function."""
+    """Custom train/test/val split function.
+
+    Notes:
+    - cpu_aug_tbl contains the "model" features for the target dataset, which will be used in training.
+    - cpu_aug_tbl is a slice of the original dataframe, so the original indices must be preserved,
+      and any new columns will be ignored/dropped.
+    - if not supplied, the default split function will randomly split the data by ratios of 60/20/20.
+    """
     # Insert custom code to set cpu_aug_tbl['split'] to 'train', 'test', or 'val'.
-    # Note: the default split function randomly splits the data by ratios of 60/20/20.
     return cpu_aug_tbl
 ```
 

--- a/user_tools/src/spark_rapids_tools/tools/qualx/model.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/model.py
@@ -332,7 +332,7 @@ def extract_model_features(
             if modified_df.index.equals(dataset_df.index):
                 cpu_aug_tbl.update(modified_df)
             else:
-                raise ValueError('Plugin: split_function for %s unexpectedly modified row indices.' % ds_name)
+                raise ValueError(f'Plugin: split_function for {ds_name} unexpectedly modified row indices.')
             cpu_aug_tbl.update(dataset_df)
 
         # handle default split function

--- a/user_tools/src/spark_rapids_tools/tools/qualx/model.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/model.py
@@ -320,6 +320,9 @@ def extract_model_features(
         if 'split' not in cpu_aug_tbl.columns:
             cpu_aug_tbl['split'] = pd.Series(dtype='str')
 
+        # save schema, since df.update() defaults all dtypes to floats
+        df_schema = cpu_aug_tbl.dtypes
+
         # extract default split function, if present
         default_split_fn = split_functions.pop('default') if 'default' in split_functions else None
 
@@ -331,6 +334,7 @@ def extract_model_features(
             modified_df = split_fn(dataset_df)
             if modified_df.index.equals(dataset_df.index):
                 cpu_aug_tbl.update(modified_df)
+                cpu_aug_tbl.astype(df_schema)
             else:
                 raise ValueError(f'Plugin: split_function for {ds_name} unexpectedly modified row indices.')
             cpu_aug_tbl.update(dataset_df)
@@ -343,6 +347,7 @@ def extract_model_features(
             modified_default_df = default_split_fn(default_df)
             if modified_default_df.index.equals(default_df.index):
                 cpu_aug_tbl.update(default_df)
+                cpu_aug_tbl.astype(df_schema)
             else:
                 raise ValueError('Default split_function unexpectedly modified row indices.')
     return cpu_aug_tbl, feature_cols, label_col

--- a/user_tools/src/spark_rapids_tools/tools/qualx/model.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/model.py
@@ -14,7 +14,7 @@
 
 """ Model training and prediction functions for QualX """
 
-from typing import Callable, Optional, List, Tuple
+from typing import Callable, Mapping, Optional, List, Tuple
 import json
 import random
 import shap
@@ -217,7 +217,7 @@ def predict(
 
 
 def extract_model_features(
-    df: pd.DataFrame, split_fn: List[Callable[[pd.DataFrame], pd.DataFrame]] = None
+    df: pd.DataFrame, split_functions: Mapping[str, Callable[[pd.DataFrame], pd.DataFrame]] = None
 ) -> Tuple[pd.DataFrame, List[str], str]:
     """Extract model features from raw features."""
     missing = expected_raw_features - set(df.columns)
@@ -314,11 +314,37 @@ def extract_model_features(
         logger.warning('Input data has extra features (removed): %s', extra)
         feature_cols = [c for c in feature_cols if c not in extra]
 
-    # add train/val/test split column, if split function provided
-    if split_fn:
-        for fn in split_fn:
-            cpu_aug_tbl = fn(cpu_aug_tbl)
+    # add train/val/test split column, if split function(s) provided
+    if split_functions:
+        # ensure 'split' column in cpu_aug_tbl
+        if 'split' not in cpu_aug_tbl.columns:
+            cpu_aug_tbl['split'] = pd.Series(dtype='str')
 
+        # extract default split function, if present
+        default_split_fn = split_functions.pop('default') if 'default' in split_functions else None
+
+        # handle all other dataset-specific split functions
+        for ds_name, split_fn in split_functions.items():
+            dataset_df = cpu_aug_tbl.loc[
+                (cpu_aug_tbl.appName == ds_name) | (cpu_aug_tbl.appName.str.startswith(f'{ds_name}:'))
+            ]
+            modified_df = split_fn(dataset_df)
+            if modified_df.index.equals(dataset_df.index):
+                cpu_aug_tbl.update(modified_df)
+            else:
+                raise ValueError('Plugin: split_function for %s unexpectedly modified row indices.' % ds_name)
+            cpu_aug_tbl.update(dataset_df)
+
+        # handle default split function
+        if default_split_fn:
+            default_df = cpu_aug_tbl.loc[~cpu_aug_tbl.appName.isin(split_functions.keys())]
+            for ds_name in split_functions.keys():
+                default_df = default_df.loc[~default_df.appName.str.startswith(f'{ds_name}:')]
+            modified_default_df = default_split_fn(default_df)
+            if modified_default_df.index.equals(default_df.index):
+                cpu_aug_tbl.update(default_df)
+            else:
+                raise ValueError('Default split_function unexpectedly modified row indices.')
     return cpu_aug_tbl, feature_cols, label_col
 
 

--- a/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
@@ -383,12 +383,14 @@ def load_profiles(
     for ds_name, plugin_path in plugins.items():
         plugin = load_plugin(plugin_path)
         if plugin:
+            df_schema = profile_df.dtypes
             dataset_df = profile_df.loc[
                 (profile_df.appName == ds_name) | (profile_df.appName.str.startswith(f'{ds_name}:'))
             ]
             modified_dataset_df = plugin.load_profiles_hook(dataset_df)
             if modified_dataset_df.index.equals(dataset_df.index):
                 profile_df.update(modified_dataset_df)
+                profile_df.astype(df_schema)
             else:
                 raise ValueError(f'Plugin: load_profiles_hook for {ds_name} unexpectedly modified row indices.')
     return profile_df

--- a/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
@@ -390,7 +390,7 @@ def load_profiles(
             if modified_dataset_df.index.equals(dataset_df.index):
                 profile_df.update(modified_dataset_df)
             else:
-                raise ValueError('Plugin: load_profiles_hook for %s unexpectedly modified row indices.' % ds_name)
+                raise ValueError(f'Plugin: load_profiles_hook for {ds_name} unexpectedly modified row indices.')
     return profile_df
 
 

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -250,7 +250,7 @@ def _predict(
             else 'raw'
         )
         logger.info('Predicting dataset (%s): %s', filter_str, dataset)
-        features, feature_cols, label_col = extract_model_features(input_df, [split_fn])
+        features, feature_cols, label_col = extract_model_features(input_df, {'default': split_fn})
         # note: dataset name is already stored in the 'appName' field
         try:
             results = predict_model(xgb_model, features, feature_cols, label_col)
@@ -462,13 +462,13 @@ def train(
             'Training data contained datasets: %s, expected: %s', profile_datasets, dataset_list
         )
 
-    split_functions = [split_train_val]
+    split_functions = {'default': split_train_val}
     for ds_name, ds_meta in datasets.items():
         if 'split_function' in ds_meta:
             plugin_path = ds_meta['split_function']
             logger.info('Using split function for %s dataset from plugin: %s', ds_name, plugin_path)
             plugin = load_plugin(plugin_path)
-            split_functions.append(plugin.split_function)
+            split_functions[ds_name] = plugin.split_function
 
     features, feature_cols, label_col = extract_model_features(profile_df, split_functions)
 


### PR DESCRIPTION
This PR isolates the rows for the targeted dataset when invoking a qualx dataset-specific plugin.

Previously, all plugins were invoked with the entire input dataframe, which relied on the plugin implementation to correctly target only the rows of its intended dataset.  While this design was simple and allowed for the full flexibility to modify the data in any way, it also can lead to unexpected behavior if a plugin accidentally targets the rows of other datasets.

I have confirmed that the full workflow of preprocessing, training, and evaluate produces the same models and evaluation results.

## Changes
1. send only the slice of the input dataframe for the specific dataset targeted by the plugin.
2. raise an error if the plugin code modifies the dataframe indices (implying invalid/unsupported modification of the rows).
3. add support for a 'default' split_function (by name vs. by presence in a list).
4. updated qualx.md doc with more details for plugin implementations.

## Test
Following CMDs have been tested:

### Internal Usage:
```
python qualx_main.py preprocess
python qualx_main.py train
python qualx_main.py evaluate
```

