### PR TITLE
Fix dataframe handling of column-types

### DIFF
--- a/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
@@ -461,7 +461,7 @@ def extract_raw_features(
 
     # normalize WholeStageCodegen labels
     ops_tbl.loc[
-        ops_tbl['nodeName'].str.startswith('WholeStageCodegen'), 'nodeName'
+        ops_tbl['nodeName'].astype(str).str.startswith('WholeStageCodegen'), 'nodeName'
     ] = 'WholeStageCodegen'
 
     # format WholeStageCodegen for merging
@@ -1140,7 +1140,7 @@ def load_qtool_execs(qtool_execs: List[str]) -> Optional[pd.DataFrame]:
         node_level_supp['Exec Is Supported'] = (
             node_level_supp['Exec Is Supported']
             | node_level_supp['Action'].apply(_is_ignore_no_perf)
-            | node_level_supp['Exec Name'].apply(
+            | node_level_supp['Exec Name'].astype(str).apply(
                 lambda x: x.startswith('WholeStageCodegen')
             )
         )


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1456

The prediction would throw an exception as the pandas dataframe can mistakenly set the columntype to float.
After investigation it was found that a missing "Exec Name" in the execs.csv was the reason for that behavior.
This PR fixes the qualification_stats that would fail consistently after #1437 was merged because it became more common that an exec csv file has no sequence of stages.

I filed another issue to investigate why do we have empty expression names #1457 

Thanks to @leewyang for spotting the empty execName