### PR TITLE
Disable dataproc enhanced optimizer configs

### DIFF
--- a/core/src/main/resources/bootstrap/tuningTable.yaml
+++ b/core/src/main/resources/bootstrap/tuningTable.yaml
@@ -19,15 +19,19 @@ tuningDefinitions:
     level: job
     category: tuning
   - label: spark.dataproc.enhanced.execution.enabled
-    description: 'Enables enhanced execution. It is recommended to turn it on for better performance on Dataproc.'
+    description: 'Enables enhanced execution. Turning this on might cause the accelerated dataproc cluster to hang.'
     enabled: true
     level: job
     category: tuning
+    comments:
+      persistent: 'should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.'
   - label: spark.dataproc.enhanced.optimizer.enabled
-    description: 'Enables enhanced optimizer. It is recommended to turn it on for better performance on Dataproc.'
+    description: 'Enables enhanced optimizer. Turning this on might cause the accelerated dataproc cluster to hang.'
     enabled: true
     level: job
     category: tuning
+    comments:
+      persistent: 'should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.'
   - label: spark.executor.cores
     description: 'The number of cores to use on each executor. It is recommended to be set to 16'
     enabled: true

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -591,8 +591,10 @@ class DataprocPlatform(gpuDevice: Option[GpuDevice],
   override val platformName: String = PlatformNames.DATAPROC
   override val defaultGpuDevice: GpuDevice = T4Gpu
   override val recommendationsToInclude: Seq[(String, String)] = Seq(
-    "spark.dataproc.enhanced.optimizer.enabled" -> "true",
-    "spark.dataproc.enhanced.execution.enabled" -> "true"
+    // Keep disabled. This property does not work well with GPU clusters.
+    "spark.dataproc.enhanced.optimizer.enabled" -> "false",
+    // Keep disabled. This property does not work well with GPU clusters.
+    "spark.dataproc.enhanced.execution.enabled" -> "false"
   )
 
   override def isPlatformCSP: Boolean = true

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntryDefinition.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntryDefinition.scala
@@ -16,13 +16,15 @@
 
 package com.nvidia.spark.rapids.tool.tuning
 
+import java.util
+
 import scala.beans.BeanProperty
+import scala.collection.JavaConverters._
+import scala.collection.breakOut
 
 import org.yaml.snakeyaml.{DumperOptions, LoaderOptions, Yaml}
 import org.yaml.snakeyaml.constructor.Constructor
 import org.yaml.snakeyaml.representer.Representer
-import scala.collection.JavaConverters._
-import scala.collection.breakOut
 
 import org.apache.spark.sql.rapids.tool.util.UTF8Source
 
@@ -40,6 +42,14 @@ import org.apache.spark.sql.rapids.tool.util.UTF8Source
  *                       Default is true.
  * @param defaultSpark The default value of the property in Spark. This is used to set the
  *                     originalValue of the property in case it is not set by the eventlog.
+ * @param comments The defaults comments to be loaded for the entry. It is a map to represent
+ *                 three different types of comments:
+ *                 1. "missing" to represent the default comment to be appended to the AutoTuner's
+ *                    comment when the property is missing.
+ *                 2. "persistent" to represent a comment that always shows up in the AutoTuner's
+ *                    output.
+ *                 3. "updated" to represent a comment that shows when a property is being set by
+ *                    the Autotuner.
  */
 class TuningEntryDefinition(
     @BeanProperty var label: String,
@@ -48,10 +58,12 @@ class TuningEntryDefinition(
     @BeanProperty var level: String,
     @BeanProperty var category: String,
     @BeanProperty var bootstrapEntry: Boolean,
-    @BeanProperty var defaultSpark: String) {
+    @BeanProperty var defaultSpark: String,
+    @BeanProperty var comments: util.LinkedHashMap[String, String]) {
   def this() = {
     this(label = "", description = "", enabled = true, level = "", category = "",
-      bootstrapEntry = true, defaultSpark = null)
+      bootstrapEntry = true, defaultSpark = null,
+      comments = new util.LinkedHashMap[String, String]())
   }
 
   def isEnabled(): Boolean = {
@@ -68,6 +80,18 @@ class TuningEntryDefinition(
    */
   def hasDefaultSpark(): Boolean = {
     defaultSpark != null
+  }
+
+  def getMissingComment(): Option[String] = {
+    Option(comments.get("missing"))
+  }
+
+  def getPersistentComment(): Option[String] = {
+    Option(comments.get("persistent"))
+  }
+
+  def getUpdatedComment(): Option[String] = {
+    Option(comments.get("updated"))
   }
 }
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -90,11 +90,12 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=2
           |--conf spark.executor.memory=32768m
@@ -117,7 +118,9 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.task.resource.gpu.amount=0.001
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.cores' was not set.
           |- 'spark.executor.instances' was not set.
@@ -142,6 +145,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
           |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
           |""".stripMargin
+    // scalastyle:on line.size.limit
     compareOutput(expectedResults, autoTunerOutput)
   }
 
@@ -283,8 +287,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=8
           |--conf spark.executor.memory=32768m
@@ -307,7 +311,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.task.resource.gpu.amount=0.001
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.cores' was not set.
           |- 'spark.executor.instances' was not set.
@@ -349,8 +355,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=2
           |--conf spark.executor.memory=32768m
@@ -373,7 +379,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.task.resource.gpu.amount=0.001
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.cores' was not set.
           |- 'spark.executor.instances' was not set.
@@ -427,8 +435,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=4
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
@@ -445,7 +453,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
@@ -491,11 +501,12 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
         platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
@@ -511,7 +522,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.sql.batchSizeBytes' was not set.
@@ -523,6 +536,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
           |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
           |""".stripMargin
+    // scalastyle:on line.size.limit
     compareOutput(expectedResults, autoTunerOutput)
   }
 
@@ -554,11 +568,12 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
         platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
@@ -572,7 +587,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.sql.batchSizeBytes' was not set.
@@ -583,6 +600,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
           |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
           |""".stripMargin
+    // scalastyle:on line.size.limit
     compareOutput(expectedResults, autoTunerOutput)
   }
 
@@ -611,11 +629,12 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
         platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
@@ -631,7 +650,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.sql.batchSizeBytes' was not set.
@@ -644,6 +665,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
           |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
           |""".stripMargin
+    // scalastyle:on line.size.limit
     compareOutput(expectedResults, autoTunerOutput)
   }
 
@@ -673,11 +695,12 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
         platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
@@ -693,7 +716,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.sql.batchSizeBytes' was not set.
@@ -706,6 +731,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
           |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
           |""".stripMargin
+    // scalastyle:on line.size.limit
     compareOutput(expectedResults, autoTunerOutput)
   }
 
@@ -726,8 +752,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=2
           |--conf spark.executor.memory=32768m
@@ -750,7 +776,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.task.resource.gpu.amount=0.001
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.cores' was not set.
           |- 'spark.executor.instances' was not set.
@@ -794,11 +822,12 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       "spark.task.resource.gpu.amount" -> "0.001")
     val sparkProps = defaultDataprocProps.++(customProps)
     val dataprocWorkerInfo = buildGpuWorkerInfoAsString(Some(sparkProps))
+    // scalastyle:off line.size.limit
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
@@ -814,7 +843,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.sql.batchSizeBytes' was not set.
@@ -825,6 +856,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
           |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
           |""".stripMargin
+    // scalastyle:on line.size.limit
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
@@ -855,11 +887,12 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       "spark.task.resource.gpu.amount" -> "0.001")
     val sparkProps = defaultDataprocProps.++(customProps)
     val dataprocWorkerInfo = buildGpuWorkerInfoAsString(Some(sparkProps))
