### PR TITLE
Add compute_precision_recall utility function

### DIFF
--- a/user_tools/src/spark_rapids_tools/tools/qualx/util.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -190,6 +190,12 @@ def compute_accuracy(
         Dictionary of display name of metric -> prediction column name.
     weight: str
         Name of column to use as weight, e.g. 'Duration' or 'appDuration'.
+
+    Returns
+    -------
+    scores: Dict[str, Dict[str, float]]
+        Dictionary of different scoring metrics per prediction column,
+        e.g. {'QXS': {'MAPE"; 1.31, 'dMAPE': 1.25}}
     """
     scores = {}
     for name, y_pred in y_preds.items():
@@ -219,6 +225,43 @@ def compute_accuracy(
                 np.log(1 + results[weight]) * np.abs(results[y] - results[y_pred])
             ) / (np.sum(np.log(1 + results[weight]) * results[y]))
     return scores
+
+
+def compute_precision_recall(results: pd.DataFrame, y: str, y_preds: Dict[str, str], threshold: float):
+    """Compute precision and recall from a dataframe using a threshold for identifying true positives.
+
+    Parameters
+    ----------
+    results: pd.DataFrame
+        Pandas dataframe containing the label column and one or more prediction columns.
+    y: str
+        Label column name.
+    y_preds: Dict[str, str]
+        Dictionary of display name of prediction -> prediction column name.
+    threshold: float
+        Threshold separating positives (inclusive of threshold) from negatives.
+
+    Returns
+    -------
+    precision: Dict[str, float]
+        Dictionary of precision metric per prediction column,
+        e.g. {'QX': 0.90, 'QXS': 0.92}
+    recall: Dict[str, float]
+        Dictionary of recall metric per prediction column,
+        e.g. {'QX': 0.78, 'QXS': 0.82}
+    """
+    precision = {}
+    recall = {}
+    for name, y_pred in y_preds.items():
+        tp = sum((results[y_pred] >= threshold) & (results[y] >= threshold))
+        fp = sum((results[y_pred] >= threshold) & (results[y] < threshold))
+        # tn = sum((results[y_pred] < threshold) & (results[y] < threshold))
+        fn = sum((results[y_pred] < threshold) & (results[y] >= threshold))
+
+        precision[name] = tp / (tp + fp) if (tp + fp) > 0 else np.nan
+        recall[name] = tp / (tp + fn) if (tp + fn) > 0 else np.nan
+
+    return precision, recall
 
 
 def load_plugin(plugin_path: str) -> types.ModuleType:

--- a/user_tools/src/spark_rapids_tools/tools/qualx/util.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/util.py
@@ -227,7 +227,9 @@ def compute_accuracy(
     return scores
 
 
-def compute_precision_recall(results: pd.DataFrame, y: str, y_preds: Dict[str, str], threshold: float):
+def compute_precision_recall(
+    results: pd.DataFrame, y: str, y_preds: Dict[str, str], threshold: float
+) -> Tuple[Dict[str, float], Dict[str, float]]:
     """Compute precision and recall from a dataframe using a threshold for identifying true positives.
 
     Parameters
@@ -255,7 +257,6 @@ def compute_precision_recall(results: pd.DataFrame, y: str, y_preds: Dict[str, s
     for name, y_pred in y_preds.items():
         tp = sum((results[y_pred] >= threshold) & (results[y] >= threshold))
         fp = sum((results[y_pred] >= threshold) & (results[y] < threshold))
-        # tn = sum((results[y_pred] < threshold) & (results[y] < threshold))
         fn = sum((results[y_pred] < threshold) & (results[y] >= threshold))
 
         precision[name] = tp / (tp + fp) if (tp + fp) > 0 else np.nan


### PR DESCRIPTION
This PR adds a function to compute precision and recall metrics for qualx predictions.

This function is often used in the evaluation notebooks, so pulling it into the qualx/util.py module.

Tested in an evaluation notebook.
