### PR TITLE
Add sqlID column to failed_jobs.csv

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DataWritingCommandExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DataWritingCommandExecParser.scala
@@ -257,23 +257,21 @@ object DataWritingCommandExecParser {
       (path, format)
     }
 
-    /**
-     * Extracts the file format from a class object string, such as
-     * "com.nvidia.spark.rapids.GpuParquetFileFormat@9f5022c".
-     *
-     * This function is designed to handle cases where the RAPIDS plugin logs raw object names
-     * instead of a user-friendly file format name. For example, it extracts "Parquet" from
-     * "com.nvidia.spark.rapids.GpuParquetFileFormat@9f5022c".
-     * Refer: https://github.com/NVIDIA/spark-rapids-tools/issues/1561
-     *
-     * If the input string does not match the expected pattern, the function returns the original
-     * string as a fallback.
-     *
-     * @param formatStr The raw format string, typically containing the class name of the file
-     *                  format.
-     * @return A user-friendly file format name (e.g., "Parquet") or the original string if no
-     *         match is found.
-     */
+    // Extracts the file format from a class object string, such as
+    // "com.nvidia.spark.rapids.GpuParquetFileFormat@9f5022c".
+    //
+    // This function is designed to handle cases where the RAPIDS plugin logs raw object names
+    // instead of a user-friendly file format name. For example, it extracts "Parquet" from
+    // "com.nvidia.spark.rapids.GpuParquetFileFormat@9f5022c".
+    // Refer: https://github.com/NVIDIA/spark-rapids-tools/issues/1561
+    //
+    // If the input string does not match the expected pattern, the function returns the original
+    // string as a fallback.
+    //
+    // @param formatStr The raw format string, typically containing the class name of the file
+    //                  format.
+    // @return A user-friendly file format name (e.g., "Parquet") or the original string if no
+    //         match is found.
     def extractFormatName(formatStr: String): String = {
       // Extracting file format from the full object string
       // 1. `.*\.` - Matches sequence of character between literal dots

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -484,17 +484,26 @@ case class FailedStagesProfileResults(appIndex: Int, stageId: Int, stageAttemptI
   }
 }
 
