### PR TITLE
Count expressions per Exec in SQLPlanParser

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable.{ArrayBuffer, WeakHashMap}
 import scala.util.control.NonFatal
 import scala.util.matching.Regex
 
-import com.nvidia.spark.rapids.tool.planparser.ops.{OperatorRefBase, OpRef, UnsupportedExprOpRef}
+import com.nvidia.spark.rapids.tool.planparser.ops.{ExprOpRef, OperatorRefTrait, OpRef, UnsupportedExprOpRef}
 import com.nvidia.spark.rapids.tool.planparser.photon.{PhotonPlanParser, PhotonStageExecParser}
 import com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker
 
@@ -75,7 +75,7 @@ object UnsupportedReasons extends Enumeration {
 case class UnsupportedExecSummary(
     sqlId: Long,
     execId: Long,
-    execRef: OperatorRefBase,
+    execRef: OperatorRefTrait,
     opType: OpTypes.OpType,
     reason: UnsupportedReasons.UnsupportedReason,
     opAction: OpActions.OpAction) {
@@ -89,8 +89,6 @@ case class UnsupportedExecSummary(
   val unsupportedOperatorCSVFormat: String = execRef.getOpNameCSV
 
   val details: String = UnsupportedReasons.reportUnsupportedReason(reason)
-
-  def isExpression: Boolean = execRef.isInstanceOf[UnsupportedExprOpRef]
 }
 
 case class ExecInfo(
@@ -110,7 +108,7 @@ case class ExecInfo(
     dataSet: Boolean,
     udf: Boolean,
     shouldIgnore: Boolean,
-    expressions: Seq[OpRef]) {
+    expressions: Seq[ExprOpRef]) {
 
   private def childrenToString = {
     val str = children.map { c =>
@@ -139,10 +137,6 @@ case class ExecInfo(
 
   def setStages(stageIDs: Set[Int]): Unit = {
     stages = stageIDs
-  }
-
-  def appendToStages(stageIDs: Set[Int]): Unit = {
-    stages ++= stageIDs
   }
 
   def setShouldRemove(value: Boolean): Unit = {
@@ -286,7 +280,7 @@ object ExecInfo {
       udf,
       shouldIgnore,
       // convert array of string expressions to OpRefs
-      expressions = expressions.map(OpRef.fromExpr)
+      expressions = ExprOpRef.fromRawExprSeq(expressions)
     )
   }
 
@@ -351,7 +345,7 @@ case class PlanInfo(
     sqlID: Long,
     sqlDesc: String,
     execInfo: Seq[ExecInfo]) {
-  def getUnsupportedExpressions: Seq[OperatorRefBase] = {
+  def getUnsupportedExpressions: Seq[OperatorRefTrait] = {
     execInfo.flatMap { e =>
       if (e.isClusterNode) {
         // wholeStageCodeGen does not have expressions/unsupported-expressions
@@ -727,21 +721,21 @@ object SQLPlanParser extends Logging {
   }
 
   private def getAllFunctionNames(regPattern: Regex, expr: String,
-      groupInd: Int = 1, isAggr: Boolean = true): Set[String] = {
+      groupInd: Int = 1, isAggr: Boolean = true): Array[String] = {
     // Returns all matches in an expression. This can be used when the SQL expression is not
     // tokenized.
     val newExpr = processSpecialFunctions(expr)
 
     // first get all the functionNames
     val exprss =
-      regPattern.findAllMatchIn(newExpr).map(_.group(groupInd)).toSet
+      regPattern.findAllMatchIn(newExpr).map(_.group(groupInd)).toSeq
 
     // For aggregate expressions we want to process the results to remove the prefix
     // DB: remove the "^partial_" and "^finalmerge_" prefixes
     // TODO:
     //    for performance sake, we can turn off the aggregate processing by enabling it only
     //    when needed. However, for now, we always do this processing until we are confident we know
-    //    the correct place to turn on/off that flag.we can use the argument isAgg only when needed
+    //    the correct place to turn on/off that flag. We can use the argument isAgg only when needed
     val results = if (isAggr) {
       exprss.collect {
         case func =>
@@ -750,7 +744,7 @@ object SQLPlanParser extends Logging {
     } else {
       exprss
     }
-    results.filterNot(ignoreExpression(_))
+    results.filterNot(ignoreExpression(_)).toArray
   }
 
   def parseProjectExpressions(exprStr: String): Array[String] = {
@@ -758,7 +752,7 @@ object SQLPlanParser extends Logging {
     // This is to split the string such that only function names are extracted. The pattern is
     // such that function name is succeeded by `(`. We use regex to extract all the function names
     // below:
-    getAllFunctionNames(functionPrefixPattern, exprStr).toArray
+    getAllFunctionNames(functionPrefixPattern, exprStr)
   }
 
   // This parser is used for SortAggregateExec, HashAggregateExec and ObjectHashAggregateExec
@@ -792,7 +786,7 @@ object SQLPlanParser extends Logging {
         }
       }
     }
-    parsedExpressions.distinct.toArray
+    parsedExpressions.toArray
   }
 
   def parseWindowExpressions(exprStr:String): Array[String] = {
@@ -828,7 +822,7 @@ object SQLPlanParser extends Logging {
         }
       }
     }
-    parsedExpressions.distinct.toArray
+    parsedExpressions.toArray
   }
 
   def parseWindowGroupLimitExpressions(exprStr: String): Array[String] = {
@@ -858,10 +852,10 @@ object SQLPlanParser extends Logging {
     //  - Some values can be NULLs. That's why we cannot limit the extract to the first row.
     //  - Nested brackets/parenthesis makes it challenging to use regex that contains
     //    brackets/parenthesis to extract expressions.
-    // The implementation Use regex to extract all function names and return distinct set of
+    // The implementation Use regex to extract all function names and return a list of
     // function names.
     // This implementation is 1 line implementation, but it can be a memory/time bottleneck.
-    getAllFunctionNames(functionPrefixPattern, exprStr).toArray
+    getAllFunctionNames(functionPrefixPattern, exprStr)
   }
 
   def parseTakeOrderedExpressions(exprStr: String): Array[String] = {
@@ -889,7 +883,7 @@ object SQLPlanParser extends Logging {
         }
       }
     }
-    parsedExpressions.distinct.toArray
+    parsedExpressions.toArray
   }
 
   def parseGenerateExpressions(exprStr: String): Array[String] = {
@@ -897,11 +891,11 @@ object SQLPlanParser extends Logging {
     // 1. Generate explode(arrays#1306), [id#1304], true, [col#1426]
     // 2. Generate json_tuple(values#1305, Zipcode, ZipCodeType, City), [id#1304],
     // false, [c0#1407, c1#1408, c2#1409]
-    getAllFunctionNames(functionPrefixPattern, exprStr).toArray
+    getAllFunctionNames(functionPrefixPattern, exprStr)
   }
 
   private def addFunctionNames(exprs: String, parsedExpressions: ArrayBuffer[String]): Unit = {
-    val functionNames = getAllFunctionNames(functionPrefixPattern, exprs).toArray
+    val functionNames = getAllFunctionNames(functionPrefixPattern, exprs)
     functionNames.foreach(parsedExpressions += _)
   }
 
@@ -946,7 +940,7 @@ object SQLPlanParser extends Logging {
     val isSortMergeSupported = !(isSortMergeJoin &&
         joinCondition.nonEmpty && isSMJConditionUnsupported(joinCondition))
 
-    (parsedExpressions.distinct.toArray, equiJoinSupportedTypes(buildSide, joinType)
+    (parsedExpressions.toArray, equiJoinSupportedTypes(buildSide, joinType)
         && isSortMergeSupported)
   }
 
@@ -1054,7 +1048,7 @@ object SQLPlanParser extends Logging {
         }
       }
     }
-    parsedExpressions.distinct.toArray
+    parsedExpressions.toArray
   }
 
   def parseFilterExpressions(exprStr: String): Array[String] = {
@@ -1109,7 +1103,7 @@ object SQLPlanParser extends Logging {
     processedExpr = nonBinaryOperatorsRegEx.replaceAllIn(processedExpr, " ")
 
     // Step-4: remove remaining parentheses '(', ')' and commas if we had functionCalls
-    if (!functionMatches.isEmpty) {
+    if (functionMatches.nonEmpty) {
       // remove ","
       processedExpr = processedExpr.replaceAll(",", " ")
     }
@@ -1147,7 +1141,6 @@ object SQLPlanParser extends Logging {
           logDebug(s"Unrecognized Token - $token")
       }
     }
-
-    parsedExpressions.distinct.toArray
+    parsedExpressions.toArray
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/WholeStageExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/WholeStageExecParser.scala
@@ -59,7 +59,7 @@ abstract class WholeStageExecParserBase(
     // The node should be marked as shouldRemove when all the children of the
     // wholeStageCodeGen are marked as shouldRemove.
     val removeNode = isDupNode || childNodes.forall(_.shouldRemove)
-    // Remove any suffix in order to get the node label without any trailing number.
+    // Remove any suffix to get the node label without any trailing number.
     val nodeLabel = nodeNameRegeX.findFirstMatchIn(node.name) match {
       case Some(m) => m.group(1)
       // in case not found, use the full exec name

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/WindowGroupLimitParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/WindowGroupLimitParser.scala
@@ -37,7 +37,7 @@ case class WindowGroupLimitParser(
 
   override def getUnsupportedExprReasonsForExec(
       expressions: Array[String]): Seq[UnsupportedExprOpRef] = {
-    expressions.flatMap { expr =>
+    expressions.distinct.flatMap { expr =>
       if (!supportedRankingExprs.contains(expr)) {
         Some(UnsupportedExprOpRef(expr,
           s"Ranking function $expr is not supported in $fullExecName"))

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ops/ExprOpRef.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ops/ExprOpRef.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.planparser.ops
+
+/**
+ * Represents a reference to an expression operator that is stored in the ExecInfo expressions
+ * @param opRef the opRef to wrap
+ * @param count the count of that expression within the exec.
+ */
+case class ExprOpRef(opRef: OpRef, count: Int = 1) extends OpRefWrapperBase(opRef)
+
+object ExprOpRef extends OpRefWrapperBaseTrait[ExprOpRef] {
+  def fromRawExprSeq(exprArr: Seq[String]): Seq[ExprOpRef] = {
+    exprArr.groupBy(identity)
+      .mapValues(expr => ExprOpRef(OpRef.fromExpr(expr.head), expr.size)).values.toSeq
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ops/OpRefWrapperBase.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ops/OpRefWrapperBase.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.planparser.ops
+
+/**
+ * An instance that wraps OpRef and exposes the OpRef methods.
+ * This is used to provide common interface for all classes that wrap OpRef along with other
+ * metadata.
+ * @param opRef the opRef to wrap
+ */
+class OpRefWrapperBase(opRef: OpRef) extends OperatorRefTrait {
+  override def getOpName: String = opRef.getOpName
+
+  override def getOpNameCSV: String = opRef.getOpNameCSV
+
+  override def getOpType: String = opRef.getOpType
+
+  override def getOpTypeCSV: String = opRef.getOpTypeCSV
+
+  def getOpRef: OpRef = opRef
+}
+
+/**
+ * A trait that provides a factory method to create instances of OpRefWrapperBase from a sequence of
+ * @tparam R the type of the OpRefWrapperBase
+ */
+trait OpRefWrapperBaseTrait[R <: OpRefWrapperBase] {
+  /**
+   * Create instances of OpRefWrapperBase from a sequence of expressions.
+   * The expressions are grouped by their value and the count of each expression is stored in the
+   * OpRefWrapperBase entry.
+   * @param exprArr the sequence of expressions
+   * @return a sequence of OpRefWrapperBase instances
+   */
+  def fromRawExprSeq(exprArr: Seq[String]): Seq[R]
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ops/UnsupportedExprOpRef.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ops/UnsupportedExprOpRef.scala
@@ -25,7 +25,17 @@ package com.nvidia.spark.rapids.tool.planparser.ops
  * @param unsupportedReason A string describing why the expression is unsupported.
  */
 case class UnsupportedExprOpRef(opRef: OpRef,
-    unsupportedReason: String) extends OperatorRefBase(opRef.value, opRef.opType)
+    unsupportedReason: String) extends OpRefWrapperBase(opRef) {
+
+  override def getOpName: String = opRef.getOpName
+
+  override def getOpNameCSV: String = opRef.getOpNameCSV
+
+  override def getOpType: String = opRef.getOpType
+
+  override def getOpTypeCSV: String = opRef.getOpTypeCSV
+
+}
 
 // Provides a factory method to create an instance from an expression name and unsupported reason.
 object UnsupportedExprOpRef {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ops/UnsupportedExprOpRef.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ops/UnsupportedExprOpRef.scala
@@ -25,17 +25,7 @@ package com.nvidia.spark.rapids.tool.planparser.ops
  * @param unsupportedReason A string describing why the expression is unsupported.
  */
 case class UnsupportedExprOpRef(opRef: OpRef,
-    unsupportedReason: String) extends OpRefWrapperBase(opRef) {
-
-  override def getOpName: String = opRef.getOpName
-
-  override def getOpNameCSV: String = opRef.getOpNameCSV
-
-  override def getOpType: String = opRef.getOpType
-
-  override def getOpTypeCSV: String = opRef.getOpTypeCSV
-
-}
+    unsupportedReason: String) extends OpRefWrapperBase(opRef)
 
 // Provides a factory method to create an instance from an expression name and unsupported reason.
 object UnsupportedExprOpRef {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -388,7 +388,7 @@ class PluginTypeChecker(platform: Platform = PlatformFactory.createInstance(),
   }
 
   def getNotSupportedExprs(exprs: Seq[String]): Seq[UnsupportedExprOpRef] = {
-    exprs.collect {
+    exprs.distinct.collect {
       case expr if !isExprSupported(expr) =>
         val reason = unsupportedOpsReasons.getOrElse(expr, "")
         UnsupportedExprOpRef(expr, reason)


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1447

Improves the operators-stats by counting the occurrence of each expression within the Exec node.

This pull request includes several changes to the `SQLPlanParser` and related classes to improve the handling of expression operators and streamline the code. The most important changes include the introduction of the `ExprOpRef` class, modifications to the `ExecInfo` and `UnsupportedExecSummary` classes, and updates to various methods to use `ExprOpRef` instead of `OpRef`.

### Improvements to expression operator handling:

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ops/ExprOpRef.scala`](diffhunk://#diff-3711ef88c5366ba9ac9c71329cf67ce9276e41eb258855dc9d25a675c9ec6606R1-R31): Introduced the `ExprOpRef` class to represent a reference to an expression operator and its associated count.
* [`core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ops/OpRefWrapperBase.scala`](diffhunk://#diff-ecffdeffc61f2dd75a591275074ceb721f4a2f0fdb5525ce066ead1655ac5eadR1-R50): Added the `OpRefWrapperBase` class and `OpRefWrapperBaseTrait` trait to provide a common interface for classes that wrap `OpRef` with additional metadata.

### Modifications to existing classes:

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala`](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL78-R78): Updated the `UnsupportedExecSummary` and `ExecInfo` classes to use `ExprOpRef` instead of `OpRef` and `OperatorRefBase`. [[1]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL78-R78) [[2]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL113-R111)
* [`core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ops/OperatorCounter.scala`](diffhunk://#diff-6f78d4b0b2312cdac53da65a21f82f43c5c75e5d3ba527079b0c7fc9db0da57eL41-R105): Modified the `OperatorCounter` class to use `ExprOpRef` and updated methods to handle the new class.
* [`core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ops/UnsupportedExprOpRef.scala`](diffhunk://#diff-b07ff4a887a3d1099d1820731d12df9640e8f0bc8dc3e8302034268fee91a676L28-R38): Updated the `UnsupportedExprOpRef` class to extend `OpRefWrapperBase`.

### Method updates:

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala`](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL730-R738): Updated methods to return arrays instead of sets and fixed minor issues in comments and variable names. [[1]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL730-R738) [[2]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL753-R755) [[3]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL795-R789) [[4]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL831-R825) [[5]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL861-R858) [[6]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL892-R898) [[7]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL949-R943) [[8]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL1057-R1051) [[9]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL1112-R1106) [[10]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL1151-R1145)

