### PR TITLE
Make '--platform' argument mandatory in qualification and profiling CLI to prevent incorrect behavior

### DIFF
--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -400,6 +400,15 @@ class ToolUserArgModel(AbsToolUserArgModel):
     def define_invalid_arg_cases(self) -> None:
         super().define_invalid_arg_cases()
         self.define_rejected_missing_eventlogs()
+        self.rejected['Missing Platform argument'] = {
+            'valid': False,
+            'callable': partial(self.raise_validation_exception,
+                                'Cannot run tool cmd without platform argument. Re-run the command '
+                                'providing the platform argument.'),
+            'cases': [
+                [ArgValueCase.UNDEFINED, ArgValueCase.IGNORE, ArgValueCase.IGNORE]
+            ]
+        }
         self.rejected['Cluster By Name Without Platform Hints'] = {
             'valid': False,
             'callable': partial(self.raise_validation_exception,


### PR DESCRIPTION
Fixes #1462.

This PR makes the `--platform` argument mandatory to address issues with incorrect platform detection. Our current platform detection logic may inaccurately identify the platform, leading to incorrect behavior and speed up estimations. For more details, refer to the issue description.

**Note:**
- Platform will be mandatory only for qualification and profiling CLI cmds.
- Other CLI cmds like `generate_instance_descriptions` or `prediction` that require a platform are not affected.

## Changes

### Enforcing Platform Argument Requirement:

* [`user_tools/src/spark_rapids_tools/cmdli/argprocessor.py`](diffhunk://#diff-3edf0a5b7367be35b2089915de50bca739dbcecf601e3924dc4da092a05605adR403-R411): Added a new rejected case for the missing platform argument in the `define_invalid_arg_cases` method.

### Test Case Updates:

* [`user_tools/tests/spark_rapids_tools_ut/test_tool_argprocessor.py`](diffhunk://#diff-5217c50d526e1655bcf59de7c8276de63a3cec05eaf52ccc58cb9c256390bcbfL134-L140): Updated the `test_with_platform_with_eventlogs` method to ensure it fails when the platform argument is not provided.
* [`user_tools/tests/spark_rapids_tools_ut/test_tool_argprocessor.py`](diffhunk://#diff-5217c50d526e1655bcf59de7c8276de63a3cec05eaf52ccc58cb9c256390bcbfL153-R161): Updated the `test_with_platform_with_eventlogs_with_jar_files` method to ensure it fails when the platform argument is not provided.
* [`user_tools/tests/spark_rapids_tools_ut/test_tool_argprocessor.py`](diffhunk://#diff-5217c50d526e1655bcf59de7c8276de63a3cec05eaf52ccc58cb9c256390bcbfL233-R237): Updated the `test_with_platform_with_cluster_props` method to ensure it fails when the platform argument is not provided.
* [`user_tools/tests/spark_rapids_tools_ut/test_tool_argprocessor.py`](diffhunk://#diff-5217c50d526e1655bcf59de7c8276de63a3cec05eaf52ccc58cb9c256390bcbfL269-L276): Updated the `test_with_platform_with_cluster_props_with_eventlogs` method to ensure it fails when the platform argument is not provided.
* [`user_tools/tests/spark_rapids_tools_ut/test_tool_argprocessor.py`](diffhunk://#diff-5217c50d526e1655bcf59de7c8276de63a3cec05eaf52ccc58cb9c256390bcbfL311-R303): Updated the `test_with_platform_with_autotuner_with_eventlogs` method to ensure it fails when the platform argument is not provided.