-case class FailedJobsProfileResults(appIndex: Int, jobId: Int,
-    jobResult: String, endReason: String) extends ProfileResult {
-  override val outputHeaders = Seq("appIndex", "jobID", "jobResult", "failureReason")
+case class FailedJobsProfileResults(
+    appIndex: Int,
+    jobId: Int,
+    sqlID: Option[Long],  // sqlID is optional because Jobs might not have a SQL (i.e., RDDs)
+    jobResult: String,
+    endReason: String) extends ProfileResult {
+  override val outputHeaders = Seq("appIndex", "jobID", "sqlID", "jobResult", "failureReason")
 
   override def convertToSeq: Seq[String] = {
-    Seq(appIndex.toString, jobId.toString,
+    Seq(appIndex.toString,
+      jobId.toString,
+      sqlID.map(_.toString).getOrElse(null),
       jobResult,
       StringUtils.renderStr(endReason, doEscapeMetaCharacters = true))
   }
   override def convertToCSVSeq: Seq[String] = {
-    Seq(appIndex.toString, jobId.toString, StringUtils.reformatCSVString(jobResult),
+    Seq(appIndex.toString,
+      jobId.toString,
+      sqlID.map(_.toString).getOrElse(null),
+      StringUtils.reformatCSVString(jobResult),
       StringUtils.reformatCSVString(
         StringUtils.renderStr(endReason, doEscapeMetaCharacters = true, maxLength = 0)))
   }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/JobView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/JobView.scala
@@ -45,13 +45,14 @@ trait AppFailedJobsViewTrait extends ViewableTrait[FailedJobsProfileResults] {
     }
     jobsFailed.map { case (id, jc) =>
       val failureStr = jc.failedReason.getOrElse("")
-      FailedJobsProfileResults(index, id, jc.jobResult.getOrElse(StringUtils.UNKNOWN_EXTRACT),
+      FailedJobsProfileResults(index, id, jc.sqlID,
+        jc.jobResult.getOrElse(StringUtils.UNKNOWN_EXTRACT),
         StringUtils.renderStr(failureStr, doEscapeMetaCharacters = false, maxLength = 0))
     }.toSeq
   }
 
   override def sortView(rows: Seq[FailedJobsProfileResults]): Seq[FailedJobsProfileResults] = {
-    rows.sortBy(cols => (cols.appIndex, cols.jobId, cols.jobResult))
+    rows.sortBy(cols => (cols.appIndex, cols.jobId, cols.sqlID, cols.jobResult))
   }
 }
 

--- a/core/src/test/resources/ProfilingExpectations/jobs_failure_eventlog_expectation.csv
+++ b/core/src/test/resources/ProfilingExpectations/jobs_failure_eventlog_expectation.csv
@@ -1,2 +1,2 @@
-appIndex,jobID,jobResult,failureReason
-1,79,"JobFailed","java.lang.Exception: Job 79 cancelled because SparkContext was shut down"
+appIndex,jobID,sqlID,jobResult,failureReason
+1,79,27,"JobFailed","java.lang.Exception: Job 79 cancelled because SparkContext was shut down"

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/HealthCheckSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/HealthCheckSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ class HealthCheckSuite extends FunSuite {
     assert(apps.size == 1)
 
     val healthCheck = new HealthCheck(apps)
-    for (app <- apps) {
+    for (_ <- apps) {
       val failedTasks = healthCheck.getFailedTasks
       // the end reason gets the delimiter changed when writing to CSV so to compare properly
       // change it to be the same here
@@ -142,7 +142,7 @@ class HealthCheckSuite extends FunSuite {
     assert(apps.size == 1)
 
     val healthCheck = new HealthCheck(apps)
-    for (app <- apps) {
+    for (_ <- apps) {
       val unsupported = healthCheck.getPossibleUnsupportedSQLPlan
       import sparkSession.implicits._
       val unsupportedPlanAccums = unsupported.toDF


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1563

- adds column `sqlID` to failed_jobs.csv
- the column might be empty if the job has no sqlID attached to it

This pull request includes several changes to improve the handling of job profiling and file format extraction in the RAPIDS plugin for Apache Spark. The most important changes include modifying the `FailedJobsProfileResults` case class to include an optional SQL ID, updating related views and tests, and simplifying the code in the `HealthCheckSuite` class.

### Sample output file

```
appIndex,jobID,sqlID,jobResult,failureReason
1,79,27,"JobFailed","java.lang.Exception: Job 79 cancelled because SparkContext was shut down"
```

### Improvements to job profiling:

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala`](diffhunk://#diff-8d5819c9445c1489d61ee8d03fd2b1ee1e0cb33896f402f4ceb7782c35deed69L487-R506): Modified the `FailedJobsProfileResults` case class to include an optional `sqlID` field and updated the `outputHeaders` and `convertToSeq` methods accordingly.
* [`core/src/main/scala/com/nvidia/spark/rapids/tool/views/JobView.scala`](diffhunk://#diff-dc7854681ef429d2afc5d99fa784cca81d4a8142c1557ce24b07c8a56c07a2e6L48-R55): Updated the `AppFailedJobsViewTrait` to handle the new `sqlID` field in `FailedJobsProfileResults` and modified the `sortView` method to include `sqlID` in the sorting criteria.
* [`core/src/test/resources/ProfilingExpectations/jobs_failure_eventlog_expectation.csv`](diffhunk://#diff-e8c89e0559be409d1fa95e98accecd65a843bd151a0c90c668475181ebf097e1L1-R2): Updated the test expectations to include the new `sqlID` field in the CSV header and data.
