### PR TITLE
Fix additional FutureWarning issues

### DIFF
--- a/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
@@ -615,7 +615,7 @@ def extract_raw_features(
             ['input_bytesRead_sum', 'input_bytesRead_cache']
         ].max(axis=1)
         full_tbl = full_tbl.drop(columns=['input_bytesRead_cache'])
-        full_tbl['cache_hit_ratio'].fillna(0.0, inplace=True)
+        full_tbl.fillna({'cache_hit_ratio': 0.0}, inplace=True)
     else:
         full_tbl['cache_hit_ratio'] = 0.0
 
@@ -1162,7 +1162,8 @@ def load_qual_csv(
     qual_csv = [os.path.join(q, csv_filename) for q in qual_dirs]
     df = None
     if qual_csv:
-        df = pd.concat([pd.read_csv(f) for f in qual_csv])
+        dfs = [pd.read_csv(f) for f in qual_csv]
+        df = pd.concat([df for df in dfs if not df.empty])
         if cols:
             df = df[cols]
     return df


### PR DESCRIPTION
This PR is a followup to #1494 to resolve additional warnings found during the `qualx evaluate` command.

Confirmed that the evaluation results are identical before/after these changes.
