### PR TITLE
Fix string comparison for memory overhead in pinned pool size recommendation in AutoTuner

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -273,15 +273,15 @@ case object Kubernetes extends SparkMaster
 case object Standalone extends SparkMaster
 
 object SparkMaster {
-    def apply(master: Option[String]): Option[SparkMaster] = {
-      master.flatMap {
-        case url if url.contains("yarn") => Some(Yarn)
-        case url if url.contains("k8s") => Some(Kubernetes)
-        case url if url.contains("local") => Some(Local)
-        case url if url.contains("spark://") => Some(Standalone)
-        case _ => None
-      }
+  def apply(master: Option[String]): Option[SparkMaster] = {
+    master.flatMap {
+      case url if url.contains("yarn") => Some(Yarn)
+      case url if url.contains("k8s") => Some(Kubernetes)
+      case url if url.contains("local") => Some(Local)
+      case url if url.contains("spark://") => Some(Standalone)
+      case _ => None
     }
+  }
 }
 
 /**
@@ -598,8 +598,8 @@ class AutoTuner(
       appendRecommendationForMemoryMB(memOverheadLookup, recomValue)
       // if using k8s and pinned pool size is set, add a comment if memory overhead is missing
       if (sparkMaster.contains(Kubernetes) &&
-          getPropertyValue(pinnedPoolSizeLookup).isDefined &&
-            getPropertyValue(memOverheadLookup).isEmpty) {
+            getPropertyValue(pinnedPoolSizeLookup).isDefined &&
+              getPropertyValue(memOverheadLookup).isEmpty) {
         appendComment(s"'$memOverheadLookup' must be set if using '$pinnedPoolSizeLookup'.")
       }
     }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -977,8 +977,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1055,8 +1054,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1124,8 +1122,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val infoProvider = getMockInfoProvider(8126464.0, Seq(0), Seq(0.004), logEventsProps,
       Some(testSparkVersion))
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1202,8 +1199,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1364,8 +1360,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1438,8 +1433,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1662,8 +1656,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1738,8 +1731,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1835,8 +1827,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1908,8 +1899,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
         .loadClusterPropertiesFromContent(dataprocWorkerInfo)
       val platform = PlatformFactory.createInstance(PlatformNames.ONPREM, clusterPropsOpt)
       val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-        .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-          platform)
+        .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
       val (_, comments) = autoTuner.getRecommendedProperties()
       val expectedComment =
         s"'$memoryOverheadLabel' must be set if using 'spark.rapids.memory.pinnedPool.size'."
@@ -1920,7 +1910,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
   // This UT sets a custom spark-property "spark.master" pointing to a spark
   // k8s value. The Autotuner should detect that the spark-master is k8s and
   // should not comment on the missing memoryOverhead value since pinned pool is not set.
-  test(s"missing memoryOverhead comment is not included for k8s without pinned pool") {
+  test(s"missing memoryOverhead comment is not included for k8s without pinned pool " +
+    s"[sparkVersion=$testSparkVersion]") {
     val sparkMaster = "k8s://https://my-cluster-endpoint.example.com:6443"
     val logEventsProps: mutable.Map[String, String] =
       mutable.LinkedHashMap[String, String](
@@ -1943,8 +1934,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.ONPREM, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val memoryOverheadLabel = ProfilingAutoTunerConfigsProvider.getMemoryOverheadLabel(
@@ -1990,7 +1980,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
   // value. The Autotuner should detect that the spark-master is yarn and
   // should not comment on the missing memoryOverhead value even though pinned
   // pool is set.
-  test("missing memoryOverhead comment is not included for yarn") {
+  test("missing memoryOverhead comment is not included for yarn " +
+    s"[sparkVersion=$testSparkVersion]") {
     val logEventsProps: mutable.Map[String, String] =
       mutable.LinkedHashMap[String, String](
         "spark.master" -> "yarn",
@@ -2013,8 +2004,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.ONPREM, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -2223,8 +2213,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -2300,8 +2289,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     assert(expectedLines.forall(line => autoTunerOutput.contains(line)),
@@ -2368,8 +2356,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -2577,8 +2564,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -2654,8 +2640,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -2719,8 +2704,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -2795,8 +2779,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -2870,8 +2853,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider,
-        platform)
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit


### PR DESCRIPTION
Fixes #1398.

There were two bugs related to setting pinned pool size:
1. Incorrect cluster memory calculation with dynamic allocation enabled -  This was resolved in [#1121](#1121) by fixing cluster shape and memory calculation.

2. Memory value string (e.g., `4G`) was incorrectly compared to the label `spark.executor.memoryOverhead`.

This PR specifically fixes the second issue by ensuring the memory comparison is performed correctly.  The corrected condition is as follows:
```
If using k8s and pinned pool size is set, add a comment if memory overhead is missing
```


## Key changes:

### Handling Spark Master Types:
* Added a sealed trait `SparkMaster` with case objects `Local`, `Yarn`, `Kubernetes`, and `Standalone` to represent different Spark master types.
* Introduced a lazy val `sparkMaster` in the `AutoTuner` class to determine the Spark master type based on the `spark.master` property.

### Memory Overhead Recommendation Logic:
* Updated the `memoryOverheadLabel` method to use the new `sparkMaster` field instead of directly accessing the `spark.master` property. [[1]](diffhunk://#diff-ef26e6d4e25cf3134245beb228e7802e2cf3be63e64e0d6e1b98587d0e2d7896L560-R589) [[2]](diffhunk://#diff-ef26e6d4e25cf3134245beb228e7802e2cf3be63e64e0d6e1b98587d0e2d7896L583-R599)
* Modified the `addRecommendationForMemoryOverhead` method to check if the Spark master is not `Standalone` before adding memory overhead recommendations.
* Removed the `enableMemoryOverheadRecommendation` method from the `AutoTunerConfigsProvider` trait as it is no longer needed.

### Test Suite Updates:
* Replaced direct assertions with the `compareOutput` method in the `ProfilingAutoTunerSuite` to improve test output comparison. [[1]](diffhunk://#diff-ada5964d4f49a559184f692ffb3fbf4823665b714ba0470adcc961a34a3c734cL132-R132) [[2]](diffhunk://#diff-ada5964d4f49a559184f692ffb3fbf4823665b714ba0470adcc961a34a3c734cL1330-R1325)
* Removed redundant comments about `spark.executor.memoryOverhead` from multiple test cases in the `ProfilingAutoTunerSuite`. [[1]](diffhunk://#diff-ada5964d4f49a559184f692ffb3fbf4823665b714ba0470adcc961a34a3c734cL1005) [[2]](diffhunk://#diff-ada5964d4f49a559184f692ffb3fbf4823665b714ba0470adcc961a34a3c734cL1084) [[3]](diffhunk://#diff-ada5964d4f49a559184f692ffb3fbf4823665b714ba0470adcc961a34a3c734cL1155) [[4]](diffhunk://#diff-ada5964d4f49a559184f692ffb3fbf4823665b714ba0470adcc961a34a3c734cL1235) [[5]](diffhunk://#diff-ada5964d4f49a559184f692ffb3fbf4823665b714ba0470adcc961a34a3c734cL1317) [[6]](diffhunk://#diff-ada5964d4f49a559184f692ffb3fbf4823665b714ba0470adcc961a34a3c734cL1397) [[7]](diffhunk://#diff-ada5964d4f49a559184f692ffb3fbf4823665b714ba0470adcc961a34a3c734cL1472) [[8]](diffhunk://#diff-ada5964d4f49a559184f692ffb3fbf4823665b714ba0470adcc961a34a3c734cL1698) [[9]](diffhunk://#diff-ada5964d4f49a559184f692ffb3fbf4823665b714ba0470adcc961a34a3c734cL1774)