### PR TITLE
[BUG] Fix sync plugin files script to handle empty or non-existing cvs files

### DIFF
--- a/scripts/sync_plugin_files/process_supported_files.py
+++ b/scripts/sync_plugin_files/process_supported_files.py
@@ -118,7 +118,11 @@ def unify_all_files(root_dir, file_name, key_names):
     for dir_name in os.listdir(root_dir):  # List entries in root_dir
         if os.path.isdir(os.path.join(root_dir, dir_name)):
             csv_file_path = os.path.join(root_dir, dir_name, file_name)
-            cur_df = pd.read_csv(csv_file_path, keep_default_na=False)
+            try:
+                cur_df = pd.read_csv(csv_file_path, keep_default_na=False)
+            except Exception as e:
+                logging.debug(f"Encountered exception when reading file {csv_file_path}: {e}")
+                continue
 
             if final_df.empty:
                 final_df = pd.DataFrame(columns=cur_df.columns.tolist())


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/1445

**Changes**

- Handles empty or non-existing csv files by skipping them in sync plugin files script [process_supported_files.py](https://github.com/NVIDIA/spark-rapids-tools/blob/dev/scripts/sync_plugin_files/process_supported_files.py)