### PR TITLE
Use a stub to store Spark StageInfo

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -417,6 +417,7 @@
         <maven.artifact.version>3.9.0</maven.artifact.version>
         <scala.javac.args>-Xlint:all,-serial,-path,-try</scala.javac.args>
         <rapids.shade.package>com.nvidia.shaded.spark</rapids.shade.package>
+        <benchmarks.checkpoints>noOp</benchmarks.checkpoints>
         <jsoup.version>1.16.1</jsoup.version>
         <!-- properties used for DeltaLake -->
         <delta10x.version>1.0.1</delta10x.version>

--- a/core/src/main/resources/configs/build.properties
+++ b/core/src/main/resources/configs/build.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,3 +23,4 @@ build.spark.version=${spark.version}
 build.hadoop.version=${hadoop.version}
 build.java.version=${java.version}
 build.scala.version=${scala.version}
+build.benchmarks.checkpoints=${benchmarks.checkpoints}

--- a/core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/DevRuntimeCheckpoint.scala
+++ b/core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/DevRuntimeCheckpoint.scala
@@ -32,6 +32,6 @@ class DevRuntimeCheckpoint extends RuntimeCheckpointTrait {
     val memoryInfo = RuntimeUtil.getJVMHeapInfo(runGC = true)
     // scalastyle:off println
     println(s"Memory Marker: $label, ${memoryInfo.mkString("\n")}")
-    // scalastyle:oon println
+    // scalastyle:on println
   }
 }

--- a/core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/DevRuntimeCheckpoint.scala
+++ b/core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/DevRuntimeCheckpoint.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rapids.tool.benchmarks
+
+import org.apache.spark.sql.rapids.tool.util.RuntimeUtil
+
+/**
+ * A simple implementation to insert checkpoints during runtime to pull some performance metrics
+ * related to Tools. This is disabled by default and can be enabled by setting the build
+ * property `benchmarks.checkpoints`.
+ */
+class DevRuntimeCheckpoint extends RuntimeCheckpointTrait {
+  /**
+   * Insert a memory marker with the given label. This will print the memory information.
+   * @param label the label for the memory marker
+   */
+  override def insertMemoryMarker(label: String): Unit = {
+    val memoryInfo = RuntimeUtil.getJVMHeapInfo(runGC = true)
+    // scalastyle:off println
+    println(s"Memory Marker: $label, ${memoryInfo.mkString("\n")}")
+    // scalastyle:oon println
+  }
+}

--- a/core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/NoOpRuntimeCheckpoint.scala
+++ b/core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/NoOpRuntimeCheckpoint.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rapids.tool.benchmarks
+
+import scala.annotation.nowarn
+
+/**
+ * An empty implementation of the Checkpoint interface that inserts NoOps.
+ * This is the default implementation that will be used in production and normal builds.
+ */
+class NoOpRuntimeCheckpoint extends RuntimeCheckpointTrait {
+  override def insertMemoryMarker(@nowarn label: String): Unit = {
+    // Do nothing. This is a noOp
+  }
+}

--- a/core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/RuntimeCheckpointTrait.scala
+++ b/core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/RuntimeCheckpointTrait.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rapids.tool.benchmarks
+
+/**
+ * API for inserting checkpoints in runtime.
+ * This is used for debugging and benchmarking purposes.
+ */
+trait RuntimeCheckpointTrait {
+  /**
+   * Insert a memory marker with the given label.
+   * @param label the label for the memory marker
+   */
+  def insertMemoryMarker(label: String): Unit
+}

