### PR TITLE
Add support for configurable qualx label column

### DIFF
--- a/user_tools/src/spark_rapids_tools/tools/qualx/config.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/config.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Config module for Qualx, controlled by environment variables.
+
+Environment variables:
+- QUALX_CACHE_DIR: cache directory for saving Profiler output.
+- QUALX_DATA_DIR: data directory containing eventlogs, primarily used in dataset JSON files.
+- QUALX_DIR: root directory for Qualx execution, primarily used in dataset JSON files to locate
+    dataset-specific plugins.
+- QUALX_LABEL: targeted label column for XGBoost model.
+- SPARK_RAPIDS_TOOLS_JAR: path to Spark RAPIDS Tools JAR file.
+"""
+import os
+
+
+def get_cache_dir() -> str:
+    """Get cache directory to save Profiler output."""
+    return os.environ.get('QUALX_CACHE_DIR', 'qualx_cache')
+
+
+def get_label() -> str:
+    """Get targeted label column for XGBoost model."""
+    label = os.environ.get('QUALX_LABEL', 'Duration')
+    assert label in ['Duration', 'duration_sum']
+    return label

--- a/user_tools/src/spark_rapids_tools/tools/qualx/model.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/model.py
@@ -186,9 +186,6 @@ def predict(
     if 'split' in cpu_aug_tbl:
         select_columns.append('split')
 
-    if label not in cpu_aug_tbl:
-        raise ValueError(f'{label} column not found in input data')
-
     # join predictions with select input features
     results_df = (
         cpu_aug_tbl[select_columns]
@@ -227,10 +224,6 @@ def extract_model_features(
     label = get_label()
     expected_model_features = expected_raw_features - ignored_features
     expected_model_features.remove(label)
-    if label == 'duration_sum':
-        # for 'duration_sum' label, also remove 'duration_mean' since it's related to 'duration_sum'
-        expected_model_features.remove('duration_mean')
-
     missing = expected_raw_features - set(df.columns)
     if missing:
         logger.warning('Input dataframe is missing expected raw features: %s', missing)

--- a/user_tools/src/spark_rapids_tools/tools/qualx/model.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/model.py
@@ -179,14 +179,15 @@ def predict(
         'appDuration',
         'sqlID',
         'scaleFactor',
+        label,
         'fraction_supported',
         'description',
     ]
     if 'split' in cpu_aug_tbl:
         select_columns.append('split')
 
-    if label in cpu_aug_tbl:
-        select_columns.append(label)
+    if label not in cpu_aug_tbl:
+        raise ValueError(f'{label} column not found in input data')
 
     # join predictions with select input features
     results_df = (

--- a/user_tools/src/spark_rapids_tools/tools/qualx/model.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import numpy as np
 import pandas as pd
 import xgboost as xgb
 from xgboost import Booster
+from spark_rapids_tools.tools.qualx.config import get_label
 from spark_rapids_tools.tools.qualx.preprocess import expected_raw_features
 from spark_rapids_tools.tools.qualx.util import get_logger
 # Import optional packages
@@ -42,7 +43,6 @@ ignored_features = {
     'appId',
     'appName',
     'description',
-    'Duration',
     'fraction_supported',
     'jobStartTime_min',
     'pluginEnabled',
@@ -52,8 +52,6 @@ ignored_features = {
     'sparkVersion',
     'sqlID'
 }
-
-expected_model_features = expected_raw_features - ignored_features
 
 
 def train(
@@ -174,18 +172,21 @@ def predict(
         preds['y'] = y
     preds_df = pd.DataFrame(preds)
 
+    label = get_label()  # Duration, duration_sum
     select_columns = [
         'appName',
         'appId',
         'appDuration',
         'sqlID',
         'scaleFactor',
-        'Duration',
         'fraction_supported',
         'description',
     ]
     if 'split' in cpu_aug_tbl:
         select_columns.append('split')
+
+    if label in cpu_aug_tbl:
+        select_columns.append(label)
 
     # join predictions with select input features
     results_df = (
@@ -196,31 +197,39 @@ def predict(
 
     if 'y' in results_df.columns:
         # reconstruct original gpu duration for validation purposes
-        results_df['gpuDuration'] = results_df['Duration'] / results_df['y']
-        results_df['gpuDuration'] = np.floor(results_df['gpuDuration'])
+        results_df[f'gpu_{label}'] = results_df[label] / results_df['y']
+        results_df[f'gpu_{label}'] = np.floor(results_df[f'gpu_{label}'])
 
     # adjust raw predictions with stage/sqlID filtering of unsupported ops
-    results_df['Duration_pred'] = results_df['Duration'] * (
+    results_df[f'{label}_pred'] = results_df[label] * (
         1.0
         - results_df['fraction_supported']
         + (results_df['fraction_supported'] / results_df['y_pred'])
     )
     # compute fraction of duration in supported ops
-    results_df['Duration_supported'] = (
-        results_df['Duration'] * results_df['fraction_supported']
+    results_df[f'{label}_supported'] = (
+        results_df[label] * results_df['fraction_supported']
     )
     # compute adjusted speedup (vs. raw speedup prediction: 'y_pred')
     # without qual data, this should be the same as the raw 'y_pred'
-    results_df['speedup_pred'] = results_df['Duration'] / results_df['Duration_pred']
+    results_df['speedup_pred'] = results_df[label] / results_df[f'{label}_pred']
     results_df = results_df.drop(columns=['fraction_supported'])
 
     return results_df
 
 
 def extract_model_features(
-    df: pd.DataFrame, split_functions: Mapping[str, Callable[[pd.DataFrame], pd.DataFrame]] = None
+    df: pd.DataFrame,
+    split_functions: Mapping[str, Callable[[pd.DataFrame], pd.DataFrame]] = None,
 ) -> Tuple[pd.DataFrame, List[str], str]:
     """Extract model features from raw features."""
+    label = get_label()
+    expected_model_features = expected_raw_features - ignored_features
+    expected_model_features.remove(label)
+    if label == 'duration_sum':
+        # for 'duration_sum' label, also remove 'duration_mean' since it's related to 'duration_sum'
+        expected_model_features.remove('duration_mean')
+
     missing = expected_raw_features - set(df.columns)
     if missing:
         logger.warning('Input dataframe is missing expected raw features: %s', missing)
@@ -256,11 +265,11 @@ def extract_model_features(
                 'appName',
                 'scaleFactor',
                 'sqlID',
-                'Duration',
+                label,
                 'description',
             ]
         ]
-        gpu_aug_tbl = gpu_aug_tbl.rename(columns={'Duration': 'xgpu_Duration'})
+        gpu_aug_tbl = gpu_aug_tbl.rename(columns={label: f'xgpu_{label}'})
         cpu_aug_tbl = cpu_aug_tbl.merge(
             gpu_aug_tbl,
             on=['appName', 'scaleFactor', 'sqlID', 'description'],
@@ -269,7 +278,7 @@ def extract_model_features(
 
         # warn for possible mismatched sqlIDs
         num_rows = len(cpu_aug_tbl)
-        num_na = cpu_aug_tbl['xgpu_Duration'].isna().sum()
+        num_na = cpu_aug_tbl[f'xgpu_{label}'].isna().sum()
         if (
             num_na / num_rows > 0.05
         ):  # arbitrary threshold, misaligned sqlIDs still may 'match' most of the time
@@ -279,14 +288,14 @@ def extract_model_features(
                 num_rows,
             )
 
-        # calculate Duration_speedup
-        cpu_aug_tbl['Duration_speedup'] = (
-            cpu_aug_tbl['Duration'] / cpu_aug_tbl['xgpu_Duration']
+        # calculate speedup
+        cpu_aug_tbl[f'{label}_speedup'] = (
+            cpu_aug_tbl[label] / cpu_aug_tbl[f'xgpu_{label}']
         )
-        cpu_aug_tbl = cpu_aug_tbl.drop(columns=['xgpu_Duration'])
+        cpu_aug_tbl = cpu_aug_tbl.drop(columns=[f'xgpu_{label}'])
 
-        # use Duration_speedup as label
-        label_col = 'Duration_speedup'
+        # use speedup as label
+        label_col = f'{label}_speedup'
     else:
         # inference dataset with CPU runs only
         label_col = None

--- a/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
@@ -455,7 +455,7 @@ def extract_raw_features(
     if get_label() == 'duration_sum':
         # override appDuration with sum(duration_sum) across all stages per appId
         app_duration_sum = job_stage_agg_tbl.groupby('appId')['duration_sum'].sum().reset_index()
-        app_duration_sum = app_duration_sum.rename(columns = {'duration_sum': 'appDuration'})
+        app_duration_sum = app_duration_sum.rename(columns={'duration_sum': 'appDuration'})
         app_tbl = app_tbl.merge(app_duration_sum, on=['appId'], how='left', suffixes=['_orig', None])
 
     # normalize dtypes

--- a/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
@@ -22,11 +22,14 @@ import glob
 import os
 import numpy as np
 import pandas as pd
+from spark_rapids_tools.tools.qualx.config import (
+    get_cache_dir,
+    get_label,
+)
 from spark_rapids_tools.tools.qualx.util import (
     ensure_directory,
     find_eventlogs,
     find_paths,
-    get_cache_dir,
     get_logger,
     get_dataset_platforms,
     load_plugin,
@@ -392,19 +395,20 @@ def load_profiles(
     )
 
     # run any plugin hooks on profile_df
-    for ds_name, plugin_path in plugins.items():
-        plugin = load_plugin(plugin_path)
-        if plugin:
-            df_schema = profile_df.dtypes
-            dataset_df = profile_df.loc[
-                (profile_df.appName == ds_name) | (profile_df.appName.str.startswith(f'{ds_name}:'))
-            ]
-            modified_dataset_df = plugin.load_profiles_hook(dataset_df)
-            if modified_dataset_df.index.equals(dataset_df.index):
-                profile_df.update(modified_dataset_df)
-                profile_df.astype(df_schema)
-            else:
-                raise ValueError(f'Plugin: load_profiles_hook for {ds_name} unexpectedly modified row indices.')
+    if not profile_df.empty:
+        for ds_name, plugin_path in plugins.items():
+            plugin = load_plugin(plugin_path)
+            if plugin:
+                df_schema = profile_df.dtypes
+                dataset_df = profile_df.loc[
+                    (profile_df.appName == ds_name) | (profile_df.appName.str.startswith(f'{ds_name}:'))
+                ]
+                modified_dataset_df = plugin.load_profiles_hook(dataset_df)
+                if modified_dataset_df.index.equals(dataset_df.index):
+                    profile_df.update(modified_dataset_df)
+                    profile_df.astype(df_schema)
+                else:
+                    raise ValueError(f'Plugin: load_profiles_hook for {ds_name} unexpectedly modified row indices.')
     return profile_df
 
 
@@ -447,6 +451,10 @@ def extract_raw_features(
         log_fallback(logger, unique_app_ids,
                      fallback_reason=f'Empty feature tables found after preprocessing: {empty_tables_str}')
         return pd.DataFrame()
+
+    if get_label() == 'duration_sum':
+        # override appDuration with sum(duration_sum) across all stages
+        app_tbl['appDuration'] = job_stage_agg_tbl['duration_sum'].astype(float).sum()
 
     # normalize dtypes
     app_int_dtypes = ['taskCpu', 'taskGpu']

--- a/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
@@ -453,8 +453,10 @@ def extract_raw_features(
         return pd.DataFrame()
 
     if get_label() == 'duration_sum':
-        # override appDuration with sum(duration_sum) across all stages
-        app_tbl['appDuration'] = job_stage_agg_tbl['duration_sum'].astype(float).sum()
+        # override appDuration with sum(duration_sum) across all stages per appId
+        app_duration_sum = job_stage_agg_tbl.groupby('appId')['duration_sum'].sum().reset_index()
+        app_duration_sum = app_duration_sum.rename(columns = {'duration_sum': 'appDuration'})
+        app_tbl = app_tbl.merge(app_duration_sum, on=['appId'], how='left', suffixes=['_orig', None])
 
     # normalize dtypes
     app_int_dtypes = ['taskCpu', 'taskGpu']

--- a/user_tools/src/spark_rapids_tools/tools/qualx/util.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/util.py
@@ -414,7 +414,7 @@ def create_row_with_default_speedup(app: pd.Series) -> pd.Series:
     """
     Create a default row for an app with no speedup prediction.
     """
-    label=get_label()
+    label = get_label()
     return pd.Series({
         'appName': app['App Name'],
         'appId': app['App ID'],

--- a/user_tools/src/spark_rapids_tools/tools/qualx/util.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/util.py
@@ -28,6 +28,7 @@ import subprocess
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
+from spark_rapids_tools.tools.qualx.config import get_label
 from tabulate import tabulate
 import numpy as np
 import pandas as pd
@@ -410,13 +411,14 @@ def create_row_with_default_speedup(app: pd.Series) -> pd.Series:
     """
     Create a default row for an app with no speedup prediction.
     """
+    label=get_label()
     return pd.Series({
         'appName': app['App Name'],
         'appId': app['App ID'],
         'appDuration': app['App Duration'],
-        'Duration': 0,
-        'Duration_pred': 0,
-        'Duration_supported': 0,
+        label: 0,
+        f'{label}_pred': 0,
+        f'{label}_supported': 0,
         'fraction_supported': 0.0,
         'appDuration_pred': app['App Duration'],
         'speedup': 1.0,

--- a/user_tools/src/spark_rapids_tools/tools/qualx/util.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/util.py
@@ -116,10 +116,6 @@ def find_eventlogs(path: str) -> List[str]:
     return eventlogs
 
 
-def get_cache_dir() -> str:
-    return os.environ.get('QUALX_CACHE_DIR', 'qualx_cache')
-
-
 def get_dataset_platforms(dataset: str) -> Tuple[List[str], str]:
     """Return list of platforms and dataset parent directory from a string path.
 

