### PR TITLE
Make spill heuristic 1 TB by default

### DIFF
--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -333,7 +333,7 @@ local:
           columns:
             - 'stageId'
             - 'SQL Nodes(IDs)'
-        spillThresholdBytes: !ENV ${RAPIDS_USER_TOOLS_SPILL_BYTES_THRESHOLD:10737418240}
+        spillThresholdBytes: !ENV ${RAPIDS_USER_TOOLS_SPILL_BYTES_THRESHOLD:1099511627776}
         allowedExecs:
           - 'Aggregate'
           - 'Join'


### PR DESCRIPTION
Fixes #1415 by putting a band aid. We can keep this issue open for the better algorithm recommended in the description of the issue. The goal of this change is to unblock difficulties with user experience of this low value heuristic. I understand that a perfect value is not trivial as just moving this value from 10 GB to 1 TB , however, this alleviates the need for SAs to tune this from the get go and also is more explainable to customers. Appreciate comments. Marking as WIP until I have tools team's blessing on the band aid. 