### PR TITLE
Include expression parsers for HashAggregate and ObjectHashAggregate

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/GenericExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/GenericExecParser.scala
@@ -59,7 +59,7 @@ class GenericExecParser(
   }
 
   protected def getExprString: String = {
-    node.desc.replaceFirst(s"${node.name} ", "")
+    node.desc.replaceFirst(s"${node.name}\\s*", "")
   }
 
   protected def getNotSupportedExprs(expressions: Array[String]): Seq[UnsupportedExpr] = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/GenericExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/GenericExecParser.scala
@@ -35,6 +35,7 @@ class GenericExecParser(
   override def parse: ExecInfo = {
     val duration = computeDuration
     val expressions = parseExpressions()
+
     val notSupportedExprs = getNotSupportedExprs(expressions)
     val isExecSupported = checker.isExecSupported(fullExecName) &&
       notSupportedExprs.isEmpty
@@ -59,7 +60,7 @@ class GenericExecParser(
   }
 
   protected def getExprString: String = {
-    node.desc.replaceFirst(s"${node.name}\\s*", "")
+    node.desc.replaceFirst(s"^${node.name}\\s*", "")
   }
 
   protected def getNotSupportedExprs(expressions: Array[String]): Seq[UnsupportedExpr] = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/HashAggregateExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/HashAggregateExecParser.scala
@@ -26,8 +26,10 @@ case class HashAggregateExecParser(
     override val node: SparkPlanGraphNode,
     override val checker: PluginTypeChecker,
     override val sqlID: Long,
+    override val expressionFunction: Option[String => Array[String]],
     appBase: AppBase) extends
-  GenericExecParser(node, checker, sqlID, app = Some(appBase)) with Logging {
+    GenericExecParser(node, checker, sqlID,
+      expressionFunction = expressionFunction, app = Some(appBase)) with Logging {
 
   override def getDurationMetricIds: Seq[Long] = {
     node.metrics.find(_.name == "time in aggregation build").map(_.accumulatorId).toSeq

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ObjectHashAggregateExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ObjectHashAggregateExecParser.scala
@@ -26,8 +26,10 @@ case class ObjectHashAggregateExecParser(
     override val node: SparkPlanGraphNode,
     override val checker: PluginTypeChecker,
     override val sqlID: Long,
+    override val expressionFunction: Option[String => Array[String]],
     appBase: AppBase) extends
-  GenericExecParser(node, checker, sqlID, app = Some(appBase)) with Logging {
+    GenericExecParser(node, checker, sqlID,
+      expressionFunction = expressionFunction, app = Some(appBase)) with Logging {
 
   override def getDurationMetricIds: Seq[Long] = {
     node.metrics.find(_.name == "time in aggregation build").map(_.accumulatorId).toSeq

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -491,11 +491,13 @@ object SQLPlanParser extends Logging {
         GenericExecParser(
           node, checker, sqlID, expressionFunction = Some(parseGenerateExpressions)).parse
       case "HashAggregate" =>
-        HashAggregateExecParser(node, checker, sqlID, app).parse
+        HashAggregateExecParser(
+          node, checker, sqlID, Some(parseAggregateExpressions), app).parse
       case i if DataWritingCommandExecParser.isWritingCmdExec(i) =>
         DataWritingCommandExecParser.parseNode(node, checker, sqlID)
       case "ObjectHashAggregate" =>
-        ObjectHashAggregateExecParser(node, checker, sqlID, app).parse
+        ObjectHashAggregateExecParser(
+          node, checker, sqlID, Some(parseAggregateExpressions), app).parse
       case "Project" =>
         GenericExecParser(
           node, checker, sqlID, expressionFunction = Some(parseProjectExpressions)).parse


### PR DESCRIPTION
This is a bug fix. This was missed while refactoring Exec Parser PR  - https://github.com/NVIDIA/spark-rapids-tools/pull/1396
Changes in this  PR : 
1. Updates the expressionParses for ObjectHashAggregate and HashAggregate.
2.  Handle whitespace after the ExecNames. While getting the expressions string, we remove the ExecName to parse only the expressions. In eventlogs, some ExecNames have "whitespace" after the Exec name and don't. So we handle that case in this PR.




<!--

Thank you for contributing to Tools of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

3. Please ensure that you have written units tests for the changes made/features
   added.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
