### PR TITLE
Reduce the log noise caused by core report summary

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/ToolTextFileWriter.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/ToolTextFileWriter.scala
@@ -70,7 +70,7 @@ class ToolTextFileWriter(
     // No need to close the outputStream.
     // Java should handle nested streams automatically.
     utf8Writer.foreach { writer =>
-      logInfo(s"$finalLocationText output location: $textOutputLoc")
+      logDebug(s"$finalLocationText output location: $textOutputLoc")
       writer.flush()
       writer.close()
     }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
@@ -119,6 +119,7 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
     progressBar.foreach(_.finishAll())
 
     // Write status reports for all event logs to a CSV file
+    logOutputPath()
     val reportResults = generateStatusResults(appStatusReporter.asScala.values.toSeq)
     ProfileOutputWriter.writeCSVTable("Profiling Status", reportResults, outputDir)
   }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -238,13 +238,6 @@ class Qualification(outputPath: String, numRows: Int, hadoopConf: Configuration,
   }
 
   /**
-   * The outputPath of the current instance of the provider
-   */
-  def getReportOutputPath: String = {
-    s"$outputDir/rapids_4_spark_qualification_output"
-  }
-
-  /**
    * Generates a qualification report based on the provided summary information.
    */
   private def generateQualificationReport(allAppsSum: Seq[QualificationSummaryInfo],
@@ -263,6 +256,7 @@ class Qualification(outputPath: String, numRows: Int, hadoopConf: Configuration,
     qWriter.writeStageReport(allAppsSum, order)
     qWriter.writeUnsupportedOpsSummaryCSVReport(allAppsSum)
     val appStatusResult = generateStatusResults(appStatusReporter.asScala.values.toSeq)
+    logOutputPath()
     qWriter.writeStatusReport(appStatusResult, order)
     if (mlOpsEnabled) {
       if (allAppsSum.exists(x => x.mlFunctions.nonEmpty)) {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/RuntimeReporter.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/RuntimeReporter.scala
@@ -27,6 +27,9 @@ trait RuntimeReporter extends Logging {
   def generateRuntimeReport(hadoopConf: Option[Configuration] = None): Unit = {
     RuntimeUtil.generateReport(outputDir, hadoopConf)
   }
+  def logOutputPath(): Unit = {
+    logInfo(s"Tools output directory: $outputDir")
+  }
 
   /**
    * Updates the status of "SUCCESS" applications to "SKIPPED" if newer attempts with


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Contributes to #1416

This change set the log level of ToolTextFileWriter to debug and summarize the logging into a single message to show the final directory


example output after the changes:

```
Qual Tool Progress 100% [=============================================] (1 succeeded + 0 failed + 0 skipped + 0 N/A) / 1
Qual Tool execution time: 1018ms
	process.success.count = 1
	process.failure.count = 0
	process.skipped.count = 0
	process.NA.count = 0
	execution.total.count = 1
24/11/15 20:43:35 INFO AutoTuner: Available memory per exec is not specified
24/11/15 20:43:35 INFO SuccessAppResult: File: file:/eventlogs/cpu/local-1731613821387, Message: Took 1001ms to process
APPLICATION SUMMARY:
================================================================================================================================================================
| App Name|             App ID|App Duration|SQL DF Duration|GPU Opportunity|        Unsupported Execs|Unsupported Expressions|Estimated Job Frequency (monthly)|
================================================================================================================================================================
|sqlmetric|local-1731613821387|        2721|            557|            436|Scan;SerializeFromObje...|                       |                               30|
================================================================================================================================================================
PER SQL SUMMARY:
==========================================================================================================================
| App Name|             App ID|Root SQL ID|SQL ID|                        SQL Description|SQL DF Duration|GPU Opportunity|
==========================================================================================================================
|sqlmetric|local-1731613821387|          5|     5|collect at SqlPlanParserSuite.scala:543|            328|            239|
|sqlmetric|local-1731613821387|          0|     0|collect at SqlPlanParserSuite.scala:537|            439|            146|
|sqlmetric|local-1731613821387|          1|     1|collect at SqlPlanParserSuite.scala:538|             82|             82|
|sqlmetric|local-1731613821387|          2|     2|collect at SqlPlanParserSuite.scala:540|             89|             30|
|sqlmetric|local-1731613821387|          4|     4|collect at SqlPlanParserSuite.scala:542|             39|              8|
|sqlmetric|local-1731613821387|          6|     6|      collect at ToolTestUtils.scala:99|             25|              8|
|sqlmetric|local-1731613821387|          3|     3|collect at SqlPlanParserSuite.scala:541|             20|              0|
==========================================================================================================================
24/11/15 20:43:35 INFO Qualification: Tools output directory: file:///output_folder/qual_20241114202203_3dfECa03-debug/rapids_4_spark_qualification_output

Process finished with exit code 0
```