### PR TITLE
user-tools should add xms argument to java cmd

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/RuntimeUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/RuntimeUtil.scala
@@ -84,10 +84,7 @@ object RuntimeUtil extends Logging {
   }
 
   def getJVMHeapArguments: Map[String, String] = {
-    val gcMxBeans = ManagementFactory.getGarbageCollectorMXBeans
-    gcMxBeans.foreach(_.getName)
-
-    val jvmHeapGCArgs = ManagementFactory.getRuntimeMXBean.getInputArguments.filter(
+    ManagementFactory.getRuntimeMXBean.getInputArguments.filter(
       p => p.startsWith("-Xmx") || p.startsWith("-Xms") || p.startsWith("-XX:")).map {
       sizeArg =>
         if (sizeArg.startsWith("-Xmx")) {
@@ -104,8 +101,6 @@ object RuntimeUtil extends Logging {
             (s"jvm.arg.gc.${parts(0)}", "")
           }
         }
-    }
-    // get remaining GC arguments
-    jvmHeapGCArgs.toMap
+    }.toMap
   }
 }

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -878,11 +878,16 @@ class RapidsJarTool(RapidsTool):
         job_args = self.ctxt.get_ctxt('jobArgs')
         result = copy.deepcopy(job_args)
         job_resources = self._get_job_submission_resources(tool_name)
+        jvm_min_heap = job_resources['jvmMinHeapSize']
         jvm_max_heap = job_resources['jvmMaxHeapSize']
-        jvm_heap_key = f'Xmx{jvm_max_heap}g'
+        jvm_max_heap_key = f'Xmx{jvm_max_heap}g'
+        jvm_min_heap_key = f'Xms{jvm_min_heap}g'
         # At this point, we need to set the heap argument for the JVM. Otherwise, the process uses
         # its default values.
-        result['platformArgs']['jvmArgs'].update({jvm_heap_key: ''})
+        result['platformArgs']['jvmArgs'].update({
+            jvm_min_heap_key: '',
+            jvm_max_heap_key: ''
+        })
         return result
 
     @timeit('Building Job Arguments and Executing Job CMD')  # pylint: disable=too-many-function-args

--- a/user_tools/src/spark_rapids_tools/utils/util.py
+++ b/user_tools/src/spark_rapids_tools/utils/util.py
@@ -291,13 +291,18 @@ class Utilities:
         else:
             prof_threads = max(1, jvm_threads - num_threads_unit) if concurrent_mode else jvm_threads
 
+        # calculate the min heap size based on the max heap size
+        min_heap = max(1, heap_unit // 2)
+
         return {
             'qualification': {
                 'jvmMaxHeapSize': heap_unit,
+                'jvmMinHeapSize': min_heap,
                 'rapidsThreads': num_threads_unit
             },
             'profiling': {
                 'jvmMaxHeapSize': prof_heap,
+                'jvmMinHeapSize': min_heap,
                 'rapidsThreads': prof_threads
             }
         }


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein <ahussein@nvidia.com>

Fixes #1382

Upon investigation, it was revealed that the min heap size could impact the runtime significantly. (see the linked issue for details of the performance impact)
This code change aims at setting the xms java argument to 50% of the max heap size.

- pass xms to the java cmd
- update the runtime report to list jvm info along with jvm arguments related to heap:
  - `runtime.jvm.*`
  - `runtime.jvm.arg*`


sample runtime.properties file. The lines that are generated by the changes in this PR are marked with `>`

```
#RAPIDS Accelerator for Apache Spark's Build/Runtime Information
#Wed Oct 23 20:26:21 UTC 2024
build.scala.version=2.12.15
build.hadoop.version=3.3.6
build.spark.version=3.5.0
> runtime.os.version=6.8.0-39-generic
> runtime.jvm.version=1.8.0_422
build.version=24.08.3-SNAPSHOT
runtime.spark.version=3.4.2
> runtime.jvm.arg.heap.min=50g
> runtime.jvm.name=OpenJDK 64-Bit Server VM
> runtime.jvm.arg.gc.UseG1GC=
> runtime.os.name=Linux
> runtime.jvm.arg.heap.max=100g
build.java.version=1.8.0_422
```

### Details

This pull request updates the handling of JVM heap arguments in the Spark RAPIDS tool. 

- The most important is setting the `Xms`  the jar CLI.
- Introduces enhancements to the `RuntimeUtil` class by adding JVM and OS information to the runtime properties, extracting JVM heap arguments, and ensuring these arguments are correctly set in the user tools.

Enhancements to `RuntimeUtil`:

* [`core/src/main/scala/org/apache/spark/sql/rapids/tool/util/RuntimeUtil.scala`](diffhunk://#diff-17ba210baa6a6a06a98ea4fc3d67a576d28f8a7e7a52be3b07c08b73f78ac4b5R20-R22): Added imports for `ManagementFactory` and Scala collection conversions.
* [`core/src/main/scala/org/apache/spark/sql/rapids/tool/util/RuntimeUtil.scala`](diffhunk://#diff-17ba210baa6a6a06a98ea4fc3d67a576d28f8a7e7a52be3b07c08b73f78ac4b5R55-R60): Added methods to include JVM and OS information in the runtime properties and to extract JVM heap arguments. [[1]](diffhunk://#diff-17ba210baa6a6a06a98ea4fc3d67a576d28f8a7e7a52be3b07c08b73f78ac4b5R55-R60) [[2]](diffhunk://#diff-17ba210baa6a6a06a98ea4fc3d67a576d28f8a7e7a52be3b07c08b73f78ac4b5L76-R111)

Updates to JVM heap arguments handling:

* [`user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py`](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0R881-R890): Updated the `_re_evaluate_platform_args` method to set both minimum and maximum heap size arguments for the JVM.
* [`user_tools/src/spark_rapids_tools/utils/util.py`](diffhunk://#diff-4cf56e95204f7361fae97ab52d5da889e23d433e44c8126f131fc7f8218c0196R294-R305): Added logic to calculate and include the minimum heap size in the tool resources.

### Related and followups:

- internal ticket was filed to update the java CLI in the CI/CD job
- there is an internal ticket to update the user guide to emphasize the important of setting the heap arguments.