### PR TITLE
Support Python 3.9-3.12

### DIFF
--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/user_tools/README.md
+++ b/user_tools/README.md
@@ -17,7 +17,7 @@ The wrapper improves end-user experience within the following dimensions:
 
 ## Getting started
 
-Set up a Python environment with a version between 3.8 and 3.11
+Set up a Python environment with a version between 3.9 and 3.12
 
 1. Run the project in a virtual environment. Note, .venv is the directory created to put
    the virtual env in, so modify if you want a different location.

--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,55 +23,66 @@ authors = [
 ]
 description = "A simple wrapper process around cloud service providers to run tools for the RAPIDS Accelerator for Apache Spark."
 readme = "README.md"
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.9,<3.13"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    # numpy-1.24.4 is the latest version to support python3.8. P.S: does not support python-3.12+
-    "numpy<=1.24.4",
+    # numpy-2.0.0 supports python [3.9, 3.13]. numpy2.1.0 drooped support for Python 3.9.
+    "numpy>=2.0.0",
+    # For moustache templates
     "chevron==0.14.0",
     "fastprogress==1.0.3",
-    "fastcore==1.7.10",
-    "fire>=0.5.0",
-    "pandas==1.4.3",
-    "pyYAML>=6.0,<=7.0",
+    "fastcore==1.7.28",
+    # Python [3.9, 3.13]
+    "fire==0.7.0",
+    # pandas python [3.9, 3.12]
+    "pandas==2.2.3",
+    # pyYaml-6.0.2 supports python[3.9, 3.13]
+    "pyYAML>=6.0.2",
     # This is used to resolve env-variable in yaml files. It requires netween 5.0 and 6.0
     "pyaml-env==1.2.1",
-    "tabulate==0.8.10",
-    "importlib-resources==5.10.2",
-    "requests==2.31.0",
-    "packaging>=23.0",
-    "certifi==2024.7.4",
-    "idna==3.4",
-    "urllib3==1.26.19",
-    "beautifulsoup4==4.11.2",
-    "pygments==2.15.0",
-    # used to apply validator on objects and models. "2.9.2" contains from_json method.
-    "pydantic==2.9.2",
-    # used to help pylint understand pydantic
-    "pylint-pydantic==0.3.0",
+    "tabulate==0.9.0",
+    # Supports Python 3.9+
+    "importlib-resources==6.5.0",
+    # supports python [3.9, 3.12]
+    "requests==2.32.3",
+    # Supports Python [3.9, 3.13]
+    "packaging==24.2",
+    # supports python[3.8, 3.13]
+    "certifi==2024.12.14",
+    # supports python[3.9, 3.13]
+    "urllib3==2.3.0",
+    # Used as a syntax highlighter for the CLI STDOUT. Python [3.9, 3.12]
+    "pygments==2.18.0",
+    # used to apply validator on objects and models.
+    # "2.9.2" contains from_json method.
+    # Python [3.9, 3.13]
+    "pydantic==2.10.4",
+    # used to help pylint understand pydantic. Python [3.9, 3.12]
+    "pylint-pydantic==0.3.4",
     # used for common API to access remote filesystems like local/s3/gcs/hdfs
-    # pin to 16.1.0 which works for both numpy-1.0 and numpy-2.0
-    "pyarrow==16.1.0",
+    # pin to 18.1.0 which supports python [3.9, 3.13]
+    "pyarrow==18.1.0",
     # used for ADLS filesystem implementation
-    # Issue-568: use 12.17.0 as the new 12.18.0 causes an error in runtime
-    "azure-storage-blob==12.17.0",
-    "adlfs==2023.4.0",
+    # Python [3.9, 3.12]
+    "azure-storage-blob==12.24.0",
+    # used for ADLS filesystem implementation. Python [3.9, 3.13]
+    "adlfs==2024.12.0",
     # used for spinner animation
     "progress==1.6",
-    # used for model estimations
-    "xgboost==2.0.3",
-    # used for model interpretability
-    "shap==0.44.1",
+    # used for model estimations python [3.9-3.11]
+    "xgboost==2.1.3",
+    # used for model interpretability. python [3.9, 3.12]
+    "shap==0.46.0",
     # used for retrieving available memory on the host
