### PR TITLE
[BUG] Fix Profiler tool index out of bound exception when generating diagnostic metrics

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSparkMetricsAnalyzer.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSparkMetricsAnalyzer.scala
@@ -498,15 +498,16 @@ object AppSparkMetricsAnalyzer  {
   def getStatistics(arr: Iterable[Long]): StatisticsMetrics = {
     if (arr.isEmpty) {
       StatisticsMetrics(0L, 0L, 0L, 0L)
-    }
-    val sortedArr = arr.toSeq.sorted
-    val len = sortedArr.size
-    val med = if (len % 2 == 0) {
-      (sortedArr(len / 2) + sortedArr(len / 2 - 1)) / 2
     } else {
-      sortedArr(len / 2)
+      val sortedArr = arr.toSeq.sorted
+      val len = sortedArr.size
+      val med = if (len % 2 == 0) {
+        (sortedArr(len / 2) + sortedArr(len / 2 - 1)) / 2
+      } else {
+        sortedArr(len / 2)
+      }
+      StatisticsMetrics(sortedArr.head, med, sortedArr(len - 1), sortedArr.sum)
     }
-    StatisticsMetrics(sortedArr.head, med, sortedArr(len - 1), sortedArr.sum)
   }
 
   def maxWithEmptyHandling(arr: Iterable[Long]): Long = {


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/1438

### Changes
- Small fix in function `getStatistics` to move a block into an `else` statement, otherwise leads to index out of bound exception when input is empty