### PR TITLE
Improve shuffle manager recommendation in AutoTuner with version validation

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -138,6 +138,39 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
   protected val supportedRuntimes: Set[SparkRuntime.SparkRuntime] = Set(
     SparkRuntime.SPARK, SparkRuntime.SPARK_RAPIDS
   )
+
+  // scalastyle:off line.size.limit
+  // Supported Spark version to RapidsShuffleManager version mapping.
+  // Reference: https://docs.nvidia.com/spark-rapids/user-guide/latest/additional-functionality/rapids-shuffle.html#rapids-shuffle-manager
+  // scalastyle:on line.size.limit
+  val supportedShuffleManagerVersionMap: Array[(String, String)] = Array(
+    "3.2.0" -> "320",
+    "3.2.1" -> "321",
+    "3.2.2" -> "322",
+    "3.2.3" -> "323",
+    "3.2.4" -> "324",
+    "3.3.0" -> "330",
+    "3.3.1" -> "331",
+    "3.3.2" -> "332",
+    "3.3.3" -> "333",
+    "3.3.4" -> "334",
+    "3.4.0" -> "340",
+    "3.4.1" -> "341",
+    "3.4.2" -> "342",
+    "3.4.3" -> "343",
+    "3.5.0" -> "350",
+    "3.5.1" -> "351"
+  )
+
+  /**
+   * Determine the appropriate RapidsShuffleManager version based on the
+   * provided spark version.
+   */
+  def getShuffleManagerVersion(sparkVersion: String): Option[String] = {
+    supportedShuffleManagerVersionMap.collectFirst {
+      case (supportedVersion, smVersion) if sparkVersion.contains(supportedVersion) => smVersion
+    }
+  }
 
   /**
    * Checks if the given runtime is supported by the platform.
@@ -536,6 +569,13 @@ abstract class DatabricksPlatform(gpuDevice: Option[GpuDevice],
     "spark.executor.cores",
     "spark.executor.instances",
     "spark.executor.memoryOverhead"
+  )
+
+  // Supported Databricks version to RapidsShuffleManager version mapping.
+  override val supportedShuffleManagerVersionMap: Array[(String, String)] = Array(
+    "11.3" -> "330db",
+    "12.2" -> "332db",
+    "13.3" -> "341db"
   )
 
   override def createClusterInfo(coresPerExecutor: Int,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -121,6 +121,7 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
     val clusterProperties: Option[ClusterProperties]) extends Logging {
   val platformName: String
   val defaultGpuDevice: GpuDevice
+  val sparkVersionLabel: String = "Spark version"
 
   // It's not deal to use vars here but to minimize changes and
   // keep backwards compatibility we put them here for now and hopefully
@@ -170,6 +171,13 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
     supportedShuffleManagerVersionMap.collectFirst {
       case (supportedVersion, smVersion) if sparkVersion.contains(supportedVersion) => smVersion
     }
+  }
+
+  /**
+   * Identify the latest supported Spark and RapidsShuffleManager version for the platform.
+   */
+  lazy val latestSupportedShuffleManagerInfo: (String, String) = {
+    supportedShuffleManagerVersionMap.maxBy(_._1)
   }
 
   /**
@@ -555,6 +563,7 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
 abstract class DatabricksPlatform(gpuDevice: Option[GpuDevice],
     clusterProperties: Option[ClusterProperties]) extends Platform(gpuDevice, clusterProperties) {
   override val defaultGpuDevice: GpuDevice = T4Gpu
+  override val sparkVersionLabel: String = "Databricks runtime"
   override def isPlatformCSP: Boolean = true
 
   override val supportedRuntimes: Set[SparkRuntime.SparkRuntime] = Set(

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -302,13 +302,16 @@ object ShuffleManagerResolver {
     "3.5.1" -> "351"
   )
 
+  private val shuffleManagerDocUrl = "https://docs.nvidia.com/spark-rapids/user-guide/latest/" +
+    "additional-functionality/rapids-shuffle.html#rapids-shuffle-manager"
+
   def buildShuffleManagerClassName(smVersion: String): String = {
     s"com.nvidia.spark.rapids.spark$smVersion.RapidsShuffleManager"
   }
 
   def commentForUnsupportedVersion(sparkVersion: String): String = {
-    s"Could not recommend RapidsShuffleManager as the provided version " +
-      s"$sparkVersion is not supported."
+    s"Cannot recommend RAPIDS Shuffle Manager for unsupported \'$sparkVersion\' version.\n" +
+    s"  See supported versions: $shuffleManagerDocUrl."
   }
 
   def commentForMissingVersion: String = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -771,10 +771,10 @@ class AutoTuner(
           case Some(smVersion) =>
             Right(autoTunerConfigsProvider.buildShuffleManagerClassName(smVersion))
           case None =>
-            Left(autoTunerConfigsProvider.shuffleManagerCommentForUnsupportedVersion(sparkVersion))
+            Left(autoTunerConfigsProvider.shuffleManagerComments("unsupported")(sparkVersion))
         }
       case None =>
-        Left(autoTunerConfigsProvider.shuffleManagerCommentForMissingVersion)
+        Left(autoTunerConfigsProvider.shuffleManagerComments("missing")(""))
     }
   }
 
@@ -1346,6 +1346,16 @@ trait AutoTunerConfigsProvider extends Logging {
   private val shuffleManagerDocUrl = "https://docs.nvidia.com/spark-rapids/user-guide/latest/" +
     "additional-functionality/rapids-shuffle.html#rapids-shuffle-manager"
 
+  val shuffleManagerComments: Map[String, String => String] = Map(
+    "unsupported" -> ((sparkVersion: String) =>
+      s"Cannot recommend RAPIDS Shuffle Manager for unsupported '$sparkVersion' version.\n" +
+        "  To enable RAPIDS Shuffle Manager, use a supported Spark version and set \n" +
+        "  'spark.shuffle.manager' to a valid RAPIDS Shuffle Manager version. \n" +
+        s"  See supported versions: $shuffleManagerDocUrl."),
+    "missing" -> (_ =>
+      "Could not recommend RapidsShuffleManager as Spark version cannot be determined.")
+  )
+
   /**
    * Abstract method to create an instance of the AutoTuner.
    */