+    // scalastyle:off line.size.limit
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=4
           |--conf spark.executor.memoryOverhead=17612m
@@ -876,7 +909,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.sql.batchSizeBytes' was not set.
@@ -887,6 +922,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
           |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
           |""".stripMargin
+    // scalastyle:on line.size.limit
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
@@ -904,8 +940,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=8
           |--conf spark.executor.memory=32768m
@@ -928,7 +964,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.task.resource.gpu.amount=0.001
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.cores' was not set.
           |- 'spark.executor.instances' was not set.
@@ -1010,8 +1048,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
@@ -1031,7 +1069,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.files.maxPartitionBytes=4096m
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
@@ -1092,8 +1132,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=5
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
@@ -1113,7 +1153,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.files.maxPartitionBytes=4096m
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
@@ -1165,8 +1207,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
@@ -1188,7 +1230,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.files.maxPartitionBytes=4096m
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
@@ -1249,8 +1293,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
@@ -1272,7 +1316,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.files.maxPartitionBytes=4096m
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
@@ -1337,8 +1383,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
@@ -1358,7 +1404,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.task.resource.gpu.amount=0.001
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
@@ -1421,8 +1469,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
@@ -1442,7 +1490,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.task.resource.gpu.amount=0.001
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
@@ -1500,8 +1550,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
@@ -1521,7 +1571,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.task.resource.gpu.amount=0.001
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
@@ -1572,8 +1624,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
@@ -1589,7 +1641,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.sql.batchSizeBytes' was not set.
@@ -1618,11 +1672,12 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     }
     val pluginJarMvnURl = "https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/" +
       s"$latestRelease/rapids-4-spark_2.12-$latestRelease.jar"
+    // scalastyle:off line.size.limit
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
@@ -1638,7 +1693,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.sql.batchSizeBytes' was not set.
@@ -1651,6 +1708,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |  Version used in application is $jarVer.
           |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
           |""".stripMargin
+    // scalastyle:on line.size.limit
     val rapidsJarsArr = Seq(s"rapids-4-spark_2.12-$jarVer.jar")
     val autoTunerOutput = generateRecommendationsForRapidsJars(rapidsJarsArr)
     compareOutput(expectedResults, autoTunerOutput)