--- a/user_tools/src/spark_rapids_tools/tools/qualx/util.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/util.py
@@ -14,8 +14,6 @@
 
 """ Utility functions for QualX """
 
-from dataclasses import dataclass
-from typing import Dict, List, Tuple, Callable
 import glob
 import importlib
 import logging
@@ -26,12 +24,17 @@ import string
 import types
 import subprocess
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from spark_rapids_tools.tools.qualx.config import get_label
-from tabulate import tabulate
+from typing import Dict, List, Tuple, Callable
+
 import numpy as np
 import pandas as pd
+from tabulate import tabulate
+
+from spark_rapids_tools.tools.qualx.config import get_label
+
 
 INTERMEDIATE_DATA_ENABLED = False
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')


### PR DESCRIPTION
This PR adds support for a configurable `label` column for the qualx xgboost model.

The default value is `Duration` (wall-clock), which is the current behavior.  Note that we subsequently derive   `Duration_speedup` (from the CPU and GPU `Duration` values) which becomes the actual label for the model.

This adds support for a new label: `duration_sum` (sum of task durations).

This does not include any pre-trained models with the `duration_sum` target, since this is mostly intended for custom model use-cases where `Duration` might be insufficient or undesired.

## Changes:
1. Adds a new `config.py` module to host configurable variables, including a new `QUALX_LABEL` env variable to define which label to use.
2. Adds support for `duration_sum` target, e.g. removing label columns from features, recomputing `appDuration`, etc.
3. Fixes minor bugs when encountering empty dataframes.

## Test
I have confirmed that the models produced before and after this commit are identical (when using the default `Duration`).

Following CMDs have been tested:
spark_rapids prediction

Internal Usage:
python qualx_main.py preprocess
python qualx_main.py train
python qualx_main.py predict
python qualx_main.py evaluate