### PR TITLE
Add qualification support for Photon jobs in the Python Tool

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -56,8 +56,6 @@ disable=
         # R0913: Too many arguments
         too-many-arguments,
         # R0914: Too many local variables
-        too-many-positional-arguments,
-        # R0917: Too many positional arguments
         too-many-locals,
         # R0801: Similar lines in 2 files
         duplicate-code,

--- a/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
@@ -215,6 +215,11 @@ class ToolContext(YAMLPropertiesContainer):
             return root_dir
         return FSUtil.build_path(root_dir, rapids_subfolder)
 
+    def get_metrics_output_folder(self) -> str:
+        root_dir = self.get_rapids_output_folder()
+        metrics_subfolder = self.get_value('toolOutput', 'metricsSubFolder')
+        return FSUtil.build_path(root_dir, metrics_subfolder)
+
     def get_log4j_properties_file(self) -> str:
         return self.get_value_silent('toolOutput', 'textFormat', 'log4jFileName')
 

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -1,6 +1,7 @@
 toolOutput:
   completeOutput: true
   subFolder: rapids_4_spark_qualification_output
+  metricsSubFolder: raw_metrics
   textFormat:
     summaryLog:
       fileName: rapids_4_spark_qualification_output.log
@@ -254,27 +255,50 @@ local:
       speedupColumnName: 'Estimated GPU Speedup'
       categoryColumnName: 'Estimated GPU Speedup Category'
       heuristicsColumnName: 'Skip by Heuristics'
-      categories:
-        - title: 'Not Applicable'
-          lowerBound: -1000000.0
-          upperBound: 1.3
-        - title: 'Small'
-          lowerBound: 1.3
-          upperBound: 2.0
-        - title: 'Medium'
-          lowerBound: 2.0
-          upperBound: 3.0
-        - title: 'Large'
-          lowerBound: 3.0
-          upperBound: 1000000.0
-      eligibilityConditions:
-        - columnName: 'Estimated GPU Speedup'
-          lowerBound: 1.3
-          upperBound: 1000000.0
-        - columnName: 'Unsupported Operators Stage Duration Percent'
-          lowerBound: 0.0
-          upperBound: 25.0
       defaultCategory: 'Not Recommended'
+      strategies:
+        spark:  # Spark specific speedup categories
+          categories:
+            - title: 'Not Applicable'
+              lowerBound: -1000000.0
+              upperBound: 1.3
+            - title: 'Small'
+              lowerBound: 1.3
+              upperBound: 2.0
+            - title: 'Medium'
+              lowerBound: 2.0
+              upperBound: 3.0
+            - title: 'Large'
+              lowerBound: 3.0
+              upperBound: 1000000.0
+          eligibilityConditions:
+            - columnName: 'Estimated GPU Speedup'
+              lowerBound: 1.3
+              upperBound: 1000000.0
+            - columnName: 'Unsupported Operators Stage Duration Percent'
+              lowerBound: 0.0
+              upperBound: 25.0
+        photon:  # Photon specific speedup categories
+          categories:
+            - title: 'Not Applicable'
+              lowerBound: -1000000.0
+              upperBound: 1.0
+            - title: 'Small'
+              lowerBound: 1.0
+              upperBound: 2.0
+            - title: 'Medium'
+              lowerBound: 2.0
+              upperBound: 3.0
+            - title: 'Large'
+              lowerBound: 3.0
+              upperBound: 1000000.0
+          eligibilityConditions:
+            - columnName: 'Estimated GPU Speedup'
+              lowerBound: 1.0
+              upperBound: 1000000.0
+            - columnName: 'Unsupported Operators Stage Duration Percent'
+              lowerBound: 0.0
+              upperBound: 25.0
     additionalHeuristics:
       appInfo:
         fileName: 'application_information.csv'

--- a/user_tools/src/spark_rapids_tools/enums.py
+++ b/user_tools/src/spark_rapids_tools/enums.py
@@ -210,3 +210,16 @@ class QualEstimationModel(EnumeratedType):
             'xgboostEnabled': model_type == QualEstimationModel.XGBOOST,
             'customModelFile': None,
         }