--- a/core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/RuntimeInjector.scala
+++ b/core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/RuntimeInjector.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rapids.tool.benchmarks
+
+import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
+
+/**
+ * The global runtime injector that will be used to insert checkpoints during runtime.
+ * This is used to pull some performance metrics related to Tools.
+ */
+object RuntimeInjector extends RuntimeCheckpointTrait {
+  /**
+   * Initializes the runtime injector based on the build properties "benchmarks.checkpoints".
+   * @return the runtime injector
+   */
+  private def loadRuntimeCheckPoint(): RuntimeCheckpointTrait = {
+    val buildProps = RapidsToolsConfUtil.loadBuildProperties
+    if (buildProps.getProperty("build.benchmarks.checkpoints").contains("dev")) {
+      // The benchmark injection is enabled.
+      new DevRuntimeCheckpoint
+    } else { // loads the noOp implementation by default
+      new NoOpRuntimeCheckpoint
+    }
+  }
+  private lazy val runtimeCheckpoint: RuntimeCheckpointTrait = loadRuntimeCheckPoint()
+
+  override def insertMemoryMarker(label: String): Unit = {
+    runtimeCheckpoint.insertMemoryMarker(label)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -33,6 +33,7 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.deploy.history.{EventLogFileReader, EventLogFileWriter}
 import org.apache.spark.internal.Logging
+import org.apache.spark.rapids.tool.benchmarks.RuntimeInjector
 import org.apache.spark.scheduler.{SparkListenerEvent, StageInfo}
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
@@ -492,6 +493,7 @@ abstract class AppBase(
   def processEvents(): Unit = {
     processEventsInternal()
     postCompletion()
+    RuntimeInjector.insertMemoryMarker("Post processing events")
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.nvidia.spark.rapids.tool.profiling.ProfileUtils
 
 import org.apache.spark.scheduler.StageInfo
 import org.apache.spark.sql.rapids.tool.annotation.{Calculated, Since, WallClock}
+import org.apache.spark.sql.rapids.tool.util.stubs.StageInfoStub
 
 /**
  * StageModel is a class to store the information of a stage.
@@ -31,7 +32,7 @@ import org.apache.spark.sql.rapids.tool.annotation.{Calculated, Since, WallClock
 @Since("24.02.3")
 class StageModel private(sInfo: StageInfo) {
 
-  var stageInfo: StageInfo = _
+  var stageInfo: StageInfoStub = _
   updateInfo(sInfo)
 
   /**
@@ -39,8 +40,8 @@ class StageModel private(sInfo: StageInfo) {
    * @return a new StageInfo object.
    * TODO: https://github.com/NVIDIA/spark-rapids-tools/issues/1260
    */
-  private def initStageInfo(newStageInfo: StageInfo): StageInfo = {
-    newStageInfo
+  private def initStageInfo(newStageInfo: StageInfo): StageInfoStub = {
+    StageInfoStub.fromStageInfo(newStageInfo)
   }
 
   @WallClock

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/RuntimeUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/RuntimeUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,5 +102,17 @@ object RuntimeUtil extends Logging {
           }
         }
     }.toMap
+  }
+
+  def getJVMHeapInfo(runGC: Boolean = true): Map[String, String] = {
+    if (runGC) {
+      System.gc()
+    }
+    val runtime = Runtime.getRuntime
+    Map(
+      "jvm.heap.max" -> runtime.maxMemory().toString,
+      "jvm.heap.total" -> runtime.totalMemory().toString,
+      "jvm.heap.free" -> runtime.freeMemory().toString
+    )
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/stubs/StageInfoStub.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/stubs/StageInfoStub.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool.util.stubs
+
+import org.apache.spark.scheduler.StageInfo
+import org.apache.spark.sql.rapids.tool.annotation.ToolsReflection
+
+@ToolsReflection("Common",
+  "StageInfo is a common class used in all versions of Spark but the constructor signature is" +
+    " different across versions.")
+case class StageInfoStub(
+    stageId: Int,
+    attemptId: Int,
+    name: String,
+    numTasks: Int,
+    details: String,
+    /** When this stage was submitted from the DAGScheduler to a TaskScheduler. */
+    submissionTime: Option[Long] = None,
+    /** Time when the stage completed or when the stage was cancelled. */
+    completionTime: Option[Long] = None,
+    /** If the stage failed, the reason why. */
+    failureReason: Option[String] = None) {
+
+  def attemptNumber(): Int = attemptId
+}
+
+object StageInfoStub {
+  def fromStageInfo(stageInfo: StageInfo): StageInfoStub = {
+    StageInfoStub(
+      stageInfo.stageId,
+      stageInfo.attemptNumber(),
+      stageInfo.name,
+      stageInfo.numTasks,
+      stageInfo.details,
+      stageInfo.submissionTime,
+      stageInfo.completionTime,
+      stageInfo.failureReason)
+  }
+}


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1524

This commit uses a smaller class `StageInfoStub` to store Spark's StageInfo. This class is common between all the spark implementations but it has more fields to the constructor across different versions.

Currently we only use a subset of the class fields. The remaining fields represent an overhead or redundant storage; especially when it comes to store the accumulables and taskMetrics for each stage.

To evaluate the memory optimization, a new `Checkpoint` mechanism was added to allow gathering information at separate stages of the execution.
The `checkpoint` design and implementation can be further improved and extended to build a performance profile to compare different tradeoffs.

This pull request introduces a new runtime checkpointing feature for performance benchmarking and debugging in the RAPIDS tools. The main changes include adding new classes for runtime checkpoints, updating build properties, and modifying existing classes to integrate the new checkpointing functionality.

### Memory evaluation:

- In order to enable the runtime injection set the build property `benchmarks.checkpoints`  to `dev`. This is achieved by changing the pom.xml file or passing the property as an arhument to the mvn command.
- This property will dump the free memory after the eventlog is processed.
- An initial test on a sample eventlog showed that it saved approximately ~ 7MB. Of course, this resulkt is a function of the number of completed stages in the eventlog and the accumulables associated with each one.

### Code Changes

#### Main core changes

* [`core/src/main/scala/org/apache/spark/sql/rapids/tool/util/stubs/StageInfoStub.scala`](diffhunk://#diff-01f45324c0321580435ceea1a21d411cc404ca921cb876ef10adb1471ff6ec88R1-R53): Added a new class `StageInfoStub` to provide a consistent interface for `StageInfo` across different Spark versions.
* [`core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala`](diffhunk://#diff-aeaf0202fd8fce5698a5c11019f3908a4692218a5ab5a47aa21796dc8884ff1cL2-R2): Updated `StageModel` to use `StageInfoStub` for compatibility with different Spark versions. [[1]](diffhunk://#diff-aeaf0202fd8fce5698a5c11019f3908a4692218a5ab5a47aa21796dc8884ff1cL2-R2) [[2]](diffhunk://#diff-aeaf0202fd8fce5698a5c11019f3908a4692218a5ab5a47aa21796dc8884ff1cR23) [[3]](diffhunk://#diff-aeaf0202fd8fce5698a5c11019f3908a4692218a5ab5a47aa21796dc8884ff1cL34-R44)

#### Build and Configuration Updates:

* [`core/pom.xml`](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR420): Added a new property `benchmarks.checkpoints` to manage the checkpointing feature.
* [`core/src/main/resources/configs/build.properties`](diffhunk://#diff-4ee540ba944e31033db425f18c11f87cd3023b192fc4e84c23c56bf3ef73c95dL2-R2): Updated build properties to include `benchmarks.checkpoints`. [[1]](diffhunk://#diff-4ee540ba944e31033db425f18c11f87cd3023b192fc4e84c23c56bf3ef73c95dL2-R2) [[2]](diffhunk://#diff-4ee540ba944e31033db425f18c11f87cd3023b192fc4e84c23c56bf3ef73c95dR26)

#### Runtime Checkpointing Feature:

* [`core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/DevRuntimeCheckpoint.scala`](diffhunk://#diff-19f5725d6e379e5b99a1f5f7e2d732e38a043892a772822b5b966eba86d72309R1-R37): Added a new class `DevRuntimeCheckpoint` to insert memory markers and print memory information during runtime for performance metrics.
* [`core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/NoOpRuntimeCheckpoint.scala`](diffhunk://#diff-9f09d79c05a71c7b8167c76f0b580fba7025ecd36a4f61edcdeeeb7fbc94bbd3R1-R29): Added a new class `NoOpRuntimeCheckpoint` as a default no-operation implementation for checkpoints.
* [`core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/RuntimeCheckpointTrait.scala`](diffhunk://#diff-d973ea161c3246fb40315695e67ee011b37dd43b3c912105ce4ec0ebf2512c5bR1-R29): Introduced a new trait `RuntimeCheckpointTrait` defining the API for inserting runtime checkpoints.
* [`core/src/main/scala/org/apache/spark/rapids/tool/benchmarks/RuntimeInjector.scala`](diffhunk://#diff-9e52f67c406c759b6781e75e533418486b30be686214497d0512b9730b8fa027R1-R44): Added a new object `RuntimeInjector` to manage and insert runtime checkpoints based on build properties.


#### Integration of Checkpoints:

* [`core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala`](diffhunk://#diff-86930ce0c9a1fa003be4b6c67827f5ea8ad2c631485286d36217d9dc2bfc30e2R36): Integrated `RuntimeInjector` to insert a memory marker after processing events. [[1]](diffhunk://#diff-86930ce0c9a1fa003be4b6c67827f5ea8ad2c631485286d36217d9dc2bfc30e2R36) [[2]](diffhunk://#diff-86930ce0c9a1fa003be4b6c67827f5ea8ad2c631485286d36217d9dc2bfc30e2R496)
* [`core/src/main/scala/org/apache/spark/sql/rapids/tool/util/RuntimeUtil.scala`](diffhunk://#diff-17ba210baa6a6a06a98ea4fc3d67a576d28f8a7e7a52be3b07c08b73f78ac4b5L2-R2): Added a method `getJVMHeapInfo` to retrieve JVM heap information. [[1]](diffhunk://#diff-17ba210baa6a6a06a98ea4fc3d67a576d28f8a7e7a52be3b07c08b73f78ac4b5L2-R2) [[2]](diffhunk://#diff-17ba210baa6a6a06a98ea4fc3d67a576d28f8a7e7a52be3b07c08b73f78ac4b5R106-R117)
