### PR TITLE
Fix Hadoop JAR Download Timeouts in Behave Tests

### DIFF
--- a/user_tools/tests/spark_rapids_tools_e2e/resources/scripts/hdfs/setup_hdfs.sh
+++ b/user_tools/tests/spark_rapids_tools_e2e/resources/scripts/hdfs/setup_hdfs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ readonly CURRENT_FILE_PATH=$(realpath "${0}")
 readonly HDFS_SCRIPTS_DIR=$(dirname "${CURRENT_FILE_PATH}")
 readonly VERIFY_HDFS_SERVICES_MAX_RETRY=3
 readonly VERIFY_HDFS_SERVICES_SLEEP_SEC=5
+readonly WGET_TIMEOUT_SEC=1800 # 30 minutes
 
 load_common_scripts() {
   local scripts_dir=$(dirname "${HDFS_SCRIPTS_DIR}")
@@ -107,19 +108,19 @@ verify_checksum() {
 # Function to download and extract Hadoop
 download_and_extract_hadoop() {
     echo "Downloading and extracting Hadoop..."
-    local hadoop_url="https://dlcdn.apache.org/hadoop/common/hadoop-${E2E_TEST_HADOOP_VERSION}/hadoop-${E2E_TEST_HADOOP_VERSION}.tar.gz"
+    local hadoop_url="https://downloads.apache.org/hadoop/common/hadoop-${E2E_TEST_HADOOP_VERSION}/hadoop-${E2E_TEST_HADOOP_VERSION}.tar.gz"
     local hadoop_tar_file="${E2E_TEST_TMP_DIR}/hadoop-${E2E_TEST_HADOOP_VERSION}.tar.gz"
     local checksum_url="${hadoop_url}.sha512"
     local checksum_file="${hadoop_tar_file}.sha512"
 
     if [ ! -f "${hadoop_tar_file}" ]; then
-        wget -O "${hadoop_tar_file}" "${hadoop_url}" || err "Failed to download Hadoop tarball."
+        wget --timeout=${WGET_TIMEOUT_SEC} -O"${hadoop_tar_file}" "${hadoop_url}" || err "Failed to download Hadoop tarball."
     fi
 
     # Verify checksum and re-download if needed
-    wget -O "${checksum_file}" "${checksum_url}" || err "Failed to download checksum file."
+    wget --timeout=${WGET_TIMEOUT_SEC} -O"${checksum_file}" "${checksum_url}" || err "Failed to download checksum file."
     if ! verify_checksum "${hadoop_tar_file}" "${checksum_file}"; then
-        wget -O "${hadoop_tar_file}" "${hadoop_url}" || err "Failed to download Hadoop tarball."
+        wget --timeout=${WGET_TIMEOUT_SEC} -O"${hadoop_tar_file}" "${hadoop_url}" || err "Failed to download Hadoop tarball."
         if ! verify_checksum "${hadoop_tar_file}" "${checksum_file}"; then
             err "Checksum verification failed after re-downloading. Exiting..."
         fi

--- a/user_tools/tests/spark_rapids_tools_e2e/resources/scripts/hdfs/setup_hdfs.sh
+++ b/user_tools/tests/spark_rapids_tools_e2e/resources/scripts/hdfs/setup_hdfs.sh
@@ -108,7 +108,7 @@ verify_checksum() {
 # Function to download and extract Hadoop
 download_and_extract_hadoop() {
     echo "Downloading and extracting Hadoop..."
-    local hadoop_url="https://downloads.apache.org/hadoop/common/hadoop-${E2E_TEST_HADOOP_VERSION}/hadoop-${E2E_TEST_HADOOP_VERSION}.tar.gz"
+    local hadoop_url="https://archive.apache.org/dist/hadoop/common/hadoop-${E2E_TEST_HADOOP_VERSION}/hadoop-${E2E_TEST_HADOOP_VERSION}.tar.gz"
     local hadoop_tar_file="${E2E_TEST_TMP_DIR}/hadoop-${E2E_TEST_HADOOP_VERSION}.tar.gz"
     local checksum_url="${hadoop_url}.sha512"
     local checksum_file="${hadoop_tar_file}.sha512"


### PR DESCRIPTION
Fixes #1502

The behave tests currently downloads Hadoop JARs from Apache CDN (dlcdn.apache.org) for HDFS testing. However, there are test failures due to download timeouts making workflows unreliable.

## Issue
- Using CDN (dlcdn.apache.org) instead of the more reliable archive.apache.org
- Insufficient timeout settings in download configurations

## Changes
1. Switch download source from dlcdn.apache.org to archive.apache.org
2. Increased timeout settings

