### PR TITLE
[FEA] Allow users to specify custom Dependency jars

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -583,7 +583,7 @@ class RapidsJarTool(RapidsTool):
                 raise ValueError(f'Invalid dependency type [{defined_dep_type}]')
             return dep_item
 
-        def cache_all_dependencies(dep_arr: List[RuntimeDependency]):
+        def cache_all_dependencies(dep_arr: List[RuntimeDependency]) -> List[str]:
             """
             Create a thread pool and download specified urls
             """

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
@@ -8,21 +8,23 @@
               "name": "Apache Spark",
               "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
               "verification": {
-                "hashLib": {
-                  "type": "sha512",
+                "fileHash": {
+                  "algorithm": "sha512",
                   "value": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319"
                 },
                 "size": 400395283
               },
-              "type": "archive",
-              "relativePath": "jars/*"
+              "dependencyType": {
+                "depType": "archive",
+                "relativePath": "jars/*"
+              }
             },
             {
               "name": "Hadoop AWS",
               "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
               "verification": {
-                "hashLib": {
-                  "type": "sha1",
+                "fileHash": {
+                  "algorithm": "sha1",
                   "value": "a65839fbf1869f81a1632e09f415e586922e4f80"
                 },
                 "size": 962685
@@ -33,8 +35,8 @@
               "name": "AWS Java SDK Bundled",
               "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
               "verification": {
-                "hashLib": {
-                  "type": "sha1",
+                "fileHash": {
+                  "algorithm": "sha1",
                   "value": "02deec3a0ad83d13d032b1812421b23d7a961eea"
                 },
                 "size": 280645251
@@ -47,38 +49,38 @@
               "name": "Apache Spark",
               "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
               "verification": {
-                "hashLib": {
+                "fileHash": {
                   "type": "sha512",
                   "value": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9"
                 },
                 "size": 299426263
               },
-              "type": "archive",
-              "relativePath": "jars/*"
+              "dependencyType": {
+                "depType": "archive",
+                "relativePath": "jars/*"
+              }
             },
             {
               "name": "Hadoop AWS",
               "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
               "verification": {
-                "hashLib": {
-                  "type": "sha1",
+                "fileHash": {
+                  "algorithm": "sha1",
                   "value": "a65839fbf1869f81a1632e09f415e586922e4f80"
                 },
                 "size": 962685
-              },
-              "type": "jar"
+              }
             },
             {
               "name": "AWS Java SDK Bundled",
               "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
               "verification": {
-                "hashLib": {
-                  "type": "sha1",
+                "fileHash": {
+                  "algorithm": "sha1",
                   "value": "02deec3a0ad83d13d032b1812421b23d7a961eea"
                 },
                 "size": 280645251
-              },
-              "type": "jar"
+              }
             }
           ]
         }

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
@@ -50,7 +50,7 @@
               "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
               "verification": {
                 "fileHash": {
-                  "type": "sha512",
+                  "algorithm": "sha512",
                   "value": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9"
                 },
                 "size": 299426263

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_azure-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_azure-configs.json
@@ -8,26 +8,27 @@
               "name": "Apache Spark",
               "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
               "verification": {
-                "hashLib": {
-                  "type": "sha512",
+                "fileHash": {
+                  "algorithm": "sha512",
                   "value": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319"
                 },
                 "size": 400395283
               },
-              "type": "archive",
-              "relativePath": "jars/*"
+              "dependencyType": {
+                "depType": "archive",
+                "relativePath": "jars/*"
+              }
             },
             {
               "name": "Hadoop Azure",
               "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/3.3.4/hadoop-azure-3.3.4.jar",
               "verification": {
-                "hashLib": {
-                  "type": "sha1",
+                "fileHash": {
+                  "algorithm": "sha1",
                   "value": "a23f621bca9b2100554150f6b0b521f94b8b419e"
                 },
                 "size": 574116
-              },
-              "type": "jar"
+              }
             }
           ],
           "333": [
@@ -35,26 +36,27 @@
               "name": "Apache Spark",
               "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
               "verification": {
-                "hashLib": {
-                  "type": "sha512",
+                "fileHash": {
+                  "algorithm": "sha512",
                   "value": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9"
                 },
                 "size": 299426263
               },
-              "type": "archive",
-              "relativePath": "jars/*"
+              "dependencyType": {
+                "depType": "archive",
+                "relativePath": "jars/*"
+              }
             },
             {
               "name": "Hadoop Azure",
               "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/3.3.4/hadoop-azure-3.3.4.jar",
               "verification": {
-                "hashLib": {
-                  "type": "sha1",
+                "fileHash": {
+                  "algorithm": "sha1",
                   "value": "a23f621bca9b2100554150f6b0b521f94b8b419e"
                 },
                 "size": 574116
-              },
-              "type": "jar"
+              }
             }
           ]
         }

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -8,26 +8,27 @@
             "name": "Apache Spark",
             "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
             "verification": {
-              "hashLib": {
-                "type": "sha512",
+              "fileHash": {
+                "algorithm": "sha512",
                 "value": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319"
               },
               "size": 400395283
             },
-            "type": "archive",
-            "relativePath": "jars/*"
+            "dependencyType": {
+              "depType": "archive",
+              "relativePath": "jars/*"
+            }
           },
           {
             "name": "GCS Connector Hadoop3",
             "uri": "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.19/gcs-connector-hadoop3-2.2.19-shaded.jar",
             "verification": {
-              "hashLib": {
-                "type": "sha1",
+              "fileHash": {
+                "algorithm": "sha1",
                 "value": "3bea6d5e62663a2a5c03d8ca44dff4921aeb3170"
               },
               "size": 39359477
-            },
-            "type": "jar"
+            }
           }
         ],
         "333": [
@@ -35,26 +36,27 @@
             "name": "Apache Spark",
             "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
             "verification": {
-              "hashLib": {
-                "type": "sha512",
+              "fileHash": {
+                "algorithm": "sha512",
                 "value": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9"
               },
               "size": 299426263
             },
-            "type": "archive",
-            "relativePath": "jars/*"
+            "dependencyType": {
+              "depType": "archive",
+              "relativePath": "jars/*"
+            }
           },
           {
             "name": "GCS Connector Hadoop3",
             "uri": "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.17/gcs-connector-hadoop3-2.2.17-shaded.jar",
             "verification": {
-              "hashLib": {
-                "type": "sha1",
+              "fileHash": {
+                "algorithm": "sha1",
                 "value": "06438f562692ff8fae5e8555eba2b9f95cb74f66"
               },
               "size": 38413466
-            },
-            "type": "jar"
+            }
           }
         ]
       }

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc_gke-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc_gke-configs.json
@@ -8,26 +8,27 @@
             "name": "Apache Spark",
             "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
             "verification": {
-              "hashLib": {
-                "type": "sha512",
+              "fileHash": {
+                "algorithm": "sha512",
                 "value": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319"
               },
               "size": 400395283
             },
-            "type": "archive",
-            "relativePath": "jars/*"
+            "dependencyType": {
+              "depType": "archive",
+              "relativePath": "jars/*"
+            }
           },
           {
             "name": "GCS Connector Hadoop3",
             "uri": "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.19/gcs-connector-hadoop3-2.2.19-shaded.jar",
             "verification": {
-              "hashLib": {
-                "type": "sha1",
+              "fileHash": {
+                "algorithm": "sha1",
                 "value": "3bea6d5e62663a2a5c03d8ca44dff4921aeb3170"
               },
               "size": 39359477
-            },
-            "type": "jar"
+            }
           }
         ],
         "333": [
@@ -35,26 +36,27 @@
             "name": "Apache Spark",
             "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
             "verification": {
-              "hashLib": {
-                "type": "sha512",
+              "fileHash": {
+                "algorithm": "sha512",
                 "value": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9"
               },
               "size": 299426263
             },
-            "type": "archive",
-            "relativePath": "jars/*"
+            "dependencyType": {
+              "depType": "archive",
+              "relativePath": "jars/*"
+            }
           },
           {
             "name": "GCS Connector Hadoop3",
             "uri": "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.17/gcs-connector-hadoop3-2.2.17-shaded.jar",
             "verification": {
-              "hashLib": {
-                "type": "sha1",
+              "fileHash": {
+                "algorithm": "sha1",
                 "value": "06438f562692ff8fae5e8555eba2b9f95cb74f66"
               },
               "size": 38413466
-            },
-            "type": "jar"
+            }
           }
         ]
       }

