### PR TITLE
TaskModel + AccumInfo refactor for memory optimisation

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/AccumInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/AccumInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/AccumInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/AccumInfo.scala
@@ -33,8 +33,8 @@ import org.apache.spark.sql.rapids.tool.util.EventUtils.parseAccumFieldToLong
  */
 class AccumInfo(val infoRef: AccumMetaRef) {
   // TODO: use sorted maps for stageIDs and taskIds?
-  val taskUpdatesMap: mutable.HashMap[Long, Long] =
-    new mutable.HashMap[Long, Long]()
+  val taskUpdatesMap: mutable.LongMap[Long] =
+    new mutable.LongMap[Long]()
   val stageValuesMap: mutable.HashMap[Int, Long] =
     new mutable.HashMap[Int, Long]()
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/TaskModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/TaskModel.scala
@@ -116,11 +116,10 @@ object TaskModel {
     }
 
 
-    val taskMetrics = immutable.IntMap.empty[Long]
+    var taskMetrics = immutable.IntMap.empty[Long]
 
     def storeIfNonZero(field: Int, value: Long): Unit =
-      if (value != 0) taskMetrics.updated(field, value)
-
+      if (value != 0) taskMetrics = taskMetrics.updated(field, value)
     storeIfNonZero(LAUNCH_TIME, taskInfo.launchTime)
     storeIfNonZero(FINISH_TIME, taskInfo.finishTime)
     storeIfNonZero(DURATION, taskInfo.duration)

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/TaskModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/TaskModel.scala
@@ -18,7 +18,9 @@ package org.apache.spark.sql.rapids.tool.store
 
 import scala.collection.immutable
 
+import org.apache.spark.TaskFailedReason
 import org.apache.spark.scheduler.SparkListenerTaskEnd
+
 
 
 object LongMetrics {
@@ -106,6 +108,13 @@ object TaskModel {
     val shuffleWrite = metrics.shuffleWriteMetrics
     val input = metrics.inputMetrics
     val output = metrics.outputMetrics
+    val reason = event.reason match {
+      case failed: TaskFailedReason =>
+        failed.toErrorString
+      case _ =>
+        event.reason.toString
+    }
+
 
     val taskMetrics = immutable.IntMap.empty[Long]
 
@@ -148,7 +157,7 @@ object TaskModel {
       stageId = event.stageId,
       stageAttemptId = event.stageAttemptId,
       taskType = event.taskType,
-      endReason = event.reason.toString,
+      endReason = reason,
       taskId = taskInfo.taskId,
       attempt = taskInfo.attemptNumber,
       successful = taskInfo.successful,


### PR DESCRIPTION
Solves for #815 

### Changes -

This PR introduces the following refactors - 

1. [core/src/main/scala/org/apache/spark/sql/rapids/tool/store/AccumInfo.scala](https://github.com/NVIDIA/spark-rapids-tools/blob/701a109634a9ce41c2c23160bbf87a1c8c51f27d/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/AccumInfo.scala) - previously AccumInfo used HashMap for maintaining  tasks to update value mapping. Now HashMap by default boxes its data i.e. long is converted to Long. This adds extra memory requirements ( references, hashes ) inflating the memory requirement ( 8B -> 24B ). LongMap does not do that internally ArrayBuffers with primitive types. 
2. [core/src/main/scala/org/apache/spark/sql/rapids/tool/store/TaskModel.scala](https://github.com/NVIDIA/spark-rapids-tools/blob/701a109634a9ce41c2c23160bbf87a1c8c51f27d/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/TaskModel.scala) - `TaskModel` is a class that maintains details related to a TaskInfo. On observation the data related to TaskModel was pretty sparse( metrics like bytesread, byteswritten are only present in a few ). Hence updating the structure to maintain the long value metrics in a map and storing them only when required non zero.

### Improvements - 

This refactor improves the shallow memory usage by **~35%**. Attached are the screenshots from the peak heap dump -

### Old heap dump -

![Screenshot 2025-02-10 at 5 32 33 PM](https://github.com/user-attachments/assets/6eb49ca4-96ec-4faa-acc9-1a86aa1c6b6c)

### Post refactor dump - 

![Screenshot 2025-02-10 at 5 27 57 PM](https://github.com/user-attachments/assets/7fd06e9d-f627-4e33-b025-4cc0621f64d4)

### Testing - 

This has been tested against a [databricks event log file](s3://spark-data/rapids-tools/tests/performance/eventlogs/cpu/eventLogs-app-20241108232659-0062.tgz) and improves the minimum heap required by **15%** down from **12GB** to **14GB**

Although the heap analysis show the peak usage going down till 9GB, the reason it still needs the extra heap buffer is the usage of LongMap and IntMap which do reallocation where it double the current Buffer size even though it does not need it.

### Optimisation -

Optimisation of this can be using 3rd party Map implementations which can further leverage the remaining heap space

### Update on further testing

On further testing and discussion, this result is not very consistent though. Mainly because of the way LongMap and IntMap function ( over allocation of fixed buffer memory ).

A better **long term** solution would be to get rid of TaskModel altogether and leverage the Accumulable to get this information. This is just used to get the Task level metrics ( min, med, max, sum) and all of these can be retrieved from the accumulable information that we are storing.