### PR TITLE
Deduplicate calls to aggregateSparkMetricsBySql

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSparkMetricsAggTrait.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSparkMetricsAggTrait.scala
@@ -35,12 +35,13 @@ trait AppSparkMetricsAggTrait extends AppIndexMapperTrait {
   def getAggRawMetrics(app: AppBase, index: Int, sqlAnalyzer: Option[AppSQLPlanAnalyzer] = None):
       AggRawMetricsResult = {
     val analysisObj = new AppSparkMetricsAnalyzer(app)
+    val sqlMetricsAgg = analysisObj.aggregateSparkMetricsBySql(index)
     AggRawMetricsResult(
       analysisObj.aggregateSparkMetricsByJob(index),
       analysisObj.aggregateSparkMetricsByStage(index),
       analysisObj.shuffleSkewCheck(index),
-      analysisObj.aggregateSparkMetricsBySql(index),
-      analysisObj.aggregateIOMetricsBySql(analysisObj.aggregateSparkMetricsBySql(index)),
+      sqlMetricsAgg,
+      analysisObj.aggregateIOMetricsBySql(sqlMetricsAgg),
       analysisObj.aggregateDurationAndCPUTimeBySql(index),
       Seq(analysisObj.maxTaskInputSizeBytesPerSQL(index)),
       analysisObj.aggregateDiagnosticMetricsByStage(index, sqlAnalyzer))


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Contributes to #1461

AppSparkMetricsAnalyzer was calling `aggregateSparkMetricsBySql` twice. This code change eleiminates this redundancy to save CPU time and memory allocations.

`aggregateSparkMetricsBySql` was responsible for more than 53% of total CPU time. This code change cashes the value then pass it to the second method.

Running the same eventlog in the issue description, the performance show the following results:

total CPU: 1,290,033ms -> improved by 24% 
total time: 9,096,942 ms -> improved by 23.6%
total allocation: 4.28 TB -> improved by 30.2%

- `getAggregateRawMetrics`: CPU Time -> 954,620  (improved by 31%)| 3.93 TB ()
  - `aggregateSparkMetricsBySql`: 496,760 ms; 35% of total, 48% of parent | 1.86 TB (44% of all; 47% of parent)
  - `aggregateSparkMetricsByJob`: 496,560 ms; 38% total, 52% of parent | 2.06 TB (48% of all, 53% of parent)

[ProfileMain_2024_12_13_194959.zip](https://github.com/user-attachments/files/18131707/ProfileMain_2024_12_13_194959.zip)