--- a/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
@@ -8,38 +8,38 @@
             "name": "Apache Spark",
             "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
             "verification": {
-              "hashLib": {
-                "type": "sha512",
+              "fileHash": {
+                "algorithm": "sha512",
                 "value": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319"
               },
               "size": 400395283
             },
-            "type": "archive",
-            "relativePath": "jars/*"
+            "dependencyType": {
+              "depType": "archive",
+              "relativePath": "jars/*"
+            }
           },
           {
             "name": "Hadoop AWS",
             "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
             "verification": {
-              "hashLib": {
-                "type": "sha1",
+              "fileHash": {
+                "algorithm": "sha1",
                 "value": "a65839fbf1869f81a1632e09f415e586922e4f80"
               },
               "size": 962685
-            },
-            "type": "jar"
+            }
           },
           {
             "name": "AWS Java SDK Bundled",
             "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
             "verification": {
-              "hashLib": {
-                "type": "sha1",
+              "fileHash": {
+                "algorithm": "sha1",
                 "value": "02deec3a0ad83d13d032b1812421b23d7a961eea"
               },
               "size": 280645251
-            },
-            "type": "jar"
+            }
           }
         ],
         "333": [
@@ -47,38 +47,38 @@
             "name": "Apache Spark",
             "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
             "verification": {
-              "hashLib": {
-                "type": "sha512",
+              "fileHash": {
+                "algorithm": "sha512",
                 "value": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9"
               },
               "size": 299426263
             },
-            "type": "archive",
-            "relativePath": "jars/*"
+            "dependencyType": {
+              "depType": "archive",
+              "relativePath": "jars/*"
+            }
           },
           {
             "name": "Hadoop AWS",
             "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
             "verification": {
-              "hashLib": {
-                "type": "sha1",
+              "fileHash": {
+                "algorithm": "sha1",
                 "value": "a65839fbf1869f81a1632e09f415e586922e4f80"
               },
               "size": 962685
-            },
-            "type": "jar"
+            }
           },
           {
             "name": "AWS Java SDK Bundled",
             "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
             "verification": {
-              "hashLib": {
-                "type": "sha1",
+              "fileHash": {
+                "algorithm": "sha1",
                 "value": "02deec3a0ad83d13d032b1812421b23d7a961eea"
               },
               "size": 280645251
-            },
-            "type": "jar"
+            }
           }
         ]
       }

--- a/user_tools/src/spark_rapids_pytools/resources/onprem-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/onprem-configs.json
@@ -8,14 +8,16 @@
             "name": "Apache Spark",
             "uri": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
             "verification": {
-              "hashLib": {
-                "type": "sha512",
+              "fileHash": {
+                "algorithm": "sha512",
                 "value": "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319"
               },
               "size": 400395283
             },
-            "type": "archive",
-            "relativePath": "jars/*"
+            "dependencyType": {
+              "depType": "archive",
+              "relativePath": "jars/*"
+            }
           }
         ],
         "342": [
@@ -23,14 +25,16 @@
             "name": "Apache Spark",
             "uri": "https://archive.apache.org/dist/spark/spark-3.4.2/spark-3.4.2-bin-hadoop3.tgz",
             "verification": {
-              "hashLib": {
-                "type": "sha512",
+              "fileHash": {
+                "algorithm": "sha512",
                 "value": "c9470a557c96fe899dd1c9ea8d0dda3310eaf0155b2bb972f70a6d97fee8cdaf838b425c30df3d5856b2c31fc2be933537c111db72d0427eabb76c6abd92c1f1"
               },
               "size": 388664780
             },
-            "type": "archive",
-            "relativePath": "jars/*"
+            "dependencyType": {
+              "depType": "archive",
+              "relativePath": "jars/*"
+            }
           }
         ],
         "333": [
@@ -38,14 +42,16 @@
             "name": "Apache Spark",
             "uri": "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz",
             "verification": {
-              "hashLib": {
-                "type": "sha512",
+              "fileHash": {
+                "algorithm": "sha512",
                 "value": "ebf79c7861f3120d5ed9465fdd8d5302a734ff30713a0454b714bbded7ab9f218b3108dc46a5de4cc2102c86e7be53908f84d2c7a19e59bc75880766eeefeef9"
               },
               "size": 299426263
             },
-            "type": "archive",
-            "relativePath": "jars/*"
+            "dependencyType": {
+              "depType": "archive",
+              "relativePath": "jars/*"
+            }
           }
         ]
       }

--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -374,7 +374,7 @@ class ToolUserArgModel(AbsToolUserArgModel):
 
     def process_tools_config(self) -> None:
         """
-        Load the tools config file if it is provided. it creates a ToolsConfig object and sets it
+        Load the tools config file if it is provided. It creates a ToolsConfig object and sets it
         in the toolArgs without processing the actual dependencies.
         :return: None
         """
@@ -387,7 +387,7 @@ class ToolUserArgModel(AbsToolUserArgModel):
                 raise PydanticCustomError(
                     'invalid_argument',
                     f'Tools config file path {self.tools_config_path} could not be loaded. '
-                    'It is expected to be a valid YAML file.\n  Error:') from ve
+                    f'It is expected to be a valid YAML file.\n  Error:{ve}')
 
     def init_extra_arg_cases(self) -> list:
         if self.eventlogs is None:

--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -389,7 +389,7 @@ class ToolUserArgModel(AbsToolUserArgModel):
                 raise PydanticCustomError(
                     'invalid_config',
                     f'Tools config file path {self.tools_config_path} could not be loaded. '
-                    f'It is expected to be a valid configuration YAML file.'
+                    'It is expected to be a valid configuration YAML file.'
                     f'\n  Error:{ve}\n') from ve
 
     def init_extra_arg_cases(self) -> list:

--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -29,6 +29,7 @@ from spark_rapids_pytools.cloud_api.sp_types import DeployMode
 from spark_rapids_pytools.common.utilities import ToolLogging, Utils
 from spark_rapids_tools.cloud import ClientCluster
 from spark_rapids_tools.utils import AbstractPropContainer, is_http_file
+from ..configuration.tools_config import ToolsConfig
 from ..enums import QualFilterApp, CspEnv, QualEstimationModel
 from ..storagelib.csppath import CspPath
 from ..tools.autotuner import AutoTunerPropMgr
