### PR TITLE
Disable Per-SQL summary text output

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -248,7 +248,6 @@ class Qualification(outputPath: String, numRows: Int, hadoopConf: Configuration,
       sortForExecutiveSummary(sortedDescDetailed, order), numRows)
     qWriter.writeDetailedCSVReport(sortedDescDetailed)
     if (reportSqlLevel) {
-      qWriter.writePerSqlTextReport(allAppsSum, numRows, maxSQLDescLength)
       qWriter.writePerSqlCSVReport(allAppsSum, maxSQLDescLength)
     }
     qWriter.writeExecReport(allAppsSum)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualOutputWriter.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualOutputWriter.scala
@@ -51,9 +51,8 @@ class RunningQualOutputWriter(
 
   // we don't know max length since process per query, hardcode for 100 for now
   private val SQL_DESC_LENGTH = 100
-  private val appNameSize = if (appName.nonEmpty) appName.size else 100
-  val headersAndSizes = QualOutputWriter.getDetailedPerSqlHeaderStringsAndSizes(appNameSize,
-    appId.size, SQL_DESC_LENGTH)
+  val headersAndSizes = QualOutputWriter.getDetailedPerSqlHeaderStringsAndSizes(appId.size,
+    SQL_DESC_LENGTH)
   val entireTextHeader = QualOutputWriter.constructOutputRowFromMap(headersAndSizes,
     TEXT_DELIMITER, true)
   private val sep = "=" * (entireTextHeader.size - 1)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
@@ -81,18 +81,9 @@ class RunningQualificationApp(
 
   // we don't know the max sql query name size so lets cap it at 100
   private val SQL_DESC_LENGTH = 100
-  private lazy val appNameSize = {
-    val runningAppName = getAppName
-    if (runningAppName.nonEmpty) {
-      runningAppName.size
-    } else {
-      100
-    }
-  }
 
   private lazy val perSqlHeadersAndSizes = {
-      QualOutputWriter.getDetailedPerSqlHeaderStringsAndSizes(appNameSize,
-        appId.size, SQL_DESC_LENGTH)
+      QualOutputWriter.getDetailedPerSqlHeaderStringsAndSizes(appId.size, SQL_DESC_LENGTH)
   }
 
   def this() = {

--- a/core/src/test/resources/QualificationExpectations/nds_q86_fail_test_expectation_persql.csv
+++ b/core/src/test/resources/QualificationExpectations/nds_q86_fail_test_expectation_persql.csv
@@ -1,26 +1,26 @@
-App Name,App ID,Root SQL ID,SQL ID,SQL Description,SQL DF Duration,GPU Opportunity
-"TPC-DS Like Bench q86","app-20210319163812-1778","",0,"Register input tables",2,2
-"TPC-DS Like Bench q86","app-20210319163812-1778","",21,"Register input tables",1,1
-"TPC-DS Like Bench q86","app-20210319163812-1778","",5,"Register input tables",1,1
-"TPC-DS Like Bench q86","app-20210319163812-1778","",6,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",15,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",3,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",12,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",18,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",9,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",19,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",1,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",10,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",16,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",7,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",22,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",13,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",4,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",14,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",20,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",2,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",11,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",17,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",8,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",23,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",24,"Benchmark Run: query=q86; iteration=0",9565,9565
+App ID,Root SQL ID,SQL ID,SQL Description,SQL DF Duration,GPU Opportunity
+"app-20210319163812-1778","",0,"Register input tables",2,2
+"app-20210319163812-1778","",21,"Register input tables",1,1
+"app-20210319163812-1778","",5,"Register input tables",1,1
+"app-20210319163812-1778","",6,"Register input tables",0,0
+"app-20210319163812-1778","",15,"Register input tables",0,0
+"app-20210319163812-1778","",3,"Register input tables",0,0
+"app-20210319163812-1778","",12,"Register input tables",0,0
+"app-20210319163812-1778","",18,"Register input tables",0,0
+"app-20210319163812-1778","",9,"Register input tables",0,0
+"app-20210319163812-1778","",19,"Register input tables",0,0
+"app-20210319163812-1778","",1,"Register input tables",0,0
+"app-20210319163812-1778","",10,"Register input tables",0,0
+"app-20210319163812-1778","",16,"Register input tables",0,0
+"app-20210319163812-1778","",7,"Register input tables",0,0
+"app-20210319163812-1778","",22,"Register input tables",0,0
+"app-20210319163812-1778","",13,"Register input tables",0,0
+"app-20210319163812-1778","",4,"Register input tables",0,0
+"app-20210319163812-1778","",14,"Register input tables",0,0
+"app-20210319163812-1778","",20,"Register input tables",0,0
+"app-20210319163812-1778","",2,"Register input tables",0,0
+"app-20210319163812-1778","",11,"Register input tables",0,0
+"app-20210319163812-1778","",17,"Register input tables",0,0
+"app-20210319163812-1778","",8,"Register input tables",0,0
+"app-20210319163812-1778","",23,"Register input tables",0,0
+"app-20210319163812-1778","",24,"Benchmark Run: query=q86; iteration=0",9565,9565

--- a/core/src/test/resources/QualificationExpectations/nds_q86_test_expectation_persql.csv
+++ b/core/src/test/resources/QualificationExpectations/nds_q86_test_expectation_persql.csv
@@ -1,26 +1,26 @@
-App Name,App ID,Root SQL ID,SQL ID,SQL Description,SQL DF Duration,GPU Opportunity
-"TPC-DS Like Bench q86","app-20210319163812-1778","",24,"Benchmark Run: query=q86; iteration=0",9565,9565
-"TPC-DS Like Bench q86","app-20210319163812-1778","",0,"Register input tables",2,2
-"TPC-DS Like Bench q86","app-20210319163812-1778","",21,"Register input tables",1,1
-"TPC-DS Like Bench q86","app-20210319163812-1778","",5,"Register input tables",1,1
-"TPC-DS Like Bench q86","app-20210319163812-1778","",6,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",15,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",3,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",12,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",18,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",9,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",19,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",1,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",10,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",16,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",7,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",22,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",13,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",4,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",14,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",20,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",2,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",11,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",17,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",8,"Register input tables",0,0
-"TPC-DS Like Bench q86","app-20210319163812-1778","",23,"Register input tables",0,0
+App ID,Root SQL ID,SQL ID,SQL Description,SQL DF Duration,GPU Opportunity
+"app-20210319163812-1778","",24,"Benchmark Run: query=q86; iteration=0",9565,9565
+"app-20210319163812-1778","",0,"Register input tables",2,2
+"app-20210319163812-1778","",21,"Register input tables",1,1
+"app-20210319163812-1778","",5,"Register input tables",1,1
+"app-20210319163812-1778","",6,"Register input tables",0,0
+"app-20210319163812-1778","",15,"Register input tables",0,0
+"app-20210319163812-1778","",3,"Register input tables",0,0
+"app-20210319163812-1778","",12,"Register input tables",0,0
+"app-20210319163812-1778","",18,"Register input tables",0,0
+"app-20210319163812-1778","",9,"Register input tables",0,0
+"app-20210319163812-1778","",19,"Register input tables",0,0
+"app-20210319163812-1778","",1,"Register input tables",0,0
+"app-20210319163812-1778","",10,"Register input tables",0,0
+"app-20210319163812-1778","",16,"Register input tables",0,0
+"app-20210319163812-1778","",7,"Register input tables",0,0
+"app-20210319163812-1778","",22,"Register input tables",0,0
+"app-20210319163812-1778","",13,"Register input tables",0,0
+"app-20210319163812-1778","",4,"Register input tables",0,0
+"app-20210319163812-1778","",14,"Register input tables",0,0
+"app-20210319163812-1778","",20,"Register input tables",0,0
+"app-20210319163812-1778","",2,"Register input tables",0,0
+"app-20210319163812-1778","",11,"Register input tables",0,0
+"app-20210319163812-1778","",17,"Register input tables",0,0
+"app-20210319163812-1778","",8,"Register input tables",0,0
+"app-20210319163812-1778","",23,"Register input tables",0,0

--- a/core/src/test/resources/QualificationExpectations/qual_test_simple_expectation_persql.csv
+++ b/core/src/test/resources/QualificationExpectations/qual_test_simple_expectation_persql.csv
@@ -1,18 +1,18 @@
-App Name,App ID,Root SQL ID,SQL ID,SQL Description,SQL DF Duration,GPU Opportunity
-"Rapids Spark Profiling Tool Unit Tests","local-1622043423018","",1,"count at QualificationInfoUtils.scala:94",7143,6719
-"Rapids Spark Profiling Tool Unit Tests","local-1622043423018","",3,"count at QualificationInfoUtils.scala:94",2052,1660
-"Rapids Spark Profiling Tool Unit Tests","local-1622043423018","",2,"count at QualificationInfoUtils.scala:94",1933,1551
-"Spark shell","local-1651187225439","",0,"show at <console>:26",498,333
-"Spark shell","local-1651188809790","",0,"show at <console>:26",715,242
-"Rapids Spark Profiling Tool Unit Tests","local-1622043423018","",0,"json at QualificationInfoUtils.scala:76",1306,164
-"Spark shell","local-1651188809790","",1,"show at <console>:26",196,135
-"Spark shell","local-1651187225439","",1,"show at <console>:26",262,110
-"Rapids Spark Profiling Tool Unit Tests","local-1623281204390","",2,"json at QualificationInfoUtils.scala:136",321,107
-"Rapids Spark Profiling Tool Unit Tests","local-1623281204390","",5,"json at QualificationInfoUtils.scala:136",129,43
-"Rapids Spark Profiling Tool Unit Tests","local-1623281204390","",8,"json at QualificationInfoUtils.scala:136",127,42
-"Rapids Spark Profiling Tool Unit Tests","local-1623281204390","",4,"createOrReplaceTempView at QualificationInfoUtils.scala:133",22,22
-"Rapids Spark Profiling Tool Unit Tests","local-1623281204390","",7,"createOrReplaceTempView at QualificationInfoUtils.scala:133",4,4
-"Rapids Spark Profiling Tool Unit Tests","local-1623281204390","",1,"createOrReplaceTempView at QualificationInfoUtils.scala:133",2,2
-"Rapids Spark Profiling Tool Unit Tests","local-1623281204390","",0,"json at QualificationInfoUtils.scala:130",1209,0
-"Rapids Spark Profiling Tool Unit Tests","local-1623281204390","",6,"json at QualificationInfoUtils.scala:130",110,0
-"Rapids Spark Profiling Tool Unit Tests","local-1623281204390","",3,"json at QualificationInfoUtils.scala:130",108,0
+App ID,Root SQL ID,SQL ID,SQL Description,SQL DF Duration,GPU Opportunity
+"local-1622043423018","",1,"count at QualificationInfoUtils.scala:94",7143,6719
+"local-1622043423018","",3,"count at QualificationInfoUtils.scala:94",2052,1660
+"local-1622043423018","",2,"count at QualificationInfoUtils.scala:94",1933,1551
+"local-1651187225439","",0,"show at <console>:26",498,333
+"local-1651188809790","",0,"show at <console>:26",715,242
+"local-1622043423018","",0,"json at QualificationInfoUtils.scala:76",1306,164
+"local-1651188809790","",1,"show at <console>:26",196,135
+"local-1651187225439","",1,"show at <console>:26",262,110
+"local-1623281204390","",2,"json at QualificationInfoUtils.scala:136",321,107
+"local-1623281204390","",5,"json at QualificationInfoUtils.scala:136",129,43
+"local-1623281204390","",8,"json at QualificationInfoUtils.scala:136",127,42
+"local-1623281204390","",4,"createOrReplaceTempView at QualificationInfoUtils.scala:133",22,22
+"local-1623281204390","",7,"createOrReplaceTempView at QualificationInfoUtils.scala:133",4,4
+"local-1623281204390","",1,"createOrReplaceTempView at QualificationInfoUtils.scala:133",2,2
+"local-1623281204390","",0,"json at QualificationInfoUtils.scala:130",1209,0
+"local-1623281204390","",6,"json at QualificationInfoUtils.scala:130",110,0
+"local-1623281204390","",3,"json at QualificationInfoUtils.scala:130",108,0


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1527

Disable the text format output generated per-sql. The target is to reduce the noise of the stdout and improve the performance of the core-tools

### Impact on the output:

- `rapids_4_spark_qualification_output_persql.log` is not generated anymore by the qualTool
- remove column `AppName` from `rapids_4_spark_qualification_output_persql.csv`
- the `rapids_4_spark_qualification_output_persql.log` can still be generated by the RunningQualificationApp
- The order of the SQls in the CSV file has changed. Sorted Desc based on (GPU opportunity, and DF duration) whithin each app. Perviously, the SQLs were sorted globally which might cause considerable overhead for a large number of eventogs.

### Impact on Performance and usability:

- Improve readability of the stdout/log generated by the tools.
- Reduce the size of lines consumed by the python wrapper.
- Sorting Sqls per-app implies less memory requirements since it is only required to maintain the list of SQL for the current iteration.
- Improve the string construction by avoiding filling `Buffer<String, Int>`
- Improve the performance by skipping generating and writing the log file to the disk.

## Details

This pull request to `core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala` includes changes to improve the performance and structure of the SQL CSV report generation and related functionality. The most important changes include the removal of the application name from the per-SQL report, the optimization of string concatenation and object allocation, and updates to the test expectations to reflect these changes.

Improvements to report generation:

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala`](diffhunk://#diff-ecc91561085c2c415a2aa0b42c1465f8db84ac48c7957f5aea86f3a504cd156dR194-R252): Added a new method `writePerSqlCSVReport` to generate the per-SQL CSV report with optimized string concatenation and reduced object allocations. Removed the application name from the report and updated the header construction accordingly. 

Changes to related classes:

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala`](diffhunk://#diff-f00396d69ba02ca86319afc1095fcf0a2d7a9f25f3d7799fe58f6e61ca65889eL251): Removed the call to `writePerSqlTextReport` and updated the call to `writePerSqlCSVReport` to reflect the new method signature.
* [`core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualOutputWriter.scala`](diffhunk://#diff-8fb9151af85918e8902b866b562094e11e3a1c5f67e4dfb024313124222af283L54-R55): Updated the header construction to remove the application name size.
* [`core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala`](diffhunk://#diff-85a71ceb5cddbd2e0c01e20a32d4168fdddfd9b462348550806c743262654cc9L84-R86): Simplified the header construction by removing the application name size.

Updates to test expectations