@@ -1465,17 +1475,6 @@ trait AutoTunerConfigsProvider extends Logging {
 
   def buildShuffleManagerClassName(smVersion: String): String = {
     s"com.nvidia.spark.rapids.spark$smVersion.RapidsShuffleManager"
-  }
-
-  def shuffleManagerCommentForUnsupportedVersion(sparkVersion: String): String = {
-    s"Cannot recommend RAPIDS Shuffle Manager for unsupported '$sparkVersion' version.\n" +
-     "  To enable RAPIDS Shuffle Manager, set 'spark.shuffle.manager' to a value\n" +
-     "  from the supported versions. \n" +
-    s"  See supported versions: $shuffleManagerDocUrl."
-  }
-
-  def shuffleManagerCommentForMissingVersion: String = {
-    "Could not recommend RapidsShuffleManager as Spark version cannot be determined."
   }
 }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -1468,8 +1468,10 @@ trait AutoTunerConfigsProvider extends Logging {
   }
 
   def shuffleManagerCommentForUnsupportedVersion(sparkVersion: String): String = {
-    s"Cannot recommend RAPIDS Shuffle Manager for unsupported \'$sparkVersion\' version.\n" +
-      s"  See supported versions: $shuffleManagerDocUrl."
+    s"Cannot recommend RAPIDS Shuffle Manager for unsupported '$sparkVersion' version.\n" +
+     "  To enable RAPIDS Shuffle Manager, set 'spark.shuffle.manager' to a value\n" +
+     "  from the supported versions. \n" +
+    s"  See supported versions: $shuffleManagerDocUrl."
   }
 
   def shuffleManagerCommentForMissingVersion: String = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -771,10 +771,10 @@ class AutoTuner(
           case Some(smVersion) =>
             Right(autoTunerConfigsProvider.buildShuffleManagerClassName(smVersion))
           case None =>
-            Left(autoTunerConfigsProvider.shuffleManagerComments("unsupported")(sparkVersion))
+            Left(autoTunerConfigsProvider.shuffleManagerCommentForUnsupportedVersion(sparkVersion))
         }
       case None =>
-        Left(autoTunerConfigsProvider.shuffleManagerComments("missing")(""))
+        Left(autoTunerConfigsProvider.shuffleManagerCommentForMissingVersion)
     }
   }
 
