### PR TITLE
Remove total core second heuristic and filter apps only in top candidate view

### DIFF
--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -246,6 +246,8 @@ local:
         compactWidth: true
         timeUnits: 's'
         columnWidth: 14
+      # This is total core seconds of an 8-core machine running for 24 hours
+      totalCoreSecThreshold: 691200
     speedupCategories:
       speedupColumnName: 'Estimated GPU Speedup'
       categoryColumnName: 'Estimated GPU Speedup Category'

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -246,6 +246,7 @@ local:
         compactWidth: true
         timeUnits: 's'
         columnWidth: 14
+      totalCoreSecCol: 'Total Core Seconds'
       # This is total core seconds of an 8-core machine running for 24 hours
       totalCoreSecThreshold: 691200
     speedupCategories:
@@ -280,9 +281,6 @@ local:
         - 'App ID'
         - 'Skip by Heuristics'
         - 'Reason'
-      totalCoreSecBased:
-        # This is total core seconds of an 8-core machine running for 24 hours
-        totalCoreSecThreshold: 691200
       spillBased:
         stageAggMetrics:
           fileName: 'stage_level_aggregated_task_metrics.csv'

--- a/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
+++ b/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
@@ -22,7 +22,6 @@ from logging import Logger
 import pandas as pd
 
 from spark_rapids_pytools.common.prop_manager import JSONPropertiesContainer
-from spark_rapids_pytools.common.sys_storage import FSUtil
 from spark_rapids_pytools.common.utilities import ToolLogging
 from spark_rapids_tools.tools.qualx.util import find_paths, RegexPattern
 from spark_rapids_tools.utils import Utilities

--- a/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
+++ b/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
@@ -50,7 +50,7 @@ class AdditionalHeuristics:
         """
         Returns a list of heuristics functions to apply to each application.
         """
-        return [self.heuristics_based_on_total_core_seconds, self.heuristics_based_on_spills]
+        return [self.heuristics_based_on_spills]
 
     def _apply_heuristics(self, app_ids: list) -> pd.DataFrame:
         """

--- a/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
+++ b/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
@@ -93,20 +93,6 @@ class AdditionalHeuristics:
 
         return pd.DataFrame(result_arr, columns=self.props.get_value('resultCols'))
 
-    def heuristics_based_on_total_core_seconds(self, app_id_path: str) -> (bool, str):
-        """
-        Apply heuristics based on total core seconds to determine if the app can be accelerated on GPU.
-        """
-        # Load app total core seconds from qualification summary dataframe
-        app_id = FSUtil.get_resource_name(app_id_path)
-        app_qual_output = self.all_apps[self.all_apps['App ID'] == app_id]  # type: ignore
-        total_core_seconds = app_qual_output['Total Core Seconds'].astype(int).iloc[0]
-        total_core_seconds_threshold = self.props.get_value('totalCoreSecBased', 'totalCoreSecThreshold')
-        if total_core_seconds <= total_core_seconds_threshold:
-            return True, f'Skipping due to total core seconds = {total_core_seconds} lower than ' + \
-                f'{total_core_seconds_threshold}.'
-        return False, ''
-
     def heuristics_based_on_spills(self, app_id_path: str) -> (bool, str):
         """
         Apply heuristics based on spills to determine if the app can be accelerated on GPU.

--- a/user_tools/src/spark_rapids_tools/tools/top_candidates.py
+++ b/user_tools/src/spark_rapids_tools/tools/top_candidates.py
@@ -67,13 +67,19 @@ class TopCandidates:
 
         category_col_name = self.props.get('categoryColumnName')
         eligible_categories = self.props.get('eligibleCategories')
+
+        # Note: `filter_condition` can be a combination of multiple filters
         # Filter based on eligible categories (Small/Medium/Large)
         filter_condition = self.tools_processed_apps[category_col_name].isin(eligible_categories)
