### PR TITLE
Add Arguments for Distributed Mode in Qualification Tool CLI

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
@@ -31,6 +31,7 @@ from spark_rapids_pytools.pricing.databricks_aws_pricing import DatabricksAWSPri
 from spark_rapids_pytools.pricing.price_provider import SavingsEstimator
 
 
+# pylint: disable=abstract-method
 @dataclass
 class DBAWSPlatform(EMRPlatform):
     """

--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
@@ -29,6 +29,7 @@ from spark_rapids_pytools.pricing.databricks_azure_pricing import DatabricksAzur
 from spark_rapids_pytools.pricing.price_provider import SavingsEstimator
 
 
+# pylint: disable=abstract-method
 @dataclass
 class DBAzurePlatform(PlatformBase):
     """

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -32,6 +32,7 @@ from spark_rapids_pytools.pricing.dataproc_pricing import DataprocPriceProvider
 from spark_rapids_pytools.pricing.price_provider import SavingsEstimator
 
 
+# pylint: disable=abstract-method
 @dataclass
 class DataprocPlatform(PlatformBase):
     """

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc_gke.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc_gke.py
@@ -29,6 +29,7 @@ from spark_rapids_pytools.pricing.dataproc_gke_pricing import DataprocGkePricePr
 from spark_rapids_tools import CspEnv
 
 
+# pylint: disable=abstract-method
 @dataclass
 class DataprocGkePlatform(DataprocPlatform):
     """

--- a/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/emr.py
@@ -31,6 +31,7 @@ from spark_rapids_pytools.pricing.emr_pricing import EMREc2PriceProvider
 from spark_rapids_pytools.pricing.price_provider import SavingsEstimator
 
 
+# pylint: disable=abstract-method
 @dataclass
 class EMRPlatform(PlatformBase):
     """

--- a/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
@@ -157,6 +157,7 @@ class OnPremLocalRapidsJob(RapidsLocalJob):
     job_label = 'onpremLocal'
 
 
+# pylint: disable=abstract-method
 @dataclass
 class OnPremDistributedRapidsJob(RapidsDistributedJob):
     """

--- a/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
@@ -19,7 +19,6 @@ from dataclasses import dataclass
 from typing import Any, List, Optional
 
 from spark_rapids_tools import CspEnv
-from spark_rapids_pytools.rapids.rapids_job import RapidsLocalJob
 from spark_rapids_pytools.cloud_api.sp_types import PlatformBase, ClusterBase, ClusterNode, \
     CMDDriverBase, ClusterGetAccessor, GpuDevice, \
     GpuHWInfo, NodeHWInfo, SparkNodeType, SysInfo
@@ -27,6 +26,7 @@ from spark_rapids_pytools.common.prop_manager import JSONPropertiesContainer
 from spark_rapids_pytools.common.sys_storage import StorageDriver
 from spark_rapids_pytools.pricing.dataproc_pricing import DataprocPriceProvider
 from spark_rapids_pytools.pricing.price_provider import SavingsEstimator
+from spark_rapids_pytools.rapids.rapids_job import RapidsLocalJob, RapidsDistributedJob
 
 
 @dataclass
@@ -48,6 +48,9 @@ class OnPremPlatform(PlatformBase):
 
     def create_local_submission_job(self, job_prop, ctxt) -> Any:
         return OnPremLocalRapidsJob(prop_container=job_prop, exec_ctxt=ctxt)
+
+    def create_distributed_submission_job(self, job_prop, ctxt) -> RapidsDistributedJob:
+        return OnPremDistributedRapidsJob(prop_container=job_prop, exec_ctxt=ctxt)
 
     def _construct_cluster_from_props(self, cluster: str, props: str = None, is_inferred: bool = False,
                                       is_props_file: bool = False):