@@ -1346,16 +1346,6 @@ trait AutoTunerConfigsProvider extends Logging {
   private val shuffleManagerDocUrl = "https://docs.nvidia.com/spark-rapids/user-guide/latest/" +
     "additional-functionality/rapids-shuffle.html#rapids-shuffle-manager"
 
-  val shuffleManagerComments: Map[String, String => String] = Map(
-    "unsupported" -> ((sparkVersion: String) =>
-      s"Cannot recommend RAPIDS Shuffle Manager for unsupported '$sparkVersion' version.\n" +
-        "  To enable RAPIDS Shuffle Manager, use a supported Spark version and set \n" +
-        "  'spark.shuffle.manager' to a valid RAPIDS Shuffle Manager version. \n" +
-        s"  See supported versions: $shuffleManagerDocUrl."),
-    "missing" -> (_ =>
-      "Could not recommend RapidsShuffleManager as Spark version cannot be determined.")
-  )
-
   /**
    * Abstract method to create an instance of the AutoTuner.
    */
@@ -1475,6 +1465,17 @@ trait AutoTunerConfigsProvider extends Logging {
 
   def buildShuffleManagerClassName(smVersion: String): String = {
     s"com.nvidia.spark.rapids.spark$smVersion.RapidsShuffleManager"
+  }
+
+  def shuffleManagerCommentForUnsupportedVersion(sparkVersion: String): String = {
+    s"Cannot recommend RAPIDS Shuffle Manager for unsupported '$sparkVersion' version.\n" +
+     "  To enable RAPIDS Shuffle Manager, set 'spark.shuffle.manager' to a value\n" +
+     "  from the supported versions. \n" +
+    s"  See supported versions: $shuffleManagerDocUrl."
+  }
+
+  def shuffleManagerCommentForMissingVersion: String = {
+    "Could not recommend RapidsShuffleManager as Spark version cannot be determined."
   }
 }
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -2192,8 +2192,8 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
       expectedSmVersion: String): Unit = {
     autoTuner.getShuffleManagerClassName match {
       case Right(smClassName) =>
-        assert(smClassName ==
-          ProfilingAutoTunerConfigsProvider.buildShuffleManagerClassName(expectedSmVersion))
+        assert(smClassName == ProfilingAutoTunerConfigsProvider
+          .buildShuffleManagerClassName(expectedSmVersion))
       case Left(comment) =>
         fail(s"Expected valid RapidsShuffleManager but got comment: $comment")
     }
@@ -2254,8 +2254,8 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
       case Right(smClassName) =>
         fail(s"Expected error comment but got valid RapidsShuffleManager: $smClassName")
       case Left(comment) =>
-        assert(comment ==
-          ProfilingAutoTunerConfigsProvider.shuffleManagerCommentForUnsupportedVersion(sparkVersion))
+        assert(comment == ProfilingAutoTunerConfigsProvider
+          .shuffleManagerCommentForUnsupportedVersion(sparkVersion))
     }
   }
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -2254,8 +2254,8 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
       case Right(smClassName) =>
         fail(s"Expected error comment but got valid RapidsShuffleManager: $smClassName")
       case Left(comment) =>
-        assert(comment ==
-          ProfilingAutoTunerConfigsProvider.shuffleManagerComments("unsupported")(sparkVersion))
+        assert(comment == ProfilingAutoTunerConfigsProvider
+          .shuffleManagerCommentForUnsupportedVersion(sparkVersion))
     }
   }
 
@@ -2314,8 +2314,7 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
       case Right(smClassName) =>
         fail(s"Expected error comment but got valid RapidsShuffleManager: $smClassName")
       case Left(comment) =>
