### PR TITLE
Add sparkRuntime property to capture runtime type in application_information

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -292,11 +292,11 @@ case class UnsupportedOpsProfileResult(appIndex: Int,
 case class AppInfoProfileResults(appIndex: Int, appName: String,
     appId: Option[String], sparkUser: String,
     startTime: Long, endTime: Option[Long], duration: Option[Long],
-    durationStr: String, sparkVersion: String,
+    durationStr: String, sparkRuntime: String, sparkVersion: String,
     pluginEnabled: Boolean)  extends ProfileResult {
   override val outputHeaders = Seq("appIndex", "appName", "appId",
     "sparkUser", "startTime", "endTime", "duration", "durationStr",
-    "sparkVersion", "pluginEnabled")
+    "sparkRuntime", "sparkVersion", "pluginEnabled")
 
   def endTimeToStr: String = {
     endTime match {
@@ -315,13 +315,14 @@ case class AppInfoProfileResults(appIndex: Int, appName: String,
   override def convertToSeq: Seq[String] = {
     Seq(appIndex.toString, appName, appId.getOrElse(""),
       sparkUser,  startTime.toString, endTimeToStr, durToStr,
-      durationStr, sparkVersion, pluginEnabled.toString)
+      durationStr, sparkRuntime, sparkVersion, pluginEnabled.toString)
   }
   override def convertToCSVSeq: Seq[String] = {
     Seq(appIndex.toString, StringUtils.reformatCSVString(appName),
       StringUtils.reformatCSVString(appId.getOrElse("")), StringUtils.reformatCSVString(sparkUser),
       startTime.toString, endTimeToStr, durToStr, StringUtils.reformatCSVString(durationStr),
-      StringUtils.reformatCSVString(sparkVersion), pluginEnabled.toString)
+      StringUtils.reformatCSVString(sparkRuntime), StringUtils.reformatCSVString(sparkVersion),
+      pluginEnabled.toString)
   }
 }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -20,7 +20,7 @@ import scala.collection.Map
 
 import org.apache.spark.resource.{ExecutorResourceRequest, TaskResourceRequest}
 import org.apache.spark.sql.rapids.tool.store.AccumMetaRef
-import org.apache.spark.sql.rapids.tool.util.StringUtils
+import org.apache.spark.sql.rapids.tool.util.{SparkRuntime, StringUtils}
 
 /**
  * This is a warehouse to store all Classes
@@ -292,7 +292,7 @@ case class UnsupportedOpsProfileResult(appIndex: Int,
 case class AppInfoProfileResults(appIndex: Int, appName: String,
     appId: Option[String], sparkUser: String,
     startTime: Long, endTime: Option[Long], duration: Option[Long],
-    durationStr: String, sparkRuntime: String, sparkVersion: String,
+    durationStr: String, sparkRuntime: SparkRuntime.SparkRuntime, sparkVersion: String,
     pluginEnabled: Boolean)  extends ProfileResult {
   override val outputHeaders = Seq("appIndex", "appName", "appId",
     "sparkUser", "startTime", "endTime", "duration", "durationStr",
@@ -315,14 +315,14 @@ case class AppInfoProfileResults(appIndex: Int, appName: String,
   override def convertToSeq: Seq[String] = {
     Seq(appIndex.toString, appName, appId.getOrElse(""),
       sparkUser,  startTime.toString, endTimeToStr, durToStr,
-      durationStr, sparkRuntime, sparkVersion, pluginEnabled.toString)
+      durationStr, sparkRuntime.toString, sparkVersion, pluginEnabled.toString)
   }
   override def convertToCSVSeq: Seq[String] = {
     Seq(appIndex.toString, StringUtils.reformatCSVString(appName),
       StringUtils.reformatCSVString(appId.getOrElse("")), StringUtils.reformatCSVString(sparkUser),
       startTime.toString, endTimeToStr, durToStr, StringUtils.reformatCSVString(durationStr),
-      StringUtils.reformatCSVString(sparkRuntime), StringUtils.reformatCSVString(sparkVersion),
-      pluginEnabled.toString)
+      StringUtils.reformatCSVString(sparkRuntime.toString),
+      StringUtils.reformatCSVString(sparkVersion), pluginEnabled.toString)
   }
 }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/InformationView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/InformationView.scala
@@ -29,7 +29,7 @@ trait AppInformationViewTrait extends ViewableTrait[AppInfoProfileResults] {
     app.appMetaData.map { a =>
       AppInfoProfileResults(index, a.appName, a.appId,
         a.sparkUser, a.startTime, a.endTime, app.getAppDuration,
-        a.getDurationString, app.sparkVersion, app.gpuMode)
+        a.getDurationString, app.sparkRuntime.toString, app.sparkVersion, app.gpuMode)
     }.toSeq
   }
   override def sortView(rows: Seq[AppInfoProfileResults]): Seq[AppInfoProfileResults] = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/InformationView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/InformationView.scala
@@ -29,7 +29,7 @@ trait AppInformationViewTrait extends ViewableTrait[AppInfoProfileResults] {
     app.appMetaData.map { a =>
       AppInfoProfileResults(index, a.appName, a.appId,
         a.sparkUser, a.startTime, a.endTime, app.getAppDuration,
-        a.getDurationString, app.sparkRuntime.toString, app.sparkVersion, app.gpuMode)
+        a.getDurationString, app.getSparkRuntime, app.sparkVersion, app.gpuMode)
     }.toSeq
   }
   override def sortView(rows: Seq[AppInfoProfileResults]): Seq[AppInfoProfileResults] = {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -37,7 +37,7 @@ import org.apache.spark.scheduler.{SparkListenerEvent, StageInfo}
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
 import org.apache.spark.sql.rapids.tool.store.{AccumManager, DataSourceRecord, SQLPlanModelManager, StageModel, StageModelManager, TaskModelManager}
-import org.apache.spark.sql.rapids.tool.util.{EventUtils, RapidsToolsConfUtil, ToolsPlanGraph, UTF8Source}
+import org.apache.spark.sql.rapids.tool.util.{EventUtils, RapidsToolsConfUtil, SparkRuntime, ToolsPlanGraph, UTF8Source}
 import org.apache.spark.util.Utils
 
 abstract class AppBase(
@@ -475,6 +475,7 @@ abstract class AppBase(
   protected def postCompletion(): Unit = {
     registerAttemptId()
     calculateAppDuration()
+    setSparkRuntime()
   }
 
   /**
@@ -484,6 +485,19 @@ abstract class AppBase(
   def processEvents(): Unit = {
     processEventsInternal()
     postCompletion()
+  }
+
+  /**
+   * Sets the spark runtime based on the properties of the application.
+   */
+  private def setSparkRuntime(): Unit = {
+    sparkRuntime = if (isPhoton) {
+      SparkRuntime.PHOTON
+    } else if (gpuMode) {
+      SparkRuntime.SPARK_RAPIDS
+    } else {
+      SparkRuntime.SPARK
+    }
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -37,7 +37,7 @@ import org.apache.spark.scheduler.{SparkListenerEvent, StageInfo}
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
 import org.apache.spark.sql.rapids.tool.store.{AccumManager, DataSourceRecord, SQLPlanModelManager, StageModel, StageModelManager, TaskModelManager}
-import org.apache.spark.sql.rapids.tool.util.{EventUtils, RapidsToolsConfUtil, SparkRuntime, ToolsPlanGraph, UTF8Source}
+import org.apache.spark.sql.rapids.tool.util.{EventUtils, RapidsToolsConfUtil, ToolsPlanGraph, UTF8Source}
 import org.apache.spark.util.Utils
 
 abstract class AppBase(
@@ -475,7 +475,6 @@ abstract class AppBase(
   protected def postCompletion(): Unit = {
     registerAttemptId()
     calculateAppDuration()
-    setSparkRuntime()
   }
 
   /**
@@ -485,19 +484,6 @@ abstract class AppBase(
   def processEvents(): Unit = {
     processEventsInternal()
     postCompletion()
-  }
-
-  /**
-   * Sets the spark runtime based on the properties of the application.
-   */
-  private def setSparkRuntime(): Unit = {
-    sparkRuntime = if (isPhoton) {
-      SparkRuntime.PHOTON
-    } else if (gpuMode) {
-      SparkRuntime.SPARK_RAPIDS
-    } else {
-      SparkRuntime.SPARK
-    }
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ClusterTagPropHandler.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ClusterTagPropHandler.scala
@@ -28,9 +28,6 @@ trait ClusterTagPropHandler extends CacheablePropsHandler {
   var clusterTagClusterId: String = ""
   var clusterTagClusterName: String = ""
 
-  // A flag to indicate whether the eventlog being processed is an eventlog from Photon.
-  var isPhoton = false
-
   // Flag used to indicate that the App was a Databricks App.
   def isDatabricks: Boolean = {
     clusterTags.nonEmpty && clusterTagClusterId.nonEmpty && clusterTagClusterName.nonEmpty

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/CacheablePropsHandler.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/CacheablePropsHandler.scala
@@ -25,6 +25,15 @@ import org.apache.spark.scheduler.{SparkListenerEnvironmentUpdate, SparkListener
 import org.apache.spark.sql.rapids.tool.AppEventlogProcessException
 import org.apache.spark.util.Utils.REDACTION_REPLACEMENT_TEXT
 
+
+/**
+ * Enum to represent different spark runtimes.
+ */
+object SparkRuntime extends Enumeration {
+  type SparkRuntime = Value
+  val SPARK, SPARK_RAPIDS, PHOTON = Value
+}
+
 // Handles updating and caching Spark Properties for a Spark application.
 // Properties stored in this container can be accessed to make decision about certain analysis
 // that depends on the context of the Spark properties.
@@ -68,10 +77,12 @@ trait CacheablePropsHandler {
 
   // caches the spark-version from the eventlogs
   var sparkVersion: String = ""
+  // caches the spark runtime based on the application properties
+  var sparkRuntime: SparkRuntime.Value = SparkRuntime.SPARK
   var gpuMode = false
   // A flag whether hive is enabled or not. Note that we assume that the
   // property is global to the entire application once it is set. a.k.a, it cannot be disabled
-  // once it is was set to true.
+  // once it was set to true.
   var hiveEnabled = false
   // Indicates the ML eventlogType (i.e., Scala or pyspark). It is set only when MLOps are detected.
   // By default, it is empty.

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -1119,14 +1119,14 @@ class ApplicationInfoSuite extends FunSuite with Logging {
   val sparkRuntimeTestCases: Seq[(SparkRuntime.Value, String)] = Seq(
     SparkRuntime.SPARK -> s"$qualLogDir/nds_q86_test",
     SparkRuntime.SPARK_RAPIDS -> s"$logDir/nds_q66_gpu.zstd",
-    SparkRuntime.PHOTON-> s"$qualLogDir/nds_q88_photon_db_13_3.zstd"
+    SparkRuntime.PHOTON -> s"$qualLogDir/nds_q88_photon_db_13_3.zstd"
   )
 
   sparkRuntimeTestCases.foreach { case (expectedSparkRuntime, eventLog) =>
     test(s"test spark runtime property for ${expectedSparkRuntime.toString} eventlog") {
       val apps = ToolTestUtils.processProfileApps(Array(eventLog), sparkSession)
       assert(apps.size == 1)
-      assert(apps.head.sparkRuntime == expectedSparkRuntime)
+      assert(apps.head.getSparkRuntime == expectedSparkRuntime)
     }
   }
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.sql.{SparkSession, TrampolineUtil}
 import org.apache.spark.sql.rapids.tool.profiling._
-import org.apache.spark.sql.rapids.tool.util.FSUtils
+import org.apache.spark.sql.rapids.tool.util.{FSUtils, SparkRuntime}
 
 class ApplicationInfoSuite extends FunSuite with Logging {
 
@@ -1113,6 +1113,20 @@ class ApplicationInfoSuite extends FunSuite with Logging {
             |} ]""".stripMargin
       // assert that the spark rapids build info json file is same as expected
       assert(actualResult == expectedResult)
+    }
+  }
+
+  val sparkRuntimeTestCases: Seq[(SparkRuntime.Value, String)] = Seq(
+    SparkRuntime.SPARK -> s"$qualLogDir/nds_q86_test",
+    SparkRuntime.SPARK_RAPIDS -> s"$logDir/nds_q66_gpu.zstd",
+    SparkRuntime.PHOTON-> s"$qualLogDir/nds_q88_photon_db_13_3.zstd"
+  )
+
+  sparkRuntimeTestCases.foreach { case (expectedSparkRuntime, eventLog) =>
+    test(s"test spark runtime property for ${expectedSparkRuntime.toString} eventlog") {
+      val apps = ToolTestUtils.processProfileApps(Array(eventLog), sparkSession)
+      assert(apps.size == 1)
+      assert(apps.head.sparkRuntime == expectedSparkRuntime)
     }
   }
 }


### PR DESCRIPTION
Fixes #1413

This PR adds a new `getSparkRuntime` method to capture the Spark Runtime type `(SPARK, PHOTON, SPARK_RAPIDS)` and store this in `application_information.csv`


## Changes
### Profiling Enhancements:
* Added `sparkRuntime` property to `AppInfoProfileResults` to capture the runtime environment and updated the `outputHeaders` and `convertToSeq` methods to include this new property. [[1]](diffhunk://#diff-8d5819c9445c1489d61ee8d03fd2b1ee1e0cb33896f402f4ceb7782c35deed69L295-R299) [[2]](diffhunk://#diff-8d5819c9445c1489d61ee8d03fd2b1ee1e0cb33896f402f4ceb7782c35deed69L318-R325)
* Updated `AppInformationViewTrait` to map the new `sparkRuntime` property when creating `AppInfoProfileResults` instances.

### Runtime Handling:
* Introduced `SparkRuntime` enumeration to represent different Spark runtimes (SPARK, PHOTON, SPARK_RAPIDS).
* Added `getSparkRuntime` method to `CacheablePropsHandler` 

### Testing:
* Added test cases in `ApplicationInfoSuite` to validate the spark runtime value for different event logs.


## Output

File: `application_information.csv`

SPARK Runtime:

```
appIndex,appName,appId,sparkUser,startTime,endTime,duration,durationStr,sparkRuntime,sparkVersion,pluginEnabled
1,"Databricks Shell","app-20240827220408-0000","root",1724796242014,1724799713682,3471668,"58 min","SPARK","13.3.x-aarch64-scala2.12",false
```

SPARK_RAPIDS Runtime:
```
appIndex,appName,appId,sparkUser,startTime,endTime,duration,durationStr,sparkRuntime,sparkVersion,pluginEnabled
1,"Databricks Shell","app-20240827233829-0000","root",1724801903175,1724802355703,452528,"7.5 min","SPARK_RAPIDS","13.3.x-gpu-ml-scala2.12",true
```

PHOTON Runtime:
```
appIndex,appName,appId,sparkUser,startTime,endTime,duration,durationStr,sparkRuntime,sparkVersion,pluginEnabled
1,"Databricks Shell","app-20240818062343-0000","root",1723962217320,1723962595796,378476,"6.3 min","PHOTON","13.3.x-aarch64-photon-scala2.12",false
```

cc: @leewyang 