@@ -152,6 +155,14 @@ class OnPremLocalRapidsJob(RapidsLocalJob):
     Implementation of a RAPIDS job that runs on a local machine.
     """
     job_label = 'onpremLocal'
+
+
+@dataclass
+class OnPremDistributedRapidsJob(RapidsDistributedJob):
+    """
+    Implementation of a RAPIDS job that runs on a distributed cluster
+    """
+    job_label = 'onpremDistributed'
 
 
 @dataclass

--- a/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/onprem.py
@@ -162,7 +162,7 @@ class OnPremDistributedRapidsJob(RapidsDistributedJob):
     """
     Implementation of a RAPIDS job that runs on a distributed cluster
     """
-    job_label = 'onpremDistributed'
+    job_label = 'onprem.distributed'
 
 
 @dataclass

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -22,11 +22,11 @@ from enum import Enum
 from logging import Logger
 from typing import Type, Any, List, Callable, Union, Optional, final, Dict
 
-from spark_rapids_tools import EnumeratedType, CspEnv
 from spark_rapids_pytools.common.prop_manager import AbstractPropertiesContainer, JSONPropertiesContainer, \
     get_elem_non_safe
 from spark_rapids_pytools.common.sys_storage import StorageDriver, FSUtil
 from spark_rapids_pytools.common.utilities import ToolLogging, SysCmd, Utils, TemplateGenerator
+from spark_rapids_tools import EnumeratedType, CspEnv
 
 
 class DeployMode(EnumeratedType):
@@ -882,6 +882,9 @@ class PlatformBase:
         raise NotImplementedError
 
     def create_local_submission_job(self, job_prop, ctxt) -> Any:
+        raise NotImplementedError
+
+    def create_distributed_submission_job(self, job_prop, ctxt) -> Any:
         raise NotImplementedError
 
     def load_platform_configs(self):

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -153,6 +153,10 @@ class Qualification(RapidsJarTool):
             estimation_model_args = QualEstimationModel.create_default_model_args(selected_model)
         self.ctxt.set_ctxt('estimationModelArgs', estimation_model_args)
 
+    def _process_distributed_mode_args(self) -> None:
+        distributed_mode_args = self.wrapper_options.get('distributedModeArgs')
+        self.ctxt.set_ctxt('distributedModeArgs', distributed_mode_args)
+
     def _process_custom_args(self) -> None:
         """
         Qualification tool processes extra arguments:
@@ -181,6 +185,7 @@ class Qualification(RapidsJarTool):
         self._process_estimation_model_args()
         self._process_offline_cluster_args()
         self._process_eventlogs_args()
+        self._process_distributed_mode_args()
         # This is noise to dump everything
         # self.logger.debug('%s custom arguments = %s', self.pretty_name(), self.ctxt.props['wrapperCtx'])
 
@@ -375,7 +380,7 @@ class Qualification(RapidsJarTool):
 
         df = self._read_qualification_output_file('summaryReport')
         # 1. Operations related to XGboost modelling
-        if self.ctxt.get_ctxt('estimationModelArgs')['xgboostEnabled']:
+        if not df.empty and self.ctxt.get_ctxt('estimationModelArgs')['xgboostEnabled']:
             try:
                 df = self.__update_apps_with_prediction_info(df,
                                                              self.ctxt.get_ctxt('estimationModelArgs'))

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -153,9 +153,9 @@ class Qualification(RapidsJarTool):
             estimation_model_args = QualEstimationModel.create_default_model_args(selected_model)
         self.ctxt.set_ctxt('estimationModelArgs', estimation_model_args)
 