-        assert(comment ==
-          ProfilingAutoTunerConfigsProvider.shuffleManagerComments("missing")(""))
+        assert(comment == ProfilingAutoTunerConfigsProvider.shuffleManagerCommentForMissingVersion)
     }
   }
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -2193,48 +2193,51 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
     autoTuner.getShuffleManagerClassName match {
       case Right(smClassName) =>
         assert(smClassName ==
-          ShuffleManagerResolver.buildShuffleManagerClassName(expectedSmVersion))
+          ProfilingAutoTunerConfigsProvider.buildShuffleManagerClassName(expectedSmVersion))
       case Left(comment) =>
         fail(s"Expected valid RapidsShuffleManager but got comment: $comment")
     }
   }
 
   test("test shuffle manager version for supported databricks version") {
+    val databricksVersion = "11.3.x-gpu-ml-scala2.12"
     val databricksWorkerInfo = buildGpuWorkerInfoAsString(None)
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin",
-        DatabricksParseHelper.PROP_TAG_CLUSTER_SPARK_VERSION_KEY -> "11.3.x-gpu-ml-scala2.12"),
-      Some("3.3.0"), Seq())
+        DatabricksParseHelper.PROP_TAG_CLUSTER_SPARK_VERSION_KEY -> databricksVersion),
+      Some(databricksVersion), Seq())
     // Do not set the platform as DB to see if it can work correctly irrespective
     val autoTuner = ProfilingAutoTunerConfigsProvider
       .buildAutoTunerFromProps(databricksWorkerInfo,
-        infoProvider, PlatformFactory.createInstance())
+        infoProvider, PlatformFactory.createInstance(PlatformNames.DATABRICKS_AWS))
     // Assert shuffle manager string for DB 11.3 tag
     verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion="330db")
   }
 
   test("test shuffle manager version for supported spark version") {
-    val databricksWorkerInfo = buildGpuWorkerInfoAsString(None)
+    val sparkVersion = "3.3.0"
+    val workerInfo = buildGpuWorkerInfoAsString(None)
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin"),
-      Some("3.3.0"), Seq())
+      Some(sparkVersion), Seq())
     val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(databricksWorkerInfo,
+      .buildAutoTunerFromProps(workerInfo,
         infoProvider, PlatformFactory.createInstance())
     // Assert shuffle manager string for supported Spark v3.3.0
     verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion="330")
   }
 
   test("test shuffle manager version for supported custom spark version") {
-    val databricksWorkerInfo = buildGpuWorkerInfoAsString(None)
+    val customSparkVersion = "3.3.0-custom"
+    val workerInfo = buildGpuWorkerInfoAsString(None)
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin"),
-      Some("3.3.0-custom"), Seq())
+      Some(customSparkVersion), Seq())
     val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(databricksWorkerInfo,
+      .buildAutoTunerFromProps(workerInfo,
         infoProvider, PlatformFactory.createInstance())
     // Assert shuffle manager string for supported custom Spark v3.3.0
     verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion="330")
@@ -2251,7 +2254,8 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
       case Right(smClassName) =>
         fail(s"Expected error comment but got valid RapidsShuffleManager: $smClassName")
       case Left(comment) =>
-        assert(comment == ShuffleManagerResolver.commentForUnsupportedVersion(sparkVersion))
+        assert(comment ==
+          ProfilingAutoTunerConfigsProvider.shuffleManagerCommentForUnsupportedVersion(sparkVersion))
     }
   }
 
