### PR TITLE
Support group-limit optimization for ROW_NUMBER in Qualification

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/WindowGroupLimitParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/WindowGroupLimitParser.scala
@@ -27,8 +27,6 @@ case class WindowGroupLimitParser(
     sqlID: Long) extends ExecParser {
 
   val fullExecName: String = node.name + "Exec"
-  // row_number() is currently not supported by the plugin (v24.04)
-  // Ref: https://github.com/NVIDIA/spark-rapids/pull/10500
   val supportedRankingExprs = Set("rank", "dense_rank", "row_number")
 
   private def validateRankingExpr(rankingExprs: Array[String]): Boolean = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/WindowGroupLimitParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/WindowGroupLimitParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ case class WindowGroupLimitParser(
   val fullExecName: String = node.name + "Exec"
   // row_number() is currently not supported by the plugin (v24.04)
   // Ref: https://github.com/NVIDIA/spark-rapids/pull/10500
-  val supportedRankingExprs = Set("rank", "dense_rank")
+  val supportedRankingExprs = Set("rank", "dense_rank", "row_number")
 
   private def validateRankingExpr(rankingExprs: Array[String]): Boolean = {
     rankingExprs.length == 1 && supportedRankingExprs.contains(rankingExprs.head)

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -1810,12 +1810,12 @@ class SQLPlanParserSuite extends BasePlanParserSuite {
 
   runConditionalTest("WindowGroupLimit expression rank is supported",
     execsSupportedSparkGTE350) {
-    runWindowGroupLimitTest("RANK", 73)
+    runWindowGroupLimitTest("RANK", skipSqlID = 73)
   }
 
   runConditionalTest("WindowGroupLimit expression row_number is supported",
     execsSupportedSparkGTE350) {
-    runWindowGroupLimitTest("ROW_NUMBER", 76)
+    runWindowGroupLimitTest("ROW_NUMBER", skipSqlID = 76)
   }
 
   runConditionalTest("CheckOverflowInsert should not exist in Physical Plan",


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1484

This code adds the `row_number` to the list of supported expressions in `WindowGroupLimit`.
Update the unit-tests to verify that the behavior is as expected.

## Detailed Changes

This pull request includes updates to the `WindowGroupLimitParser` and its corresponding test suite to support the `row_number` expression. Additionally, it includes some refactoring to simplify the test cases.

Support for `row_number` expression:

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/WindowGroupLimitParser.scala`](diffhunk://#diff-89ec92cbb88708c84625cc3ea461132f06ebe7285390f41277ebfde5af2e1f46L32-R32): Added `row_number` to the set of supported ranking expressions.

Refactoring of test cases:

* [`core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala`](diffhunk://#diff-7eedce7e5b4fa927eb339f6bbe77d4b29b8e5adc42f432d064f709090dea17c6L1764-R1781): Introduced a helper method `runWindowGroupLimitTest` to streamline test cases for `WindowGroupLimit` expressions. Updated existing test cases to use this helper method. [[1]](diffhunk://#diff-7eedce7e5b4fa927eb339f6bbe77d4b29b8e5adc42f432d064f709090dea17c6L1764-R1781) [[2]](diffhunk://#diff-7eedce7e5b4fa927eb339f6bbe77d4b29b8e5adc42f432d064f709090dea17c6L1790-R1795) [[3]](diffhunk://#diff-7eedce7e5b4fa927eb339f6bbe77d4b29b8e5adc42f432d064f709090dea17c6L1806-R1818)