-    def _process_distributed_mode_args(self) -> None:
-        distributed_mode_args = self.wrapper_options.get('distributedModeArgs')
-        self.ctxt.set_ctxt('distributedModeArgs', distributed_mode_args)
+    def _process_distributed_tools_args(self) -> None:
+        distributed_tools_enabled = self.wrapper_options.get('distributedToolsEnabled')
+        self.ctxt.set_ctxt('distributedToolsEnabled', distributed_tools_enabled)
 
     def _process_custom_args(self) -> None:
         """
@@ -185,7 +185,7 @@ class Qualification(RapidsJarTool):
         self._process_estimation_model_args()
         self._process_offline_cluster_args()
         self._process_eventlogs_args()
-        self._process_distributed_mode_args()
+        self._process_distributed_tools_args()
         # This is noise to dump everything
         # self.logger.debug('%s custom arguments = %s', self.pretty_name(), self.ctxt.props['wrapperCtx'])
 

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_job.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_job.py
@@ -17,12 +17,13 @@
 import os
 from dataclasses import dataclass, field
 from logging import Logger
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from spark_rapids_pytools.common.prop_manager import JSONPropertiesContainer
 from spark_rapids_pytools.common.utilities import ToolLogging, Utils
 from spark_rapids_pytools.rapids.tool_ctxt import ToolContext
 from spark_rapids_tools.storagelib import LocalPath
+from spark_rapids_tools_distributed.jar_cmd_args import JarCmdArgs
 
 
 @dataclass
@@ -90,10 +91,10 @@ class RapidsJob:
         rapids_arguments.extend(extra_rapids_args)
         return rapids_arguments
 
-    def _build_submission_cmd(self) -> list:
+    def _build_submission_cmd(self) -> Union[list, JarCmdArgs]:
         raise NotImplementedError
 
-    def _submit_job(self, cmd_args: list) -> str:
+    def _submit_job(self, cmd_args: Union[list, JarCmdArgs]) -> str:
         raise NotImplementedError
 
     def _print_job_output(self, job_output: str):
@@ -124,13 +125,6 @@ class RapidsJob:
         finally:
             self._cleanup_temp_log4j_files()
         return job_output
-
-
-@dataclass
-class RapidsLocalJob(RapidsJob):
-    """
-    Implementation of a RAPIDS job that runs local on a machine.
-    """
 
     def _get_hadoop_classpath(self) -> Optional[str]:
         """
@@ -202,6 +196,13 @@ class RapidsLocalJob(RapidsJob):
                 vm_args.append(val)
         return vm_args
 
+
+@dataclass
+class RapidsLocalJob(RapidsJob):
+    """
+    Implementation of a RAPIDS job that runs local on a machine.
+    """
+
     def _build_submission_cmd(self) -> list:
         # env vars are added later as a separate dictionary
         classpath_arr = self._build_classpath()
@@ -218,3 +219,31 @@ class RapidsLocalJob(RapidsJob):
         out_std = self.exec_ctxt.platform.cli.run_sys_cmd(cmd=cmd_args,
                                                           env_vars=env_args)
         return out_std
+
+
+@dataclass
+class RapidsDistributedJob(RapidsJob):
+    """
+    Implementation of a RAPIDS job that runs distributed on a cluster.
+    """
+
+    def _build_submission_cmd(self) -> JarCmdArgs:
+        classpath_arr = self._build_classpath()
+        hadoop_cp = self._get_hadoop_classpath()
+        jvm_args_arr = self._build_jvm_args()
+        jar_main_class = self.prop_container.get_jar_main_class()
+        jar_output_dir_args = self._get_persistent_rapids_args()
+        extra_rapids_args = self.prop_container.get_rapids_args()
+        return JarCmdArgs(jvm_args_arr, classpath_arr, hadoop_cp, jar_main_class,
+                          jar_output_dir_args, extra_rapids_args)
+
+    def _build_classpath(self) -> List[str]:
+        """
+        Only the Spark RAPIDS Tools JAR file is needed for the classpath.
+        Each worker node should the Spark Jars pre-installed.
+        """
+        return ['-cp', self.prop_container.get_jar_file()]
+
+    def _submit_job(self, cmd_args: JarCmdArgs) -> None:
+        # TODO: Support for submitting the Tools JAR to a Spark cluster
+        raise NotImplementedError('Distributed job submission is not yet supported')

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_job.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_job.py
@@ -39,6 +39,8 @@ class RapidsJobPropContainer(JSONPropertiesContainer):
             self.props['sparkConfArgs'] = {}
         if self.get_value_silent('platformArgs') is None:
             self.props['platformArgs'] = {}
+        if self.get_value_silent('distributedToolsConfigs') is None:
+            self.props['distributedToolsConfigs'] = {}
 
     def get_jar_file(self):
         return self.get_value('rapidsArgs', 'jarFile')
@@ -48,6 +50,9 @@ class RapidsJobPropContainer(JSONPropertiesContainer):
 
     def get_rapids_args(self):
         return self.get_value('rapidsArgs', 'jarArgs')
