### PR TITLE
Improve scalastyle rules to detect spaces

### DIFF
--- a/core/scalastyle-config.xml
+++ b/core/scalastyle-config.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2023-2024, NVIDIA CORPORATION. All Rights Reserved.
+  Copyright (c) 2023-2025, NVIDIA CORPORATION. All Rights Reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -40,6 +40,12 @@ You can also disable only one rule, by specifying its rule id, as specified in:
 
     <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"/>
 
+    <check level="error" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
+
+    <check level="error" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+
+    <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+
     <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
         <parameters>
             <parameter name="maxLineLength"><![CDATA[100]]></parameter>
@@ -56,6 +62,24 @@ You can also disable only one rule, by specifying its rule id, as specified in:
             <parameter name="group.3rdParty">(?!org\.apache\.spark\.).*</parameter>
             <parameter name="group.spark">org\.apache\.spark\..*</parameter>
         </parameters>
+    </check>
+
+    <check level="error" class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" enabled="true">
+        <parameters>
+            <parameter name="tokens">COMMA</parameter>
+        </parameters>
+    </check>
+
+    <check customId="SingleSpaceBetweenRParenAndLCurlyBrace" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+        <parameters><parameter name="regex">\)\{</parameter></parameters>
+        <customMessage><![CDATA[
+            Single Space between ')' and `{`.
+        ]]></customMessage>
+    </check>
+
+    <check customId="OmitBracesInCase" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+        <parameters><parameter name="regex">case[^\n>]*=>\s*\{</parameter></parameters>
+        <customMessage>Omit braces in case clauses.</customMessage>
     </check>
 
     <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
@@ -92,9 +116,34 @@ You can also disable only one rule, by specifying its rule id, as specified in:
         </parameters>
     </check>
 
+    <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+
+    <check level="error" class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" enabled="true"></check>
+
+    <check level="error" class="org.scalastyle.scalariform.EnsureSingleSpaceBeforeTokenChecker" enabled="true">
+        <parameters>
+            <parameter name="tokens">ARROW, EQUALS, ELSE, TRY, CATCH, FINALLY, LARROW, RARROW</parameter>
+        </parameters>
+    </check>
+
+    <check level="error" class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" enabled="true">
+        <parameters>
+            <parameter name="tokens">ARROW, EQUALS, COMMA, COLON, IF, ELSE, DO, WHILE, FOR, MATCH, TRY, CATCH, FINALLY, LARROW, RARROW</parameter>
+        </parameters>
+    </check>
+
     <!-- ??? usually shouldn't be checked into the code base. -->
     <check level="error" class="org.scalastyle.scalariform.NotImplementedErrorUsage"
            enabled="true"/>
+
+    <!-- Similar to Spark, all printlns need to be wrapped in '// scalastyle:off/on println' -->
+    <check customId="println" level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="true">
+        <parameters><parameter name="regex">^println$</parameter></parameters>
+        <customMessage><![CDATA[Are you sure you want to println? If yes, wrap the code block with
+      // scalastyle:off println
+      println(...)
+      // scalastyle:on println]]></customMessage>
+    </check>
 
     <check customId="NoScalaDoc" level="error" class="org.scalastyle.file.RegexChecker"
            enabled="true">
@@ -119,4 +168,12 @@ You can also disable only one rule, by specifying its rule id, as specified in:
     <!-- This project uses Javadoc rather than Scaladoc so scaladoc checks are disabled -->
     <check enabled="false" class="org.scalastyle.scalariform.ScalaDocChecker" level="warning"/>
 
+    <check customId="argcount" level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="false">
+        <parameters><parameter name="maxParameters"><![CDATA[10]]></parameter></parameters>
+    </check>
+
+    <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="false"></check>
+
+    <!-- Unit test uses ascii characters. So, we need to clean that up first -->
+    <check customId="nonascii" level="error" class="org.scalastyle.scalariform.NonASCIICharacterChecker" enabled="false"></check>
 </scalastyle>

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/AppSummaryInfoBaseProvider.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/AppSummaryInfoBaseProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ class AppSummaryInfoBaseProvider extends AppInfoPropertyGetter
   override def getProperty(propKey: String): Option[String] = {
     if (propKey.startsWith(ToolUtils.PROPS_RAPIDS_KEY_PREFIX)) {
       getRapidsProperty(propKey)
-    } else if (propKey.startsWith("spark")){
+    } else if (propKey.startsWith("spark")) {
       getSparkProperty(propKey)
     } else {
       getSystemProperty(propKey)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -432,7 +432,7 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
   /**
    * Attempts to get the instance type based on the core and gpu requirements.
    */
-  def getInstanceByResources(cores:Int, numGpus: Int): Option[InstanceInfo] = None
+  def getInstanceByResources(cores: Int, numGpus: Int): Option[InstanceInfo] = None
 
   /**
    * Recommend a GPU Instance type to use for this application.
@@ -452,7 +452,7 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
       // we could put on a node.
       if (origClusterNumExecsPerNode == -1) {
         maxGpusSupported
-      }  else {
+      } else {
         origClusterNumExecsPerNode
       }
     } else {
@@ -611,7 +611,7 @@ class DatabricksAwsPlatform(gpuDevice: Option[GpuDevice],
     clusterProperties: Option[ClusterProperties])
   extends DatabricksPlatform(gpuDevice, clusterProperties)
   with Logging {
-  override val platformName: String =  PlatformNames.DATABRICKS_AWS
+  override val platformName: String = PlatformNames.DATABRICKS_AWS
   override val defaultGpuDevice: GpuDevice = A10GGpu
 
   override def getInstanceByResources(
@@ -665,7 +665,7 @@ class DatabricksAzurePlatform(gpuDevice: Option[GpuDevice],
 
 class DataprocPlatform(gpuDevice: Option[GpuDevice],
     clusterProperties: Option[ClusterProperties]) extends Platform(gpuDevice, clusterProperties) {
-  override val platformName: String =  PlatformNames.DATAPROC
+  override val platformName: String = PlatformNames.DATAPROC
   override val defaultGpuDevice: GpuDevice = T4Gpu
   override def isPlatformCSP: Boolean = true
   override def maxGpusSupported: Int = 4
@@ -694,7 +694,7 @@ class DataprocPlatform(gpuDevice: Option[GpuDevice],
 class DataprocServerlessPlatform(gpuDevice: Option[GpuDevice],
     clusterProperties: Option[ClusterProperties])
   extends DataprocPlatform(gpuDevice, clusterProperties) {
-  override val platformName: String =  PlatformNames.DATAPROC_SL
+  override val platformName: String = PlatformNames.DATAPROC_SL
   override val defaultGpuDevice: GpuDevice = L4Gpu
   override def isPlatformCSP: Boolean = true
 }
@@ -702,13 +702,13 @@ class DataprocServerlessPlatform(gpuDevice: Option[GpuDevice],
 class DataprocGkePlatform(gpuDevice: Option[GpuDevice],
     clusterProperties: Option[ClusterProperties])
   extends DataprocPlatform(gpuDevice, clusterProperties) {
-  override val platformName: String =  PlatformNames.DATAPROC_GKE
+  override val platformName: String = PlatformNames.DATAPROC_GKE
   override def isPlatformCSP: Boolean = true
 }
 
 class EmrPlatform(gpuDevice: Option[GpuDevice],
     clusterProperties: Option[ClusterProperties]) extends Platform(gpuDevice, clusterProperties) {
-  override val platformName: String =  PlatformNames.EMR
+  override val platformName: String = PlatformNames.EMR
   override val defaultGpuDevice: GpuDevice = A10GGpu
 
   override def isPlatformCSP: Boolean = true
@@ -755,7 +755,7 @@ class EmrPlatform(gpuDevice: Option[GpuDevice],
 
 class OnPremPlatform(gpuDevice: Option[GpuDevice],
     clusterProperties: Option[ClusterProperties]) extends Platform(gpuDevice, clusterProperties) {
-  override val platformName: String =  PlatformNames.ONPREM
+  override val platformName: String = PlatformNames.ONPREM
   // Note we don't have an speedup factor file for onprem l4's but we want auto tuner
   // to use L4.
   override val defaultGpuDevice: GpuDevice = L4Gpu

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DeltaLakeHelper.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DeltaLakeHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ class DLWriteWithFormatAndSchemaParser(node: SparkPlanGraphNode,
 object DeltaLakeHelper {
   // we look for the serdeLibrary which is part of the node description:
   // Serde Library: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-  //private val serdeRegex = "Serde Library: ([\\w.]+)".r
+  // private val serdeRegex = "Serde Library: ([\\w.]+)".r
   private val serdeRegex = "Serde Library: ([\\w.]+)".r
   // We look for the schema in the node description. It is in the following format
   // Schema: root

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ReadParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ReadParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ object ReadParser extends Logging {
   }
 
   // This tries to get just the field specified by tag in a string that
-  // may contain multiple fields.  It looks for a comma to delimit fields.
+  // may contain multiple fields. It looks for a comma to delimit fields.
   private def getFieldWithoutTag(str: String, tag: String): String = {
     val index = str.indexOf(tag)
     // remove the tag from the final string returned
@@ -187,7 +187,6 @@ object ReadParser extends Logging {
       }
       ReadMetaData(schema, location, fileFormat, tags = extractReadTags(node.desc))
     }
-
   }
 
   // For the read score we look at the read format and datatypes for each

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ object UnsupportedReasons extends Enumeration {
       case IS_UNSUPPORTED => "Unsupported"
       case CONTAINS_UNSUPPORTED_EXPR => "Contains unsupported expr"
       case UNSUPPORTED_IO_FORMAT => "Unsupported IO format"
-      case customReason @ _  => customReason.toString
+      case customReason @ _ => customReason.toString
     }
   }
 }
@@ -163,7 +163,7 @@ case class ExecInfo(
         OpActions.IgnoreNoPerf
       } else if (shouldIgnore) {
         OpActions.IgnorePerf
-      } else  {
+      } else {
         OpActions.Triage
       }
     }
@@ -296,7 +296,7 @@ object ExecInfo {
       children: Option[Seq[ExecInfo]], // only one level deep
       stages: Set[Int] = Set.empty,
       shouldRemove: Boolean = false,
-      unsupportedExecReason:String = "",
+      unsupportedExecReason: String = "",
       unsupportedExprs: Seq[UnsupportedExprOpRef] = Seq.empty,
       dataSet: Boolean = false,
       udf: Boolean = false,
@@ -660,7 +660,7 @@ object SQLPlanParser extends Logging {
     maxDuration
   }
 
-  private def ignoreExpression(expr:String): Boolean = {
+  private def ignoreExpression(expr: String): Boolean = {
     ignoreExpressions.contains(expr.toLowerCase)
   }
 
@@ -789,7 +789,7 @@ object SQLPlanParser extends Logging {
     parsedExpressions.toArray
   }
 
-  def parseWindowExpressions(exprStr:String): Array[String] = {
+  def parseWindowExpressions(exprStr: String): Array[String] = {
     val parsedExpressions = ArrayBuffer[String]()
     // [sum(cast(level#30 as bigint)) windowspecdefinition(device#29, id#28 ASC NULLS FIRST,
     // specifiedwindowframe(RangeFrame, unboundedpreceding$(), currentrow$())) AS sum#35L,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/DriverLogProcessor.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/DriverLogProcessor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,6 @@ class DriverLogProcessor(logPath: String)
     countsMap.map(x => DriverLogUnsupportedOperators(x._1._1, x._2, x._1._2)).toSeq
   }
 }
-
 
 object BaseDriverLogInfoProvider {
   def noneDriverLog: BaseDriverLogInfoProvider = new BaseDriverLogInfoProvider()

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimeline.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimeline.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ class TimelineTaskInfo(val stageId: Int, val taskId: Long,
 
 class TimelineStageInfo(val stageId: Int,
     startTime: Long,
-    endTime:Long,
+    endTime: Long,
     val duration: Long) extends TimelineTiming(startTime, endTime)
 
 class TimelineJobInfo(val jobId: Int,
@@ -279,7 +279,7 @@ object GenerateTimeline {
       .flatMap(_.taskUpdatesMap.values).sum
 
     val semMetricsMs = app.accumManager.accumInfoMap.flatMap {
-        case (_,accumInfo: AccumInfo)
+        case (_, accumInfo: AccumInfo)
             if accumInfo.infoRef.name == AccumNameRef.NAMES_TABLE.get("gpuSemaphoreWait") =>
             Some(accumInfo.taskUpdatesMap.values.sum)
         case _ => None

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/HealthCheck.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/HealthCheck.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ class HealthCheck(apps: Seq[ApplicationInfo]) {
     ProfRemovedExecutorView.getRawView(apps)
   }
 
-  //Function to list all *possible* not-supported plan nodes if GPU Mode=on
+  // Function to list all *possible* not-supported plan nodes if GPU Mode=on
   def getPossibleUnsupportedSQLPlan: Seq[UnsupportedOpsProfileResult] = {
     val res = apps.flatMap { app =>
       app.planMetricProcessor.unsupportedSQLPlan.map { unsup =>

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -203,7 +203,7 @@ class SQLExecutionInfoClass(
 }
 
 case class SQLAccumProfileResults(appIndex: Int, sqlID: Long, nodeID: Long,
-    nodeName: String, accumulatorId: Long, name: String, min: Long, median:Long,
+    nodeName: String, accumulatorId: Long, name: String, min: Long, median: Long,
     max: Long, total: Long, metricType: String, stageIds: String) extends ProfileResult {
   override val outputHeaders = Seq("appIndex", "sqlID", "nodeID", "nodeName", "accumulatorId",
     "name", "min", "median", "max", "total", "metricType", "stageIds")
@@ -310,7 +310,7 @@ case class AppInfoProfileResults(appIndex: Int, appName: String,
 
   override def convertToSeq: Seq[String] = {
     Seq(appIndex.toString, appName, appId.getOrElse(""),
-      sparkUser,  startTime.toString, endTimeToStr, durToStr,
+      sparkUser, startTime.toString, endTimeToStr, durToStr,
       durationStr, sparkRuntime.toString, sparkVersion, pluginEnabled.toString)
   }
   override def convertToCSVSeq: Seq[String] = {
@@ -1105,7 +1105,7 @@ case class WholeStageCodeGenResults(
   }
 }
 
-case class RecommendedPropertyResult(property: String, value: String){
+case class RecommendedPropertyResult(property: String, value: String) {
   override def toString: String = "--conf %s=%s".format(property, value)
 }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -162,7 +162,7 @@ class PluginTypeChecker(platform: Platform = PlatformFactory.createInstance(),
     // Some SQL function names have backquotes(`) around their names,
     // so we remove them before saving.
     readOperators(source, "exprs", true).map(
-      x => (x._1.toLowerCase.replaceAll("\\`", "").replaceAll(" ",""), x._2))
+      x => (x._1.toLowerCase.replaceAll("\\`", "").replaceAll(" ", ""), x._2))
   }
 
   def readUnsupportedOpsByDefaultReasons: Map[String, String] = {
@@ -170,7 +170,7 @@ class PluginTypeChecker(platform: Platform = PlatformFactory.createInstance(),
     val unsupportedExecsBydefault = readOperators(execsSource, "execs", false)
     val exprsSource = UTF8Source.fromResource(SUPPORTED_EXPRS_FILE)
     val unsupportedExprsByDefault = readOperators(exprsSource, "exprs", false).map(
-      x => (x._1.toLowerCase.replaceAll("\\`", "").replaceAll(" ",""), x._2))
+      x => (x._1.toLowerCase.replaceAll("\\`", "").replaceAll(" ", ""), x._2))
     unsupportedExecsBydefault ++ unsupportedExprsByDefault
   }
 
@@ -222,13 +222,13 @@ class PluginTypeChecker(platform: Platform = PlatformFactory.createInstance(),
   // In the notes section of the supported csv files, it specifies reason for why it is not
   // supported by default. We use this information to propagate it unsupported operators
   // csv file.
-  private def processOperatorLine(cols: Array[String], operatorType:String,
+  private def processOperatorLine(cols: Array[String], operatorType: String,
       isSupported: Boolean): Seq[(String, String)] = {
     operatorType match {
       case "exprs" if isSupported =>
         // Logic for supported expressions
         val exprName = Seq((cols(0), cols(1)))
-        val sqlFuncNames = if (cols(2).nonEmpty && cols(2) != NONE ){
+        val sqlFuncNames = if (cols(2).nonEmpty && cols(2) != NONE) {
           // There are addidtional checks for Expressions. In physical plan, SQL function name is
           // printed instead of expression name. We have to save both expression name and
           // SQL function name(if there is one) so that we don't miss the expression while

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ class Qualification(outputPath: String, numRows: Int, hadoopConf: Configuration,
     timeout: Option[Long], nThreads: Int, order: String,
     pluginTypeChecker: PluginTypeChecker, reportReadSchema: Boolean,
     printStdout: Boolean, enablePB: Boolean,
-    reportSqlLevel: Boolean, maxSQLDescLength: Int, mlOpsEnabled:Boolean,
+    reportSqlLevel: Boolean, maxSQLDescLength: Int, mlOpsEnabled: Boolean,
     penalizeTransitions: Boolean, tunerContext: Option[TunerContext],
     clusterReport: Boolean, platformArg: String, workerInfoPath: String) extends ToolBase(timeout) {
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningAppMetadata.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningAppMetadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualOutputWriter.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualOutputWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ class RunningQualOutputWriter(
     outputDir: String,
     hadoopConf: Option[Configuration] = None,
     fileNameSuffix: String = "")
-  extends QualOutputWriter(outputDir, reportReadSchema=false, printStdout=false,
+  extends QualOutputWriter(outputDir, reportReadSchema = false, printStdout = false,
     prettyPrintOrder = "desc", hadoopConf) {
 
   private lazy val csvPerSQLFileWriter = new ToolTextFileWriter(outputDir,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ class RunningQualificationApp(
     perSqlOnly: Boolean = false,
     pluginTypeChecker: PluginTypeChecker = new PluginTypeChecker(),
     platform: Platform = PlatformFactory.createInstance())
-  extends QualificationAppInfo(None, None, pluginTypeChecker, reportSqlLevel=false,
+  extends QualificationAppInfo(None, None, pluginTypeChecker, reportSqlLevel = false,
     perSqlOnly, platform = platform) {
   // note we don't use the per sql reporting providing by QualificationAppInfo so we always
   // send down false for it

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -843,7 +843,7 @@ class AutoTuner(
       getPropertyValue("spark.sql.adaptive.advisoryPartitionSizeInBytes")
     if (appInfoProvider.getMeanInput <
       autoTunerConfigsProvider.AQE_INPUT_SIZE_BYTES_THRESHOLD) {
-      if(advisoryPartitionSizeProperty.isEmpty) {
+      if (advisoryPartitionSizeProperty.isEmpty) {
         // The default is 64m, but 128m is slightly better for the GPU as the GPU has sub-linear
         // scaling until it is full and 128m makes the GPU more full, but too large can be
         // slightly problematic because this is the compressed shuffle size
@@ -1470,7 +1470,7 @@ trait AutoTunerConfigsProvider extends Logging {
 
   def shuffleManagerCommentForUnsupportedVersion(
       sparkVersion: String, platform: Platform): String = {
-    val (latestSparkVersion, latestSmVersion)  = platform.latestSupportedShuffleManagerInfo
+    val (latestSparkVersion, latestSmVersion) = platform.latestSupportedShuffleManagerInfo
     // scalastyle:off line.size.limit
     s"""
        |Cannot recommend RAPIDS Shuffle Manager for unsupported ${platform.sparkVersionLabel}: '$sparkVersion'.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/QualRawReportGenerator.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/QualRawReportGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,14 @@ package com.nvidia.spark.rapids.tool.views
 import com.nvidia.spark.rapids.tool.analysis.{AggRawMetricsResult, AppSQLPlanAnalyzer, QualSparkMetricsAnalyzer}
 import com.nvidia.spark.rapids.tool.profiling.{DataSourceProfileResult, ProfileOutputWriter, ProfileResult, SQLAccumProfileResults}
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.rapids.tool.qualification.QualificationAppInfo
 
 /**
  * This object generates the raw metrics view for the qualification tool. It is used to generate
  * the CSV files without applying any heuristics or estimation.
  */
-object QualRawReportGenerator {
+object QualRawReportGenerator extends Logging {
 
   private def constructLabelsMaps(
       aggRawResult: AggRawMetricsResult): Map[String, Seq[ProfileResult]] = {
@@ -110,7 +111,7 @@ object QualRawReportGenerator {
       pWriter.write(QualRemovedExecutorView.getLabel, QualRemovedExecutorView.getRawView(Seq(app)))
     } catch {
       case e: Exception =>
-        println(s"Error generating raw metrics for ${app.appId}: ${e.getMessage}")
+        logError(s"Error generating raw metrics for ${app.appId}: ${e.getMessage}")
     } finally {
       pWriter.close()
     }

--- a/core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/Benchmark.scala
+++ b/core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/Benchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,6 +76,7 @@ class Benchmark(
   def run(): Seq[Result] = {
     require(benchmarks.nonEmpty)
     val separator = "-" * 80
+    // scalastyle:off println
     println(separator)
     println("Running benchmark: " + name)
     println(separator)
@@ -85,6 +86,7 @@ class Benchmark(
       measure(c.name, c.numIters)(c.fn)
     }
     println
+    // scalastyle:on println
     results
   }
 
@@ -93,6 +95,7 @@ class Benchmark(
    * the rate of the function.
    */
   def measure(name: String, overrideNumIters: Int)(f: ToolsTimer => Unit): Result = {
+    // scalastyle:off println
     System.gc()  // ensures garbage from previous cases don't impact this one
     val separator = "-" * 80
     for (wi <- 0 until warmUpIterations) {
@@ -102,7 +105,7 @@ class Benchmark(
     val runTimes = ArrayBuffer[Long]()
     val gcCounts = ArrayBuffer[Long]()
     val gcTimes = ArrayBuffer[Long]()
-    //For tracking maximum GC over iterations
+    // For tracking maximum GC over iterations
     for (i <- 0 until minIters) {
       System.gc()  // ensures GC for a consistent state across different iterations
       val timer = new ToolsTimer(i)
@@ -144,14 +147,15 @@ class Benchmark(
       bestRuntime / 1000000.0,
       stdevRunTime / 1000000.0,
       JVMMemoryParams(avgGcTime, avgGcCount, stdevGcCount, maxGcCount, maxGcTime))
+    // scalastyle:on println
   }
 }
 
 
 object Benchmark {
   case class Case(name: String, fn: ToolsTimer => Unit, numIters: Int)
-  case class JVMMemoryParams( avgGCTime:Double, avgGCCount:Double,
-      stdDevGCCount: Double, maxGCCount: Long, maxGcTime:Long)
+  case class JVMMemoryParams(avgGCTime: Double, avgGCCount: Double,
+      stdDevGCCount: Double, maxGCCount: Long, maxGcTime: Long)
   case class Result(caseName: String, avgMs: Double, bestMs: Double, stdevMs: Double,
       memoryParams: JVMMemoryParams)
 }

--- a/core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/BenchmarkArgs.scala
+++ b/core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/BenchmarkArgs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ Benchmarker class for running various benchmarks.
   val iterations: ScallopOption[Int] = opt[Int](short = 'i', default = Some(5),
     descr = "Total iterations to run excluding warmup (for avg time calculation)." +
       " Default is 5 iterations", validate = _ > 0)
-  val warmupIterations: ScallopOption[Int] = opt[Int](short = 'w' ,
+  val warmupIterations: ScallopOption[Int] = opt[Int](short = 'w',
     default = Some(3), descr = "Total number of warmup iterations to run. Can take " +
       "any input >=0. Warm up is important for benchmarking to ensure initial " +
       "JVM operations do not skew the result ( classloading etc. )", validate = _ >= 0)

--- a/core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/BenchmarkBase.scala
+++ b/core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/BenchmarkBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,8 +71,9 @@ abstract class BenchmarkBase {
     val firstBest = results.head.bestMs
     val nameLen = Math.max(40, results.map(_.caseName.length).max)
     printStream.printf(s"%-${nameLen}s %14s %14s %11s %20s %18s %18s %18s %18s %10s\n",
-      "Benchmark :", "Best Time(ms)", "Avg Time(ms)", "Stdev(ms)","Avg GC Time(ms)",
-      "Avg GC Count", "Stdev GC Count","Max GC Time(ms)","Max GC Count", "Relative")
+      "Benchmark :", "Best Time(ms)", "Avg Time(ms)", "Stdev(ms)", "Avg GC Time(ms)",
+      "Avg GC Count", "Stdev GC Count", "Max GC Time(ms)", "Max GC Count", "Relative")
+    // scalastyle:off println
     printStream.println("-" * (nameLen + 160))
     results.foreach { result =>
       printStream.printf(s"%-${nameLen}s %14s %14s %11s %20s %18s %18s %18s %18s %10s\n",
@@ -88,6 +89,7 @@ abstract class BenchmarkBase {
         "%3.2fX" format (firstBest / result.bestMs))
     }
     printStream.println()
+    // scalastyle:on println
   }
 
   /**
@@ -99,17 +101,17 @@ abstract class BenchmarkBase {
   private def printSystemInformation(warmUpIterations: Int, iterations: Int,
       inputArgs: String ): Unit = {
     val jvmInfo = RuntimeUtil.getJVMOSInfo
-    output.get.printf(s"%-26s :   %s \n","JVM Name", jvmInfo("jvm.name"))
-    output.get.printf(s"%-26s :   %s \n","Java Version", jvmInfo("jvm.version"))
-    output.get.printf(s"%-26s :   %s \n","OS Name", jvmInfo("os.name"))
-    output.get.printf(s"%-26s :   %s \n","OS Version", jvmInfo("os.version"))
-    output.get.printf(s"%-26s :   %s MB \n","MaxHeapMemory",
+    output.get.printf(s"%-26s :   %s \n", "JVM Name", jvmInfo("jvm.name"))
+    output.get.printf(s"%-26s :   %s \n", "Java Version", jvmInfo("jvm.version"))
+    output.get.printf(s"%-26s :   %s \n", "OS Name", jvmInfo("os.name"))
+    output.get.printf(s"%-26s :   %s \n", "OS Version", jvmInfo("os.version"))
+    output.get.printf(s"%-26s :   %s MB \n", "MaxHeapMemory",
       (Runtime.getRuntime.maxMemory()/1024/1024).toString)
-    output.get.printf(s"%-26s :   %s \n","Total Warm Up Iterations",
+    output.get.printf(s"%-26s :   %s \n", "Total Warm Up Iterations",
       warmUpIterations.toString)
-    output.get.printf(s"%-26s :   %s \n","Total Runtime Iterations",
+    output.get.printf(s"%-26s :   %s \n", "Total Runtime Iterations",
       iterations.toString)
-    output.get.printf(s"%-26s :   %s \n \n","Input Arguments", inputArgs)
+    output.get.printf(s"%-26s :   %s \n \n", "Input Arguments", inputArgs)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -355,7 +355,7 @@ abstract class AppBase(
     ".*second\\(.*\\).*" -> "TIMEZONE second()"
   )
 
-  def findPotentialIssues(desc: String): Set[String] =  {
+  def findPotentialIssues(desc: String): Set[String] = {
     val potentialIssuesRegexs = potentialIssuesRegexMap
     val issues = potentialIssuesRegexs.filterKeys(desc.matches(_))
     issues.values.toSet

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppFilterImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppFilterImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ class AppFilterImpl(
     val apps: Seq[AppFilterReturnParameters] = appsForFiltering.asScala.toSeq
 
     appArgs match {
-      case profileArgs:ProfileArgs =>
+      case profileArgs: ProfileArgs =>
         filterEventLogsInternal(apps, profileArgs)
       case qualificationArgs: QualificationArgs =>
         filterEventLogsInternal(apps, qualificationArgs)
@@ -274,7 +274,7 @@ class AppFilterImpl(
     val startAppInfo = new FilterAppInfo(path, hadoopConf)
     val appInfo = AppFilterReturnParameters(startAppInfo, path)
     if (!startAppInfo.isAppMetaDefined) {
-      logWarning("Cannot process file due to missing start event: " + path) 
+      logWarning("Cannot process file due to missing start event: " + path)
     } else {
       appsForFiltering.add(appInfo)
     }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,7 +131,7 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
 
   def doSparkListenerLogStart(
       app: T,
-      event: SparkListenerLogStart): Unit  = {
+      event: SparkListenerLogStart): Unit = {
     logDebug("Processing event: " + event.getClass)
     app.handleLogStartForCachedProps(event)
   }
@@ -174,7 +174,7 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
     val SparkListenerDriverAccumUpdates(sqlID, accumUpdates) = event
     accumUpdates.foreach { accum =>
       val driverAccum = DriverAccumCase(sqlID, accum._1, accum._2)
-      val arrBuf =  app.driverAccumMap.getOrElseUpdate(accum._1,
+      val arrBuf = app.driverAccumMap.getOrElseUpdate(accum._1,
         ArrayBuffer[DriverAccumCase]())
       arrBuf += driverAccum
     }
@@ -202,7 +202,7 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
 
   def doSparkRapidsBuildInfoEvent(
       app: T,
-      event: SparkRapidsBuildInfoEvent): Unit  = {
+      event: SparkRapidsBuildInfoEvent): Unit = {
     logDebug("Processing event: " + event.getClass)
     app.sparkRapidsBuildInfo = event
   }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ class SparkPlanInfoWithStage(
   import SparkPlanInfoWithStage._
 
   def debugEquals(other: Any, depth: Int = 0): Boolean = {
+    // scalastyle:off println
     System.err.println(s"${" " * depth}DOES $this == $other?")
     other match {
       case o: SparkPlanInfo =>
@@ -68,6 +69,7 @@ class SparkPlanInfoWithStage(
         System.err.println(s"${" " * depth}NOT EQUAL WRONG TYPE")
         false
     }
+    // scalastyle:on println
   }
 
   override def toString: String = {
@@ -157,7 +159,7 @@ object SparkPlanInfoWithStage {
     "HashAggregate" -> "Aggregate",
     "SortAggregate" -> "Aggregate",
     "GpuHashAggregate" -> "Aggregate",
-    "RunningWindow" -> "Window", //GpuWindow and Window are already covered
+    "RunningWindow" -> "Window", // GpuWindow and Window are already covered
     "GpuRunningWindow" -> "Window")
 
   private def isShuffledTopN(info: SparkPlanInfoWithStage): Boolean = {
@@ -188,7 +190,7 @@ class ApplicationInfo(
     platform: Platform = PlatformFactory.createInstance())
   extends AppBase(Some(eLogInfo), Some(hadoopConf), Some(platform)) with Logging {
 
-  private lazy val eventProcessor =  new EventsProcessor(this)
+  private lazy val eventProcessor = new EventsProcessor(this)
 
   // Process all events
   processEvents()

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ class QualificationAppInfo(
 
   val notSupportFormatAndTypes: HashMap[String, Set[String]] = HashMap[String, Set[String]]()
 
-  private lazy val eventProcessor =  new QualificationEventProcessor(this, perSqlOnly)
+  private lazy val eventProcessor = new QualificationEventProcessor(this, perSqlOnly)
 
   /**
    * Important system properties that should be retained. We also include
@@ -485,7 +485,7 @@ class QualificationAppInfo(
   def aggregateStats(): Option[QualificationSummaryInfo] = {
     appMetaData.map { info =>
       val appDuration = calculateAppDuration().getOrElse(0L)
-      //calculateAppDuration(info.startTime).getOrElse(0L)
+      // calculateAppDuration(info.startTime).getOrElse(0L)
 
       // if either job or stage failures then we mark as N/A
       // TODO - what about incomplete, do we want to change those?
@@ -754,9 +754,9 @@ class QualificationAppInfo(
       }
 
       // Consider stageInfo to have below string as an example
-      //org.apache.spark.rdd.RDD.first(RDD.scala:1463)
-      //org.apache.spark.mllib.feature.PCA.fit(PCA.scala:44)
-      //org.apache.spark.ml.feature.PCA.fit(PCA.scala:93)
+      // org.apache.spark.rdd.RDD.first(RDD.scala:1463)
+      // org.apache.spark.mllib.feature.PCA.fit(PCA.scala:44)
+      // org.apache.spark.ml.feature.PCA.fit(PCA.scala:93)
       val splitString = stageInfoDetails.split("\n")
 
       // filteredString = org.apache.spark.ml.feature.PCA.fit

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/DataSourceRecord.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/DataSourceRecord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ case class NonFinalDataSourceCase(
     partitionFilters: String) extends DataSourceRecord {
 
   override def isFromFinalPlan: Boolean = false
-  override def comments: String =  DataSourceRecord.COMMENT_NON_FINAL_PLAN
+  override def comments: String = DataSourceRecord.COMMENT_NON_FINAL_PLAN
 }
 
 case class FinalDataSourceCase(
@@ -57,12 +57,12 @@ case class FinalDataSourceCase(
     partitionFilters: String) extends DataSourceRecord {
 
   override def isFromFinalPlan: Boolean = true
-  override def comments: String =  DataSourceRecord.COMMENT_FINAL_PLAN
+  override def comments: String = DataSourceRecord.COMMENT_FINAL_PLAN
 }
 
 object DataSourceRecord {
-  val COMMENT_NON_FINAL_PLAN="isFinalPlan=false"
-  val COMMENT_FINAL_PLAN="isFinalPlan=true"
+  val COMMENT_NON_FINAL_PLAN = "isFinalPlan=false"
+  val COMMENT_FINAL_PLAN = "isFinalPlan=true"
 
   def apply(
       sqlID: Long,

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManager.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,8 +66,8 @@ class SQLPlanModelManager {
    * @param physicalDescription String representation of the physical plan for the new version.
    */
   def addNewExecution(id: Long, planInfo: SparkPlanInfo, physicalDescription: String): Unit = {
-    //TODO: in future we should pass more arguments to this method to capture the common information
-    //      of an SqlPlan (i.e., startTime,..etc))
+    // TODO: in future we should pass more arguments to this method to capture the common
+    //  information of an SqlPlan (i.e., startTime,..etc))
     val planModel = sqlPlans.getOrElseUpdate(id, new SQLPlanModelWithDSCaching(id))
     planModel.addPlan(planInfo, physicalDescription)
   }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanVersion.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanVersion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ class SQLPlanVersion(
           readSchema,
           ReadParser.extractTagFromV1ReadMeta(ReadParser.METAFIELD_TAG_DATA_FILTERS, meta),
           ReadParser.extractTagFromV1ReadMeta(ReadParser.METAFIELD_TAG_PARTITION_FILTERS, meta),
-          fromFinalPlan=isFinal))
+          fromFinalPlan = isFinal))
       } else {
         None
       }
@@ -116,7 +116,7 @@ class SQLPlanVersion(
         res.schema,
         res.dataFilters,
         res.partitionFilters,
-        fromFinalPlan=isFinal)
+        fromFinalPlan = isFinal)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ui/ConsoleProgressBar.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ui/ConsoleProgressBar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -186,11 +186,13 @@ class ConsoleProgressBar(
       ""
     }
     val consoleLine = header + bar + tailer
+    // scalastyle:off println
     if (inlinePBEnabled) {
       System.out.print(CR + consoleLine + CR)
     } else {
       System.out.println(consoleLine)
     }
+    // scalastyle:on println
     lastUpdateTime = now
     lastUpdatedCount = currentCount
     lastProgressBar = consoleLine

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,8 +47,8 @@ object EventUtils extends Logging {
     // from pull https://github.com/apache/spark/pull/23551/files
     "number of files" -> "number of files read", // type sum
     "metadata time (ms)" -> "metadata time", // type sum spark2.x, but it was fixed to be timing
-    "time to build (ms)" -> "time to build", //type timing
-    "time to broadcast (ms)" -> "time to broadcast", //type timing
+    "time to build (ms)" -> "time to build", // type timing
+    "time to broadcast (ms)" -> "time to broadcast", // type timing
     "total time to update rows" -> "time to update",
     "total time to remove rows" -> "time to remove",
     "bytes of written output" -> "written output", // type sum

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/MemoryMetricsTracker.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/MemoryMetricsTracker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,12 +37,12 @@ class MemoryMetricsTracker {
   }
 
   def getTotalGCCount: Long = {
-    val (newGcCount:Long, _) = getCurrentGCMetrics
+    val (newGcCount: Long, _) = getCurrentGCMetrics
     newGcCount - startGCMetrics._1
   }
 
   def getTotalGCTime: Long = {
-    val (_, newGcTime:Long) = getCurrentGCMetrics
+    val (_, newGcTime: Long) = getCurrentGCMetrics
     newGcTime - startGCMetrics._2
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/OperationResult.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/OperationResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ class AppResult(path: String, message: String) extends Logging {
     val messageToLog = s"File: $path, Message: $message"
     exp match {
       case Some(e) => logWarning(messageToLog, e)
-      case None    => logWarning(messageToLog)
+      case None => logWarning(messageToLog)
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/stubs/db/DBGraphSQLMetricStub.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/stubs/db/DBGraphSQLMetricStub.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ case class DBGraphSQLMetricStub(m: Mirror)
   extends GraphReflectionEntry[org.apache.spark.sql.execution.ui.SQLPlanMetric](
     m, "org.apache.spark.sql.execution.ui.SQLPlanMetric") {
   // DataBricks has different constructor of the sparkPlanGraphNode
-  //Array(final java.lang.String name, final long accumulatorId,
+  // Array(final java.lang.String name, final long accumulatorId,
   // final java.lang.String metricType, final boolean experimental)
 
   // for 10.4 it is only one constructor with 3 arguments.

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -69,7 +69,11 @@ class SQLPlanParserSuite extends BasePlanParserSuite {
           } else {
             l
           }
-        ).foreach(modifiedLine => pWriter.println(modifiedLine))
+        ).foreach { modifiedLine =>
+          // scalastyle:off println
+          pWriter.println(modifiedLine)
+          // scalastyle:on println
+        }
       } finally {
         bufferedSource.close()
         pWriter.close()
@@ -169,14 +173,14 @@ class SQLPlanParserSuite extends BasePlanParserSuite {
         "spark-events-qualification/db_subExecution_id.zstd")
     val app = createAppFromEventlog(eventlog)
     // Get sum of durations of all the sqlIds. It contains duplicate values
-     val totalSqlDuration = app.sqlIdToInfo.values.map(x=> x.duration.getOrElse(0L)).sum
+     val totalSqlDuration = app.sqlIdToInfo.values.map(x => x.duration.getOrElse(0L)).sum
 
     // This is to group the sqlIds based on the rootExecutionId. So that we can verify the
     // subExecutionId to rootExecutionId mapping.
      val rootIdToSqlId = app.sqlIdToInfo.groupBy { case (_, info) =>
       info.rootExecutionID
     }
-    assert(rootIdToSqlId(Some(5L)).keySet == Set(5,6,7,8,9,10))
+    assert(rootIdToSqlId(Some(5L)).keySet == Set(5, 6, 7, 8, 9, 10))
 
     TrampolineUtil.withTempDir { outpath =>
       val allArgs = Array(
@@ -1381,7 +1385,7 @@ class SQLPlanParserSuite extends BasePlanParserSuite {
     for ((condExpr, expectedExpressionCounts) <- expressionsMap) {
       val rawExpressions = SQLPlanParser.parseConditionalExpressions(condExpr)
       val expected = expectedExpressionCounts.map(e => ExprOpRef(OpRef.fromExpr(e._1), e._2))
-      val actualExpressions =  ExprOpRef.fromRawExprSeq(rawExpressions)
+      val actualExpressions = ExprOpRef.fromRawExprSeq(rawExpressions)
       actualExpressions should ===(expected)
     }
   }
@@ -1437,7 +1441,7 @@ class SQLPlanParserSuite extends BasePlanParserSuite {
       "EqualTo" -> 4, // EqualTo comes from the = operator
       "Not" -> 2).map(e => ExprOpRef(OpRef.fromExpr(e._1), e._2))
     val rawExpressions = SQLPlanParser.parseFilterExpressions(exprString)
-    val actualExpressions =  ExprOpRef.fromRawExprSeq(rawExpressions)
+    val actualExpressions = ExprOpRef.fromRawExprSeq(rawExpressions)
     actualExpressions should ===(expected)
   }
 
@@ -1458,7 +1462,7 @@ class SQLPlanParserSuite extends BasePlanParserSuite {
       "trim" -> 1,
       "unbase64" -> 4).map(e => ExprOpRef(OpRef.fromExpr(e._1), e._2))
     val rawExpressions = SQLPlanParser.parseAggregateExpressions(exprString)
-    val actualExpressions =  ExprOpRef.fromRawExprSeq(rawExpressions)
+    val actualExpressions = ExprOpRef.fromRawExprSeq(rawExpressions)
     actualExpressions should ===(expected)
   }
 
@@ -1528,7 +1532,7 @@ class SQLPlanParserSuite extends BasePlanParserSuite {
           //      +- FileScan parquet [] Batched: true, DataFilters: [], Format: Parquet, Location:
           //         InMemoryFileIndex(1 paths)[file:/tmp_folder/T/toolTest..., PartitionFilters: []
           //         PushedFilters: [], ReadSchema: struct<>
-          df2.selectExpr("current_database()","current_database() as my_db")
+          df2.selectExpr("current_database()", "current_database() as my_db")
         }
         val pluginTypeChecker = new PluginTypeChecker()
         val app = createAppFromEventlog(eventLog)

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AnalysisSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AnalysisSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -196,15 +196,15 @@ class AnalysisSuite extends FunSuite {
     val sqlAggDurCpu = aggResults.sqlDurAggs
     val resultExpectation = new File(expRoot, expectFile)
     val schema = new StructType()
-      .add("appIndex",IntegerType,true)
-      .add("appID",StringType,true)
-      .add("rootsqlID",LongType,true)
-      .add("sqlID",LongType,true)
-      .add("sqlDuration",LongType,true)
-      .add("containsDataset",BooleanType,true)
-      .add("appDuration",LongType,true)
-      .add("potentialProbs",StringType,true)
-      .add("executorCpuTime",DoubleType,true)
+      .add("appIndex", IntegerType, true)
+      .add("appID", StringType, true)
+      .add("rootsqlID", LongType, true)
+      .add("sqlID", LongType, true)
+      .add("sqlDuration", LongType, true)
+      .add("containsDataset", BooleanType, true)
+      .add("appDuration", LongType, true)
+      .add("potentialProbs", StringType, true)
+      .add("executorCpuTime", DoubleType, true)
     val actualDf = sqlAggDurCpu.toDF
 
     val dfExpect = sparkSession.read.option("header", "true").option("nullValue", "-")

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AppFilterSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AppFilterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,23 +62,23 @@ class AppFilterSuite extends BaseTestSuite {
   }
 
   test("time period minute parsing fail") {
-    testTimePeriod(msMinAgo(16), "10min", failFilter=true)
+    testTimePeriod(msMinAgo(16), "10min", failFilter = true)
   }
 
   test("time period hour parsing fail") {
-    testTimePeriod(msHoursAgo(10), "8h", failFilter=true)
+    testTimePeriod(msHoursAgo(10), "8h", failFilter = true)
   }
 
   test("time period day parsing fail") {
-    testTimePeriod(msDaysAgo(40), "38d", failFilter=true)
+    testTimePeriod(msDaysAgo(40), "38d", failFilter = true)
   }
 
   test("time period week parsing fail") {
-    testTimePeriod(msWeeksAgo(2), "1w", failFilter=true)
+    testTimePeriod(msWeeksAgo(2), "1w", failFilter = true)
   }
 
   test("time period month parsing fail") {
-    testTimePeriod(msMonthsAgo(8), "7m", failFilter=true)
+    testTimePeriod(msMonthsAgo(8), "7m", failFilter = true)
   }
 
   private def testTimePeriod(eventLogTime: Long, startTimePeriod: String,
@@ -124,7 +124,7 @@ class AppFilterSuite extends BaseTestSuite {
     appTime: Long, uniqueId: Int)
 
   private val appsWithFsAndStartTimeToTest = Array(
-    TestEventLogFSAndAppStartInfo("app-ndshours18", msHoursAgo(16),msHoursAgo(18), 1),
+    TestEventLogFSAndAppStartInfo("app-ndshours18", msHoursAgo(16), msHoursAgo(18), 1),
     TestEventLogFSAndAppStartInfo("app-ndsweeks2", msWeeksAgo(2), msWeeksAgo(2), 1),
     TestEventLogFSAndAppStartInfo("app-nds86-1", msDaysAgo(3), msDaysAgo(4), 1),
     TestEventLogFSAndAppStartInfo("app-nds86-2", msDaysAgo(13), msWeeksAgo(2), 2))

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -479,7 +479,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
     val eventlogPaths = appArgs.eventlog()
     for (path <- eventlogPaths) {
       apps += new ApplicationInfo(hadoopConf,
-        EventLogPathProcessor.getEventLogInfo(path,hadoopConf).head._1, index)
+        EventLogPathProcessor.getEventLogInfo(path, hadoopConf).head._1, index)
       index += 1
     }
     assert(apps.size == 1)
@@ -558,7 +558,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
 
 
   test("test multiple resource profile in single app") {
-    val apps :ArrayBuffer[ApplicationInfo] = ArrayBuffer[ApplicationInfo]()
+    val apps: ArrayBuffer[ApplicationInfo] = ArrayBuffer[ApplicationInfo]()
     val appArgs = new ProfileArgs(Array(s"$logDir/rp_nosql_eventlog"))
     var index: Int = 1
     val eventlogPaths = appArgs.eventlog()
@@ -753,7 +753,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
       // verify  ucx parameters are captured.
       assert(rows.contains("spark.executorEnv.UCX_RNDV_SCHEME"))
 
-      //verify gds parameters are captured.
+      // verify gds parameters are captured.
       assert(rows.contains("spark.rapids.memory.gpu.direct.storage.spill.alignedIO"))
 
       val sparkProps = collect.getSparkProperties

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimelineSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimelineSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ class GenerateTimelineSuite extends FunSuite with BeforeAndAfterAll with Logging
         val tempSubDir = new File(dotFileDir, s"${Profiler.SUBDIR}/$appId")
 
         // assert that a file was generated
-        val outputDirs = ToolTestUtils.listFilesMatching(tempSubDir, { f => 
+        val outputDirs = ToolTestUtils.listFilesMatching(tempSubDir, { f =>
           f.endsWith("timeline.svg")
         })
         assert(outputDirs.length === 1)

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/QualificationInfoUtils.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/QualificationInfoUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ object QualificationInfoUtils extends Logging {
   def generateFriendsDataset(spark: SparkSession): Dataset[RapidsFriends] = {
     import spark.implicits._
     val df = spark.sparkContext.parallelize(
-      Seq.fill(1000){(randomAlpha(10), randomAlpha(5), randomInt)})
+      Seq.fill(1000) {(randomAlpha(10), randomAlpha(5), randomInt)})
       .toDF("name", "friend", "age")
     df.as[RapidsFriends]
   }
@@ -96,7 +96,7 @@ object QualificationInfoUtils extends Logging {
     TrampolineUtil.withTempPath { jsonOutFile =>
       val ageFunc = udf(parseAge)
       val ds = generateFriendsDataset(spark)
-      ds.withColumn("ageCategory",ageFunc(col("age")))
+      ds.withColumn("ageCategory", ageFunc(col("age")))
       val dsAge = ds.filter(d => d.age > 25).map(d => (d.friend, d.age))
       dsAge.write.json(jsonOutFile.getCanonicalPath)
     }
@@ -147,13 +147,17 @@ object QualificationInfoUtils extends Logging {
    */
   def main(args: Array[String]): Unit = {
     if (args.length == 0) {
+      // scalastyle:off println
       println(s"ERROR: must specify a logType dataset, udfds, dsAndDf or udffunc")
+      // scalastyle:on println
       System.exit(1)
     }
     val logType = args(0)
     if (logType != "dataset" && logType != "udfds" && logType != "udffunc"
         && logType != "dsAndDf") {
+      // scalastyle:off println
       println(s"ERROR: logType must be one of: dataset, udfds, dsAndDf or udffunc")
+      // scalastyle:on println
       System.exit(1)
     }
     val eventDir = if (args.length > 1) args(1) else "/tmp/spark-eventLogTest"
@@ -179,7 +183,9 @@ object QualificationInfoUtils extends Logging {
       genjoinDataFrameOpEventLog(spark)
       genjoinDataFrameOpEventLog(spark)
     } else {
+      // scalastyle:off println
       println(s"ERROR: Invalid log type specified: $logType")
+      // scalastyle:on println
       System.exit(1)
     }
     spark.stop()

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/AppFilterSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/AppFilterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,23 +62,23 @@ class AppFilterSuite extends BaseTestSuite {
   }
 
   test("time period minute parsing fail") {
-    testTimePeriod(msMinAgo(16), "10min", failFilter=true)
+    testTimePeriod(msMinAgo(16), "10min", failFilter = true)
   }
 
   test("time period hour parsing fail") {
-    testTimePeriod(msHoursAgo(10), "8h", failFilter=true)
+    testTimePeriod(msHoursAgo(10), "8h", failFilter = true)
   }
 
   test("time period day parsing fail") {
-    testTimePeriod(msDaysAgo(40), "38d", failFilter=true)
+    testTimePeriod(msDaysAgo(40), "38d", failFilter = true)
   }
 
   test("time period week parsing fail") {
-    testTimePeriod(msWeeksAgo(2), "1w", failFilter=true)
+    testTimePeriod(msWeeksAgo(2), "1w", failFilter = true)
   }
 
   test("time period month parsing fail") {
-    testTimePeriod(msMonthsAgo(8), "7m", failFilter=true)
+    testTimePeriod(msMonthsAgo(8), "7m", failFilter = true)
   }
 
   private def testTimePeriod(eventLogTime: Long, startTimePeriod: String,
@@ -559,7 +559,7 @@ class AppFilterSuite extends BaseTestSuite {
 
   test("App Name Regex match with all user name") {
     testAppNameRegexAndUserName(appsWithAppNameRegexAndUserNameToTest,
-      "10-newest", "[Nn].*", "user", "all" ,7)
+      "10-newest", "[Nn].*", "user", "all", 7)
   }
 
   test("App Name Regex match with user name match") {
@@ -569,7 +569,7 @@ class AppFilterSuite extends BaseTestSuite {
 
   test("App Name Regex exclude with user name match") {
     testAppNameRegexAndUserName(appsWithAppNameRegexAndUserNameToTest,
-      "10-newest", "[^Nn].*", "user3", "all",0)
+      "10-newest", "[^Nn].*", "user3", "all", 0)
   }
 
   test("App Name partial with username match") {
@@ -657,7 +657,7 @@ class AppFilterSuite extends BaseTestSuite {
   test("Test disjunction no appName") {
     testConjunctionAndDisjunction(appsNameConjunctionAndDisjunctionToTest,
       filterCriteria("10-newest") ++
-          startTimePeriod("2w") ++ userName("user3"),      6, "any")
+          startTimePeriod("2w") ++ userName("user3"), 6, "any")
   }
 
   test("Test disjunction no startTime") {
@@ -832,7 +832,7 @@ class AppFilterSuite extends BaseTestSuite {
     Array("--application-name", appName)
   }
 
-  def matchFileName(appName:String): Array[String] = {
+  def matchFileName(appName: String): Array[String] = {
     Array("--match-event-logs", appName)
   }
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeCheckerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,7 +133,7 @@ class PluginTypeCheckerSuite extends FunSuite with Logging {
     assert(result.contains("isnull"))
   }
 
-  test("write data format"){
+  test("write data format") {
     val inputString = Array("Execute InsertIntoHadoopFsRelationCommand " +
       "file:/home/ubuntu/eventlogs/complex_nested_decimal, false," +
       " Parquet, Map(path -> complex_nested_decimal), Append, [name, subject]",
@@ -178,7 +178,7 @@ class PluginTypeCheckerSuite extends FunSuite with Logging {
     // Using databricks azure speedup factor as custom file
     val platform = PlatformFactory.createInstance(PlatformNames.DATABRICKS_AZURE)
     val speedupFactorFile = ToolTestUtils.getTestResourcePath(platform.getOperatorScoreFile)
-    val checker = new PluginTypeChecker(speedupFactorFile=Some(speedupFactorFile))
+    val checker = new PluginTypeChecker(speedupFactorFile = Some(speedupFactorFile))
     assert(checker.getSpeedupFactor("SortExec") == 13.11)
     assert(checker.getSpeedupFactor("FilterExec") == 3.14)
   }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -485,20 +485,24 @@ class QualificationSuite extends BaseTestSuite {
       try {
         val allEventLines = bufferedSource.getLines.toList
         // the following val will contain the last two lines of the eventlog
-        //59 = "{"Event":"SparkListenerTaskEnd",
-        //60 = "{"Event":"SparkListenerStageCompleted"
-        //61 = "{"Event":"SparkListenerJobEnd","Job ID":5,"Completion Time":1718401564645,"
-        //62 = "{"Event":"org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd","
-        //63 = "{"Event":"SparkListenerApplicationEnd","Timestamp":1718401564663}"
+        // 59 = "{"Event":"SparkListenerTaskEnd",
+        // 60 = "{"Event":"SparkListenerStageCompleted"
+        // 61 = "{"Event":"SparkListenerJobEnd","Job ID":5,"Completion Time":1718401564645,"
+        // 62 = "{"Event":"org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd","
+        // 63 = "{"Event":"SparkListenerApplicationEnd","Timestamp":1718401564663}"
         val tailLines = allEventLines.takeRight(5)
         val selectedLines: List[String] = allEventLines.dropRight(5)
+        // scalastyle:off println
         selectedLines.foreach { line =>
           pwList.foreach(pw => pw.println(line))
         }
+        // scalastyle:on println
         for (i <- 0 to tailLines.length - 1) {
           if (i == 0) {
             // add truncatedTaskEvent to the brokenEventlog
+            // scalastyle:off println
             pwList(2).println(tailLines(i).substring(0, 59))
+            // scalastyle:on println
           }
           // Write all the lines to the unfinishedLog and incompleteLog.
           // We do not want to ApplicationEnd in the incompleteLog
@@ -508,7 +512,9 @@ class QualificationSuite extends BaseTestSuite {
             0 // index of incomplete
           }
           for (lIndex <- startListInd to 1) {
+            // scalastyle:off println
             pwList(lIndex).println(tailLines(i))
+            // scalastyle:on println
           }
         }
         // For the first two eventlogs, add a random incomplete line
@@ -610,12 +616,12 @@ class QualificationSuite extends BaseTestSuite {
 
   test("test eventlog with no jobs") {
     val logFiles = Array(s"$logDir/empty_eventlog")
-    runQualificationTest(logFiles, shouldReturnEmpty=true)
+    runQualificationTest(logFiles, shouldReturnEmpty = true)
   }
 
   test("test eventlog with rdd only jobs") {
     val logFiles = Array(s"$logDir/rdd_only_eventlog")
-    runQualificationTest(logFiles, shouldReturnEmpty=true)
+    runQualificationTest(logFiles, shouldReturnEmpty = true)
   }
 
   test("test truncated log file 1") {
@@ -721,7 +727,7 @@ class QualificationSuite extends BaseTestSuite {
     dfGen.write.parquet(dir)
   }
 
-  private def createIntFile(spark:SparkSession, dir:String): Unit = {
+  private def createIntFile(spark: SparkSession, dir: String): Unit = {
     import spark.implicits._
     val t1 = Seq((1, 2), (3, 4), (1, 6)).toDF("a", "b")
     t1.write.parquet(dir)
@@ -791,7 +797,7 @@ class QualificationSuite extends BaseTestSuite {
         // Spark3.2.+ generates a plan with 6 stages. StageID 3 and 4 are both
         // "isEmpty at RowMatrix.scala:441"
         val expStageCount = if (ToolUtils.isSpark320OrLater()) 6 else 5
-        assert(mlOpsRes.mlFunctions.get.map(x=> x.stageId).size == expStageCount)
+        assert(mlOpsRes.mlFunctions.get.map(x => x.stageId).size == expStageCount)
         assert(mlOpsRes.mlFunctions.get.head.mlOps.mkString.contains(
           "org.apache.spark.ml.feature.PCA.fit"))
         assert(mlOpsRes.mlFunctionsStageDurations.get.head.mlFuncName.equals("PCA"))
@@ -1056,7 +1062,7 @@ class QualificationSuite extends BaseTestSuite {
         val df1 = spark.sparkContext.parallelize(List(10, 20, 30, 40)).toDF
         df1.filter(hex($"value") === "A") // hex is not supported in GPU yet.
       }
-      //stdout output tests
+      // stdout output tests
       val sumOut = qualApp.getSummary()
       val detailedOut = qualApp.getDetailed()
       assert(sumOut.nonEmpty)
@@ -1092,7 +1098,7 @@ class QualificationSuite extends BaseTestSuite {
         // so create a new one to read in the csv file
         createSparkSession()
 
-        //csv output tests
+        // csv output tests
         val outputResults = s"$outpath/rapids_4_spark_qualification_output/" +
           s"rapids_4_spark_qualification_output.csv"
         val outputActual = readExpectedFile(new File(outputResults), "\"")
@@ -1100,7 +1106,7 @@ class QualificationSuite extends BaseTestSuite {
         assert(rows.size == 1)
 
         val expectedExecs = "Scan unknown;Filter;SerializeFromObject" // Unsupported Execs
-        val expectedExprs = "hex" //Unsupported Exprs
+        val expectedExprs = "hex" // Unsupported Exprs
         val unsupportedExecs =
           outputActual.select(QualOutputWriter.UNSUPPORTED_EXECS).first.getString(0)
         val unsupportedExprs =
@@ -1223,7 +1229,7 @@ class QualificationSuite extends BaseTestSuite {
             val expr = ".*to_json.*"
             val matches = lines.filter(_.matches(expr))
             assert(matches.length == 1)
-            //get line number containing to_json
+            // get line number containing to_json
             val lineNum = lines.indexOf(matches(0))
             // check if lineNum has the expected value "This is disabled by default"
             assert(lines(lineNum).contains("This is disabled by default"))
@@ -1467,12 +1473,12 @@ class QualificationSuite extends BaseTestSuite {
   }
 
   test("test frequency of repeated job") {
-    val logFiles = Array(s"$logDir/empty_eventlog",  s"$logDir/nested_type_eventlog")
+    val logFiles = Array(s"$logDir/empty_eventlog", s"$logDir/nested_type_eventlog")
     runQualificationTest(logFiles, "multi_run_freq_test_expectation.csv")
   }
 
   test("test CSV qual output with escaped characters") {
-    val jobNames = List("test,name",  "\"test\"name\"", "\"", ",", ",\"")
+    val jobNames = List("test,name", "\"test\"name\"", "\"", ",", ",\"")
     jobNames.foreach { jobName =>
       TrampolineUtil.withTempDir { eventLogDir =>
         val (eventLog, _) =

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -43,7 +43,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       gpuMemory: Option[String] = Some(GpuDevice.DEFAULT.getMemory),
       gpuDevice: Option[String] = Some(GpuDevice.DEFAULT.toString)): String = {
     buildWorkerInfoAsString(customProps, numCores, systemMemory, numWorkers,
-      gpuCount, gpuMemory,gpuDevice)
+      gpuCount, gpuMemory, gpuDevice)
   }
 
   private def getGpuAppMockInfoProvider: AppSummaryInfoBaseProvider = {
@@ -2212,7 +2212,7 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
       .buildAutoTunerFromProps(databricksWorkerInfo,
         infoProvider, PlatformFactory.createInstance(PlatformNames.DATABRICKS_AWS))
     // Assert shuffle manager string for DB 11.3 tag
-    verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion="330db")
+    verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion = "330db")
   }
 
   test("test shuffle manager version for supported spark version") {
@@ -2226,7 +2226,7 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
       .buildAutoTunerFromProps(workerInfo,
         infoProvider, PlatformFactory.createInstance())
     // Assert shuffle manager string for supported Spark v3.3.0
-    verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion="330")
+    verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion = "330")
   }
 
   test("test shuffle manager version for supported custom spark version") {
@@ -2240,7 +2240,7 @@ We recommend using nodes/workers with more memory. Need at least 7796MB memory."
       .buildAutoTunerFromProps(workerInfo,
         infoProvider, PlatformFactory.createInstance())
     // Assert shuffle manager string for supported custom Spark v3.3.0
-    verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion="330")
+    verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion = "330")
   }
 
   /**

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -57,7 +57,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
     val workerInfo = buildCpuWorkerInfoAsString(None, Some(32),
       Some("212992MiB"), Some(5))
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
-      logEventsProps,  Some(testSparkVersion))
+      logEventsProps, Some(testSparkVersion))
     val clusterPropsOpt = QualificationAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(workerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.EMR, clusterPropsOpt)


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Contributes to #1158

This pull request includes several changes to the `core/scalastyle-config.xml` file and updates to copyright years across multiple Scala files. Additionally, it includes minor code cleanups.

### Updates to `scalastyle-config.xml`:

* Added new style checks:
  - `SpacesAfterPlusChecker`, `SpacesBeforePlusChecker`, `WhitespaceEndOfLineChecker`
  - `DisallowSpaceBeforeTokenChecker`, `SingleSpaceBetweenRParenAndLCurlyBrace`, `OmitBracesInCase`
  - `NewLineAtEofChecker`, `SpaceAfterCommentStartChecker`, `EnsureSingleSpaceBeforeTokenChecker`, `EnsureSingleSpaceAfterTokenChecker`
  - `TokenChecker` for `println` statements
  - Disabled checks: `ParameterNumberChecker`, `PublicMethodsHaveTypeChecker`, `NonASCIICharacterChecker`
