### PR TITLE
Generate a detailed report for the write ops

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/HiveParseHelper.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/HiveParseHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids.tool.planparser
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
-import org.apache.spark.sql.rapids.tool.util.EventUtils
+import org.apache.spark.sql.rapids.tool.util.{EventUtils, StringUtils}
 
 // A wrapper class to map between
 case class HiveScanSerdeClasses(className: String, format: String) extends Logging {
@@ -68,7 +68,7 @@ object HiveParseHelper extends Logging {
   }
 
   def getHiveFormatFromSimpleStr(str: String): String = {
-    LOADED_SERDE_CLASSES.find(_.accepts(str)).map(_.format).getOrElse("unknown")
+    LOADED_SERDE_CLASSES.find(_.accepts(str)).map(_.format).getOrElse(StringUtils.UNKNOWN_EXTRACT)
   }
 
   // Given a "scan hive" NodeGraph, construct the MetaData based on the SerDe class.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ReadParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ReadParser.scala
@@ -22,6 +22,7 @@ import com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
+import org.apache.spark.sql.rapids.tool.util.StringUtils
 
 case class ReadMetaData(schema: String, location: String, format: String,
     tags: Map[String, String] = ReadParser.DEFAULT_METAFIELD_MAP) {
@@ -60,7 +61,7 @@ object ReadParser extends Logging {
   val METAFIELD_TAG_FORMAT = "Format"
   val METAFIELD_TAG_LOCATION = "Location"
 
-  val UNKNOWN_METAFIELD: String = "unknown"
+  val UNKNOWN_METAFIELD: String = StringUtils.UNKNOWN_EXTRACT
   val DEFAULT_METAFIELD_MAP: Map[String, String] = collection.immutable.Map(
     METAFIELD_TAG_DATA_FILTERS -> UNKNOWN_METAFIELD,
     METAFIELD_TAG_PUSHED_FILTERS -> UNKNOWN_METAFIELD,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ops/OperatorRefBase.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ops/OperatorRefBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,8 @@ import org.apache.spark.sql.rapids.tool.util.StringUtils
 
 class OperatorRefBase(val value: String, val opType: OpTypes.OpType) extends OperatorRefTrait {
   // Preformatted values for CSV output to avoid reformatting multiple times.
-  val csvValue: String = StringUtils.reformatCSVString(value)
-  val csvOpType: String = StringUtils.reformatCSVString(opType.toString)
+  lazy val csvValue: String = StringUtils.reformatCSVString(value)
+  lazy val csvOpType: String = StringUtils.reformatCSVString(opType.toString)
 
   override def getOpName: String = value
   override def getOpNameCSV: String = csvValue

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids.tool.profiling
 
 import com.nvidia.spark.rapids.SparkRapidsBuildInfoEvent
 import com.nvidia.spark.rapids.tool.AppSummaryInfoBaseProvider
+import com.nvidia.spark.rapids.tool.views.WriteOpProfileResult
 
 case class ApplicationSummaryInfo(
     appInfo: Seq[AppInfoProfileResults],
@@ -47,7 +48,8 @@ case class ApplicationSummaryInfo(
     ioMetrics: Seq[IOAnalysisProfileResult],
     sysProps: Seq[RapidsPropertyProfileResult],
     sqlCleanedAlignedIds: Seq[SQLCleanAndAlignIdsProfileResult],
-    sparkRapidsBuildInfo: Seq[SparkRapidsBuildInfoEvent])
+    sparkRapidsBuildInfo: Seq[SparkRapidsBuildInfoEvent],
+    writeOpsInfo: Seq[WriteOpProfileResult])
 
 trait AppInfoPropertyGetter {
   // returns all the properties (i.e., spark)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
@@ -56,6 +56,11 @@ class CollectInformation(apps: Seq[ApplicationInfo]) extends Logging {
     ProfDataSourceView.getRawView(apps, cachedSqlAccum)
   }
 
+  // get the write records information
+  def getWriteOperationInfo: Seq[WriteOpProfileResult] = {
+    ProfWriteOpsView.getRawView(apps)
+  }
+
   // get executor related information
   def getExecutorInfo: Seq[ExecutorInfoProfileResult] = {
     ProfExecutorView.getRawView(apps)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualSQLPlanAnalyzer.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualSQLPlanAnalyzer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,7 @@
 package com.nvidia.spark.rapids.tool.qualification
 
 import com.nvidia.spark.rapids.tool.analysis.AppSQLPlanAnalyzer
-import com.nvidia.spark.rapids.tool.planparser.DataWritingCommandExecParser
 
-import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
 import org.apache.spark.sql.rapids.tool.qualification.QualificationAppInfo
 
 /**
@@ -35,14 +33,4 @@ import org.apache.spark.sql.rapids.tool.qualification.QualificationAppInfo
 class QualSQLPlanAnalyzer(
     app: QualificationAppInfo, appIndex: Integer) extends AppSQLPlanAnalyzer(app, appIndex) {
 
-  override def visitNode(visitor: SQLPlanVisitorContext,
-      node: SparkPlanGraphNode): Unit = {
-    super.visitNode(visitor, node)
-    // Get the write data format
-    if (!app.perSqlOnly) {
-      DataWritingCommandExecParser.getWriteCMDWrapper(node).map { wWrapper =>
-        app.writeDataFormat += wWrapper.dataFormat
-      }
-    }
-  }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/JobView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/JobView.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ trait AppFailedJobsViewTrait extends ViewableTrait[FailedJobsProfileResults] {
     }
     jobsFailed.map { case (id, jc) =>
       val failureStr = jc.failedReason.getOrElse("")
-      FailedJobsProfileResults(index, id, jc.jobResult.getOrElse("Unknown"),
+      FailedJobsProfileResults(index, id, jc.jobResult.getOrElse(StringUtils.UNKNOWN_EXTRACT),
         StringUtils.renderStr(failureStr, doEscapeMetaCharacters = false, maxLength = 0))
     }.toSeq
   }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/QualRawReportGenerator.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/QualRawReportGenerator.scala
@@ -109,6 +109,8 @@ object QualRawReportGenerator extends Logging {
       pWriter.write(QualAppFailedJobView.getLabel, QualAppFailedJobView.getRawView(Seq(app)))
       pWriter.write(QualRemovedBLKMgrView.getLabel, QualRemovedBLKMgrView.getRawView(Seq(app)))
       pWriter.write(QualRemovedExecutorView.getLabel, QualRemovedExecutorView.getRawView(Seq(app)))
+      // we only need to write the CSV report of the WriteOps
+      pWriter.writeCSVTable(QualWriteOpsView.getLabel, QualWriteOpsView.getRawView(Seq(app)))
     } catch {
       case e: Exception =>
         logError(s"Error generating raw metrics for ${app.appId}: ${e.getMessage}")

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/WriteOpsView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/WriteOpsView.scala
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.views
+
+import scala.collection.breakOut
+
+import com.nvidia.spark.rapids.tool.analysis.{ProfAppIndexMapperTrait, QualAppIndexMapperTrait}
+import com.nvidia.spark.rapids.tool.profiling.ProfileResult
+
+import org.apache.spark.sql.rapids.tool.AppBase
+import org.apache.spark.sql.rapids.tool.store.WriteOperationRecord
+import org.apache.spark.sql.rapids.tool.util.StringUtils
+
+/**
+ * Represents a single write operation profiling result.
+ * This case class implements the `ProfileResult` trait and provides methods
+ * to convert the result into sequences of strings for display or CSV export.
+ *
+ * @param appIndex The index of the application this result belongs to.
+ * @param record The write operation record containing metadata and details.
+ */
+case class WriteOpProfileResult(
+    appIndex: Int,
+    record: WriteOperationRecord) extends ProfileResult {
+
+  /**
+   * Defines the headers for the output display.
+   */
+  override val outputHeaders: Seq[String] = {
+    Seq("appIndex", "sqlID", "sqlPlanVersion", "nodeId", "fromFinalPlan", "execName", "format",
+      "location", "tableName", "dataBase", "outputColumns", "writeMode", "fullDescription")
+  }
+
+  /**
+   * Converts the profiling result into a sequence of strings for display.
+   * Escapes special characters in the description and truncates long strings.
+   */
+  override def convertToSeq: Seq[String] = {
+    Seq(appIndex.toString,
+      record.sqlID.toString,
+      record.version.toString,
+      record.nodeId.toString,
+      record.fromFinalPlan.toString,
+      // Extract metadata information
+      record.operationMeta.execName(),
+      record.operationMeta.dataFormat(),
+      record.operationMeta.outputPath(),
+      record.operationMeta.table(),
+      record.operationMeta.dataBase(),
+      record.operationMeta.outputColumns(),
+      record.operationMeta.writeMode(),
+      // Escape special characters in the description
+      StringUtils.renderStr(record.operationMeta.fullDescr(), doEscapeMetaCharacters = true,
+        maxLength = 500, showEllipses = true))
+  }
+
+  /**
+   * Converts the profiling result into a sequence of strings formatted for CSV output.
+   * Escapes special characters and truncates long descriptions to a maximum length.
+   */
+  override def convertToCSVSeq: Seq[String] = {
+    Seq(appIndex.toString,
+      record.sqlID.toString,
+      record.version.toString,
+      record.nodeId.toString,
+      record.fromFinalPlan.toString,
+      // Extract metadata information for CSV
+      record.operationMeta.execNameCSV,
+      record.operationMeta.formatCSV,
+      StringUtils.reformatCSVString(record.operationMeta.outputPath()),
+      StringUtils.reformatCSVString(record.operationMeta.table()),
+      StringUtils.reformatCSVString(record.operationMeta.dataBase()),
+      StringUtils.reformatCSVString(record.operationMeta.outputColumns()),
+      record.operationMeta.writeMode(),
+      StringUtils.reformatCSVString(
+        // Escape special characters in the description and trim at 500 characters.
+        StringUtils.renderStr(record.operationMeta.fullDescr(), doEscapeMetaCharacters = true,
+          maxLength = 500, showEllipses = true)))
+  }
+}
+
+/**
+ * A trait for creating views of write operation profiling results.
+ * This trait provides methods to extract raw results, sort them, and label the view.
+ */
+trait WriteOpsViewTrait extends ViewableTrait[WriteOpProfileResult] {
+
+  /**
+   * Returns the label for the view.
+   */
+  override def getLabel: String = "Write Operations"
+
+  /**
+   * Extracts raw write operation records from the given application and maps them
+   * to `WriteOpProfileResult` instances.
+   *
+   * @param app The application containing write operation records.
+   * @param index The index of the application.
+   * @return A sequence of `WriteOpProfileResult` instances.
+   */
+  def getRawView(app: AppBase, index: Int): Seq[WriteOpProfileResult] = {
+    app.getWriteOperationRecords().map { w =>
+      WriteOpProfileResult(index, w)
+    }(breakOut)
+  }
+
+  /**
+   * Sorts the write operation profiling results by application index, SQL ID,
+   * plan version, and node ID.
+   *
+   * @param rows The sequence of profiling results to sort.
+   * @return A sorted sequence of profiling results.
+   */
+  override def sortView(rows: Seq[WriteOpProfileResult]): Seq[WriteOpProfileResult] = {
+    rows.sortBy(cols => (cols.appIndex, cols.record.sqlID, cols.record.version,
+      cols.record.nodeId))
+  }
+}
+
+/**
+ * A view for write operation profiling results specific to Qualification workflows.
+ * Extends `WriteOpsViewTrait` and implements `QualAppIndexMapperTrait` for customization.
+ */
+object QualWriteOpsView extends WriteOpsViewTrait with QualAppIndexMapperTrait {
+  // Placeholder for future customization specific to Qualification workflows.
+}
+
+/**
+ * A view for write operation profiling results specific to Profiling workflows.
+ * Extends `WriteOpsViewTrait` and implements `ProfAppIndexMapperTrait` for customization.
+ */
+object ProfWriteOpsView extends WriteOpsViewTrait with ProfAppIndexMapperTrait {
+  // Placeholder for future customization specific to Profiling workflows.
+}

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.rapids.tool.qualification
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
 import scala.collection.mutable.{ArrayBuffer, HashMap}
-import scala.collection.mutable
 
 import com.nvidia.spark.rapids.tool.{EventLogInfo, Platform}
 import com.nvidia.spark.rapids.tool.planparser.{ExecInfo, PlanInfo, SQLPlanParser}
@@ -47,9 +46,6 @@ class QualificationAppInfo(
 
   var lastJobEndTime: Option[Long] = None
   var lastSQLEndTime: Option[Long] = None
-  // Keeps track of the WriteDataFormats used in the WriteExecs
-  // Use LinkedHashSet to preserve Order of insertion and avoid duplicates
-  val writeDataFormat: mutable.AbstractSet[String] = mutable.LinkedHashSet[String]()
 
   val sqlIDToTaskEndSum: HashMap[Long, StageTaskQualificationSummary] =
     HashMap.empty[Long, StageTaskQualificationSummary]
@@ -505,7 +501,7 @@ class QualificationAppInfo(
         val typeString = types.mkString(":").replace(",", ":")
         s"${format}[$typeString]"
       }.toSeq
-      val writeFormat = writeFormatNotSupported(writeDataFormat)
+      val writeFormat = writeFormatNotSupported(getWriteDataFormats())
       val (allComplexTypes, nestedComplexTypes) = reportComplexTypes
       val problems = getPotentialProblemsForDf
 
@@ -827,7 +823,7 @@ class QualificationAppInfo(
     }
   }
 
-  private def writeFormatNotSupported(writeFormat: mutable.AbstractSet[String]): Seq[String] = {
+  private def writeFormatNotSupported(writeFormat: Set[String]): Seq[String] = {
     // Filter unsupported write data format
     val unSupportedWriteFormat = pluginTypeChecker.getUnsupportedWriteFormat(writeFormat)
     unSupportedWriteFormat.toSeq

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,8 @@ class SQLPlanModel(val id: Long) {
   // After adding a new version, reset the previous plan if necessary
   protected def resetPreviousPlan(): Unit = {
     plan.resetFinalFlag()
+    // call any cleanup code necessary for the plan
+    plan.cleanUpPlan()
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManager.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManager.scala
@@ -16,8 +16,7 @@
 
 package org.apache.spark.sql.rapids.tool.store
 
-import scala.collection.immutable
-import scala.collection.mutable
+import scala.collection.{breakOut, immutable, mutable}
 
 import org.apache.spark.sql.execution.SparkPlanInfo
 
@@ -125,5 +124,22 @@ class SQLPlanModelManager {
    */
   def getPlanInfos: immutable.Map[Long, SparkPlanInfo] = {
     immutable.SortedMap[Long, SparkPlanInfo]() ++ sqlPlans.mapValues(_.planInfo)
+  }
+
+  /**
+   * Gets all the writeRecords of of the final plan of the SQL
+   * @return Iterable of WriteOperationRecord representing the write operations.
+   */
+  def getWriteOperationRecords(): Iterable[WriteOperationRecord] = {
+    sqlPlans.values.flatMap(_.plan.writeRecords)
+  }
+
+  /**
+   * Converts the writeOperations into a String set to represent the format of the writeOps.
+   * This only pulls the information from the final plan of the SQL.
+   * @return a set of write formats
+   */
+  def getWriteFormats(): Set[String] = {
+    sqlPlans.values.flatMap(_.plan.getWriteDataFormats)(breakOut)
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelWithDSCaching.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelWithDSCaching.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ class SQLPlanModelWithDSCaching(sqlId: Long) extends SQLPlanModel(sqlId) {
     plan.resetFinalFlag()
     // cache the datasource records from previous plan if any
     cachedDataSources ++= plan.getAllReadDS
+    // call any cleanup code necessary for the plan
+    plan.cleanUpPlan()
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/WriteOperationStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/WriteOperationStore.scala
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool.store
+
+
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.util.control.NonFatal
+
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.rapids.tool.util.StringUtils
+
+/**
+ * Represents a unique reference for a name, with a reformatted CSV value.
+ * @param value The original name value.
+ */
+case class UniqueNameRef(value: String) {
+  // Lazily reformats the name value into a CSV-compatible string.
+  lazy val csvValue: String = StringUtils.reformatCSVString(value)
+}
+
+/**
+ * Trait defining metadata for write operations.
+ * This trait provides default implementations for metadata fields
+ * related to write operations, which can be overridden by subclasses.
+ */
+trait WriteOperationMetadataTrait {
+  def execName(): String = StringUtils.UNKNOWN_EXTRACT // Name of the execution
+  def dataFormat(): String = StringUtils.UNKNOWN_EXTRACT // Data format (e.g., CSV, Parquet)
+  def outputPath(): String = StringUtils.UNKNOWN_EXTRACT // Output path for the write operation
+  def outputColumns(): String = StringUtils.UNKNOWN_EXTRACT // Output columns involved
+  def writeMode(): String = StringUtils.UNKNOWN_EXTRACT // Save mode (e.g., Overwrite, Append)
+  def table(): String = StringUtils.UNKNOWN_EXTRACT // Table name (if applicable)
+  def dataBase(): String = StringUtils.UNKNOWN_EXTRACT // Database name (if applicable)
+  def fullDescr(): String = "..." // Full description of the operation
+  def execNameCSV: String // CSV-compatible execution name
+  def formatCSV: String // CSV-compatible data format
+}
+
+/**
+ * Metadata implementation for write operations with a specific format.
+ * @param writeExecName The execution name reference.
+ * @param format The data format reference.
+ * @param descr Optional description of the operation.
+ */
+class WriteOperationMetaWithFormat(
+    writeExecName: UniqueNameRef,
+    format: UniqueNameRef,
+    descr: Option[String]) extends WriteOperationMetadataTrait {
+  override def dataFormat(): String = format.value
+  override def fullDescr(): String = descr.getOrElse("")
+  override def execName(): String = writeExecName.value
+  override def execNameCSV: String = writeExecName.csvValue
+  override def formatCSV: String = format.csvValue
+}
+
+/**
+ * Metadata implementation for write operations with additional details.
+ * @param writeExecName The execution name reference.
+ * @param format The data format reference.
+ * @param outputPathValue Optional output path.
+ * @param outputColumnsValue Optional output columns.
+ * @param saveMode Optional save mode.
+ * @param tableName Table name (if applicable).
+ * @param dataBaseName Database name (if applicable).
+ * @param descr Optional description of the operation.
+ */
+case class WriteOperationMeta(
+    writeExecName: UniqueNameRef,
+    format: UniqueNameRef,
+    outputPathValue: Option[String],
+    outputColumnsValue: Option[String],
+    saveMode: Option[SaveMode],
+    tableName: String,
+    dataBaseName: String,
+    descr: Option[String]) extends WriteOperationMetaWithFormat(
+      writeExecName, format, descr) {
+  override def writeMode(): String = {
+    saveMode match {
+      case Some(w) => w.toString
+      case _ => StringUtils.UNKNOWN_EXTRACT
+    }
+  }
+  override def outputPath(): String = outputPathValue.getOrElse(StringUtils.UNKNOWN_EXTRACT)
+  override def outputColumns(): String = outputColumnsValue.getOrElse(StringUtils.UNKNOWN_EXTRACT)
+  override def table(): String = tableName
+  override def dataBase(): String = dataBaseName
+}
+
+/**
+ * Represents a record of a write operation.
+ * @param sqlID The SQL ID associated with the operation.
+ * @param version The version of the operation.
+ * @param nodeId The node ID in the execution plan.
+ * @param operationMeta Metadata for the write operation.
+ * @param fromFinalPlan Indicates if the metadata is from the final execution plan.
+ */
+case class WriteOperationRecord(
+    sqlID: Long,
+    version: Int,
+    nodeId: Long,
+    operationMeta: WriteOperationMetadataTrait,
+    fromFinalPlan: Boolean = true)
+
+/**
+ * Builder object for creating instances of WriteOperationMetadataTrait.
+ * Provides utility methods to construct metadata objects with various levels of detail.
+ */
+object WriteOperationMetaBuilder {
+  // Default unknown name reference
+  private val UNKNOWN_NAME_REF = UniqueNameRef(StringUtils.UNKNOWN_EXTRACT)
+
+  // Default unknown metadata
+  private val UNKNOWN_WRITE_META =
+    new WriteOperationMetaWithFormat(UNKNOWN_NAME_REF, UNKNOWN_NAME_REF, None)
+
+  // Concurrent hash map to store data format references
+  private val DATA_FORMAT_TABLE: ConcurrentHashMap[String, UniqueNameRef] = {
+    val initMap = new ConcurrentHashMap[String, UniqueNameRef]()
+    initMap.put(StringUtils.UNKNOWN_EXTRACT, UNKNOWN_NAME_REF)
+    initMap
+  }
+
+  // Concurrent hash map to store execution name references
+  private val WRITE_EXEC_TABLE: ConcurrentHashMap[String, UniqueNameRef] = {
+    val initMap = new ConcurrentHashMap[String, UniqueNameRef]()
+    initMap.put(StringUtils.UNKNOWN_EXTRACT, UNKNOWN_NAME_REF)
+    initMap
+  }
+
+  /**
+   * Returns a default value if the input string is null or empty.
+   * @param value The input string.
+   * @return The default value or the input string.
+   */
+  private def defaultIfUnknown(value: String): String = {
+    if (value == null || value.isEmpty) StringUtils.UNKNOWN_EXTRACT else value
+  }
+
+  /**
+   * Retrieves or creates a UniqueNameRef for the given data format.
+   * @param name The data format name.
+   * @return A UniqueNameRef for the data format.
+   */
+  private def getOrCreateFormatRef(name: String): UniqueNameRef = {
+    DATA_FORMAT_TABLE.computeIfAbsent(defaultIfUnknown(name), k => UniqueNameRef(k))
+  }
+
+  /**
+   * Retrieves or creates a UniqueNameRef for the given execution name.
+   * @param name The execution name.
+   * @return A UniqueNameRef for the execution name.
+   */
+  private def getOrCreateExecRef(name: String): UniqueNameRef = {
+    WRITE_EXEC_TABLE.computeIfAbsent(defaultIfUnknown(name), k => UniqueNameRef(k))
+  }
+
+  /**
+   * Converts a string to a SaveMode, if possible.
+   * @param name The string representation of the save mode.
+   * @return An Option containing the SaveMode, or None if conversion fails.
+   */
+  private def getSaveModeFromString(name: String): Option[SaveMode] = {
+    val str = defaultIfUnknown(name)
+    try {
+      Some(SaveMode.valueOf(str))
+    } catch { // Failed to convert the string to SaveMode.
+      case NonFatal(_) => None
+    }
+  }
+
+  /**
+   * Builds a WriteOperationMetadataTrait with detailed metadata.
+   * @param execName The execution name.
+   * @param dataFormat The data format.
+   * @param outputPath Optional output path.
+   * @param outputColumns Optional output columns.
+   * @param writeMode The save mode.
+   * @param tableName The table name.
+   * @param dataBaseName The database name.
+   * @param fullDescr Optional full description.
+   * @return A WriteOperationMetadataTrait instance.
+   */
+  def build(execName: String, dataFormat: String, outputPath: Option[String],
+    outputColumns: Option[String],
+    writeMode: String,
+    tableName: String,
+    dataBaseName: String,
+    fullDescr: Option[String]): WriteOperationMetadataTrait = {
+    WriteOperationMeta(getOrCreateExecRef(execName), getOrCreateFormatRef(dataFormat),
+      outputPath, outputColumns, getSaveModeFromString(writeMode),
+      defaultIfUnknown(tableName), defaultIfUnknown(dataBaseName),
+      fullDescr)
+  }
+
+  /**
+   * Builds a WriteOperationMetadataTrait with minimal metadata.
+   * @param execName The execution name.
+   * @param dataFormat The data format.
+   * @param fullDescr Optional full description.
+   * @return A WriteOperationMetadataTrait instance.
+   */
+  def build(execName: String, dataFormat: String,
+    fullDescr: Option[String]): WriteOperationMetadataTrait = {
+    new WriteOperationMetaWithFormat(getOrCreateExecRef(execName),
+      getOrCreateFormatRef(dataFormat), fullDescr)
+  }
+
+  /**
+   * Builds a WriteOperationMetadataTrait with no metadata.
+   * @param fullDescr Optional full description.
+   * @return A WriteOperationMetadataTrait instance with unknown metadata.
+   */
+  def buildNoMeta(fullDescr: Option[String]): WriteOperationMetadataTrait = {
+    if (fullDescr.isDefined) {
+      new WriteOperationMetaWithFormat(UNKNOWN_NAME_REF, UNKNOWN_NAME_REF, fullDescr)
+    } else {
+      UNKNOWN_WRITE_META
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/StringUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/StringUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ import org.apache.spark.internal.Logging
  * strings.
  */
 object StringUtils extends Logging {
+  // Constant used to replace the unknown values
+  val UNKNOWN_EXTRACT: String = "unknown"
   // Regular expression for duration-format 'H+:MM:SS.FFF'
   // Note: this is not time-of-day. Hours can be larger than 12.
   private val regExDurationFormat = "^(\\d+):([0-5]\\d):([0-5]\\d\\.\\d+)$"

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/WriteOperationParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/WriteOperationParserSuite.scala
@@ -67,7 +67,7 @@ class WriteOperationParserSuite extends FunSuite {
       desc = "Execute InsertIntoHadoopFsRelationCommand gs://path/to/database/table1, " +
         "false, Parquet, " +
         "[serialization.format=1, mergeschema=false, __hive_compatible_bucketed_table_insertion__=true], " +
-        "Append, spark_catalog`.`database`.`table`, org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe, " +
+        "Append, `spark_catalog`.`database`.`table`, org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe, " +
         "org.apache.spark.sql.execution.datasources.InMemoryFileIndex(gs://path/to/database/table1), " +
         "[col01, col02, col03]",
       Seq.empty
@@ -158,7 +158,7 @@ class WriteOperationParserSuite extends FunSuite {
       desc = "Execute InsertIntoHadoopFsRelationCommand gs://path/to/database/table1, " +
         "false, Parquet, " +
         "[serialization.format=1, mergeschema=false, __hive_compatible_bucketed_table_insertion__=true], " +
-        "Append, spark_catalog`.`database`.`table`, org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe, " +
+        "Append, `spark_catalog`.`database`.`table`, org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe, " +
         "org.apache.spark.sql.execution.datasources.InMemoryFileIndex(gs://path/to/database/table1), " +
         "[]",
       Seq.empty
@@ -182,7 +182,7 @@ class WriteOperationParserSuite extends FunSuite {
       desc = "Execute InsertIntoHadoopFsRelationCommand gs://path/to/database/table1, " +
         "false, [paths=(path)], Parquet, " +
         "[serialization.format=1, mergeschema=false, __hive_compatible_bucketed_table_insertion__=true], " +
-        "Append, spark_catalog`.`database`.`table`, org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe, " +
+        "Append, `spark_catalog`.`database`.`table`, org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe, " +
         "org.apache.spark.sql.execution.datasources.InMemoryFileIndex(gs://path/to/database/table1), " +
         "[col01]",
       Seq.empty

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/WriteOperationParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/WriteOperationParserSuite.scala
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.planparser
+
+import org.scalatest.FunSuite
+
+import org.apache.spark.sql.execution.ui
+import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
+import org.apache.spark.sql.rapids.tool.store.WriteOperationMetadataTrait
+import org.apache.spark.sql.rapids.tool.util.StringUtils
+
+
+class WriteOperationParserSuite extends FunSuite {
+
+  /**
+   * Helper method to test `getWriteOpMetaFromNode`.
+   *
+   * @param node The input `SparkPlanGraphNode`.
+   * @param expectedExecName The expected execution name.
+   * @param expectedDataFormat The expected data format.
+   * @param expectedOutputPath The expected output path (optional).
+   * @param expectedOutputColumns The expected output columns (optional).
+   * @param expectedWriteMode The expected write mode.
+   * @param expectedTableName The expected table name.
+   * @param expectedDatabaseName The expected database name.
+   */
+  private def testGetWriteOpMetaFromNode(
+    node: SparkPlanGraphNode,
+    expectedExecName: String,
+    expectedDataFormat: String,
+    expectedOutputPath: String,
+    expectedOutputColumns: String,
+    expectedWriteMode: String,
+    expectedTableName: String,
+    expectedDatabaseName: String): Unit = {
+
+    val metadata: WriteOperationMetadataTrait =
+      DataWritingCommandExecParser.getWriteOpMetaFromNode(node)
+
+    assert(metadata.execName() == expectedExecName, "execName")
+    assert(metadata.dataFormat() == expectedDataFormat, "dataFormat")
+    assert(metadata.outputPath() == expectedOutputPath, "outputPath")
+    assert(metadata.outputColumns() == expectedOutputColumns, "outputColumns")
+    assert(metadata.writeMode() == expectedWriteMode, "writeMode")
+    assert(metadata.table() == expectedTableName, "tableName")
+    assert(metadata.dataBase() == expectedDatabaseName, "databaseName")
+  }
+  // scalastyle:off line.size.limit
+  test("InsertIntoHadoopFsRelationCommand - Common case") {
+    val node = new SparkPlanGraphNode(
+      id = 1,
+      name = "Execute InsertIntoHadoopFsRelationCommand",
+      desc = "Execute InsertIntoHadoopFsRelationCommand gs://path/to/database/table1, " +
+        "false, Parquet, " +
+        "[serialization.format=1, mergeschema=false, __hive_compatible_bucketed_table_insertion__=true], " +
+        "Append, spark_catalog`.`database`.`table`, org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe, " +
+        "org.apache.spark.sql.execution.datasources.InMemoryFileIndex(gs://path/to/database/table1), " +
+        "[col01, col02, col03]",
+      Seq.empty
+    )
+    testGetWriteOpMetaFromNode(
+      node,
+      expectedExecName = "InsertIntoHadoopFsRelationCommand",
+      expectedDataFormat = "Parquet",
+      expectedOutputPath = "gs://path/to/database/table1",
+      expectedOutputColumns = "col01;col02;col03",
+      expectedWriteMode = "Append",
+      expectedTableName = "table1",
+      expectedDatabaseName = "database"
+    )
+  }
+
+  test("getWriteOpMetaFromNode - Unknown command") {
+    val node = new SparkPlanGraphNode(
+      id = 2,
+      name = "UnknownWrite",
+      desc = "Some random description",
+      Seq.empty
+    )
+    testGetWriteOpMetaFromNode(
+      node,
+      expectedExecName = StringUtils.UNKNOWN_EXTRACT,
+      expectedDataFormat = StringUtils.UNKNOWN_EXTRACT,
+      expectedOutputPath = StringUtils.UNKNOWN_EXTRACT,
+      expectedOutputColumns = StringUtils.UNKNOWN_EXTRACT,
+      expectedWriteMode = StringUtils.UNKNOWN_EXTRACT,
+      expectedTableName = StringUtils.UNKNOWN_EXTRACT,
+      expectedDatabaseName = StringUtils.UNKNOWN_EXTRACT
+    )
+  }
+
+  test("AppendDataExecV1 - delta format") {
+    val node = new SparkPlanGraphNode(
+      id = 3,
+      name = "AppendDataExecV1",
+      // the description should include Delta keywords; otherwise it would be considered a spark Op.
+      desc =
+        s"""|AppendDataExecV1 [num_affected_rows#18560L, num_inserted_rows#18561L], DeltaTableV2(org.apache.spark.sql.SparkSession@5aa5327e,abfss://abfs_path,Some(CatalogTable(
+            |Catalog: spark_catalog
+            |Database: database
+            |Table: tableName
+            |Owner: root
+            |Created Time: Wed Sep 15 16:47:47 UTC 2021
+            |Last Access: UNKNOWN
+            |Created By: Spark 3.1.1
+            |Type: EXTERNAL
+            |Provider: delta
+            |Table Properties: [bucketing_version=2, delta.lastCommitTimestamp=1631724453000, delta.lastUpdateVersion=0, delta.minReaderVersion=1, delta.minWriterVersion=2]
+            |Location: abfss://abfs_path
+            |Serde Library: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            |InputFormat: org.apache.hadoop.mapred.SequenceFileInputFormat
+            |OutputFormat: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+            |Partition Provider: Catalog
+            |Schema: root
+            | |-- field_00: string (nullable = true)
+            | |-- field_01: string (nullable = true)
+            | |-- field_02: string (nullable = true)
+            | |-- field_03: string (nullable = true)
+            | |-- field_04: string (nullable = true)
+            | |-- field_05: string (nullable = true)
+            | |-- field_06: string (nullable = true)
+            | |-- field_07: string (nullable = true)
+            | |-- field_08: string (nullable = true)
+            |)),Some(spark_catalog.adl.tableName),None,Map()), Project [from_unixtime(unix_timestamp(current_timestamp(), yyyy-MM-dd HH:mm:ss, Some(Etc/UTC), false), yyyy-MM-dd HH:mm:ss, Some(Etc/UTC)) AS field_00#15200, 20240112 AS field_01#15201, load_func00 AS field_02#15202, completed AS field_03#15203, from_unixtime(unix_timestamp(current_timestamp(), yyyy-MM-dd HH:mm:ss, Some(Etc/UTC), false), yyyy-MM-dd HH:mm:ss, Some(Etc/UTC)) AS field_04#15204, from_unixtime(unix_timestamp(current_timestamp(), yyyy-MM-dd HH:mm:ss, Some(Etc/UTC), false), yyyy-MM-dd HH:mm:ss, Some(Etc/UTC)) AS field_05#15205, ddsdmsp AS field_06#15206, rename_01 AS field_07#15207, from_unixtime(unix_timestamp(current_timestamp(), yyyy-MM-dd HH:mm:ss, Some(Etc/UTC), false), yyyyMMdd, Some(Etc/UTC)) AS field_08#15208], org.apache.spark.sql.execution.datasources.v2.DataSourceV2Strategy$$$$Lambda$$12118/1719387317@5a111bfa, com.databricks.sql.transaction.tahoe.catalog.WriteIntoDeltaBuilder$$$$anon$$1@24257336
+            |""".stripMargin,
+      Seq.empty
+    )
+    testGetWriteOpMetaFromNode(
+      node,
+      expectedExecName = "AppendDataExecV1",
+      expectedDataFormat = DeltaLakeHelper.getWriteFormat, // Special handling for DeltaLake
+      expectedOutputPath = StringUtils.UNKNOWN_EXTRACT,
+      expectedOutputColumns = StringUtils.UNKNOWN_EXTRACT,
+      expectedWriteMode = StringUtils.UNKNOWN_EXTRACT,
+      expectedTableName = StringUtils.UNKNOWN_EXTRACT,
+      expectedDatabaseName = StringUtils.UNKNOWN_EXTRACT
+    )
+  }
+
+  test("InsertIntoHadoopFsRelationCommand - Empty output columns") {
+    val node = new SparkPlanGraphNode(
+      id = 5,
+      name = "Execute InsertIntoHadoopFsRelationCommand",
+      desc = "Execute InsertIntoHadoopFsRelationCommand gs://path/to/database/table1, " +
+        "false, Parquet, " +
+        "[serialization.format=1, mergeschema=false, __hive_compatible_bucketed_table_insertion__=true], " +
+        "Append, spark_catalog`.`database`.`table`, org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe, " +
+        "org.apache.spark.sql.execution.datasources.InMemoryFileIndex(gs://path/to/database/table1), " +
+        "[]",
+      Seq.empty
+    )
+    testGetWriteOpMetaFromNode(
+      node,
+      expectedExecName = "InsertIntoHadoopFsRelationCommand",
+      expectedDataFormat = "Parquet",
+      expectedOutputPath = "gs://path/to/database/table1",
+      expectedOutputColumns = "",
+      expectedWriteMode = "Append",
+      expectedTableName = "table1",
+      expectedDatabaseName = "database"
+    )
+  }
+
+  test("InsertIntoHadoopFsRelationCommand - Format is 4th element") {
+    val node = new SparkPlanGraphNode(
+      id = 5,
+      name = "Execute InsertIntoHadoopFsRelationCommand",
+      desc = "Execute InsertIntoHadoopFsRelationCommand gs://path/to/database/table1, " +
+        "false, [paths=(path)], Parquet, " +
+        "[serialization.format=1, mergeschema=false, __hive_compatible_bucketed_table_insertion__=true], " +
+        "Append, spark_catalog`.`database`.`table`, org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe, " +
+        "org.apache.spark.sql.execution.datasources.InMemoryFileIndex(gs://path/to/database/table1), " +
+        "[col01]",
+      Seq.empty
+    )
+    testGetWriteOpMetaFromNode(
+      node,
+      expectedExecName = "InsertIntoHadoopFsRelationCommand",
+      expectedDataFormat = "Parquet",
+      expectedOutputPath = "gs://path/to/database/table1",
+      expectedOutputColumns = "col01",
+      expectedWriteMode = "Append",
+      expectedTableName = "table1",
+      expectedDatabaseName = "database"
+    )
+  }
+
+  test("InsertIntoHadoopFsRelationCommand - Long schema") {
+    // Long schema will show up as ellipses in the description
+    val node = new ui.SparkPlanGraphNode(
+      id = 5,
+      name = "Execute InsertIntoHadoopFsRelationCommand",
+      desc = "Execute InsertIntoHadoopFsRelationCommand gs://path/to/database/table1, " +
+        "false, [paths=(path)], Parquet, " +
+        "[serialization.format=1, mergeschema=false, __hive_compatible_bucketed_table_insertion__=true], " +
+        "Append, spark_catalog`.`database`.`table`, org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe, " +
+        "org.apache.spark.sql.execution.datasources.InMemoryFileIndex(gs://path/to/database/table1), " +
+        "[col01, col02, col03, ... 4 more fields]",
+      Seq.empty
+    )
+    testGetWriteOpMetaFromNode(
+      node,
+      expectedExecName = "InsertIntoHadoopFsRelationCommand",
+      expectedDataFormat = "Parquet",
+      expectedOutputPath = "gs://path/to/database/table1",
+      expectedOutputColumns = "col01;col02;col03;... 4 more fields",
+      expectedWriteMode = "Append",
+      expectedTableName = "table1",
+      expectedDatabaseName = "database"
+    )
+  }
+  // scalastyle:on line.size.limit
+}


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1536

This commits adds a new report containing the write operations.
The generated report is mostly functional for `InsertIntoHadoopFsRelationCommand` and more incremental improvements need to follow.

## New report:

No text format is generated for this report. The reason is that it is not readable to have the path and the node description into Text and it will represent unecessary overhead

The generated report is called `write_operations.csv` and it looks like the following:

- `sqlPlanVersion` the number of the plan version. This is helpful if we want to generate the write operations for all the plans when AQE is enabled.
- `fromFinalPlan`: True when the plan is final.
- If fields are not extracted, it will insert "`unknown`"
- the `fullDescription` contains the actual node-secr truncated at 500 characters.
- `outputColumns`: lists the columns separated by semicolumn. In case of truncated schema, the column will include something like `... and 24 more fields`.

```
appIndex	sqlID	sqlPlanVersion	nodeId	fromFinalPlan	execName	format	location	tableName	dataBase	outputColumns	writeMode	fullDescription
1	4	0	0	true	InsertIntoHadoopFsRelationCommand	 Parquet	gs://path/to/store/database/table_name	table_name	database	station_id;date;element;value;mflag;qflag;sflag;time;year	Append	Execute InsertIntoHadoopFsRelationCommand gs://path/to/store/database/table_name, false, Parquet, [serialization.format=1, mergeschema=false, __hive_compatible_bucketed_table_insertion__=true], Append, `spark_catalog`.`weather`.`table_name`, org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe, org.apache.spark.sql.execution.datasources.InMemoryFileIndex(gs://path/to/store/database/table_name), [station_id, date, element, value, mflag, qflag, sflag, time, year]
1	7	2	1	true	InsertIntoHadoopFsRelationCommand	 Parquet	gs://path/to/store/database/table_name_2	table_name_2	database	station_id;date;element;value;mflag;qflag;sflag;time;station_latitude;station_longitude;station_elevation;station_state;station_name	Append	Execute InsertIntoHadoopFsRelationCommand gs://path/to/store/database/table_name_2, false, Parquet, [serialization.format=1, mergeschema=false, __hive_compatible_bucketed_table_insertion__=true], Append, `spark_catalog`.`weather`.`table_name_2`, org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe, org.apache.spark.sql.execution.datasources.InMemoryFileIndex(gs://path/to/store/database/table_name_2), [station_id, date, element, value, mflag, qflag, sflag, time, station_latitude, station_longitude, station_elevation, station_state, station_name]
1	10	0	0	true	InsertIntoHadoopFsRelationCommand	 Parquet	gs://path/to/store/database/temp_valid_data	temp_valid_data	database	station_id;date;element;value;mflag;qflag;sflag;time;station_latitude;station_longitude;station_elevation;station_state;station_name	Append	Execute InsertIntoHadoopFsRelationCommand gs://path/to/store/database/temp_valid_data, false, Parquet, [serialization.format=1, mergeschema=false, __hive_compatible_bucketed_table_insertion__=true], Append, `spark_catalog`.`weather`.`temp_valid_data`, org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe, org.apache.spark.sql.execution.datasources.InMemoryFileIndex(gs://path/to/store/database/temp_valid_data), [station_id, date, element, value, mflag, qflag, sflag, time, station_latitude, station_longitude, station_elevation, station_state, station_name]
1	11	4	1	true	InsertIntoHadoopFsRelationCommand	 Parquet	gs://path/to/store/database/weather_result	weather_result	database	station_state;element;record_count;avg_value;max_value;min_value;rank;state_name	Overwrite	Execute InsertIntoHadoopFsRelationCommand gs://path/to/store/database/weather_result, false, Parquet, [serialization.format=1, mergeschema=false, __hive_compatible_bucketed_table_insertion__=true], Overwrite, `spark_catalog`.`weather`.`weather_result`, org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe, org.apache.spark.sql.execution.datasources.InMemoryFileIndex(gs://path/to/store/database/weather_result), [station_state, element, record_count, avg_value, max_value, min_value, rank, state_name]

```

## What is missing in this PR:

- the report does not include metrics of the writeOp. We can consider adding those metrics if needed.
- add unit test to evaluate the generated CSV file.
- evaluate the behavior with hive operations like "insertIntoHiveTable"
- extract the metadata from DeltaLake write operations.
- test with eventlogs generated by Spark2.x
- we need a followup to remove redundancy resulting from created a ToolsPlanGraph outside the SqlPlanModel. This refactor will improve the memory utilization and reduce the overhead from building the graph multiple times.


## Detailed descriptions of the changes.

In addition to the new report, this pull request includes several changes to enhance the functionality and maintainability of the codebase, particularly in the `planparser` and `profiling` modules. The most important changes involve the addition of new metadata extraction methods, the introduction of a new utility class, and updates to existing classes to accommodate these changes.

Enhancements in metadata extraction and utility usage:

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DataWritingCommandExecParser.scala`](diffhunk://#diff-846ad57629291e86ed2cf9b4ea5ea6fbbebb241431abac28307c6c284ea49038R180-R341): Added a new method `extractWriteOpRecord` to extract metadata from write operation nodes and updated the `getWriteOpMetaFromNode` method to utilize this new method. [[1]](diffhunk://#diff-846ad57629291e86ed2cf9b4ea5ea6fbbebb241431abac28307c6c284ea49038R180-R341) [[2]](diffhunk://#diff-846ad57629291e86ed2cf9b4ea5ea6fbbebb241431abac28307c6c284ea49038L109-R117)
* [`core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DeltaLakeHelper.scala`](diffhunk://#diff-96914e2ff13a7ca6242bc95eba12d6269cf1ba19ca7e495fa2f20917f5928683R147-R165): Introduced a new method `getWriteCMDWrapper` to retrieve the write command wrapper for Delta Lake write operations.

Introduction of `StringUtils` utility class:

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DataWritingCommandExecParser.scala`](diffhunk://#diff-846ad57629291e86ed2cf9b4ea5ea6fbbebb241431abac28307c6c284ea49038L109-R117): Replaced hardcoded "unknown" strings with `StringUtils.UNKNOWN_EXTRACT` for consistency.
* [`core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/HiveParseHelper.scala`](diffhunk://#diff-35c291098a0644f80cfe7cb7712d768782605f18ff8591a0fd7aec4c2323e681L71-R71): Updated the method `getHiveFormatFromSimpleStr` to use `StringUtils.UNKNOWN_EXTRACT`.
* [`core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ReadParser.scala`](diffhunk://#diff-015bbc8d54f2843377dd82a97c3fc75ffaf27a1387b77e22e421fd782295b51fL63-R64): Replaced `UNKNOWN_METAFIELD` with `StringUtils.UNKNOWN_EXTRACT`.

Enhancements in profiling:

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala`](diffhunk://#diff-56f8f43c29a4842fda9381a3199ebf71e51ce90491357ce8051d8493d902925bL50-R52): Added a new field `writeOpsInfo` to store write operation profile results.
* [`core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala`](diffhunk://#diff-d730a6c3d48ef0ddc22e721372d31caf6adc2240cc408f751fdda409c346ac56L407-R410): Updated the `Profiler` class to include write operation information in the profiling output. [[1]](diffhunk://#diff-d730a6c3d48ef0ddc22e721372d31caf6adc2240cc408f751fdda409c346ac56L407-R410) [[2]](diffhunk://#diff-d730a6c3d48ef0ddc22e721372d31caf6adc2240cc408f751fdda409c346ac56L505-R508) [[3]](diffhunk://#diff-d730a6c3d48ef0ddc22e721372d31caf6adc2240cc408f751fdda409c346ac56R552-R553)

These changes collectively improve the code's robustness, maintainability, and functionality, particularly in handling write operations and profiling.