### PR TITLE
Update error handling in python for parsing cluster information

### DIFF
--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -78,7 +78,8 @@ class ClusterInference:
         num_worker_nodes = cluster_info_df.get('Num Worker Nodes')
         # If number of worker nodes is invalid, log error and return
         if pd.isna(num_worker_nodes) or num_worker_nodes <= 0:
-            self._log_inference_failure(app_id, 'Number of worker nodes cannot be determined. See logs for details.')
+            self._log_inference_failure(app_id, 'Number of worker nodes cannot be determined. '
+                                                'See logs for details.')
             return None
 
         cores_per_executor = cluster_info_df.get('Cores Per Executor')
@@ -92,7 +93,8 @@ class ClusterInference:
         if self.platform.get_platform_name() == CspEnv.ONPREM:
             # For on-prem, if total cores per node is invalid, log error and return
             if pd.isna(total_cores_per_node) or total_cores_per_node <= 0:
-                self._log_inference_failure(app_id, 'Total cores per node cannot be determined. See logs for details.')
+                self._log_inference_failure(app_id, 'Total cores per node cannot be determined. '
+                                                    'See logs for details.')
                 return None
             # For on-prem, we need to include number of cores per worker node
             cluster_prop['NUM_WORKER_CORES'] = int(total_cores_per_node)
@@ -106,7 +108,8 @@ class ClusterInference:
             if pd.isna(worker_node_type):
                 # For CSPs, if worker instance is not set and total cores per node is invalid, log error and return
                 if pd.isna(total_cores_per_node) or total_cores_per_node <= 0:
-                    self._log_inference_failure(app_id, 'Total cores per node cannot be determined. See logs for details.')
+                    self._log_inference_failure(app_id, 'Total cores per node cannot be determined. '
+                                                        'See logs for details.')
                     return None
                 # TODO - need to account for number of GPUs per executor
                 worker_node_type = self.platform.get_matching_worker_node_type(total_cores_per_node)

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -76,6 +76,11 @@ class ClusterInference:
         num_driver_nodes = 1
         app_id = cluster_info_df.get('App ID')
         num_worker_nodes = cluster_info_df.get('Num Worker Nodes')
+        # If number of worker nodes is invalid, log error and return
+        if pd.isna(num_worker_nodes) or num_worker_nodes <= 0:
+            self._log_inference_failure(app_id, 'Number of worker nodes cannot be determined. See logs for details.')
+            return None
+
         cores_per_executor = cluster_info_df.get('Cores Per Executor')
         execs_per_node = cluster_info_df.get('Num Executors Per Node')
         total_cores_per_node = execs_per_node * cores_per_executor
@@ -85,6 +90,10 @@ class ClusterInference:
             'NUM_WORKER_NODES': int(num_worker_nodes),
         }
         if self.platform.get_platform_name() == CspEnv.ONPREM:
+            # For on-prem, if total cores per node is invalid, log error and return
+            if pd.isna(total_cores_per_node) or total_cores_per_node <= 0:
+                self._log_inference_failure(app_id, 'Total cores per node cannot be determined. See logs for details.')
+                return None
             # For on-prem, we need to include number of cores per worker node
             cluster_prop['NUM_WORKER_CORES'] = int(total_cores_per_node)
         else:
@@ -95,9 +104,9 @@ class ClusterInference:
                 driver_node_type = self.platform.configs.get_value('clusterInference', 'defaultCpuInstances', 'driver')
             worker_node_type = cluster_info_df.get('Worker Node Type')
             if pd.isna(worker_node_type):
-                # If worker instance is not set, use the default value based on the number of cores
-                if pd.isna(total_cores_per_node):
-                    self._log_inference_failure(app_id, 'Total cores per node cannot be determined.')
+                # For CSPs, if worker instance is not set and total cores per node is invalid, log error and return
+                if pd.isna(total_cores_per_node) or total_cores_per_node <= 0:
+                    self._log_inference_failure(app_id, 'Total cores per node cannot be determined. See logs for details.')
                     return None
                 # TODO - need to account for number of GPUs per executor
                 worker_node_type = self.platform.get_matching_worker_node_type(total_cores_per_node)


### PR DESCRIPTION
Fixes #1392. 

The Python code parses cluster information generated by Scala for display on STDOUT and store in `app_metadata.json`.

This PR ensures that new changes on the Scala side are properly handled by Python.

## Error Handling Improvements:

Added a check to log an error:
   - If the number of worker nodes is invalid.
   - If the total cores per node is invalid for on-prem platforms.
   - If worker instance type is not set and the total cores per node is invalid for CSPs

## Test
- Tested on the original event logs that had caused this error. 
- In the given set of event logs, Scala side could not generate cluster information and would log the error message as follows:
```
Qualification-0 WARN QualificationAppInfo: Could not determine if any executors were allocated or the number of cores used per executor. Can't build existing cluster information!
``` 
- However, the Python side would not handle this case properly and show the logs as:
```
ERROR rapids.tools.cluster_inference: Error while inferring cluster: cannot convert float NaN to integer
INFO rapids.tools.cluster_inference: For App ID: application_1717064107684_0009, Unable to infer CPU cluster. Reason - No matching worker node found for num cores = -4.0
INFO rapids.tools.cluster_inference: For App ID: application_1717064107684_0008, Unable to infer CPU cluster. Reason - No matching worker node found for num cores = -4.0
```

- After this change, the logs in Python align with the behavior from Scala side.
```
INFO rapids.tools.cluster_inference: For App ID: application_1666141048720_0001, Unable to infer CPU cluster. Reason - Number of worker nodes cannot be determined. See logs for details.
INFO rapids.tools.cluster_inference: For App ID: application_1717064107684_0009, Unable to infer CPU cluster. Reason - Total cores per node cannot be determined. See logs for details.
INFO rapids.tools.cluster_inference: For App ID: application_1717064107684_0008, Unable to infer CPU cluster. Reason - Total cores per node cannot be determined. See logs for details.
```