+
+    def get_distribution_tools_configs(self):
+        return self.get_value('distributedToolsConfigs')
 
 
 @dataclass

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -957,8 +957,8 @@ class RapidsJarTool(RapidsTool):
             if self.ctxt.is_distributed_mode():
                 return config_obj.distributed_tools
             self.logger.warning(
-                'Distributed tool configurations detected, but distributed mode is not active. '
-                'Switching to local mode.'
+                'Distributed tool configurations detected, but distributed mode is not enabled.'
+                'Use \'--distributed\' flag to enable distributed mode. Switching to local mode.'
             )
         elif self.ctxt.is_distributed_mode():
             self.logger.warning(

--- a/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
@@ -89,6 +89,10 @@ class ToolContext(YAMLPropertiesContainer):
     def is_fat_wheel_mode(self) -> bool:
         return self.get_ctxt('fatWheelModeEnabled')
 
+    def is_distributed_mode(self) -> bool:
+        distributed_mode_args = self.get_ctxt('distributedModeArgs')
+        return distributed_mode_args is not None and distributed_mode_args.get('distributedModeEnabled', False)
+
     def set_ctxt(self, key: str, val: Any):
         self.props['wrapperCtx'][key] = val
 

--- a/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
@@ -90,8 +90,7 @@ class ToolContext(YAMLPropertiesContainer):
         return self.get_ctxt('fatWheelModeEnabled')
 
     def is_distributed_mode(self) -> bool:
-        distributed_mode_args = self.get_ctxt('distributedModeArgs')
-        return distributed_mode_args is not None and distributed_mode_args.get('distributedModeEnabled', False)
+        return self.get_ctxt('distributedToolsEnabled') or False
 
     def set_ctxt(self, key: str, val: Any):
         self.props['wrapperCtx'][key] = val

--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -470,7 +470,7 @@ class QualifyUserArgModel(ToolUserArgModel):
     """
     filter_apps: Optional[QualFilterApp] = None
     estimation_model_args: Optional[Dict] = dataclasses.field(default_factory=dict)
-    distributed_mode_args: Optional[Dict] = dataclasses.field(default_factory=dict)
+    distributed_tools_enabled: Optional[bool] = None
 
     def init_tool_args(self) -> None:
         self.p_args['toolArgs']['platform'] = self.platform
@@ -534,7 +534,7 @@ class QualifyUserArgModel(ToolUserArgModel):
             'filterApps': QualFilterApp.fromstring(self.p_args['toolArgs']['filterApps']),
             'toolsJar': self.p_args['toolArgs']['toolsJar'],
             'estimationModelArgs': self.p_args['toolArgs']['estimationModelArgs'],
-            'distributedModeArgs': self.distributed_mode_args
+            'distributedToolsEnabled': self.distributed_tools_enabled
         }
         return wrapped_args
 
@@ -755,28 +755,4 @@ class InstanceDescriptionUserArgModel(AbsToolUserArgModel):
             'targetPlatform': CspEnv(self.target_platform),
             'output_folder': self.output_folder,
             'platformOpts': {},
-        }
-
-
-@dataclass
-@register_tool_arg_validator('distributed_mode')
-class DistributedModeArgProcessor(AbsToolUserArgModel):
-    """
-    Class to validate the arguments of Distributed Mode
-    """
-    distributed_mode: Optional[bool] = None
-    spark_config_file: Optional[str] = None
-
-    def validate_spark_conf_file(self) -> None:
-        # validate the spark configuration file path is valid
-        if self.spark_config_file is not None:
-            if not CspPath.is_file_path(self.spark_config_file, extensions=['conf']):
-                raise PydanticCustomError(
-                    'spark_conf_file',
-                    f'spark configuration file path {self.spark_config_file} is not valid\n  Error:')
-
-    def build_tools_args(self) -> dict:
-        return {
-            'distributedModeEnabled': self.distributed_mode,
-            'sparkConfigFile': self.spark_config_file,
         }

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -46,6 +46,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                       jvm_threads: int = None,
                       verbose: bool = None,
                       tools_config_file: str = None,
+                      distributed: bool = None,
+                      spark_config_file: str = None,
                       **rapids_options) -> None:
         """The Qualification cmd provides estimated speedups by migrating Apache Spark applications
         to GPU accelerated clusters.
@@ -83,6 +85,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         :param tools_config_file: Path to a configuration file that contains the tools' options.
                For sample configuration files, please visit
                https://github.com/NVIDIA/spark-rapids-tools/tree/main/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid
+        :param distributed: True or False to enable distributed mode.
+        :param spark_config_file: Path to a Spark configuration file to be used in distributed mode.
         :param rapids_options: A list of valid Qualification tool options.
                 Note that the wrapper ignores ["output-directory", "platform"] flags, and it does not support
                 multiple "spark-property" arguments.
@@ -107,6 +111,9 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                                                      custom_model_file=custom_model_file)
         if estimation_model_args is None:
             return None
