### PR TITLE
Add stringType and binaryType to the list of dataType map

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -318,15 +318,17 @@ class PluginTypeChecker(platform: Platform = PlatformFactory.createInstance(),
     (allSupportedReadSources.toMap, allSupportedWriteFormats)
   }
 
-  def getOtherTypes(typeRead: String): Seq[String] = {
+  private def getOtherTypes(typeRead: String): Seq[String] = {
     typeRead match {
+      case "binary" => Seq("blob")
+      case "byte" => Seq("tinyint")
+      case "calendar" => Seq("interval")
+      case "decimal" => Seq("dec", "numeric")
+      case "float" => Seq("real")
+      case "int" => Seq("integer")
       case "long" => Seq("bigint")
       case "short" => Seq("smallint")
-      case "int" => Seq("integer")
-      case "byte" => Seq("tinyint")
-      case "float" => Seq("real")
-      case "decimal" => Seq("dec", "numeric")
-      case "calendar" => Seq("interval")
+      case "string" => Seq("varchar", "char")
       case _ => Seq.empty[String]
     }
   }


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1492

Adds 2 new entries to the dataTypes map defined in the PluginTypeChecker
- string: varchar, car
- binary: blob