@@ -2266,51 +2270,51 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
     // Do not set the platform as DB to see if it can work correctly irrespective
     val autoTuner = ProfilingAutoTunerConfigsProvider
       .buildAutoTunerFromProps(databricksWorkerInfo,
-        infoProvider, PlatformFactory.createInstance())
+        infoProvider, PlatformFactory.createInstance(PlatformNames.DATABRICKS_AWS))
     verifyUnsupportedSparkVersionForShuffleManager(autoTuner, databricksVersion)
   }
 
   test("test shuffle manager version for unsupported spark version") {
     val sparkVersion = "3.1.2"
-    val databricksWorkerInfo = buildGpuWorkerInfoAsString(None)
+    val workerInfo = buildGpuWorkerInfoAsString(None)
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin"),
       Some(sparkVersion), Seq())
     val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(databricksWorkerInfo,
+      .buildAutoTunerFromProps(workerInfo,
         infoProvider, PlatformFactory.createInstance())
     verifyUnsupportedSparkVersionForShuffleManager(autoTuner, sparkVersion)
   }
 
   test("test shuffle manager version for unsupported custom spark version") {
     val customSparkVersion = "3.1.2-custom"
-    val databricksWorkerInfo = buildGpuWorkerInfoAsString(None)
+    val workerInfo = buildGpuWorkerInfoAsString(None)
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin"),
       Some(customSparkVersion), Seq())
     val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(databricksWorkerInfo,
+      .buildAutoTunerFromProps(workerInfo,
         infoProvider, PlatformFactory.createInstance())
     verifyUnsupportedSparkVersionForShuffleManager(autoTuner, customSparkVersion)
   }
 
   test("test shuffle manager version for missing spark version") {
-    val databricksWorkerInfo = buildGpuWorkerInfoAsString(None)
+    val workerInfo = buildGpuWorkerInfoAsString(None)
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin"),
       None, Seq())
     val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(databricksWorkerInfo,
+      .buildAutoTunerFromProps(workerInfo,
         infoProvider, PlatformFactory.createInstance())
     // Verify that the shuffle manager is not recommended for missing Spark version
     autoTuner.getShuffleManagerClassName match {
       case Right(smClassName) =>
         fail(s"Expected error comment but got valid RapidsShuffleManager: $smClassName")
       case Left(comment) =>
-        assert(comment == ShuffleManagerResolver.commentForMissingVersion)
+        assert(comment == ProfilingAutoTunerConfigsProvider.shuffleManagerCommentForMissingVersion)
     }
   }
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -2191,14 +2191,15 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
       autoTuner: AutoTuner,
       expectedSmVersion: String): Unit = {
     autoTuner.getShuffleManagerClassName match {
-      case Right(smVersion) =>
-        assert(smVersion == ShuffleManagerResolver.buildShuffleManagerClassName(expectedSmVersion))
+      case Right(smClassName) =>
+        assert(smClassName ==
+          ShuffleManagerResolver.buildShuffleManagerClassName(expectedSmVersion))
       case Left(comment) =>
         fail(s"Expected valid RapidsShuffleManager but got comment: $comment")
     }
   }
 
-  test("test shuffle manager version for supported databricks") {
+  test("test shuffle manager version for supported databricks version") {
     val databricksWorkerInfo = buildGpuWorkerInfoAsString(None)
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
       mutable.Map("spark.rapids.sql.enabled" -> "true",
@@ -2213,7 +2214,7 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
     verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion="330db")
   }
 
-  test("test shuffle manager version for supported non-databricks") {
+  test("test shuffle manager version for supported spark version") {
     val databricksWorkerInfo = buildGpuWorkerInfoAsString(None)
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
       mutable.Map("spark.rapids.sql.enabled" -> "true",
@@ -2226,7 +2227,7 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
     verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion="330")
   }
 
-  test("test shuffle manager version for supported custom version") {
+  test("test shuffle manager version for supported custom spark version") {
     val databricksWorkerInfo = buildGpuWorkerInfoAsString(None)
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
       mutable.Map("spark.rapids.sql.enabled" -> "true",
@@ -2247,14 +2248,14 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
       autoTuner: AutoTuner,
       sparkVersion: String): Unit = {
     autoTuner.getShuffleManagerClassName match {
-      case Right(smVersion) =>
-        fail(s"Expected error comment but got valid RapidsShuffleManager with version $smVersion")
+      case Right(smClassName) =>
+        fail(s"Expected error comment but got valid RapidsShuffleManager: $smClassName")
       case Left(comment) =>
         assert(comment == ShuffleManagerResolver.commentForUnsupportedVersion(sparkVersion))
     }
   }
 
-  test("test shuffle manager version for unsupported databricks") {
+  test("test shuffle manager version for unsupported databricks version") {
     val databricksVersion = "9.1.x-gpu-ml-scala2.12"
     val databricksWorkerInfo = buildGpuWorkerInfoAsString(None)
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
@@ -2269,7 +2270,7 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
     verifyUnsupportedSparkVersionForShuffleManager(autoTuner, databricksVersion)
   }
 
-  test("test shuffle manager version for unsupported non-databricks") {
+  test("test shuffle manager version for unsupported spark version") {
     val sparkVersion = "3.1.2"
     val databricksWorkerInfo = buildGpuWorkerInfoAsString(None)
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
@@ -2282,7 +2283,7 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
     verifyUnsupportedSparkVersionForShuffleManager(autoTuner, sparkVersion)
   }
 
-  test("test shuffle manager version for unsupported custom version") {
+  test("test shuffle manager version for unsupported custom spark version") {
     val customSparkVersion = "3.1.2-custom"
     val databricksWorkerInfo = buildGpuWorkerInfoAsString(None)
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
@@ -2306,8 +2307,8 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
         infoProvider, PlatformFactory.createInstance())
     // Verify that the shuffle manager is not recommended for missing Spark version
     autoTuner.getShuffleManagerClassName match {
-      case Right(smVersion) =>
-        fail(s"Expected error comment but got valid RapidsShuffleManager with version $smVersion")
+      case Right(smClassName) =>
+        fail(s"Expected error comment but got valid RapidsShuffleManager: $smClassName")
       case Left(comment) =>
         assert(comment == ShuffleManagerResolver.commentForMissingVersion)
     }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -2254,8 +2254,8 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
       case Right(smClassName) =>
         fail(s"Expected error comment but got valid RapidsShuffleManager: $smClassName")
       case Left(comment) =>
-        assert(comment == ProfilingAutoTunerConfigsProvider
-          .shuffleManagerCommentForUnsupportedVersion(sparkVersion))
+        assert(comment ==
+          ProfilingAutoTunerConfigsProvider.shuffleManagerComments("unsupported")(sparkVersion))
     }
   }
 
@@ -2314,7 +2314,8 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
       case Right(smClassName) =>
         fail(s"Expected error comment but got valid RapidsShuffleManager: $smClassName")
       case Left(comment) =>
-        assert(comment == ProfilingAutoTunerConfigsProvider.shuffleManagerCommentForMissingVersion)
+        assert(comment ==
+          ProfilingAutoTunerConfigsProvider.shuffleManagerComments("missing")(""))
     }
   }
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -2255,7 +2255,7 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
         fail(s"Expected error comment but got valid RapidsShuffleManager: $smClassName")
       case Left(comment) =>
         assert(comment == ProfilingAutoTunerConfigsProvider
-          .shuffleManagerCommentForUnsupportedVersion(sparkVersion))
+          .shuffleManagerCommentForUnsupportedVersion(sparkVersion, autoTuner.platform))
     }
   }
 