+
+
+class AppExecutionType(EnumeratedType):
+    """
+    Represents the execution type for the application (e.g. Spark, Photon or GPU).
+    """
+    SPARK = 'spark'
+    PHOTON = 'photon'
+    GPU = 'gpu'
+
+    @classmethod
+    def get_default(cls) -> 'AppExecutionType':
+        return cls.SPARK

--- a/user_tools/src/spark_rapids_tools/utils/util.py
+++ b/user_tools/src/spark_rapids_tools/utils/util.py
@@ -328,3 +328,13 @@ class Utilities:
             num_bytes /= 1024.0
             i += 1
         return f'{num_bytes:.2f} {size_units[i]}'
+
+    @classmethod
+    def convert_df_to_dict(cls, df: pd.DataFrame) -> dict:
+        """
+        Converts a DataFrame with exactly two columns into a dictionary. The first column is used as keys
+        and the second column as values.
+        """
+        assert len(df.columns) == 2, 'Cannot convert DataFrame to dict, expected 2 columns'
+        key_col, value_col = df.columns[0], df.columns[1]
+        return df.set_index(key_col)[value_col].to_dict()


### PR DESCRIPTION
Issue #251

This PR adds support for qualifying Photon jobs in the Python tool. We use a different strategy from Spark for qualifying Photon jobs.
- For Spark jobs, recommend apps having speed up > 1.3x
- For Photon jobs, recommend apps having speed up > 1x

## Changes
### Speed Up Strategy Builder
- [`user_tools/src/spark_rapids_pytools/rapids/qualification.py`](diffhunk://#diff-b0a32bd51bc60911ea7a9d91a6794a312db06d32a1df38c5aeac8243a4f4816fR306-R354): 
    - Introduced `SpeedupStrategyBuilder` and integrated it to dynamically build speedup strategies based on application type.
- [`user_tools/src/spark_rapids_tools/tools/speedup_category.py`](diffhunk://#diff-c410b2f13834f7c9bf6dd6944eea8dfeb370d2cf4894c8993b54e620999ac938R22-R98):
   - Added `SpeedupStrategy` and `SpeedupStrategyBuilder` classes to encapsulate speedup strategy logic. 
   - Modified `SpeedupCategory` to use these new classes. [[1]](diffhunk://#diff-c410b2f13834f7c9bf6dd6944eea8dfeb370d2cf4894c8993b54e620999ac938R22-R98) [[2]](diffhunk://#diff-c410b2f13834f7c9bf6dd6944eea8dfeb370d2cf4894c8993b54e620999ac938L47-R117) [[3]](diffhunk://#diff-c410b2f13834f7c9bf6dd6944eea8dfeb370d2cf4894c8993b54e620999ac938R147-R152)

### New Configuration Options:
- [`user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml`](diffhunk://#diff-22b8de975769653e2557b95d5f322532457b5d98a27e023cf4dac69b5daff963R4): 
   - Added `metricsSubFolder` and new speedup strategy configurations for different application types. [[1]](diffhunk://#diff-22b8de975769653e2557b95d5f322532457b5d98a27e023cf4dac69b5daff963R4) [[2]](diffhunk://#diff-22b8de975769653e2557b95d5f322532457b5d98a27e023cf4dac69b5daff963R258-R260) [[3]](diffhunk://#diff-22b8de975769653e2557b95d5f322532457b5d98a27e023cf4dac69b5daff963L277-R301)
- [`user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py`](diffhunk://#diff-478d74668cb7f8438192c9f044fe6312bd2f11df130607745e51223aa039004dR218-R222):
   - Added `get_metrics_output_folder` method to retrieve the metrics output folder path.

### Minor Code Adjustments:
* [`.pylintrc`](diffhunk://#diff-ba293004ae8f18975051e825bd8d5c70137a8b5d42d16e0f7c9354aa634c446cL59-L60): Removed redundant pylint disable rules.