+
         # Filter based on total core seconds threshold
         total_core_sec_col = self.props.get('totalCoreSecCol')
         total_core_sec_threshold = self.props.get('totalCoreSecThreshold')
         total_core_sec_cond = self.tools_processed_apps[total_core_sec_col] > total_core_sec_threshold
-        self.filtered_apps = self.tools_processed_apps[filter_condition][total_core_sec_cond]
+        filter_condition = filter_condition & total_core_sec_cond
+
+        # Apply all filter conditions to get top candidate view apps
+        self.filtered_apps = self.tools_processed_apps[filter_condition]
 
     def _generate_output_table(self, output_df: pd.DataFrame) -> str:
         """

--- a/user_tools/src/spark_rapids_tools/tools/top_candidates.py
+++ b/user_tools/src/spark_rapids_tools/tools/top_candidates.py
@@ -75,8 +75,8 @@ class TopCandidates:
         # Filter based on total core seconds threshold
         total_core_sec_col = self.props.get('totalCoreSecCol')
         total_core_sec_threshold = self.props.get('totalCoreSecThreshold')
-        total_core_sec_cond = self.tools_processed_apps[total_core_sec_col] > total_core_sec_threshold
-        filter_condition = filter_condition & total_core_sec_cond
+        total_core_sec_condition = self.tools_processed_apps[total_core_sec_col] > total_core_sec_threshold
+        filter_condition = filter_condition & total_core_sec_condition
 
         # Apply all filter conditions to get top candidate view apps
         self.filtered_apps = self.tools_processed_apps[filter_condition]


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/1367

### Changes

- Remove total core seconds filter from the `qualification_summary.csv` file.
- Apply total core second threshold filter only in Stdout Top Candidate View table when `--filter_apps=TOP_CANDIDATES`. Nothing should be affected when `--filter_apps=ALL`.

### Testing

Cmd: `spark_rapids qualification -v -e <my-event-logs> --filter_apps 'ALL'`
Stdout:
```
+----+-----------------------------------------------+--------------------------------+-----------------+------------------------------------+-------------------------------------+------------------------------------+
|    | App Name                                      | App ID                         | Estimated GPU   | Qualified                          | Full Cluster                        | GPU Config                         |
|    |                                               |                                | Speedup         | Cluster                            | Config                              | Recommendation                     |
|    |                                               |                                | Category**      | Recommendation                     | Recommendations*                    | Breakdown*                         |
|----+-----------------------------------------------+--------------------------------+-----------------+------------------------------------+-------------------------------------+------------------------------------|
|  2 | sanity_test                                   | application_1673503196578_0001 | Small           | 4 x Node with 8 vCPUs (1 L4 each)  | application_1673503196578_0001.conf | application_1673503196578_0001.log |
|  3 | sanity_test                                   | application_1673503196578_0001 | Small           | 4 x Node with 8 vCPUs (1 L4 each)  | application_1673503196578_0001.conf | application_1673503196578_0001.log |
|  8 | Spark shell                                   | local-1713904114464            | Not Recommended | 1 x Node with 64 vCPUs (1 L4 each) | local-1713904114464.conf            | local-1713904114464.log            |
|  7 | Spark shell                                   | local-1713464523119            | Not Recommended | 4 x Node with 8 vCPUs (1 L4 each)  | Does not exist, see log for errors  | Does not exist, see log for errors |
+----+-----------------------------------------------+--------------------------------+-----------------+------------------------------------+-------------------------------------+------------------------------------+
* Config Recommendations can be found in <path>.
** Estimated GPU Speedup Category assumes the user is using the node type recommended and config recommendations with the same size cluster as was used with the CPU side.

Report Summary:
----------------------  --
Total applications      6
Processed applications  4
Top candidates           0
----------------------  --
```

Cmd: `spark_rapids qualification -v -e <my-event-logs>`
Stdout:
```
Qualification tool found no qualified applications after applying the filters.
See the CSV file for the full report or disable the filters.

Report Summary:
----------------------  --
Total applications      6
Processed applications  4
Top candidates           0
----------------------  --
```