### PR TITLE
Pin scikit-learn dependency for shap

### DIFF
--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -81,6 +81,7 @@ dependencies = [
     "xgboost==2.1.3",
     # used for model interpretability. python [3.9, 3.12]
     "shap==0.46.0",
+    "scikit-learn==1.5.2",
     # used for retrieving available memory on the host
     "psutil==6.1.1"
 ]

--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -81,6 +81,7 @@ dependencies = [
     "xgboost==2.1.3",
     # used for model interpretability. python [3.9, 3.12]
     "shap==0.46.0",
+    # dependency of shap, python [3.9, 3.12]
     "scikit-learn==1.5.2",
     # used for retrieving available memory on the host
     "psutil==6.1.1"


### PR DESCRIPTION
This PR pins the `scikit-learn` dependency of `shap` to version 1.5.2, since the most recent [1.6.0 version](ttps://scikit-learn.org/stable/auto_examples/release_highlights/plot_release_highlights_1_6_0.html) (released on 12/9/2024) modified the behavior of the `BaseEstimator.__sklearn_tags__`, which is causing this error when running `optuna` hyperparameter search:
```
AttributeError: 'super' object has no attribute '__sklearn_tags__'
```