@@ -349,6 +350,7 @@ class ToolUserArgModel(AbsToolUserArgModel):
     eventlogs: Optional[str] = None
     jvm_heap_size: Optional[int] = None
     jvm_threads: Optional[int] = None
+    tools_config_path: Optional[str] = None
 
     def is_concurrent_submission(self) -> bool:
         return False
@@ -369,6 +371,23 @@ class ToolUserArgModel(AbsToolUserArgModel):
         self.p_args['toolArgs']['jvmMaxHeapSize'] = jvm_heap
         self.p_args['toolArgs']['jobResources'] = adjusted_resources
         self.p_args['toolArgs']['log4jPath'] = Utils.resource_path('dev/log4j.properties')
+
+    def process_tools_config(self) -> None:
+        """
+        Load the tools config file if it is provided. it creates a ToolsConfig object and sets it
+        in the toolArgs without processing the actual dependencies.
+        :return: None
+        """
+        self.p_args['toolArgs']['toolsConfig'] = None
+        if self.tools_config_path is not None:
+            # the CLI provides a tools config file
+            try:
+                self.p_args['toolArgs']['toolsConfig'] = ToolsConfig.load_from_file(self.tools_config_path)
+            except ValidationError as ve:
+                raise PydanticCustomError(
+                    'invalid_argument',
+                    f'Tools config file path {self.tools_config_path} could not be loaded. '
+                    'It is expected to be a valid YAML file.\n  Error:') from ve
 
     def init_extra_arg_cases(self) -> list:
         if self.eventlogs is None:
@@ -481,11 +500,14 @@ class QualifyUserArgModel(ToolUserArgModel):
         runtime_platform = self.get_or_set_platform()
         # process JVM arguments
         self.process_jvm_args()