+        distributed_mode_args = AbsToolUserArgModel.create_tool_args('distributed_mode',
+                                                                     distributed_mode=distributed,
+                                                                     spark_config_file=spark_config_file)
         qual_args = AbsToolUserArgModel.create_tool_args('qualification',
                                                          eventlogs=eventlogs,
                                                          cluster=cluster,
@@ -117,7 +124,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                                          jvm_threads=jvm_threads,
                                                          filter_apps=filter_apps,
                                                          estimation_model_args=estimation_model_args,
-                                                         tools_config_path=tools_config_file)
+                                                         tools_config_path=tools_config_file,
+                                                         distributed_mode_args=distributed_mode_args)
         if qual_args:
             tool_obj = QualificationAsLocal(platform_type=qual_args['runtimePlatform'],
                                             output_folder=qual_args['outputFolder'],

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -47,7 +47,6 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                       verbose: bool = None,
                       tools_config_file: str = None,
                       distributed: bool = None,
-                      spark_config_file: str = None,
                       **rapids_options) -> None:
         """The Qualification cmd provides estimated speedups by migrating Apache Spark applications
         to GPU accelerated clusters.
@@ -86,7 +85,6 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                For sample configuration files, please visit
                https://github.com/NVIDIA/spark-rapids-tools/tree/main/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid
         :param distributed: True or False to enable distributed mode.
-        :param spark_config_file: Path to a Spark configuration file to be used in distributed mode.
         :param rapids_options: A list of valid Qualification tool options.
                 Note that the wrapper ignores ["output-directory", "platform"] flags, and it does not support
                 multiple "spark-property" arguments.
@@ -111,9 +109,6 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                                                      custom_model_file=custom_model_file)
         if estimation_model_args is None:
             return None
-        distributed_mode_args = AbsToolUserArgModel.create_tool_args('distributed_mode',
-                                                                     distributed_mode=distributed,
-                                                                     spark_config_file=spark_config_file)
         qual_args = AbsToolUserArgModel.create_tool_args('qualification',
                                                          eventlogs=eventlogs,
                                                          cluster=cluster,
@@ -125,7 +120,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                                          filter_apps=filter_apps,
                                                          estimation_model_args=estimation_model_args,
                                                          tools_config_path=tools_config_file,
-                                                         distributed_mode_args=distributed_mode_args)
+                                                         distributed_tools_enabled=distributed)
         if qual_args:
             tool_obj = QualificationAsLocal(platform_type=qual_args['runtimePlatform'],
                                             output_folder=qual_args['outputFolder'],

--- a/user_tools/src/spark_rapids_tools/configuration/distributed_tools_config.py
+++ b/user_tools/src/spark_rapids_tools/configuration/distributed_tools_config.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Configuration file for distributed tools """
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class SparkProperty(BaseModel):
+    """Represents a single Spark property with a name and value."""
+    name: str = Field(
+        description='The name of the Spark property, e.g., "spark.executor.memory".')
+    value: str = Field(
+        description='The value of the Spark property, e.g., "4g".')
+
+
+class DistributedToolsConfig(BaseModel):
+    """Configuration class for distributed tools"""
+    spark_properties: List[SparkProperty] = Field(
+        default_factory=list,
+        description='List of Spark properties to be used for the Spark session.',
+        examples=[{'name': 'spark.executor.memory', 'value': '4g'},
+                  {'name': 'spark.executor.cores', 'value': '4'}]
+    )