-    "psutil==5.9.8"
+    "psutil==6.1.1"
 ]
 dynamic=["entry-points", "version"]
 
@@ -95,8 +106,10 @@ test = [
     "tox", 'pytest', 'cli_test_helpers', 'behave',
     # use flak-8 plugin for pydantic
     'flake8-pydantic',
-    # use pylint specific version
-    'pylint==3.2.7',
+    # Use pylint for static code analysis.
+    # Latest version to drop Python 3.8 is 3.27.
+    # Set specific version to avoid breaking test with newer pylint releases. Python [3.9-3.13]
+    'pylint==3.3.3'
 ]
 qualx = [
     "holoviews",

--- a/user_tools/src/spark_rapids_pytools/common/utilities.py
+++ b/user_tools/src/spark_rapids_pytools/common/utilities.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ class Utils:
         :param suffix_len:
         :return:
         """
-        ts = datetime.datetime.utcnow().strftime('%Y%m%d%H%M%S')
+        ts = datetime.datetime.now().astimezone().strftime('%Y%m%d%H%M%S')
         uuid_parts = [] if pref is None else [pref]
         uuid_parts.append(ts)
         if suffix_len > 0:

--- a/user_tools/tox.ini
+++ b/user_tools/tox.ini
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 [tox]
 envlist =
-    python{3.8,3.9,3.10,3.11}
+    python{3.9,3.10,3.11,3.12}
     coverage
     pylint
     flake8
@@ -28,10 +28,10 @@ isolated_build = True
 
 [gh-actions]
 python =
-    3.8: python3.8, pylint, flake8, behave
     3.9: python3.9, pylint, flake8, behave
     3.10: python3.10, pylint, flake8, behave
     3.11: python3.11, pylint, flake8, behave
+    3.12: python3.12, pylint, flake8, behave
 
 [testenv]
 deps =
@@ -61,7 +61,7 @@ commands =
     coverage combine
     coverage report
 depends =
-    python{3.8,3.9,3.10,3.11}
+    python{3.9,3.10,3.11,3.12}
 
 [coverage:paths]
 source = src/spark_rapids_pytools


### PR DESCRIPTION
Fixes #1153
Fixes #1453

Some of the changes were done to ensure the project is up-to-date with the latest Python versions and dependencies, improving compatibility and functionality.

* bump pylint to 3.3.3
* remove idna and bump fire and packaging
* add 3.12 to githubworkflows and remove 3.8
* remove upper bound for numpy
* remove unused beautifulsoup
* Update the README file to reflect the minimum python 3.9

This pull request includes several updates to the project to support newer Python versions and update dependencies. The changes span across configuration files, documentation, and source code to ensure compatibility and improve functionality.

### Python version updates:

* Updated Python version matrix to include Python 3.12 and drop Python 3.8 in `.github/workflows/python-unit-test.yml`, `user_tools/README.md`, `user_tools/pyproject.toml`, and `user_tools/tox.ini`. [[1]](diffhunk://#diff-1dd2e8dd081d4d6d7ab32e8aac3b6aea5038fda38d0a7e69382a9eaf80152831L27-R27) [[2]](diffhunk://#diff-0947db450e466ca126483075d009cfdd54df53bb17a9f841af5d8fb4ab763628L20-R20) [[3]](diffhunk://#diff-4567c711bb2a94833399095b675b18e161015821d727f84acb42052a55996616L26-R85) [[4]](diffhunk://#diff-c83303edf712b3edc8532fb2a1cb9dd3cedfae27d7002b146db1e510a82e21b2L22-R22) [[5]](diffhunk://#diff-c83303edf712b3edc8532fb2a1cb9dd3cedfae27d7002b146db1e510a82e21b2L31-R34) [[6]](diffhunk://#diff-c83303edf712b3edc8532fb2a1cb9dd3cedfae27d7002b146db1e510a82e21b2L64-R64)

### Dependency updates:

* Updated dependencies in `user_tools/pyproject.toml` to support Python 3.9 to 3.13 and removed outdated versions.

### Code updates:

* Changed the method to generate timestamps in `user_tools/src/spark_rapids_pytools/common/utilities.py` to use timezone-aware datetime.