+        # process the tools config file
+        self.process_tools_config()
 
         # finally generate the final values
         wrapped_args = {
             'runtimePlatform': runtime_platform,
             'outputFolder': self.output_folder,
+            'toolsConfig': self.p_args['toolArgs']['toolsConfig'],
             'platformOpts': {
                 'credentialFile': None,
                 'deployMode': DeployMode.LOCAL
@@ -601,10 +623,12 @@ class ProfileUserArgModel(ToolUserArgModel):
 
         # process JVM arguments
         self.process_jvm_args()
-
+        # process the tools config file
+        self.process_tools_config()
         # finally generate the final values
         wrapped_args = {
             'runtimePlatform': runtime_platform,
+            'toolsConfig': self.p_args['toolArgs']['toolsConfig'],
             'outputFolder': self.output_folder,
             'platformOpts': {
                 'credentialFile': None,

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -45,6 +45,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                       jvm_heap_size: int = None,
                       jvm_threads: int = None,
                       verbose: bool = None,
+                      tools_config_file: str = None,
                       **rapids_options) -> None:
         """The Qualification cmd provides estimated speedups by migrating Apache Spark applications
         to GPU accelerated clusters.
@@ -79,6 +80,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         :param jvm_threads: Number of threads to use for parallel processing on the eventlogs batch.
                 Default is calculated as a function of the total number of cores and the heap size on the host.
         :param verbose: True or False to enable verbosity of the script.
+        :param tools_config_file: Path to a configuration file that contains the tools' options.
         :param rapids_options: A list of valid Qualification tool options.
                 Note that the wrapper ignores ["output-directory", "platform"] flags, and it does not support
                 multiple "spark-property" arguments.
@@ -112,7 +114,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                                          jvm_heap_size=jvm_heap_size,
                                                          jvm_threads=jvm_threads,
                                                          filter_apps=filter_apps,
-                                                         estimation_model_args=estimation_model_args)
+                                                         estimation_model_args=estimation_model_args,
+                                                         tools_config_path=tools_config_file)
         if qual_args:
             tool_obj = QualificationAsLocal(platform_type=qual_args['runtimePlatform'],
                                             output_folder=qual_args['outputFolder'],
@@ -131,6 +134,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                   jvm_heap_size: int = None,
                   jvm_threads: int = None,
                   verbose: bool = None,
+                  tools_config_file: str = None,
                   **rapids_options):
         """The Profiling cmd provides information which can be used for debugging and profiling
         Apache Spark applications running on GPU accelerated clusters.
@@ -158,6 +162,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         :param jvm_threads: Number of thread to use for parallel processing on the eventlogs batch.
                 Default is calculated as a function of the total number of cores and the heap size on the host.
         :param verbose: True or False to enable verbosity of the script.
+        :param tools_config_file: Path to a configuration file that contains the tools' options.
         :param rapids_options: A list of valid Profiling tool options.
                 Note that the wrapper ignores ["output-directory", "worker-info"] flags, and it does not support
                 multiple "spark-property" arguments.
@@ -182,7 +187,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                                          jvm_heap_size=jvm_heap_size,
                                                          jvm_threads=jvm_threads,
                                                          output_folder=output_folder,
-                                                         tools_jar=tools_jar)
+                                                         tools_jar=tools_jar,
+                                                         tools_config_path=tools_config_file)
         if prof_args:
             rapids_options.update(prof_args['rapidOptions'])
             tool_obj = ProfilingAsLocal(platform_type=prof_args['runtimePlatform'],

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -81,6 +81,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                 Default is calculated as a function of the total number of cores and the heap size on the host.
         :param verbose: True or False to enable verbosity of the script.
         :param tools_config_file: Path to a configuration file that contains the tools' options.
+               For sample configuration files, please visit
+               https://github.com/NVIDIA/spark-rapids-tools/tree/main/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid
         :param rapids_options: A list of valid Qualification tool options.
                 Note that the wrapper ignores ["output-directory", "platform"] flags, and it does not support
                 multiple "spark-property" arguments.
@@ -163,6 +165,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                 Default is calculated as a function of the total number of cores and the heap size on the host.
         :param verbose: True or False to enable verbosity of the script.
         :param tools_config_file: Path to a configuration file that contains the tools' options.
+               For sample configuration files, please visit
+               https://github.com/NVIDIA/spark-rapids-tools/tree/main/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid
         :param rapids_options: A list of valid Profiling tool options.
                 Note that the wrapper ignores ["output-directory", "worker-info"] flags, and it does not support
                 multiple "spark-property" arguments.

--- a/user_tools/src/spark_rapids_tools/configuration/__init__.py
+++ b/user_tools/src/spark_rapids_tools/configuration/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""init file of the tools configurations module"""
+
+from .common import RuntimeDependencyType, DependencyVerification, RuntimeDependency
+
+__all__ = [
+    'RuntimeDependency',
+    'RuntimeDependencyType',
+    'DependencyVerification'
+]

--- a/user_tools/src/spark_rapids_tools/configuration/common.py
+++ b/user_tools/src/spark_rapids_tools/configuration/common.py
@@ -68,7 +68,7 @@ class RuntimeDependency(BaseModel):
                   'https://mvn-url/24.08.1/rapids-4-spark-tools_2.12-24.08.1.jar',
                   'gs://bucket-name/path/to/file.jar'])
     dependency_type: RuntimeDependencyType = Field(
-        default_factory=lambda: RuntimeDependencyType(dep_type=DependencyType.JAR),
+        default_factory=lambda: RuntimeDependencyType(dep_type=DependencyType.get_default()),
         description='The type of the dependency and how to find the lib files after decompression.',
         validation_alias=AliasChoices('dependency_type', 'dependencyType'))
     verification: DependencyVerification = Field(

--- a/user_tools/src/spark_rapids_tools/configuration/common.py
+++ b/user_tools/src/spark_rapids_tools/configuration/common.py
@@ -23,33 +23,28 @@ from spark_rapids_tools.storagelib.tools.fs_utils import FileHashAlgorithm
 
 
 class RuntimeDependencyType(BaseModel):
-    """Defines the type of dependency. It can be one of the following:
-       - Archived file (.tgz)
-       - Simple JAR file (*.jar)
-       - Classpath directory (not yet supported)
-
-    Note: The 'classpath' type is reserved for future use, allowing users to point to a directory
-    in the classpath without needing to download or copy any binaries."""
+    """Defines the type of runtime dependency required by the tools' java cmd."""
 
     dep_type: DependencyType = Field(
-        description='The type of the dependency',
+        description='The type of the dependency.',
         validation_alias=AliasChoices('dep_type', 'depType'))
     relative_path: str = Field(
         default=None,
-        description='The relative path of the dependency in the classpath. This is relevant for tar files',
+        description='Specifies the relative path from within the archive file which will be added to the java cmd. '
+                    'Requires field dep_type to be set to (archive).',
         validation_alias=AliasChoices('relative_path', 'relativePath'),
-        examples=['jars/*'])
+        examples=['*'])
 
 
 class DependencyVerification(BaseModel):
-    """The verification information of the dependency."""
+    """The verification information of a runtime dependency required by the tools' java cmd."""
     size: int = Field(
         default=0,
         description='The size of the dependency file.',
         examples=[3265393])
     file_hash: FileHashAlgorithm = Field(
         default=None,
-        description='The hash function to verify the file',
+        description='The hash function to verify the file.',
         validation_alias=AliasChoices('file_hash', 'fileHash'),
         examples=[
             {
@@ -59,29 +54,21 @@ class DependencyVerification(BaseModel):
 
 
 class RuntimeDependency(BaseModel):
-    """The runtime dependency required by the tools Jar cmd. All elements are downloaded and added
-    to the classPath."""
-    name: str = Field(description='The name of the dependency')
+    """Holds information about a runtime dependency required by the tools' java cmd."""
+    name: str = Field(
+        description='The name of the dependency.',
+        examples=['Spark-3.5.0', 'AWS Java SDK'])
     uri: Union[AnyUrl, FilePath] = Field(
-        description='The FileURI of the dependency. It can be a local file or a remote file',
-        examples=['file:///path/to/file.jar',
+        description='The location of the dependency file. It can be a URL to a remote web/storage or a file path.',
+        examples=['file:///path/to/file.tgz',
                   'https://mvn-url/24.08.1/rapids-4-spark-tools_2.12-24.08.1.jar',
                   'gs://bucket-name/path/to/file.jar'])
     dependency_type: RuntimeDependencyType = Field(
         default_factory=lambda: RuntimeDependencyType(dep_type=DependencyType.get_default()),
-        description='The type of the dependency and how to find the lib files after decompression.',
+        description='Specifies the dependency type to determine how the item is processed. '
+                    'For example, jar files are appended to the java classpath while archive files '
+                    'such as spark are extracted first before adding subdirectory _/jars/* to the classpath.',
         validation_alias=AliasChoices('dependency_type', 'dependencyType'))
     verification: DependencyVerification = Field(
         default=None,
-        description='The verification information of the dependency.',
-        examples=[
-            {
-                'size': 3265393
-            },
-            {
-                'fileHash': {
-                    'algorithm': 'md5',
-                    'value': 'bc9bf7fedde0e700b974426fbd8d869c'
-                }
-            }
-        ])
+        description='Optional specification to verify the dependency file.')

--- a/user_tools/src/spark_rapids_tools/configuration/common.py
+++ b/user_tools/src/spark_rapids_tools/configuration/common.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common types and definitions used by the configurations. This module is used by other
+modules as well."""
+
+from typing import Union
+from pydantic import BaseModel, Field, AnyUrl, FilePath, AliasChoices
+
+from spark_rapids_tools.enums import DependencyType
+from spark_rapids_tools.storagelib.tools.fs_utils import FileHashAlgorithm
+
+
+class RuntimeDependencyType(BaseModel):
+    """Defines the type of dependency. It can be one of the following:
+       - Archived file (.tgz)
+       - Simple JAR file (*.jar)
+       - Classpath directory (not yet supported)
+
+    Note: The 'classpath' type is reserved for future use, allowing users to point to a directory
+    in the classpath without needing to download or copy any binaries."""
+
+    dep_type: DependencyType = Field(
+        description='The type of the dependency',
+        validation_alias=AliasChoices('dep_type', 'depType'))
+    relative_path: str = Field(
+        default=None,
+        description='The relative path of the dependency in the classpath. This is relevant for tar files',
+        validation_alias=AliasChoices('relative_path', 'relativePath'),
+        examples=['jars/*'])
+
+
+class DependencyVerification(BaseModel):
+    """The verification information of the dependency."""
+    size: int = Field(
+        default=0,
+        description='The size of the dependency file.',
+        examples=[3265393])
+    file_hash: FileHashAlgorithm = Field(
+        default=None,
+        description='The hash function to verify the file',
+        validation_alias=AliasChoices('file_hash', 'fileHash'),
+        examples=[
+            {
+                'algorithm': 'md5',
+                'value': 'bc9bf7fedde0e700b974426fbd8d869c'
+            }])
+
+
+class RuntimeDependency(BaseModel):
+    """The runtime dependency required by the tools Jar cmd. All elements are downloaded and added
+    to the classPath."""
+    name: str = Field(description='The name of the dependency')
+    uri: Union[AnyUrl, FilePath] = Field(
+        description='The FileURI of the dependency. It can be a local file or a remote file',
+        examples=['file:///path/to/file.jar',
+                  'https://mvn-url/24.08.1/rapids-4-spark-tools_2.12-24.08.1.jar',
+                  'gs://bucket-name/path/to/file.jar'])
+    dependency_type: RuntimeDependencyType = Field(
+        default_factory=lambda: RuntimeDependencyType(dep_type=DependencyType.JAR),
+        description='The type of the dependency and how to find the lib files after decompression.',
+        validation_alias=AliasChoices('dependency_type', 'dependencyType'))
+    verification: DependencyVerification = Field(
+        default=None,
+        description='The verification information of the dependency.',
+        examples=[
+            {
+                'size': 3265393
+            },
+            {
+                'fileHash': {
+                    'algorithm': 'md5',
+                    'value': 'bc9bf7fedde0e700b974426fbd8d869c'
+                }
+            }
+        ])

--- a/user_tools/src/spark_rapids_tools/configuration/common.py
+++ b/user_tools/src/spark_rapids_tools/configuration/common.py
@@ -33,7 +33,7 @@ class RuntimeDependencyType(BaseModel):
         description='Specifies the relative path from within the archive file which will be added to the java cmd. '
                     'Requires field dep_type to be set to (archive).',
         validation_alias=AliasChoices('relative_path', 'relativePath'),
-        examples=['*'])
+        examples=['jars/*'])
 
 
 class DependencyVerification(BaseModel):

--- a/user_tools/src/spark_rapids_tools/configuration/runtime_conf.py
+++ b/user_tools/src/spark_rapids_tools/configuration/runtime_conf.py
@@ -24,5 +24,7 @@ from spark_rapids_tools.configuration.common import RuntimeDependency
 class ToolsRuntimeConfig(BaseModel):
     """The runtime configurations of the tools as defined by the user."""
     dependencies: List[RuntimeDependency] = Field(
-        description='The list of runtime dependencies required by the tools Jar cmd. '
-                    'All elements are downloaded and added to the classPath')
+        description='The list of runtime dependencies required by the tools java cmd. '
+                    'Set this list to specify Spark binaries along with any other required jar '
+                    'files (i.e., hadoop jars, gcp connectors,..etc.). '
+                    'When specified, the default predefined dependencies will be ignored.')

--- a/user_tools/src/spark_rapids_tools/configuration/runtime_conf.py
+++ b/user_tools/src/spark_rapids_tools/configuration/runtime_conf.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The runtime configurations of the tools as defined by the user."""
+
+from typing import List
+
+from pydantic import BaseModel, Field
+
+from spark_rapids_tools.configuration.common import RuntimeDependency
+
+
+class ToolsRuntimeConfig(BaseModel):
+    """The runtime configurations of the tools as defined by the user."""
+    dependencies: List[RuntimeDependency] = Field(
+        description='The list of runtime dependencies required by the tools Jar cmd. '
+                    'All elements are downloaded and added to the classPath')

--- a/user_tools/src/spark_rapids_tools/configuration/tools_config.py
+++ b/user_tools/src/spark_rapids_tools/configuration/tools_config.py
@@ -19,7 +19,6 @@ import json
 from typing import Union, Optional
 
 from pydantic import BaseModel, Field, ValidationError
-from pydantic_core import PydanticCustomError
 
 from spark_rapids_tools import CspPathT
 from spark_rapids_tools.configuration.runtime_conf import ToolsRuntimeConfig
@@ -31,12 +30,12 @@ class ToolsConfig(BaseModel):
     api_version: float = Field(
         description='The version of the API that the tools are using. '
                     'This is used to test the compatibility of the '
-                    'configuration file against the current tools release',
+                    'configuration file against the current tools release.',
         examples=['1.0'],
         le=1.0,  # minimum version compatible with the current tools implementation
         ge=1.0)
     runtime: ToolsRuntimeConfig = Field(
-        description='Configuration related to the runtime environment of the tools')
+        description='Configuration related to the runtime environment of the tools.')
 
     @classmethod
     def load_from_file(cls, file_path: Union[str, CspPathT]) -> Optional['ToolsConfig']:
@@ -45,9 +44,9 @@ class ToolsConfig(BaseModel):
             prop_container = AbstractPropContainer.load_from_file(file_path)
             return cls(**prop_container.props)
         except ValidationError as e:
+            # Do nothing. This is kept as a place holder if we want to log the error inside the
+            # class first
             raise e
-            # raise PydanticCustomError('invalid_argument',
-            #                           'Invalid Tools Configuration File\n Error:') from e
 
     @classmethod
     def get_schema(cls) -> str:

--- a/user_tools/src/spark_rapids_tools/configuration/tools_config.py
+++ b/user_tools/src/spark_rapids_tools/configuration/tools_config.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Container for the custom tools configurations. This is the parts of the configuration that can
+be passed as an input to the CLI"""
+
+import json
+from typing import Union, Optional
+
+from pydantic import BaseModel, Field, ValidationError
+from pydantic_core import PydanticCustomError
+
+from spark_rapids_tools import CspPathT
+from spark_rapids_tools.configuration.runtime_conf import ToolsRuntimeConfig
+from spark_rapids_tools.utils import AbstractPropContainer
+
+
+class ToolsConfigInfo(BaseModel):
+    """
+    High level metadata about the tools configurations (i.e., the api-version and any other relevant
+    metadata).
+    """
+    api_version: float = Field(
+        description='The version of the API that the tools are using. '
+                    'This is used to test the compatibility of the '
+                    'configuration file against the current tools release',
+        examples=['1.0'],
+        le=1.0,  # minimum version compatible with the current tools implementation
+        ge=1.0)
+
+
+class ToolsConfig(BaseModel):
+    """Main container for the user's defined tools configuration"""
+    info: ToolsConfigInfo = Field(
+        description='Metadata information of the tools configuration')
+    runtime: ToolsRuntimeConfig = Field(
+        description='Configuration related to the runtime environment of the tools')
+
+    @classmethod
+    def load_from_file(cls, file_path: Union[str, CspPathT]) -> Optional['ToolsConfig']:
+        """Load the tools configuration from a file"""
+        try:
+            prop_container = AbstractPropContainer.load_from_file(file_path)
+            return cls(**prop_container.props)
+        except ValidationError as e:
+            raise PydanticCustomError('Invalid Tools Configuration File', e) from e
+
+    @classmethod
+    def get_schema(cls) -> str:
+        """Returns a JSON schema of the tools' configuration. This is useful for generating an API
+        documentation of the model."""
+        return json.dumps(cls.model_json_schema(), indent=2)

--- a/user_tools/src/spark_rapids_tools/configuration/tools_config.py
+++ b/user_tools/src/spark_rapids_tools/configuration/tools_config.py
@@ -26,11 +26,8 @@ from spark_rapids_tools.configuration.runtime_conf import ToolsRuntimeConfig
 from spark_rapids_tools.utils import AbstractPropContainer
 
 
-class ToolsConfigInfo(BaseModel):
-    """
-    High level metadata about the tools configurations (i.e., the api-version and any other relevant
-    metadata).
-    """
+class ToolsConfig(BaseModel):
+    """Main container for the user's defined tools configuration"""
     api_version: float = Field(
         description='The version of the API that the tools are using. '
                     'This is used to test the compatibility of the '
@@ -38,12 +35,6 @@ class ToolsConfigInfo(BaseModel):
         examples=['1.0'],
         le=1.0,  # minimum version compatible with the current tools implementation
         ge=1.0)
-
-
-class ToolsConfig(BaseModel):
-    """Main container for the user's defined tools configuration"""
-    info: ToolsConfigInfo = Field(
-        description='Metadata information of the tools configuration')
     runtime: ToolsRuntimeConfig = Field(
         description='Configuration related to the runtime environment of the tools')
 
@@ -54,7 +45,9 @@ class ToolsConfig(BaseModel):
             prop_container = AbstractPropContainer.load_from_file(file_path)
             return cls(**prop_container.props)
         except ValidationError as e:
-            raise PydanticCustomError('Invalid Tools Configuration File', e) from e
+            raise e
+            # raise PydanticCustomError('invalid_argument',
+            #                           'Invalid Tools Configuration File\n Error:') from e
 
     @classmethod
     def get_schema(cls) -> str:

--- a/user_tools/src/spark_rapids_tools/enums.py
+++ b/user_tools/src/spark_rapids_tools/enums.py
@@ -101,6 +101,21 @@ class HashAlgorithm(EnumeratedType):
         }
         return hash_functions[self]
 
+
+class DependencyType(EnumeratedType):
+    """Represents the dependency type for the jar cmd"""
+    JAR = 'jar'
+    ARCHIVE = 'archive'
+    # When classpath is used, it means that the url of a dependency is used as is.
+    # i.e., it is a folder, or a path that is added to the classPath for java CLI.
+    CLASSPATH = 'classpath'
+
+    @classmethod
+    def get_default(cls):
+        """Returns the default dependency type"""
+        return cls.JAR
+
+
 ###########
 # CSP Enums
 ###########

--- a/user_tools/src/spark_rapids_tools/enums.py
+++ b/user_tools/src/spark_rapids_tools/enums.py
@@ -92,7 +92,7 @@ class HashAlgorithm(EnumeratedType):
         return None
 
     def get_hash_func(self) -> Callable:
-        """Maps the hash function to the appropriate hashing algorithm"""
+        """Maps the hash function to the appropriate hashing algorithm."""
         hash_functions = {
             self.MD5: hashlib.md5,
             self.SHA1: hashlib.sha1,
@@ -103,16 +103,13 @@ class HashAlgorithm(EnumeratedType):
 
 
 class DependencyType(EnumeratedType):
-    """Represents the dependency type for the jar cmd"""
+    """Represents the dependency type for the tools' java cmd."""
     JAR = 'jar'
     ARCHIVE = 'archive'
-    # When classpath is used, it means that the url of a dependency is used as is.
-    # i.e., it is a folder, or a path that is added to the classPath for java CLI.
-    CLASSPATH = 'classpath'
 
     @classmethod
-    def get_default(cls):
-        """Returns the default dependency type"""
+    def get_default(cls) -> 'DependencyType':
+        """Returns the default dependency type."""
         return cls.JAR
 
 

--- a/user_tools/src/spark_rapids_tools/storagelib/tools/fs_utils.py
+++ b/user_tools/src/spark_rapids_tools/storagelib/tools/fs_utils.py
@@ -67,19 +67,21 @@ def raise_invalid_file(file_path: CspPath, msg: str, error_type: str = 'invalid_
 @dataclass
 class FileHashAlgorithm:
     """
-    Represents a file hash algorithm and its value. Used for verification against an
-    existing file.
-    ```py
-    try:
-        file_algo = FileHashAlgorithm(algorithm=HashAlgorithm.SHA256, value='...')
-        file_algo.verify_file(CspPath('file://path/to/file'))
-    except ValidationError as e:
-        print(e)
-    ```
+    Represents a file hash algorithm and its value. Used for verification against an existing file.
     """
     algorithm: HashAlgorithm
     value: str
 
+    """
+    Example usage for the class:
+    ```py
+        try:
+            file_algo = FileHashAlgorithm(algorithm=HashAlgorithm.SHA256, value='...')
+            file_algo.verify_file(CspPath('file://path/to/file'))
+        except ValidationError as e:
+            print(e)
+    ```
+    """
     def verify_file(self, file_path: CspPath) -> bool:
         cb = self.algorithm.get_hash_func()
         with file_path.open_input_stream() as stream:

--- a/user_tools/tests/spark_rapids_tools_ut/conftest.py
+++ b/user_tools/tests/spark_rapids_tools_ut/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,6 +47,26 @@ csp_cpu_cluster_props = [(e_1, e_2) for (e_1, e_2) in all_cpu_cluster_props if e
 csps = ['dataproc', 'dataproc_gke', 'emr', 'databricks_aws', 'databricks_azure']
 all_csps = csps + ['onprem']
 autotuner_prop_path = 'worker_info.yaml'
+# valid tools config files
+valid_tools_conf_files = ['tools_config_00.yaml']
+# invalid tools config files
+invalid_tools_conf_files = [
+    # test older API_version
+    #  Error:1 validation error for ToolsConfig
+    #  api_version
+    #    Input should be greater than or equal to 1 [type=greater_than_equal, input_value='0.9', input_type=str]
+    'tools_config_inv_00.yaml',
+    # test empty runtime configs
+    #  Error:1 validation error for ToolsConfig
+    #  runtime.dependencies
+    #   Input should be a valid list [type=list_type, input_value=None, input_type=NoneType]
+    'tools_config_inv_01.yaml',
+    # test local dependency file does not exist
+    #  Error:1 validation error for ToolsConfig
+    #  runtime.dependencies
+    #   Input should be a valid list [type=list_type, input_value=None, input_type=NoneType]
+    'tools_config_inv_02.yaml'
+]
 
 
 class SparkRapidsToolsUT:  # pylint: disable=too-few-public-methods

--- a/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/invalid/tools_config_inv_00.yaml
+++ b/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/invalid/tools_config_inv_00.yaml
@@ -1,0 +1,11 @@
+# This yaml file is a configuration file for a tool that uses Spark 3.5.0 as dependency
+# invalid: API version is smaller than accepted API version
+api_version: '0.9'
+runtime:
+  dependencies:
+    - name: my-spark350
+      uri: https:///archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz
+      dependency_type:
+        dep_type: archive
+        # for tgz files, it is required to give the subfolder where the jars are located
+        relative_path: jars/*

--- a/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/invalid/tools_config_inv_01.yaml
+++ b/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/invalid/tools_config_inv_01.yaml
@@ -1,0 +1,8 @@
+# This yaml file is a configuration file
+# invalid: empty file
+#  Error:1 validation error for ToolsConfig
+#  runtime.dependencies
+#   Input should be a valid list [type=list_type, input_value=None, input_type=NoneType]
+api_version: '1.0'
+runtime:
+  dependencies:

--- a/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/invalid/tools_config_inv_02.yaml
+++ b/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/invalid/tools_config_inv_02.yaml
@@ -1,0 +1,17 @@
+# This yaml file is a configuration file for a tool that uses Spark 3.5.0 as dependency
+# invalid: Local file can be verified during the initialization and it should fail because no such
+# file exists.
+#   Error:2 validation errors for ToolsConfig
+# runtime.dependencies.0.uri.url
+#  Input should be a valid URL, relative URL without a base [type=url_parsing, input_value='/home/user/workdir...k-3.5.0-bin-hadoop3.tgz', input_type=str]
+#    For further information visit https://errors.pydantic.dev/2.9/v/url_parsing
+# runtime.dependencies.0.uri.function-after[validate_file(), lax-or-strict[lax=union[json-or-python[json=function-after[path_validator(), str],python=is-instance[Path]],function-after[path_validator(), str]],strict=json-or-python[json=function-after[path_validator(), str],python=is-instance[Path]]]]
+#  Path does not point to a file [type=path_not_file, input_value='/home/archive.apache.org...k-3.5.0-bin-hadoop3.tgz', input_type=str]
+api_version: '1.0'
+runtime:
+  dependencies:
+    - name: my-spark350
+      uri:  /home/user/workdir/spark-3.5.0-bin-hadoop3.tgz
+      dependency_type:
+        dep_type: archive
+        relative_path: jars/*

--- a/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/sample-config-specification.json
+++ b/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/sample-config-specification.json
@@ -125,7 +125,7 @@
           "default": null,
           "description": "Specifies the relative path from within the archive file which will be added to the java cmd. Requires field dep_type to be set to (archive).",
           "examples": [
-            "*"
+            "jars/*"
           ],
           "title": "Relative Path",
           "type": "string"

--- a/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/sample-config-specification.json
+++ b/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/sample-config-specification.json
@@ -1,0 +1,182 @@
+{
+  "$defs": {
+    "DependencyType": {
+      "description": "Represents the dependency type for the tools' java cmd.",
+      "enum": [
+        "jar",
+        "archive"
+      ],
+      "title": "DependencyType",
+      "type": "string"
+    },
+    "DependencyVerification": {
+      "description": "The verification information of a runtime dependency required by the tools' java cmd.",
+      "properties": {
+        "size": {
+          "default": 0,
+          "description": "The size of the dependency file.",
+          "examples": [
+            3265393
+          ],
+          "title": "Size",
+          "type": "integer"
+        },
+        "file_hash": {
+          "$ref": "#/$defs/FileHashAlgorithm",
+          "default": null,
+          "description": "The hash function to verify the file.",
+          "examples": [
+            {
+              "algorithm": "md5",
+              "value": "bc9bf7fedde0e700b974426fbd8d869c"
+            }
+          ]
+        }
+      },
+      "title": "DependencyVerification",
+      "type": "object"
+    },
+    "FileHashAlgorithm": {
+      "description": "Represents a file hash algorithm and its value. Used for verification against an existing file.",
+      "properties": {
+        "algorithm": {
+          "$ref": "#/$defs/HashAlgorithm"
+        },
+        "value": {
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "algorithm",
+        "value"
+      ],
+      "title": "FileHashAlgorithm",
+      "type": "object"
+    },
+    "HashAlgorithm": {
+      "description": "Represents the supported hashing algorithms",
+      "enum": [
+        "md5",
+        "sha1",
+        "sha256",
+        "sha512"
+      ],
+      "title": "HashAlgorithm",
+      "type": "string"
+    },
+    "RuntimeDependency": {
+      "description": "Holds information about a runtime dependency required by the tools' java cmd.",
+      "properties": {
+        "name": {
+          "description": "The name of the dependency.",
+          "examples": [
+            "Spark-3.5.0",
+            "AWS Java SDK"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "uri": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "format": "file-path",
+              "type": "string"
+            }
+          ],
+          "description": "The location of the dependency file. It can be a URL to a remote web/storage or a file path.",
+          "examples": [
+            "file:///path/to/file.tgz",
+            "https://mvn-url/24.08.1/rapids-4-spark-tools_2.12-24.08.1.jar",
+            "gs://bucket-name/path/to/file.jar"
+          ],
+          "title": "Uri"
+        },
+        "dependency_type": {
+          "$ref": "#/$defs/RuntimeDependencyType",
+          "description": "Specifies the dependency type to determine how the item is processed. For example, jar files are appended to the java classpath while archive files such as spark are extracted first before adding subdirectory _/jars/* to the classpath."
+        },
+        "verification": {
+          "$ref": "#/$defs/DependencyVerification",
+          "default": null,
+          "description": "Optional specification to verify the dependency file."
+        }
+      },
+      "required": [
+        "name",
+        "uri"
+      ],
+      "title": "RuntimeDependency",
+      "type": "object"
+    },
+    "RuntimeDependencyType": {
+      "description": "Defines the type of runtime dependency required by the tools' java cmd.",
+      "properties": {
+        "dep_type": {
+          "$ref": "#/$defs/DependencyType",
+          "description": "The type of the dependency."
+        },
+        "relative_path": {
+          "default": null,
+          "description": "Specifies the relative path from within the archive file which will be added to the java cmd. Requires field dep_type to be set to (archive).",
+          "examples": [
+            "*"
+          ],
+          "title": "Relative Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "dep_type"
+      ],
+      "title": "RuntimeDependencyType",
+      "type": "object"
+    },
+    "ToolsRuntimeConfig": {
+      "description": "The runtime configurations of the tools as defined by the user.",
+      "properties": {
+        "dependencies": {
+          "description": "The list of runtime dependencies required by the tools java cmd. Set this list to specify Spark binaries along with any other required jar files (i.e., hadoop jars, gcp connectors,..etc.). When specified, the default predefined dependencies will be ignored.",
+          "items": {
+            "$ref": "#/$defs/RuntimeDependency"
+          },
+          "title": "Dependencies",
+          "type": "array"
+        }
+      },
+      "required": [
+        "dependencies"
+      ],
+      "title": "ToolsRuntimeConfig",
+      "type": "object"
+    }
+  },
+  "description": "Main container for the user's defined tools configuration",
+  "properties": {
+    "api_version": {
+      "description": "The version of the API that the tools are using. This is used to test the compatibility of the configuration file against the current tools release.",
+      "examples": [
+        "1.0"
+      ],
+      "maximum": 1.0,
+      "minimum": 1.0,
+      "title": "Api Version",
+      "type": "number"
+    },
+    "runtime": {
+      "$ref": "#/$defs/ToolsRuntimeConfig",
+      "description": "Configuration related to the runtime environment of the tools."
+    }
+  },
+  "required": [
+    "api_version",
+    "runtime"
+  ],
+  "title": "ToolsConfig",
+  "type": "object"
+}

--- a/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid/tools_config_00.yaml
+++ b/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid/tools_config_00.yaml
@@ -1,0 +1,11 @@
+# This yaml file is a configuration file for a tool that uses Spark 3.5.0 as dependency
+# Minimal file content.
+api_version: '1.0'
+runtime:
+  dependencies:
+    - name: my-spark350
+      uri: https:///archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz
+      dependency_type:
+        dep_type: archive
+        # for tgz files, it is required to give the subfolder where the jars are located
+        relative_path: jars/*


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein <ahussein@nvidia.com>

Fixes #1359

Add a new input argument that takes a path to a yaml file `--tools_config_file` The config file allows the users to define their own binaries that need to be added to the classpath of the tools jar cmd. This change is important because users can use the user-tools wrapper with their custom spark.

### Sample usage and specifications

- the dependenices can be `https:` or `file:///`
- assume that the spark binaries are for `spark-3.3.1-bin-hadoop3` which exists on local disk: `/local/path/to/spark-3.3.1-bin-hadoop3.tgz`
- We can define the config-file `/home/tools-conf.yaml` as follows:
    ```yaml
    info:
      api_version: '1.0'
    runtime:
      dependencies:
        - name: my-spark331
          uri: file:///local/path/to/spark-3.3.1-bin-hadoop3.tgz
          dependency_type:
            dep_type: archive
            # for tgz files, it is required to give the subfolder where the jars are located
            relative_path: jars/*
    ```
- now, we can run the python command as :

  ```
  spark_rapids profiling \
    --tools_config_file /home/tools-conf.yaml \
    --output_folder $LOCAL_OUTPUT_DIR \
    --eventlogs $LOCAL_GPU_EVENT_LOGS \
    --tools_jar $LOCAL_JAR \
    --verbose
  ```

- Assume that there are more jar files needed for the classpath, then the user can define an array of dependencies
  ```yaml
  info:
    api_version: '1.0'
  runtime:
    dependencies:
      - name: Hadoop AWS
        uri: https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar
        verification:
          size: 962685
      - name: AWS Java SDK Bundled
        uri: https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar
        verification:
          file_hash:
            algorithm: sha1
            value: 02deec3a0ad83d13d032b1812421b23d7a961eea
      - name: spark-3.5.0
        uri: https:///archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz
        verification:
          file_hash:
            algorithm: sha512
            value: 8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319
        dependency_type:
          dep_type: archive
          relative_path: jars/*
  ```

<details><summary>The specification of the file is as follows </summary>
<p>

```yaml
---
"$defs":
  DependencyType:
    description: Represents the dependency type for the jar cmd
    enum:
    - jar
    - archive
    - classpath
    title: DependencyType
    type: string
  DependencyVerification:
    description: The verification information of the dependency.
    properties:
      size:
        default: 0
        description: The size of the dependency file.
        examples:
        - 3265393
        title: Size
        type: integer
      file_hash:
        "$ref": "#/$defs/FileHashAlgorithm"
        default: 
        description: The hash function to verify the file
        examples:
        - algorithm: md5
          value: bc9bf7fedde0e700b974426fbd8d869c
    title: DependencyVerification
    type: object
  FileHashAlgorithm:
    description: |-
      Represents a file hash algorithm and its value. Used for verification against an
      existing file.
      ```py
      try:
          file_algo = FileHashAlgorithm(algorithm=HashAlgorithm.SHA256, value='...')
          file_algo.verify_file(CspPath('file://path/to/file'))
      except ValidationError as e:
          print(e)
      ```
    properties:
      algorithm:
        "$ref": "#/$defs/HashAlgorithm"
      value:
        title: Value
        type: string
    required:
    - algorithm
    - value
    title: FileHashAlgorithm
    type: object
  HashAlgorithm:
    description: Represents the supported hashing algorithms
    enum:
    - md5
    - sha1
    - sha256
    - sha512
    title: HashAlgorithm
    type: string
  RuntimeDependency:
    description: |-
      The runtime dependency required by the tools Jar cmd. All elements are downloaded and added
      to the classPath.
    properties:
      name:
        description: The name of the dependency
        title: Name
        type: string
      uri:
        anyOf:
        - format: uri
          minLength: 1
          type: string
        - format: file-path
          type: string
        description: The FileURI of the dependency. It can be a local file or a remote
          file
        examples:
        - file:///path/to/file.jar
        - https://mvn-url/24.08.1/rapids-4-spark-tools_2.12-24.08.1.jar
        - gs://bucket-name/path/to/file.jar
        title: Uri
      dependency_type:
        "$ref": "#/$defs/RuntimeDependencyType"
        description: The type of the dependency and how to find the lib files after
          decompression.
      verification:
        "$ref": "#/$defs/DependencyVerification"
        default: 
        examples:
        - size: 3265393
        - fileHash:
            algorithm: md5
            value: bc9bf7fedde0e700b974426fbd8d869c
    required:
    - name
    - uri
    title: RuntimeDependency
    type: object
  RuntimeDependencyType:
    description: |-
      Defines the type of dependency. It can be one of the following:
         - Archived file (.tgz)
         - Simple JAR file (*.jar)
         - Classpath directory (not yet supported)

      Note: The 'classpath' type is reserved for future use, allowing users to point to a directory
      in the classpath without needing to download or copy any binaries.
    properties:
      dep_type:
        "$ref": "#/$defs/DependencyType"
        description: The type of the dependency
      relative_path:
        default: 
        description: The relative path of the dependency in the classpath. This is
          relevant for tar files
        examples:
        - jars/*
        title: Relative Path
        type: string
    required:
    - dep_type
    title: RuntimeDependencyType
    type: object
  ToolsConfigInfo:
    description: |-
      High level metadata about the tools configurations (i.e., the api-version and any other relevant
      metadata).
    properties:
      api_version:
        description: The version of the API that the tools are using. This is used
          to test the compatibility of the configuration file against the current
          tools release
        examples:
        - '1.0'
        maximum: 1
        minimum: 1
        title: Api Version
        type: number
    required:
    - api_version
    title: ToolsConfigInfo
    type: object
  ToolsRuntimeConfig:
    description: The runtime configurations of the tools as defined by the user.
    properties:
      dependencies:
        description: The list of runtime dependencies required by the tools Jar cmd.
          All elements are downloaded and added to the classPath
        items:
          "$ref": "#/$defs/RuntimeDependency"
        title: Dependencies
        type: array
    required:
    - dependencies
    title: ToolsRuntimeConfig
    type: object
description: Main container for the user's defined tools configuration
properties:
  info:
    "$ref": "#/$defs/ToolsConfigInfo"
    description: Metadata information of the tools configuration
  runtime:
    "$ref": "#/$defs/ToolsRuntimeConfig"
    description: Configuration related to the runtime environment of the tools
required:
- info
- runtime
title: ToolsConfig
type: object

```
</p>
</details> 

### detailed code changes

This pull request includes several changes to the `user_tools` module, focusing on improving dependency management and configuration handling. The changes include importing new modules, adding methods for handling tool configurations, and updating the way dependencies are processed and verified.

#### Configuration Handling Enhancements:

* [`user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py`](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0R75-R81): Added a method `get_tools_config_obj` to retrieve the tools configuration object from CLI arguments.
* [`user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py`](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0R607-R619): Added a method `populate_dependency_list` to check for dependencies in a config file before falling back to default dependencies.

#### Minor Code Improvements:
* [`user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py`](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0L139-R148): Corrected a comment typo in `_process_output_args` method.
* [`user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py`](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0L396-R406): Adjusted the formatting of the `get_rapids_tools_dependencies` method for better readability.
* [`user_tools/src/spark_rapids_pytools/resources/dev/prepackage_mgr.py`](diffhunk://#diff-48f4c8d291d66fc725353b1a3d40b1a126a974b64c6e1daa149f3f765654fdc5L21): Added import for `CspPath` and `RuntimeDependency` to support new dependency handling. [[1]](diffhunk://#diff-48f4c8d291d66fc725353b1a3d40b1a126a974b64c6e1daa149f3f765654fdc5L21) [[2]](diffhunk://#diff-48f4c8d291d66fc725353b1a3d40b1a126a974b64c6e1daa149f3f765654fdc5L30-R30)

#### Modified the format of platform configuration to match the same structure

* [`user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py`](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0L41-R45): Added imports for `RuntimeDependency`, `ToolsConfig`, and `DependencyType` to better manage dependencies. Updated methods to use `RuntimeDependency` objects instead of dictionaries. [[1]](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0L41-R45) [[2]](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0L535-R586)
* [`user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json`](diffhunk://#diff-15ad57b52cf137d0237436d0e4658507fea041f8b955bbb1220f049052d1dd97L11-R27): Replaced `hashLib` with `fileHash` for verification and added `dependencyType` for better dependency classification. [[1]](diffhunk://#diff-15ad57b52cf137d0237436d0e4658507fea041f8b955bbb1220f049052d1dd97L11-R27) [[2]](diffhunk://#diff-15ad57b52cf137d0237436d0e4658507fea041f8b955bbb1220f049052d1dd97L36-R39) [[3]](diffhunk://#diff-15ad57b52cf137d0237436d0e4658507fea041f8b955bbb1220f049052d1dd97L50-R83)
* [`user_tools/src/spark_rapids_pytools/resources/databricks_azure-configs.json`](diffhunk://#diff-50b97b00c2b96b04b67a582b7826208b2c306260d5141b4ed434ce343bbcf29eL11-R59): Similar changes to the AWS configs, updating verification and dependency type fields.
* [`user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json`](diffhunk://#diff-56742e03e6d5dc473bb7bcaecc167cd8af5651bed08e86c485129fab8e6631e9L11-R59): Updated verification and dependency type fields for Dataproc configurations.
* [`user_tools/src/spark_rapids_pytools/resources/dataproc_gke-configs.json`](diffhunk://#diff-27f1ca42cde0f902634144f1a166dd3d8f96f6c81bed5f94ff90ed737acac66cL11-R59): Similar updates to verification and dependency type fields for GKE configurations.