--- a/user_tools/src/spark_rapids_tools/configuration/distributed_tools_config.py
+++ b/user_tools/src/spark_rapids_tools/configuration/distributed_tools_config.py
@@ -21,9 +21,9 @@ from pydantic import BaseModel, Field
 class SparkProperty(BaseModel):
     """Represents a single Spark property with a name and value."""
     name: str = Field(
-        description='The name of the Spark property, e.g., "spark.executor.memory".')
+        description='Name of the Spark property, e.g., "spark.executor.memory".')
     value: str = Field(
-        description='The value of the Spark property, e.g., "4g".')
+        description='Value of the Spark property, e.g., "4g".')
 
 
 class DistributedToolsConfig(BaseModel):

--- a/user_tools/src/spark_rapids_tools/configuration/tools_config.py
+++ b/user_tools/src/spark_rapids_tools/configuration/tools_config.py
@@ -21,6 +21,7 @@ from typing import Union, Optional
 from pydantic import BaseModel, Field, ValidationError
 
 from spark_rapids_tools import CspPathT
+from spark_rapids_tools.configuration.distributed_tools_config import DistributedToolsConfig
 from spark_rapids_tools.configuration.runtime_conf import ToolsRuntimeConfig
 from spark_rapids_tools.utils import AbstractPropContainer
 
@@ -34,8 +35,14 @@ class ToolsConfig(BaseModel):
         examples=['1.0'],
         le=1.0,  # minimum version compatible with the current tools implementation
         ge=1.0)
