### PR TITLE
Improve AutoTuner cluster configuration recommendations for GPU runs

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/ClusterConfigurationStrategy.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/ClusterConfigurationStrategy.scala
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool
+
+import com.nvidia.spark.rapids.tool.tuning.ClusterProperties
+
+import org.apache.spark.sql.rapids.tool.ExistingClusterInfo
+import org.apache.spark.sql.rapids.tool.util.StringUtils
+
+/**
+ * Represents the configuration for a recommended cluster.
+ */
+case class RecommendedClusterConfig(
+    numExecutors: Int,
+    numExecsPerNode: Int,
+    coresPerExec: Int,
+    memoryPerNodeMb: Long) {
+
+  def coresPerNode: Int = {
+    coresPerExec * numExecsPerNode
+  }
+
+  def numGpusPerNode: Int = {
+    numExecsPerNode
+  }
+}
+
+/**
+ * Base trait for different cluster configuration strategies.
+ */
+trait ClusterConfigurationStrategy {
+  protected val numGpus: Int
+  protected val maxGpusSupported: Int
+  protected val sparkProperties: Map[String, String]
+
+  private val MIN_CORES_PER_EXEC = 16
+
+  protected def getNumExecutors: Int
+  protected def getNumExecsPerNode: Int
+  protected def getMemoryPerNodeMb: Long
+  protected def getNumGpusPerNode: Int
+  protected def getCoresPerExec: Int
+
+  /**
+   * Generates the recommended cluster configuration based on the strategy.
+   */
+  final def getRecommendedConfig: Option[RecommendedClusterConfig] = {
+    val numExecutors = getNumExecutors
+    if (numExecutors <= 0) {
+      None
+    } else {
+      val coresPerExec = getCoresPerExec
+      val totalCoreCount = coresPerExec * numExecutors
+      val minCoresPerExec = Math.max(coresPerExec, MIN_CORES_PER_EXEC)
+      val recommendedCoresPerExec = Math.min(minCoresPerExec, totalCoreCount)
+      val recommendedNumExecutors =
+        Math.ceil(totalCoreCount.toDouble / recommendedCoresPerExec).toInt
+      val recommendedNumExecPerNode = Math.min(maxGpusSupported, recommendedNumExecutors)
+
+      Some(RecommendedClusterConfig(
+        numExecutors = recommendedNumExecutors,
+        numExecsPerNode = recommendedNumExecPerNode,
+        coresPerExec = recommendedCoresPerExec,
+        memoryPerNodeMb = getMemoryPerNodeMb))
+    }
+  }
+}
+
+/**
+ * Strategy for cluster configuration based on user specified cluster properties.
+ */
+class ClusterPropertyBasedStrategy(
+    clusterProperties: ClusterProperties,
+    val numGpus: Int,
+    val maxGpusSupported: Int,
+    val sparkProperties: Map[String, String]) extends ClusterConfigurationStrategy {
+
+  override protected def getNumExecutors: Int = {
+    val numWorkers = Math.max(1, clusterProperties.system.numWorkers)
+    numGpus * numWorkers
+  }
+
+  override protected def getNumExecsPerNode: Int = {
+    1
+  }
+
+  override protected def getMemoryPerNodeMb: Long = {
+    StringUtils.convertToMB(clusterProperties.system.getMemory)
+  }
+
+  override protected def getNumGpusPerNode: Int = {
+    Math.min(1, maxGpusSupported)
+  }
+
+  override protected def getCoresPerExec: Int = {
+    clusterProperties.system.getNumCores / getNumGpusPerNode
+  }
+}
+
+/**
+ * Strategy for cluster configuration based on cluster information from event log.
+ */
+class EventLogBasedStrategy(
+    clusterInfoFromEventLog: ExistingClusterInfo,
+    val numGpus: Int,
+    val maxGpusSupported: Int,
+    val sparkProperties: Map[String, String]) extends ClusterConfigurationStrategy {
+
+  override protected def getNumExecutors: Int = {
+    val dynamicAllocationEnabled = Platform.isDynamicAllocationEnabled(sparkProperties)
+    val execInstFromProps = sparkProperties.get("spark.executor.instances")
+
+    if (execInstFromProps.isDefined && !dynamicAllocationEnabled) {
+      execInstFromProps.get.toInt
+    } else {
+      clusterInfoFromEventLog.numExecutors
+    }
+  }
+
+  override protected def getNumExecsPerNode: Int = {
+    if (clusterInfoFromEventLog.numExecsPerNode == -1) {
+      maxGpusSupported
+    }
+    else {
+      clusterInfoFromEventLog.numExecsPerNode
+    }
+  }
+
+  override protected def getMemoryPerNodeMb: Long = {
+    val heapMemMB = clusterInfoFromEventLog.executorHeapMemory
+    val overheadMemMB = Platform.getExecutorOverheadMemoryMB(sparkProperties)
+    (heapMemMB + overheadMemMB) * getNumExecsPerNode
+  }
+
+  override protected def getNumGpusPerNode: Int = {
+    Math.max(numGpus, Math.min(getNumExecsPerNode, maxGpusSupported))
+  }
+
+  override protected def getCoresPerExec: Int = {
+    clusterInfoFromEventLog.coresPerExecutor
+  }
+}
+
+/**
+ * Companion object to create appropriate cluster configuration strategy.
+ */
+object ClusterConfigurationStrategy {
+  def getStrategy(
+      clusterProperties: Option[ClusterProperties],
+      clusterInfoFromEventLog: Option[ExistingClusterInfo],
+      numGpus: Int,
+      maxGpusSupported: Int,
+      sparkProperties: Map[String, String]): Option[ClusterConfigurationStrategy] = {
+    if (clusterProperties.isDefined) {
+      // Use strategy based on cluster properties
+      Some(new ClusterPropertyBasedStrategy(
+        clusterProperties.get, numGpus, maxGpusSupported, sparkProperties))
+    } else if (clusterInfoFromEventLog.isDefined) {
+      // Use strategy based on cluster information from event log
+      Some(new EventLogBasedStrategy(
+        clusterInfoFromEventLog.get, numGpus, maxGpusSupported, sparkProperties))
+    } else {
+      // Neither cluster properties are defined nor cluster information from event log is available
+      None
+    }
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/ClusterConfigurationStrategy.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/ClusterConfigurationStrategy.scala
@@ -16,50 +16,69 @@
 
 package com.nvidia.spark.rapids.tool
 
-import com.nvidia.spark.rapids.tool.tuning.ClusterProperties
-
 import org.apache.spark.sql.rapids.tool.ExistingClusterInfo
 import org.apache.spark.sql.rapids.tool.util.StringUtils
 
 /**
- * Represents the configuration for a recommended cluster.
+ * Configuration for the recommended cluster to run the application with Spark RAPIDS.
  */
 case class RecommendedClusterConfig(
-  numExecutors: Int,
-  numExecsPerNode: Int,
-  coresPerExec: Int,
-  memoryPerNodeMb: Long // For onprem or cases where a matching CSP instance type is unavailable
+    numExecutors: Int,
+    coresPerExec: Int,
+    numGpusPerNode: Int,
+    memoryPerNodeMb: Long // For onprem or cases where a matching CSP instance type is unavailable
 ) {
-
-  def coresPerNode: Int = {
-    coresPerExec * numExecsPerNode
+  def execsPerNode: Int = {
+    numGpusPerNode
   }
 
-  def numGpusPerNode: Int = {
-    numExecsPerNode
+  def coresPerNode: Int = {
+    coresPerExec * execsPerNode
   }
 }
 
 /**
  * Base trait for different cluster configuration strategies.
  */
-abstract class ClusterConfigurationStrategy(maxGpusSupported: Int) {
-  private val MIN_CORES_PER_EXEC = 16
-
-  // Returns the initial number of executors to be used for the app.
-  protected def getInitialNumExecutors: Int
-  // Returns the initial number of cores per executor to be used for the app.
-  protected def getInitialCoresPerExec: Int
-  // For onprem or cases where a matching CSP instance type is unavailable,
-  // Returns the memory per node
-  protected def getMemoryPerNodeMb(numExecPerNode: Int): Long
+abstract class ClusterConfigurationStrategy(
+    platform: Platform,
+    sparkProperties: Map[String, String]) {
 
   /**
-   * Helper function to limit the value within the specified range
+   * Calculates the initial number of executors based on the strategy.
    */
-  private final def limit(value: Int, min: Int, max: Int): Int = {
-    Math.max(min, Math.min(max, value))
+  protected def calculateInitialNumExecutors: Int
+
+  private def getInitialNumExecutors: Int = {
+    val dynamicAllocationEnabled = Platform.isDynamicAllocationEnabled(sparkProperties)
+    val execInstFromProps = sparkProperties.get("spark.executor.instances")
+    // If dynamic allocation is disabled, use spark.executor.instances in precedence
+    if (execInstFromProps.isDefined && !dynamicAllocationEnabled) {
+      // Spark Properties are in order:
+      // P0. User defined software properties in Cluster Properties
+      // P1. Spark Properties defined in the application information
+      execInstFromProps.get.toInt
+    } else {
+      calculateInitialNumExecutors
+    }
   }
+
+  /**
+   * Calculates the initial number of cores per executor based on the strategy.
+   */
+  protected def calculateInitialCoresPerExec: Int
+
+  private def getInitialCoresPerExec: Int = {
+    val coresFromProps = sparkProperties.get("spark.executor.cores")
+    // Use spark.executor.cores in precedence
+    if (coresFromProps.isDefined) {
+      coresFromProps.get.toInt
+    } else {
+      calculateInitialCoresPerExec
+    }
+  }
+
+  protected def getMemoryPerNodeMb: Long
 
   /**
    * Generates the recommended cluster configuration based on the strategy.
@@ -68,11 +87,10 @@ abstract class ClusterConfigurationStrategy(maxGpusSupported: Int) {
    * 1. Calculate the initial number of executors and cores per executor.
    * 2. Calculate the total core count by multiplying initial cores per executor
    *    by the initial number of executors.
-   * 3. Determine the recommended cores per executor, limit it within the
-   *    bounds of `MIN_CORES_PER_EXEC` and `totalCoresCount`.
+   * 3. Retrieve the recommended cores per executor from the platform (default is 16),
+   *    for onprem, limit the recommended cores per executor to the total core count.
    * 4. Calculate the recommended number of executors by dividing the total core count
    *    by the recommended cores per executor.
-   * 5. Limit the number of executors per node to the maximum supported GPUs.
    */
   final def getRecommendedConfig: Option[RecommendedClusterConfig] = {
     val initialNumExecutors = getInitialNumExecutors
@@ -81,19 +99,19 @@ abstract class ClusterConfigurationStrategy(maxGpusSupported: Int) {
     } else {
       val initialCoresPerExec = getInitialCoresPerExec
       val totalCoresCount = initialCoresPerExec * initialNumExecutors
-      val recommendedCoresPerExec = limit(initialCoresPerExec, MIN_CORES_PER_EXEC, totalCoresCount)
+      val recommendedCoresPerExec = if (platform.isPlatformCSP) {
+        platform.recommendedCoresPerExec
+      } else {
+        // For onprem, recommended cores per executor should not exceed total core count
+        math.min(platform.recommendedCoresPerExec, totalCoresCount)
+      }
       val recommendedNumExecutors =
-        Math.ceil(totalCoresCount.toDouble / recommendedCoresPerExec).toInt
-      val recommendedNumExecPerNode = Math.min(maxGpusSupported, recommendedNumExecutors)
-      // Memory per node is needed for onprem or cases where a matching CSP instance type
-      // is unavailable
-      val recommendedMemoryPerNodeMb = getMemoryPerNodeMb(recommendedNumExecPerNode)
-
+        math.ceil(totalCoresCount.toDouble / recommendedCoresPerExec).toInt
       Some(RecommendedClusterConfig(
         numExecutors = recommendedNumExecutors,
-        numExecsPerNode = recommendedNumExecPerNode,
         coresPerExec = recommendedCoresPerExec,
-        memoryPerNodeMb = recommendedMemoryPerNodeMb))
+        numGpusPerNode = platform.recommendedGpusPerNode,
+        memoryPerNodeMb = getMemoryPerNodeMb))
     }
   }
 }
@@ -102,32 +120,40 @@ abstract class ClusterConfigurationStrategy(maxGpusSupported: Int) {
  * Strategy for cluster configuration based on user specified cluster properties.
  */
 class ClusterPropertyBasedStrategy(
-    clusterProperties: ClusterProperties,
-    maxGpusSupported: Int) extends ClusterConfigurationStrategy(maxGpusSupported) {
+    platform: Platform,
+    sparkProperties: Map[String, String])
+  extends ClusterConfigurationStrategy(platform, sparkProperties) {
+
+  private val clusterProperties = platform.clusterProperties.getOrElse(
+      throw new IllegalArgumentException("Cluster properties must be defined"))
 
   // Calculate the number of GPUs per node based on the cluster properties
-  private val numGpusPerNode: Int = {
-    val gpuOption = clusterProperties.getGpu
-    val numGpusPerNode = if (!gpuOption.isEmpty && gpuOption.getCount > 0) {
-      gpuOption.getCount
-    } else {
-      // if the cluster properties do not specify GPU count, assume 1 GPU per node
-      1
+  private lazy val numGpusFromProps: Int = {
+    // User provided num GPUs, fall back to platform default
+    val userProvidedNumGpus = clusterProperties.getGpu.getCount match {
+      case count if count > 0 => count
+      case _ => platform.defaultNumGpus
     }
-    Math.min(numGpusPerNode, maxGpusSupported)
+
+    // Apply platform-specific GPU limits for CSP, no limits for on-prem
+    if (platform.isPlatformCSP) {
+      math.min(userProvidedNumGpus, platform.maxGpusSupported)
+    } else {
+      userProvidedNumGpus
+    }
   }
 
-  override protected def getInitialNumExecutors: Int = {
-    val numWorkers = Math.max(1, clusterProperties.system.numWorkers)
-    numGpusPerNode * numWorkers
+  override protected def calculateInitialNumExecutors: Int = {
+    val numWorkers = math.max(1, clusterProperties.system.numWorkers)
+    numGpusFromProps * numWorkers
   }
 
-  override protected def getInitialCoresPerExec: Int = {
-    val coresPerGpu = clusterProperties.system.getNumCores.toDouble / numGpusPerNode
-    Math.ceil(coresPerGpu).toInt
+  override protected def calculateInitialCoresPerExec: Int = {
+    val coresPerGpu = clusterProperties.system.getNumCores.toDouble / numGpusFromProps
+    math.ceil(coresPerGpu).toInt
   }
 
-  override protected def getMemoryPerNodeMb(numExecPerNode: Int): Long = {
+  override protected def getMemoryPerNodeMb: Long = {
     StringUtils.convertToMB(clusterProperties.system.getMemory)
   }
 }
@@ -136,48 +162,49 @@ class ClusterPropertyBasedStrategy(
  * Strategy for cluster configuration based on cluster information from event log.
  */
 class EventLogBasedStrategy(
-  clusterInfoFromEventLog: ExistingClusterInfo,
-  sparkProperties: Map[String, String],
-  maxGpusSupported: Int) extends ClusterConfigurationStrategy(maxGpusSupported) {
+    platform: Platform,
+    sparkProperties: Map[String, String]
+  ) extends ClusterConfigurationStrategy(platform, sparkProperties) {
 
-  override protected def getInitialNumExecutors: Int = {
-    val dynamicAllocationEnabled = Platform.isDynamicAllocationEnabled(sparkProperties)
-    val execInstFromProps = sparkProperties.get("spark.executor.instances")
-
-    if (execInstFromProps.isDefined && !dynamicAllocationEnabled) {
-      execInstFromProps.get.toInt
-    } else {
-      clusterInfoFromEventLog.numExecutors
-    }
+  private val clusterInfoFromEventLog: ExistingClusterInfo = {
+    platform.clusterInfoFromEventLog.getOrElse(
+      throw new IllegalArgumentException("Cluster information from event log must be defined"))
   }
 
-  override protected def getInitialCoresPerExec: Int = {
-    clusterInfoFromEventLog.coresPerExecutor
-  }
-
-  override protected def getMemoryPerNodeMb(numExecPerNode: Int): Long = {
+  // For onprem or cases where a matching CSP instance type is unavailable,
+  // Returns the memory per node
+  override def getMemoryPerNodeMb: Long = {
     val heapMemMB = clusterInfoFromEventLog.executorHeapMemory
-    val overheadMemMB = Platform.getExecutorOverheadMemoryMB(sparkProperties)
-    (heapMemMB + overheadMemMB) * numExecPerNode
+    val overheadMemMB = platform.getExecutorOverheadMemoryMB(sparkProperties)
+    heapMemMB + overheadMemMB
+  }
+
+  override def calculateInitialNumExecutors: Int = {
+    clusterInfoFromEventLog.numExecutors
+  }
+
+  override def calculateInitialCoresPerExec: Int = {
+    clusterInfoFromEventLog.coresPerExecutor
   }
 }
 
 /**
  * Companion object to create appropriate cluster configuration strategy.
+ *
+ * Strategy Precedence:
+ * 1. Cluster Properties based strategy
+ * 2. Event Log based strategy
  */
 object ClusterConfigurationStrategy {
   def getStrategy(
-      clusterProperties: Option[ClusterProperties],
-      clusterInfoFromEventLog: Option[ExistingClusterInfo],
-      maxGpusSupported: Int,
+      platform: Platform,
       sparkProperties: Map[String, String]): Option[ClusterConfigurationStrategy] = {
-    if (clusterProperties.isDefined) {
+    if (platform.clusterProperties.isDefined) {
       // Use strategy based on cluster properties
-      Some(new ClusterPropertyBasedStrategy(clusterProperties.get, maxGpusSupported))
-    } else if (clusterInfoFromEventLog.isDefined) {
+      Some(new ClusterPropertyBasedStrategy(platform, sparkProperties))
+    } else if (platform.clusterInfoFromEventLog.isDefined) {
       // Use strategy based on cluster information from event log
-      Some(new EventLogBasedStrategy(clusterInfoFromEventLog.get, sparkProperties,
-        maxGpusSupported))
+      Some(new EventLogBasedStrategy(platform, sparkProperties))
     } else {
       // Neither cluster properties are defined nor cluster information from event log is available
       None

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -507,7 +507,7 @@ object QualOutputWriter {
   val DRIVER_HOST = "Driver Host"
   val CLUSTER_ID_STR = "Cluster Id" // Different from ClusterId used for Databricks Tags
   val CLUSTER_NAME = "Cluster Name"
-  val RECOMMENDED_NUM_GPUS = "Recommended Num GPUs Per Node"
+  val RECOMMENDED_NUM_GPUS_PER_NODE = "Recommended Num GPUs Per Node"
   val RECOMMENDED_GPU_DEVICE = "Recommended GPU Device"
   val NUM_EXECS_PER_NODE = "Num Executors Per Node"
   val NUM_EXECS = "Num Executors"
@@ -855,7 +855,7 @@ object QualOutputWriter {
       NUM_EXECS, EXECUTOR_HEAP_MEMORY, DYN_ALLOC_ENABLED, DYN_ALLOC_MAX, DYN_ALLOC_MIN,
       DYN_ALLOC_INIT, CORES_PER_EXEC, RECOMMENDED_WORKER_NODE_TYPE, RECOMMENDED_NUM_EXECS,
       RECOMMENDED_NUM_WORKER_NODES, RECOMMENDED_CORES_PER_EXEC, RECOMMENDED_GPU_DEVICE,
-      RECOMMENDED_NUM_GPUS, RECOMMENDED_VENDOR, RECOMMENDED_DYN_ALLOC_ENABLED,
+      RECOMMENDED_NUM_GPUS_PER_NODE, RECOMMENDED_VENDOR, RECOMMENDED_DYN_ALLOC_ENABLED,
       RECOMMENDED_DYN_ALLOC_MAX, RECOMMENDED_DYN_ALLOC_MIN, RECOMMENDED_DYN_ALLOC_INIT).map {
       key => (key, key.length)
     }
@@ -951,7 +951,8 @@ object QualOutputWriter {
       refactorCSVFuncWithOption(recClusterInfo.map(_.coresPerExecutor.toString),
         RECOMMENDED_CORES_PER_EXEC),
       refactorCSVFuncWithOption(recClusterInfo.map(_.gpuDevice), RECOMMENDED_GPU_DEVICE),
-      refactorCSVFuncWithOption(recClusterInfo.map(_.numGpus.toString), RECOMMENDED_NUM_GPUS),
+      refactorCSVFuncWithOption(recClusterInfo.map(_.numGpusPerNode.toString),
+        RECOMMENDED_NUM_GPUS_PER_NODE),
       refactorCSVFuncWithOption(recClusterInfo.map(_.vendor), RECOMMENDED_VENDOR),
       refactorCSVFuncWithOption(recClusterInfo.map(_.dynamicAllocationEnabled.toString),
         RECOMMENDED_DYN_ALLOC_ENABLED),

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -358,9 +358,10 @@ class AutoTuner(
     fromProfile.orElse(Option(clusterProps.softwareProperties.get(key)))
   }
 
-  def getAllProperties: collection.Map[String, String] = {
-    // the app properties override the cluster properties
-    clusterProps.getSoftwareProperties.asScala ++ appInfoProvider.getAllProperties
+  private lazy val getAllProperties: collection.Map[String, String] = {
+    // the cluster properties override the app properties as
+    // it is provided by the user.
+    appInfoProvider.getAllProperties ++ clusterProps.getSoftwareProperties.asScala
   }
 
   def initRecommendations(): Unit = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -422,11 +422,11 @@ class AutoTuner(
    * Returns None if the platform doesn't support specific instance types.
    */
   private def configureGPURecommendedInstanceType(): Unit = {
-    val gpuClusterRec = platform.getGPUInstanceTypeRecommendation(getAllProperties.toMap)
-    if (gpuClusterRec.isDefined) {
-      appendRecommendation("spark.executor.cores", gpuClusterRec.get.coresPerExecutor)
-      if (gpuClusterRec.get.numExecutors > 0) {
-        appendRecommendation("spark.executor.instances", gpuClusterRec.get.numExecutors)
+    platform.createRecommendedGpuClusterInfo(getAllProperties.toMap)
+    platform.recommendedClusterInfo.foreach { gpuClusterRec =>
+      appendRecommendation("spark.executor.cores", gpuClusterRec.coresPerExecutor)
+      if (gpuClusterRec.numExecutors > 0) {
+        appendRecommendation("spark.executor.instances", gpuClusterRec.numExecutors)
       }
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ClassWarehouse.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ClassWarehouse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ case class RecommendedClusterInfo(
     vendor: String,
     coresPerExecutor: Int,
     numWorkerNodes: Int,
-    numGpus: Int,
+    numGpusPerNode: Int,
     numExecutors: Int,
     gpuDevice: String,
     dynamicAllocationEnabled: Boolean,
@@ -82,7 +82,7 @@ case class RecommendedClusterInfo(
     driverNodeType: Option[String] = None,
     workerNodeType: Option[String] = None) extends ClusterInfo {
     // The number of executors per node is the same as the number of GPUs
-    def numExecsPerNode: Int = numGpus
+    def numExecsPerNode: Int = numGpusPerNode
 }
 
 case class ClusterSummary(

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
@@ -140,4 +140,21 @@ abstract class BaseAutoTunerSuite extends FunSuite with BeforeAndAfterEach with 
       sparkVersion, rapidsJars, distinctLocationPct, redundantReadSize, meanInput, meanShuffleRead,
       shuffleStagesWithPosSpilling, shuffleSkewStages)
   }
+
+  /**
+   * Helper method to compare the expected results with the actual output from the AutoTuner.
+   *
+   * In case of a mismatch, displays the complete output, which is useful for updating the
+   * expected results.
+   */
+  protected def compareOutput(expectedResults: String, autoTunerOutput: String): Unit = {
+    val outputsMatch = expectedResults == autoTunerOutput
+    assert(outputsMatch,
+      s"""|=== Expected ===
+          |$expectedResults
+          |
+          |=== Actual ===
+          |$autoTunerOutput
+          |""".stripMargin)
+  }
 }

--- a/user_tools/tests/spark_rapids_tools_e2e/features/installation_checks.feature
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/installation_checks.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,10 +28,10 @@ Feature: Tool Installation Checks
 
     Examples:
       | platform         | cli    | expected_stdout                 |
-      | dataproc         | gcloud | 3 x n1-standard-16 (4 T4 each)  |
-      | emr              | aws    | 10 x g5.xlarge                  |
-      | databricks-aws   | aws    | 10 x g5.xlarge                  |
-      | databricks-azure | az     | 3 x Standard_NC64as_T4_v3       |
+      | dataproc         | gcloud | 2 x n1-standard-16 (1 T4 each)  |
+      | emr              | aws    | 2 x g5.4xlarge                  |
+      | databricks-aws   | aws    | 2 x g5.4xlarge                  |
+      | databricks-azure | az     | 2 x Standard_NC16as_T4_v3       |
 
   @test_id_IC_0002
   Scenario: Environment has missing java


### PR DESCRIPTION
Fixes #1121
Fixes #1334 

### Summary
Introduces a new strategy-based approach for recommending GPU cluster configurations (num executors, core count and num worker nodes (CSPs only)).

### Key Changes
- Standardized executor core count to 16 cores per executor for GPU runs.
- Shifted from multi-GPU instances to smaller, single-GPU instances 
- Implemented two configuration strategies:
  1. Cluster Property Strategy: Generates recommendations based on user-specified cluster properties
  2. Event Log Strategy: Generates recommendations based on event logs

### Reasoning
- Analysis of NDS performance metrics shows 16 cores/executor provides optimal performance
- Configurations with 4 or 64 cores/executor showed reduced performance and cost efficiency
- Smaller instances with distributed GPUs improve:
  - System fault tolerance
  - I/O performance (both disk and network)
  - Resource utilization
 

### Code Changes


Cluster configuration strategy:

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/ClusterConfigurationStrategy.scala`](diffhunk://#diff-1407805efc49b0c67ad7ccfe1648c533688c4a246841a5fdc60329120b97f4f1R1-R213): Added new classes `ClusterConfigurationStrategy`, `ClusterPropertyBasedStrategy`, and `EventLogBasedStrategy` to encapsulate different cluster configuration strategies.
* [`core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala`](diffhunk://#diff-cc81398d095d289f60b6eb03dde5b6995956258b6c176f31cc2df56382cb1a98L259-L264): Refactored the `Platform` class to use the new strategy classes for recommending cluster configurations and removed redundant methods. [[1]](diffhunk://#diff-cc81398d095d289f60b6eb03dde5b6995956258b6c176f31cc2df56382cb1a98L259-L264) [[2]](diffhunk://#diff-cc81398d095d289f60b6eb03dde5b6995956258b6c176f31cc2df56382cb1a98L336-L385) [[3]](diffhunk://#diff-cc81398d095d289f60b6eb03dde5b6995956258b6c176f31cc2df56382cb1a98L433-R502)

Enhancements to instance information handling:

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala`](diffhunk://#diff-cc81398d095d289f60b6eb03dde5b6995956258b6c176f31cc2df56382cb1a98L58-R72): Added `getMemoryPerExec` method to `InstanceInfo` and created a companion object for default instance creation.
* [`core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala`](diffhunk://#diff-cc81398d095d289f60b6eb03dde5b6995956258b6c176f31cc2df56382cb1a98L617-R562): Updated `DatabricksAwsPlatform` to use `getInstanceByResourcesMap` for instance type mapping.

Default recommendations and properties:

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala`](diffhunk://#diff-cc81398d095d289f60b6eb03dde5b6995956258b6c176f31cc2df56382cb1a98L134-R154): Added default recommendations for cores per executor and GPUs per node.