@@ -1664,11 +1722,12 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       case Some(v) => v
       case None => fail("Could not find pull the latest release successfully")
     }
+    // scalastyle:off line.size.limit
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
@@ -1684,7 +1743,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.sql.batchSizeBytes' was not set.
@@ -1694,6 +1755,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
           |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
           |""".stripMargin
+    // scalastyle:on line.size.limit
     val rapidsJarsArr = Seq(s"rapids-4-spark_2.12-$latestRelease.jar")
     val autoTunerOutput = generateRecommendationsForRapidsJars(rapidsJarsArr)
     compareOutput(expectedResults, autoTunerOutput)
@@ -1738,8 +1800,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
@@ -1760,7 +1822,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.task.resource.gpu.amount=0.001
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.filecache.enabled' was not set.
@@ -1819,8 +1883,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
@@ -1840,7 +1904,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.task.resource.gpu.amount=0.001
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
@@ -1921,8 +1987,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32768m
           |--conf spark.locality.wait=0
@@ -1941,7 +2007,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.files.maxPartitionBytes=4096m
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.sql.batchSizeBytes' was not set.
@@ -2337,8 +2405,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
@@ -2358,7 +2426,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.files.maxPartitionBytes=4096m
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
@@ -2692,8 +2762,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
@@ -2714,7 +2784,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.shuffle.partitions=400
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
@@ -2775,8 +2847,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
@@ -2796,7 +2868,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.sql.files.maxPartitionBytes=3669m
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
@@ -2837,8 +2911,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
@@ -2862,7 +2936,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.task.resource.gpu.amount=0.001
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.kryo.registrator' was not set.
@@ -2909,8 +2985,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
@@ -2934,7 +3010,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.task.resource.gpu.amount=0.001
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.memory.pinnedPool.size' was not set.
@@ -2980,8 +3058,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
@@ -3005,7 +3083,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.task.resource.gpu.amount=0.001
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.memory.pinnedPool.size' was not set.
@@ -3122,8 +3202,8 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=true
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
@@ -3146,7 +3226,9 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.task.resource.gpu.amount=0.001
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.memory.pinnedPool.size' was not set.
@@ -3191,7 +3273,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.dataproc.enhanced.optimizer.enabled=true
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
@@ -3214,6 +3296,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.task.resource.gpu.amount=0.001
           |
           |Comments:
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.memory.pinnedPool.size' was not set.


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1550

For dataproc GPU clusters, the Autotuner should set the following 2 properties to false. In addition, the autotuner appends a comment to warn the user that those properties might be problematic to the GPU run.

- "spark.dataproc.enhanced.optimizer.enabled": "false"
- "spark.dataproc.enhanced.execution.enabled": "false"

The autotuner output will add a message stating that:

"should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang."

****
### Changes

This pull request includes several changes aimed at improving the handling of tuning properties and enhancing the auto-tuning functionality for Dataproc clusters. The most important changes involve updating descriptions and adding comments for certain properties, modifying default recommendations, and introducing methods to append comments in the auto-tuner.

**Changes to tuning properties:**

* [`core/src/main/resources/bootstrap/tuningTable.yaml`](diffhunk://#diff-f5fa862fcd8265f7c4e87c92208a52d899c3b14eab00fa9a4d7864040bc7e877L22-R34): Updated descriptions for `spark.dataproc.enhanced.execution.enabled` and `spark.dataproc.enhanced.optimizer.enabled` to indicate that enabling these properties might cause the GPU accelerated Dataproc cluster to hang. Added persistent comments for these properties.

**Modifications to default recommendations:**

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala`](diffhunk://#diff-cc81398d095d289f60b6eb03dde5b6995956258b6c176f31cc2df56382cb1a98L594-R597): Changed default recommendations for `spark.dataproc.enhanced.optimizer.enabled` and `spark.dataproc.enhanced.execution.enabled` to `false` due to compatibility issues with GPU clusters.

**Enhancements to auto-tuning functionality:**

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala`](diffhunk://#diff-ef26e6d4e25cf3134245beb228e7802e2cf3be63e64e0d6e1b98587d0e2d7896R333-R373): Added methods `appendMissingComment` and `appendPersistentComment` to handle comments for tuning properties. Updated `appendRecommendation` method to use these new methods.

**Updates to `TuningEntryDefinition` class:**

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntryDefinition.scala`](diffhunk://#diff-0d8a226360720b196e09b7874e7ee3f88b3f86f0d1579b735b49d0b28f696999R45-R52): Added a `comments` field to store different types of comments and methods to retrieve these comments. [[1]](diffhunk://#diff-0d8a226360720b196e09b7874e7ee3f88b3f86f0d1579b735b49d0b28f696999R45-R52) [[2]](diffhunk://#diff-0d8a226360720b196e09b7874e7ee3f88b3f86f0d1579b735b49d0b28f696999L51-R66) [[3]](diffhunk://#diff-0d8a226360720b196e09b7874e7ee3f88b3f86f0d1579b735b49d0b28f696999R84-R95)
