### PR TITLE
AutoTuner/Bootstrapper should recommend Dataproc Spark performance enhancements

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -590,6 +590,11 @@ class DataprocPlatform(gpuDevice: Option[GpuDevice],
     clusterProperties: Option[ClusterProperties]) extends Platform(gpuDevice, clusterProperties) {
   override val platformName: String = PlatformNames.DATAPROC
   override val defaultGpuDevice: GpuDevice = T4Gpu
+  override val recommendationsToInclude: Seq[(String, String)] = Seq(
+    "spark.dataproc.enhanced.optimizer.enabled" -> "true",
+    "spark.dataproc.enhanced.execution.enabled" -> "true"
+  )
+
   override def isPlatformCSP: Boolean = true
   override def maxGpusSupported: Int = 4
 


### PR DESCRIPTION
Fixes #1538.

This PR updates AutoTuner/Bootstrapper to recommend the following Dataproc Spark performance enhancements

```
spark.dataproc.enhanced.optimizer.enabled=true
spark.dataproc.enhanced.execution.enabled=true
```

Reference - https://cloud.google.com/dataproc/docs/guides/performance-enhancements