### PR DESCRIPTION
Fixes #1402

This PR improves the `AutoTuner` module by adding a new `ShuffleManagerResolver` object to better handle the resolution of the appropriate `RapidsShuffleManager` class name based on the Spark or Databricks version. In case an unsupported Spark version is detected then `ShuffleManagerResolver` returns an appropriate error comment.

### Output Example for Unsupported Spark Version

**CMD:**
```
spark_rapids qualification --platform <platform> --eventlogs <any_spark_313_eventlog> --tools_jar <tools_jar>
```

**Output:**
File: `qual_2025xxx/rapids_4_spark_qualification_output/tuning/application_xxx.log`
Contents:
```
.... <other recommendations> ....
- Cannot recommend RAPIDS Shuffle Manager for unsupported '3.1.3' version.
  To enable RAPIDS Shuffle Manager, use a supported Spark version and set
  'spark.shuffle.manager' to a valid RAPIDS Shuffle Manager version.
  See supported versions: https://docs.nvidia.com/spark-rapids/user-guide/latest/additional-functionality/rapids-shuffle.html#rapids-shuffle-manager.
.... <other recommendations> ....
```

## Changes

### Enhancements to Shuffle Manager Resolution:
* Added `ShuffleManagerResolver` object to determine the appropriate `RapidsShuffleManager` class name based on Spark or Databricks version mappings. (`core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala`)

### Updates to `AutoTuner` Class:
* Modified `getShuffleManagerClassName` method to use `ShuffleManagerResolver` for resolving the class name and returning either the class name or an error message. (`core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala`)
* Updated the logic in the `AutoTuner` class to handle the new `Either` type returned by `getShuffleManagerClassName`. (`core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala`)

## Tests:
* Added helper methods and new test cases in `ProfilingAutoTunerSuite` to verify the recommended shuffle manager version for various supported and unsupported Spark and Databricks versions. (`core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala`) [[1]](diffhunk://#diff-ada5964d4f49a559184f692ffb3fbf4823665b714ba0470adcc961a34a3c734cL2186-R2202) [[2]](diffhunk://#diff-ada5964d4f49a559184f692ffb3fbf4823665b714ba0470adcc961a34a3c734cL2197-R2217) [[3]](diffhunk://#diff-ada5964d4f49a559184f692ffb3fbf4823665b714ba0470adcc961a34a3c734cL2211-R2314)
