### PR TITLE
Improve implementation of finding median in StatisticsMetrics

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala
@@ -30,8 +30,6 @@ import org.apache.spark.sql.rapids.tool.qualification.QualificationAppInfo
 import org.apache.spark.sql.rapids.tool.store.DataSourceRecord
 import org.apache.spark.sql.rapids.tool.util.ToolsPlanGraph
 
-
-
 /**
  * This class processes SQL plan to build some information such as: metrics, wholeStage nodes, and
  * connecting operators to nodes. The implementation used to be directly under Profiler's

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/AccumInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/AccumInfo.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.tool.store
 
-import scala.collection.mutable
+import scala.collection.{breakOut, mutable}
 
 import com.nvidia.spark.rapids.tool.analysis.StatisticsMetrics
 
@@ -98,22 +98,8 @@ class AccumInfo(val infoRef: AccumMetaRef) {
   }
 
   def calculateAccStats(): StatisticsMetrics = {
-    val sortedTaskUpdates = taskUpdatesMap.values.toSeq.sorted
-    if (sortedTaskUpdates.isEmpty) {
-      // do not check stage values because the stats is only meant for task updates
-      StatisticsMetrics.ZERO_RECORD
-    } else {
-      val min = sortedTaskUpdates.head
-      val max = sortedTaskUpdates.last
-      val sum = sortedTaskUpdates.sum
-      val median = if (sortedTaskUpdates.size % 2 == 0) {
-        val mid = sortedTaskUpdates.size / 2
-        (sortedTaskUpdates(mid) + sortedTaskUpdates(mid - 1)) / 2
-      } else {
-        sortedTaskUpdates(sortedTaskUpdates.size / 2)
-      }
-      StatisticsMetrics(min, median, max, sum)
-    }
+    // do not check stage values because the stats is only meant for task updates
+    StatisticsMetrics.createFromArr(taskUpdatesMap.map(_._2)(breakOut))
   }
 
   def getMaxStageValue: Option[Long] = {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/InPlaceMedianArrView.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/InPlaceMedianArrView.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool.util
+
+import scala.annotation.tailrec
+import scala.language.postfixOps
+
+/**
+ * Allows for in-place partitioning and finding the median.
+ * The tools used to find the median of a sequence by sorting the entire sequence, then returning
+ * the elements in the middle. As we started to capture all the accumulators in Spark plans,
+ * sorting is inefficient for large eventlogs that contain huge number of tasks and
+ * Accumulables. Thus, this class is an optimized version to get the median in a linear
+ * complexity while doing it in place to avoid allocating new array to store the sorted elements.
+ * The code is copied from a Stackoverflow thread:
+ * https://stackoverflow.com/questions/4662292/scala-median-implementation
+ *
+ * Notes:
+ * - The implementation assumes that the array is not empty.
+ */
+case class InPlaceMedianArrView(arr: Array[Long], from: Int, until: Int) {
+  def apply(n: Int): Long = {
+    if (from + n < until) {
+      arr(from + n)
+    } else {
+      throw new ArrayIndexOutOfBoundsException(n)
+    }
+  }
+
+  /**
+   * Returns a new view of the array with the same elements but a different range.
+   * @param p a predicate to apply on the elements to proceed with the partitioning.
+   * @return a tuple of 2 views, the first one contains the elements that satisfy the predicate,
+   *         and the second one contains the rest.
+   */
+  def partitionInPlace(p: Long => Boolean): (InPlaceMedianArrView, InPlaceMedianArrView) = {
+    var upper = until - 1
+    var lower = from
+    while (lower < upper) {
+      while (lower < until && p(arr(lower))) lower += 1
+      while (upper >= from && !p(arr(upper))) upper -= 1
+      if (lower < upper) { val tmp = arr(lower); arr(lower) = arr(upper); arr(upper) = tmp }
+    }
+    (copy(until = lower), copy(from = lower))
+  }
+
+  def size: Int = {
+    until - from
+  }
+
+  def isEmpty: Boolean = {
+    size <= 0
+  }
+
+  override def toString = {
+    arr mkString ("ArraySize(", ", ", ")")
+  }
+}
+
+/**
+ * Companion object for InPlaceMedianArrView.
+ */
+object InPlaceMedianArrView {
+
+  def apply(arr: Array[Long]): InPlaceMedianArrView = {
+    InPlaceMedianArrView(arr, 0, arr.size)
+  }
+
+  /**
+   * Finds the median of the array in place.
+   * @param arr the Array[Long] to be processed
+   * @param k the index of the median
+   * @param choosePivot a function to choose the pivot index. This useful to choose different
+   *                    strategies. For example, choosing the midpoint works better for sorted
+   *                    arrays.
+   * @return the median of the array.
+   */
+  @tailrec
+  def findKMedianInPlace(arr: InPlaceMedianArrView, k: Int)
+    (implicit choosePivot: InPlaceMedianArrView => Long): Long = {
+    val a = choosePivot(arr)
+    val (s, b) = arr partitionInPlace (a >)
+    if (s.size == k) {
+      a
+    } else if (s.isEmpty) {
+      val (s, b) = arr partitionInPlace (a ==)
+      if (s.size > k) {
+        a
+      } else {
+        findKMedianInPlace(b, k - s.size)
+      }
+    } else if (s.size < k) {
+      findKMedianInPlace(b, k - s.size)
+    } else {
+      findKMedianInPlace(s, k)
+    }
+  }
+
+  /**
+   * Choose a random pivot in the array. This can lead to worst case for sorted arrays.
+   * @param arr the array to choose the pivot from.
+   * @return a random element from the array.
+   */
+  def chooseRandomPivotInPlace(arr: InPlaceMedianArrView): Long = {
+    arr(scala.util.Random.nextInt(arr.size))
+  }
+
+  /**
+   * Choose the element in the middle as a pivot. This works better to find median of sorted arrays.
+   * @param arr the array to choose the pivot from.
+   * @return the element in the middle of the array.
+   */
+  def chooseMidpointPivotInPlace(arr: InPlaceMedianArrView): Long = {
+    arr((arr.size - 1) / 2)
+  }
+
+  /**
+   * Finds the median of the array in place.
+   * @param arr the Array[Long] to be processed.
+   * @param choosePivot a function to choose the pivot index.
+   * @return the median of the array.
+   */
+  def findMedianInPlace(
+    arr: Array[Long])(implicit choosePivot: InPlaceMedianArrView => Long): Long = {
+    val midIndex = (arr.size - 1) / 2
+    if (arr.size % 2 == 0) {
+      // For even-length arrays, find the two middle elements and compute their average
+      val mid1 = findKMedianInPlace(InPlaceMedianArrView(arr), midIndex)
+      val mid2 = findKMedianInPlace(InPlaceMedianArrView(arr), midIndex + 1)
+      (mid1 + mid2) / 2
+    } else {
+      // For odd-length arrays, return the middle element
+      findKMedianInPlace(InPlaceMedianArrView(arr), midIndex)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1461

Adds an InPlace median finding to improve the performance of the metric aggregates.
We used to sort a sequence to create StatisticsMetrics which turned out to be very expensive in large eventlogs.

It was found that there is a bottleneck in `generateStageLevelAccums` and `generateSQLAccums` due to the cost of sorting and using sequences of Long on metrics aggregates.

### Impact on performance:

The PR improves the Qualification runtime. methods like

- `generateSQLAccums` is down from 21,550 to 3,480 ms (~80% improvement)
- `generateStageLevelAccums`  is down from  115580 to 61,611 ms (~45% improvement)

### Main optimization

_Median finding_: we used to convert a map to sequence. Then get it sorted. Then we pick the median, max, and min, and then we call `seq.sum`
  - This turned to be expensive for large eventlogs
  - This PR implements adds finding-median in linear time. On average, this is a linear complexity compared to sorting
- This pull request includes several changes to the `AppSQLPlanAnalyzer` and `AppSparkMetricsAnalyzer` classes to improve performance and simplify the codebase by using the `breakOut` method for collection transformations and introducing new methods in `StatisticsMetrics`. Additionally, it removes an unused object and refactors the `AccumInfo` class.

### Impact on output

By doing a diff on the output folder, it was found that the `sql_plan_metrics_for_application.csv` is differemt. The new output sounds more correct

In output generated by the dev branch:

```
appIndex,sqlID,nodeID,nodeName,accumulatorId,name,min,median,max,total,metricType,stageIds
1,236,0,"Execute InsertIntoHadoopFsRelationCommand",0,"number of written files",0,0,0,2,"sum","2"
```
The above seems incorrect because the total is non-zero while min, max and median are zeros.

Vs the new output
```
appIndex,sqlID,nodeID,nodeName,accumulatorId,name,min,median,max,total,metricType,stageIds
1,236,0,"Execute InsertIntoHadoopFsRelationCommand",0,"number of written files",2,2,2,2,"sum","2"
```

### Improvements to Collection Transformations:

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSQLPlanAnalyzer.scala`](diffhunk://#diff-d56ed990ec181a2ef118996b608fdff3b53818cf6138baba59b51e4eb407d79eL268-R271): Replaced intermediate collection variables with direct transformations using `breakOut` to improve performance. [[1]](diffhunk://#diff-d56ed990ec181a2ef118996b608fdff3b53818cf6138baba59b51e4eb407d79eL268-R271) [[2]](diffhunk://#diff-d56ed990ec181a2ef118996b608fdff3b53818cf6138baba59b51e4eb407d79eL286-R289) [[3]](diffhunk://#diff-d56ed990ec181a2ef118996b608fdff3b53818cf6138baba59b51e4eb407d79eL297-R303) [[4]](diffhunk://#diff-d56ed990ec181a2ef118996b608fdff3b53818cf6138baba59b51e4eb407d79eL328-R321) [[5]](diffhunk://#diff-d56ed990ec181a2ef118996b608fdff3b53818cf6138baba59b51e4eb407d79eL344-L377)
* [`core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSparkMetricsAnalyzer.scala`](diffhunk://#diff-4b0aab10a86746bb7480cc3bde4e013c04707758c61782934c07604443160b40L82-R83): Applied `breakOut` to streamline collection processing and reduce memory overhead. [[1]](diffhunk://#diff-4b0aab10a86746bb7480cc3bde4e013c04707758c61782934c07604443160b40L82-R83) [[2]](diffhunk://#diff-4b0aab10a86746bb7480cc3bde4e013c04707758c61782934c07604443160b40L129-R130) [[3]](diffhunk://#diff-4b0aab10a86746bb7480cc3bde4e013c04707758c61782934c07604443160b40L166-R166) [[4]](diffhunk://#diff-4b0aab10a86746bb7480cc3bde4e013c04707758c61782934c07604443160b40L175-R175) [[5]](diffhunk://#diff-4b0aab10a86746bb7480cc3bde4e013c04707758c61782934c07604443160b40L232-R232) [[6]](diffhunk://#diff-4b0aab10a86746bb7480cc3bde4e013c04707758c61782934c07604443160b40L244-R243) [[7]](diffhunk://#diff-4b0aab10a86746bb7480cc3bde4e013c04707758c61782934c07604443160b40L256-R255) [[8]](diffhunk://#diff-4b0aab10a86746bb7480cc3bde4e013c04707758c61782934c07604443160b40L292-R290) [[9]](diffhunk://#diff-4b0aab10a86746bb7480cc3bde4e013c04707758c61782934c07604443160b40L341-R338) [[10]](diffhunk://#diff-4b0aab10a86746bb7480cc3bde4e013c04707758c61782934c07604443160b40L362-R359)

### Introduction of New Methods in `StatisticsMetrics`:

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/StatisticsMetrics.scala`](diffhunk://#diff-13353883e8b8763b970c1ad85d6c670336d17e492997f1cfb812902b2c436a6cR19-R54): Added `createFromArr` and `createOptionalFromArr` methods to compute statistics directly from arrays, improving code reuse and readability.

### Refactoring and Cleanup:

* [`core/src/main/scala/org/apache/spark/sql/rapids/tool/store/AccumInfo.scala`](diffhunk://#diff-2cdf5cec29c5cfc15962382b2134c8e88b6623afdfd7cc6a81ec3dfc5663b4a1L101-R102): Refactored the `calculateAccStats` method to use the new `createFromArr` method from `StatisticsMetrics`, simplifying the code.
* [`core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/AppSparkMetricsAnalyzer.scala`](diffhunk://#diff-4b0aab10a86746bb7480cc3bde4e013c04707758c61782934c07604443160b40L459-L479): Removed the unused `AppSparkMetricsAnalyzer` object and its `getStatistics` method.