-    runtime: ToolsRuntimeConfig = Field(
+
+    runtime: Optional[ToolsRuntimeConfig] = Field(
+        default=None,
         description='Configuration related to the runtime environment of the tools.')
+
+    distributed_tools: Optional[DistributedToolsConfig] = Field(
+        default=None,
+        description='Configuration related to the distributed tools.')
 
     @classmethod
     def load_from_file(cls, file_path: Union[str, CspPathT]) -> Optional['ToolsConfig']:

--- a/user_tools/src/spark_rapids_tools/tools/qualification_stats_report.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualification_stats_report.py
@@ -105,7 +105,7 @@ App ID  SQL ID   Operator  Count StageTaskDuration TotalSQLTaskDuration  % of To
         self.execs_df = (self.execs_df.explode('Exec Stages').
                          dropna(subset=['Exec Stages']).
                          rename(columns={'Exec Stages': 'Stage ID'}))
-        self.execs_df['Stage ID'] = self.execs_df['Stage ID'].astype(int)
+        self.execs_df['Stage ID'] = self.execs_df['Stage ID'].astype(float)
 
         # Remove duplicate 'Stage ID' rows and rename some columns so that join on dataframes
         # can be done easily

--- a/user_tools/src/spark_rapids_tools_distributed/jar_cmd_args.py
+++ b/user_tools/src/spark_rapids_tools_distributed/jar_cmd_args.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Jar command arguments for running the Tools JAR on Spark """
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class JarCmdArgs:
+    """
+    Wrapper class to store the arguments required to run the Tools JAR on Spark.
+    """
+    jvm_args: List[str] = field(default=None, init=True)
+    classpath_arr: List[str] = field(default=None, init=True)
+    hadoop_classpath: str = field(default=None, init=True)
+    jar_main_class: str = field(default=None, init=True)
+    jar_output_dir_args: List[str] = field(default=None, init=True)
+    extra_rapids_args: List[str] = field(default=None, init=True)

--- a/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/sample-config-specification.json
+++ b/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/sample-config-specification.json
@@ -36,6 +36,31 @@
       "title": "DependencyVerification",
       "type": "object"
     },
+    "DistributedToolsConfig": {
+      "description": "Configuration class for distributed tools",
+      "properties": {
+        "spark_properties": {
+          "description": "List of Spark properties to be used for the Spark session.",
+          "examples": [
+            {
+              "name": "spark.executor.memory",
+              "value": "4g"
+            },
+            {
+              "name": "spark.executor.cores",
+              "value": "4"
+            }
+          ],
+          "items": {
+            "$ref": "#/$defs/SparkProperty"
+          },
+          "title": "Spark Properties",
+          "type": "array"
+        }
+      },
+      "title": "DistributedToolsConfig",
+      "type": "object"
+    },
     "FileHashAlgorithm": {
       "description": "Represents a file hash algorithm and its value. Used for verification against an existing file.",
       "properties": {
@@ -137,6 +162,27 @@
       "title": "RuntimeDependencyType",
       "type": "object"
     },
+    "SparkProperty": {
+      "description": "Represents a single Spark property with a name and value.",
+      "properties": {
+        "name": {
+          "description": "The name of the Spark property, e.g., \"spark.executor.memory\".",
+          "title": "Name",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value of the Spark property, e.g., \"4g\".",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "title": "SparkProperty",
+      "type": "object"
+    },
     "ToolsRuntimeConfig": {
       "description": "The runtime configurations of the tools as defined by the user.",
       "properties": {
@@ -169,13 +215,32 @@
       "type": "number"
     },
     "runtime": {
-      "$ref": "#/$defs/ToolsRuntimeConfig",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ToolsRuntimeConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
       "description": "Configuration related to the runtime environment of the tools."
+    },
+    "distributed_tools": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/DistributedToolsConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Configuration related to the distributed tools."
     }
   },
   "required": [
-    "api_version",
-    "runtime"
+    "api_version"
   ],
   "title": "ToolsConfig",
   "type": "object"

--- a/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/sample-config-specification.json
+++ b/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/sample-config-specification.json
@@ -166,12 +166,12 @@
       "description": "Represents a single Spark property with a name and value.",
       "properties": {
         "name": {
-          "description": "The name of the Spark property, e.g., \"spark.executor.memory\".",
+          "description": "Name of the Spark property, e.g., \"spark.executor.memory\".",
           "title": "Name",
           "type": "string"
         },
         "value": {
-          "description": "The value of the Spark property, e.g., \"4g\".",
+          "description": "Value of the Spark property, e.g., \"4g\".",
           "title": "Value",
           "type": "string"
         }

--- a/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid/tools_config_01.yaml
+++ b/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid/tools_config_01.yaml
@@ -4,4 +4,4 @@ api_version: '1.0'
 distributed_tools:
   spark_properties:
     - name: 'spark.executor.memory'
-      value: '32g'
+      value: '20g'

--- a/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid/tools_config_01.yaml
+++ b/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid/tools_config_01.yaml
@@ -1,0 +1,7 @@
+# This yaml file is a configuration file for a tool that uses defines the spark properties
+# for the distributed tools.
+api_version: '1.0'
+distributed_tools:
+  spark_properties:
+    - name: 'spark.executor.memory'
+      value: '32g'


### PR DESCRIPTION
This PR add arguments to enable distributed tools for qualification tool.


### Changes
- Extended `RapidsJob`: Introduced two subclasses—`RapidsDistributedJob` and `RapidsLocalJob` and a concrete class for the `OnPrem` platform.
- Created a `JarCmdArgs` class to encapsulate all arguments needed to construct the JAR command.
- Implemented the `DistributedToolsConfig` class, allowing configurations for distributed tools (like Spark properties) to be specified via the `--tools_config_file` option.


## Example

**CMD:**
```bash
spark_rapids qualification --platform onprem --eventlogs /path/to/eventlogs  --verbose --filter_apps all \
 --distributed --tools_config_file /path/to/custom_conf_file.yaml
```

 **Sample Config File:**
```yaml
api_version: '1.0'
distributed_tools:
  spark_properties:
    - name: 'spark.executor.memory'
      value: '20g'
```


## Details:

* [`user_tools/src/spark_rapids_pytools/cloud_api/onprem.py`](diffhunk://#diff-ea6c11b9e4ba7eb2410be402c2f601ecd70d70fd9258efe144db50227f301ae3R52-R54): Added a new class `OnPremDistributedRapidsJob` and a method `create_distributed_submission_job` to support distributed RAPIDS jobs. [[1]](diffhunk://#diff-ea6c11b9e4ba7eb2410be402c2f601ecd70d70fd9258efe144db50227f301ae3R52-R54) [[2]](diffhunk://#diff-ea6c11b9e4ba7eb2410be402c2f601ecd70d70fd9258efe144db50227f301ae3R160-R167)
* [`user_tools/src/spark_rapids_pytools/rapids/rapids_job.py`](diffhunk://#diff-9e0e9986a6839f29f7182dde7bbf6ae4f80c8b630decd213a4100a6b9766f809R227-R254): Introduced `RapidsDistributedJob` class and updated methods to handle distributed tool configurations. [[1]](diffhunk://#diff-9e0e9986a6839f29f7182dde7bbf6ae4f80c8b630decd213a4100a6b9766f809R227-R254) [[2]](diffhunk://#diff-9e0e9986a6839f29f7182dde7bbf6ae4f80c8b630decd213a4100a6b9766f809R42-R43) [[3]](diffhunk://#diff-9e0e9986a6839f29f7182dde7bbf6ae4f80c8b630decd213a4100a6b9766f809R54-R56) [[4]](diffhunk://#diff-9e0e9986a6839f29f7182dde7bbf6ae4f80c8b630decd213a4100a6b9766f809L93-R102)
* [`user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py`](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0R988-R991): Added methods to get distributed tools configurations and submit distributed jobs. [[1]](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0R988-R991) [[2]](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0R943-R969)

Enhancements to argument processing:

* [`user_tools/src/spark_rapids_pytools/rapids/qualification.py`](diffhunk://#diff-b0a32bd51bc60911ea7a9d91a6794a312db06d32a1df38c5aeac8243a4f4816fR156-R159): Added methods to process distributed tools arguments. [[1]](diffhunk://#diff-b0a32bd51bc60911ea7a9d91a6794a312db06d32a1df38c5aeac8243a4f4816fR156-R159) [[2]](diffhunk://#diff-b0a32bd51bc60911ea7a9d91a6794a312db06d32a1df38c5aeac8243a4f4816fR188)
* [`user_tools/src/spark_rapids_tools/cmdli/argprocessor.py`](diffhunk://#diff-3edf0a5b7367be35b2089915de50bca739dbcecf601e3924dc4da092a05605adR473): Updated `QualifyUserArgModel` and `build_tools_args` to include `distributed_tools_enabled`. [[1]](diffhunk://#diff-3edf0a5b7367be35b2089915de50bca739dbcecf601e3924dc4da092a05605adR473) [[2]](diffhunk://#diff-3edf0a5b7367be35b2089915de50bca739dbcecf601e3924dc4da092a05605adL535-R537)

Platform class updates:

* `user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py`, `databricks_azure.py`, `dataproc.py`, `dataproc_gke.py`, `emr.py`: Disabled pylint warnings for abstract methods. [[1]](diffhunk://#diff-1890b8a7039441aa3661e7dbfe5c30747f52a943176d2aa02679682a68cc4afbR34) [[2]](diffhunk://#diff-b94cad976d46e288b75038c287b912291e861859a6eb86a6c34a15154cf325f4R32) [[3]](diffhunk://#diff-82e6eff621dfb3a8d539178741ab91d581d03b70f32acb4445853a8dc5f96074R35) [[4]](diffhunk://#diff-648aa3b7bf6933e0d58040d8493d17680084ccd976cf2a526091a05d8b23e432R32) [[5]](diffhunk://#diff-13bb430cdbeab9ade138dfb9d6760100c022dc6b98e7f1d24717f071ab2b6d4bR34)

Other improvements:

* [`user_tools/src/spark_rapids_pytools/rapids/qualification.py`](diffhunk://#diff-b0a32bd51bc60911ea7a9d91a6794a312db06d32a1df38c5aeac8243a4f4816fL378-R383): Added a check to ensure the DataFrame is not empty before accessing it.
* [`user_tools/src/spark_rapids_tools/cmdli/tools_cli.py`](diffhunk://#diff-b93aac4011b6df99eb1e4ce667e23103255d5b09ee5459438acb8bf4535b7eb5R49): Added a new parameter `distributed` to the `qualification` function.
