### PR TITLE
Rapids tools 1572 code critic 02

### DIFF
--- a/core/src/main/resources/bootstrap/tuningTable.yaml
+++ b/core/src/main/resources/bootstrap/tuningTable.yaml
@@ -14,171 +14,250 @@
 
 tuningDefinitions:
   - label: spark.databricks.adaptive.autoOptimizeShuffle.enabled
-    description: 'Auto-Optimized shuffle. It is recommended to turn it off to set (spark.sql.shuffle.partitions) manually.'
+    description: >-
+      Auto-Optimized shuffle. It is recommended to turn it off to set 'spark.sql.shuffle.partitions' manually.
     enabled: true
     level: job
     category: tuning
   - label: spark.dataproc.enhanced.execution.enabled
-    description: 'Enables enhanced execution. Turning this on might cause the accelerated dataproc cluster to hang.'
+    description: Enables enhanced execution. Turning this on might cause the accelerated dataproc cluster to hang.
     enabled: true
     level: job
     category: tuning
     comments:
-      persistent: 'should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.'
+      persistent: >-
+        should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
   - label: spark.dataproc.enhanced.optimizer.enabled
-    description: 'Enables enhanced optimizer. Turning this on might cause the accelerated dataproc cluster to hang.'
+    description: Enables enhanced optimizer. Turning this on might cause the accelerated dataproc cluster to hang.
     enabled: true
     level: job
     category: tuning
     comments:
-      persistent: 'should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.'
+      persistent: >-
+        should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
   - label: spark.executor.cores
-    description: 'The number of cores to use on each executor. It is recommended to be set to 16'
+    description: The number of cores to use on each executor. It is recommended to be set to 16.
     enabled: true
     level: cluster
     category: tuning
   - label: spark.executor.instances
-    description: 'Controls parellelism level. It is recommended to be set to (cpuCoresPerNode * numWorkers) / spark.executor.cores.'
+    description: >-
+      Controls parallelism level. It is recommended to be set to (cpuCoresPerNode * numWorkers) / spark.executor.cores.
     enabled: true
     level: cluster
     category: tuning
   - label: spark.executor.memory
-    description: 'Amount of memory to use per executor process. This is tuned based on the available CPU memory on worker node.'
+    description: >-
+      Amount of memory to use per executor process. This is tuned based on the available CPU memory on worker node.
     enabled: true
     level: cluster
     category: tuning
   - label: spark.executor.memoryOverhead
-    description: 'Amount of additional memory to be allocated per executor process, in MiB unless otherwise specified. This is memory that accounts for things like VM overheads, interned strings, other native overheads, etc. This tends to grow with the executor size.'
+    description: >-
+      Amount of additional memory to be allocated per executor process, in MiB unless otherwise specified.
+      This is memory that accounts for things like VM overheads, interned strings, other native overheads, etc.
+      This tends to grow with the executor size.
     enabled: true
     level: cluster
     category: tuning
   - label: spark.executor.memoryOverheadFactor
-    description: 'Fraction of executor memory to be allocated as additional non-heap memory per executor process. This is memory that accounts for things like VM overheads, interned strings, other native overheads, etc. This tends to grow with the container size.'
+    description: >-
+      Fraction of executor memory to be allocated as additional non-heap memory per executor process.
+      This is memory that accounts for things like VM overheads, interned strings, other native overheads, etc.
+      This tends to grow with the container size.
     enabled: true
     level: cluster
     category: tuning
+  - label: spark.kryo.registrator
+    description: >-
+      Fraction of executor memory to be allocated as additional non-heap memory per executor process.
+      This is memory that accounts for things like VM overheads, interned strings, other native overheads, etc.
+      This tends to grow with the container size.
+    enabled: true
+    level: job
+    category: functionality
+    comments:
+      missing: should include GpuKryoRegistrator when using Kryo serialization.
+      updated: GpuKryoRegistrator must be appended to the existing value when using Kryo serialization.
   - label: spark.kubernetes.memoryOverheadFactor
-    description: 'Specific to K8s. Fraction of executor memory to be allocated as additional non-heap memory per executor process.'
+    description: >-
+      Specific to K8s. Fraction of executor memory to be allocated as additional non-heap memory per executor process.
     enabled: true
     level: cluster
     category: tuning
   - label: spark.locality.wait
-    description: 'The time to wait to launch a data-local task before giving up and launching it on a less-local node. It is recommended to avoid waiting for a data-local task.'
+    description: >-
+      The time to wait to launch a data-local task before giving up and launching it on a less-local node.
+      It is recommended to avoid waiting for a data-local task.
     enabled: true
     level: cluster
     category: tuning
     defaultSpark: "3s"
   - label: spark.rapids.filecache.enabled
-    description: 'Enables RAPIDS file cache. The file cache stores data locally in the same local directories that have been configured for the Spark executor.'
+    description: >-
+      Enables RAPIDS file cache. The file cache stores data locally in the same local directories
+      that have been configured for the Spark executor.
     enabled: true
     level: job
     category: tuning
   - label: spark.rapids.memory.pinnedPool.size
-    description: 'The size of the pinned memory pool in bytes unless otherwise specified. Use 0 to disable the pool.'
+    description: The size of the pinned memory pool in bytes unless otherwise specified. Use 0 to disable the pool.
     enabled: true
     level: cluster
     category: tuning
   - label: spark.rapids.shuffle.multiThreaded.maxBytesInFlight
-    description: 'This property controls the amount of bytes we allow in flight per Spark task. This typically happens on the reader side, when blocks are received from the network, they’re queued onto these threads for decompression and decode. '
+    description: >-
+      This property controls the amount of bytes we allow in flight per Spark task.
+      This typically happens on the reader side, when blocks are received from the network,
+      they’re queued onto these threads for decompression and decode.
     enabled: true
     level: cluster
     category: tuning
   - label: spark.rapids.shuffle.multiThreaded.reader.threads
-    description: 'The shuffle reader is a single implementation irrespective of the number of partitions. Set the value to zero to turn off multi-threaded reader entirely.'
+    description: >-
+      The shuffle reader is a single implementation irrespective of the number of partitions.
+      Set the value to zero to turn off multi-threaded reader entirely.
     enabled: true
     level: cluster
     category: tuning
   - label: spark.rapids.shuffle.multiThreaded.writer.threads
-    description: ''
+    description: >-
+      Controls the number of threads used for writing shuffle data in a multi-threaded shuffle writer
+      for the Rapids shuffle implementation.
     enabled: true
     level: cluster
     category: tuning
   - label: spark.rapids.sql.batchSizeBytes
-    description: 'Set the target number of bytes for a GPU batch. Splits sizes for input data is covered by separate configs.'
+    description: >-
+      Set the target number of bytes for a GPU batch. Splits sizes for input data is covered by separate configs.
     enabled: true
     level: job
     category: tuning
   - label: spark.rapids.sql.concurrentGpuTasks
-    description: 'Set the number of tasks that can execute concurrently per GPU. Tasks may temporarily block when the number of concurrent tasks in the executor exceeds this amount. Allowing too many concurrent tasks on the same GPU may lead to GPU out of memory errors.'
+    description: >-
+      Set the number of tasks that can execute concurrently per GPU. Tasks may temporarily block when the number of
+      concurrent tasks in the executor exceeds this amount. Allowing too many concurrent tasks on the same GPU may
+      lead to GPU out of memory errors.
     enabled: true
     level: cluster
     category: tuning
   - label: spark.rapids.sql.format.parquet.multithreaded.combine.waitTime
-    description: 'When using the multithreaded parquet reader with combine mode, how long to wait, in milliseconds, for more files to finish if haven’t met the size threshold. Note that this will wait this amount of time from when the last file was available, so total wait time could be larger then this. DEPRECATED: use spark.rapids.sql.reader.multithreaded.combine.waitTime instead.'
+    description: >-
+      When using the multithreaded parquet reader with combine mode, how long to wait, in milliseconds,
+      for more files to finish if haven’t met the size threshold. Note that this will wait this amount
+      of time from when the last file was available, so total wait time could be larger then this.
+      DEPRECATED: use spark.rapids.sql.reader.multithreaded.combine.waitTime instead.
     enabled: true
     level: cluster
     category: tuning
   - label: spark.rapids.sql.enabled
-    description: 'Should be true to enable SQL operations on the GPU.'
+    description: Should be true to enable SQL operations on the GPU.
     enabled: true
     level: cluster
     category: functionality
   - label: spark.rapids.sql.multiThreadedRead.numThreads
-    description: 'The maximum number of threads on each executor to use for reading small files in parallel.'
+    description: The maximum number of threads on each executor to use for reading small files in parallel.
     enabled: true
     level: cluster
     category: tuning
   - label: spark.rapids.sql.reader.multithreaded.combine.sizeBytes
-    description: 'The target size in bytes to combine multiple small files together when using the MULTITHREADED parquet or orc reader. With combine disabled, the MULTITHREADED reader reads the files in parallel and sends individual files down to the GPU, but that can be inefficient for small files.'
+    description: >-
+      The target size in bytes to combine multiple small files together when using the MULTITHREADED
+      parquet or orc reader. With combine disabled, the MULTITHREADED reader reads the files in parallel
+      and sends individual files down to the GPU, but that can be inefficient for small files.
     enabled: true
-    level: cluster
+    level: job
+    category: tuning
+  - label: spark.serializer
+    description: >-
+      Specifies which serialization mechanism to use when serializing objects during distributed computation.
+      This impacts performance, memory usage, and efficiency in data shuffling and caching.
+      When set to Kryo, then the GPU configuration has to include GpuKryoRegistrator for the kryo registrator property.
+    enabled: true
+    level: job
     category: tuning
   - label: spark.shuffle.manager
-    description: 'The RAPIDS Shuffle Manager is an implementation of the ShuffleManager interface in Apache Spark that allows custom mechanisms to exchange shuffle data. We currently expose two modes of operation: Multi Threaded and UCX.'
+    description: >-
+      The RAPIDS Shuffle Manager is an implementation of the ShuffleManager interface in Apache Spark that
+      allows custom mechanisms to exchange shuffle data.
+      We currently expose two modes of operation; Multi Threaded and UCX.
     enabled: true
     level: cluster
     category: tuning
   - label: spark.sql.adaptive.enabled
-    description: 'When true, enable adaptive query execution, which re-optimizes the query plan in the middle of query execution, based on accurate runtime statistics.'
+    description: >-
+      When true, enable adaptive query execution, which re-optimizes the query plan in the middle of
+      query execution, based on accurate runtime statistics.
     enabled: true
     level: job
     category: tuning
     defaultSpark: "true"
   - label: spark.sql.adaptive.advisoryPartitionSizeInBytes
-    description: 'The advisory size in bytes of the shuffle partition during adaptive optimization (when spark.sql.adaptive.enabled is true). It takes effect when Spark coalesces small shuffle partitions or splits skewed shuffle partition.'
+    description: >-
+      The advisory size in bytes of the shuffle partition during adaptive optimization
+      (when 'spark.sql.adaptive.enabled' is true).
+      It takes effect when Spark coalesces small shuffle partitions or splits skewed shuffle partition.
     enabled: true
     level: job
     category: tuning
   - label: spark.sql.adaptive.coalescePartitions.initialPartitionNum
-    description: 'The initial number of shuffle partitions before coalescing. If not set, it equals to spark.sql.shuffle.partitions.'
+    description: >-
+      The initial number of shuffle partitions before coalescing. If not set, it equals to
+      'spark.sql.shuffle.partitions'.
     enabled: true
     level: job
     category: tuning
   - label: spark.sql.adaptive.coalescePartitions.minPartitionNum
-    description: '(deprecated) The suggested (not guaranteed) minimum number of shuffle partitions after coalescing. If not set, the default value is the default parallelism of the Spark cluster.'
+    description: >-
+      (deprecated) The suggested (not guaranteed) minimum number of shuffle partitions after coalescing.
+      If not set, the default value is the default parallelism of the Spark cluster.
     enabled: true
     level: job
     category: tuning
   - label: spark.sql.adaptive.coalescePartitions.minPartitionSize
-    description: 'The minimum size of shuffle partitions after coalescing. This is useful when the adaptively calculated target size is too small during partition coalescing.'
+    description: >-
+      The minimum size of shuffle partitions after coalescing. This is useful when the adaptively calculated
+      target size is too small during partition coalescing.
     enabled: true
     level: job
     category: tuning
-    defaultSpark: "1m"
+    defaultSpark: 1m
   - label: spark.sql.adaptive.coalescePartitions.parallelismFirst
-    description: 'When true, Spark does not respect the target size specified by (spark.sql.adaptive.advisoryPartitionSizeInBytes) (default 64MB) when coalescing contiguous shuffle partitions, but adaptively calculate the target size according to the default parallelism of the Spark cluster.'
+    description: >-
+      When true, Spark does not respect the target size specified by 'spark.sql.adaptive.advisoryPartitionSizeInBytes'
+      (default 64MB) when coalescing contiguous shuffle partitions, but adaptively calculate the target size
+      according to the default parallelism of the Spark cluster.
     enabled: true
     level: job
     category: tuning
     defaultSpark: "true"
   - label: spark.sql.adaptive.autoBroadcastJoinThreshold
-    description: 'Configures the maximum size in bytes for a table that will be broadcast to all worker nodes when performing a join. By setting this value to -1, broadcasting can be disabled.'
+    description: >-
+      Configures the maximum size in bytes for a table that will be broadcast to all worker nodes when
+      performing a join. By setting this value to -1, broadcasting can be disabled.
     enabled: true
     level: job
     category: tuning
   - label: spark.sql.files.maxPartitionBytes
-    description: 'The maximum number of bytes to pack into a single partition when reading files. This configuration is effective only when using file-based sources such as Parquet, JSON and ORC.'
+    description: >-
+      The maximum number of bytes to pack into a single partition when reading files.
+      This configuration is effective only when using file-based sources such as Parquet, JSON and ORC.
     enabled: true
     level: job
     category: tuning
   - label: spark.sql.shuffle.partitions
-    description: 'The default number of partitions to use when shuffling data for joins or aggregations. Note: For structured streaming, this configuration cannot be changed between query restarts from the same checkpoint location.'
+    description: >-
+      The default number of partitions to use when shuffling data for joins or aggregations.
+      Note that for structured streaming, this configuration cannot be changed between query
+      restarts from the same checkpoint location.
     enabled: true
     level: job
     category: tuning
     defaultSpark: "200"
   - label: spark.task.resource.gpu.amount
-    description: 'The GPU resource amount per task when Apache Spark schedules GPU resources. For example, setting the value to 1 means that only one task will run concurrently per executor.'
+    description: >-
+      The GPU resource amount per task when Apache Spark schedules GPU resources.
+      For example, setting the value to 1 means that only one task will run concurrently per executor.
     enabled: true
     level: cluster
     category: tuning

--- a/core/src/main/resources/bootstrap/tuningTable.yaml
+++ b/core/src/main/resources/bootstrap/tuningTable.yaml
@@ -79,6 +79,17 @@ tuningDefinitions:
     comments:
       missing: should include GpuKryoRegistrator when using Kryo serialization.
       updated: GpuKryoRegistrator must be appended to the existing value when using Kryo serialization.
+  - label: spark.kryoserializer.buffer.max
+    description: >-
+      This property helps manage the buffer used by Kryo during serialization, preventing out-of-memory
+      errors when dealing with large objects.
+    enabled: true
+    level: job
+    category: tuning
+    defaultSpark: "64MB"
+    comments:
+      missing: setting the max buffer to prevent out-of-memory errors.
+      updated: increasing the max buffer to prevent out-of-memory errors.
   - label: spark.kubernetes.memoryOverheadFactor
     description: >-
       Specific to K8s. Fraction of executor memory to be allocated as additional non-heap memory per executor process.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -337,8 +337,8 @@ class AutoTuner(
   private def appendMissingComment(key: String): Unit = {
     val missingComment = TuningEntryDefinition.TUNING_TABLE.get(key)
       .flatMap(_.getMissingComment())
-      .getOrElse(s"'$key' was not set.")
-    appendComment(missingComment)
+      .getOrElse(s"was not set.")
+    appendComment(s"'$key' $missingComment")
   }
 
   /**
@@ -349,6 +349,19 @@ class AutoTuner(
   private def appendPersistentComment(key: String): Unit = {
     TuningEntryDefinition.TUNING_TABLE.get(key).foreach { eDef =>
       eDef.getPersistentComment().foreach { comment =>
+        appendComment(s"'$key' $comment")
+      }
+    }
+  }
+
+  /**
+   * Append a comment to the list by looking up the updated comment if any in the tuningEntry
+   * table. If it is not defined in the table, then add nothing.
+   * @param key the property set by the autotuner.
+   */
+  private def appendUpdatedComment(key: String): Unit = {
+    TuningEntryDefinition.TUNING_TABLE.get(key).foreach { eDef =>
+      eDef.getUpdatedComment().foreach { comment =>
         appendComment(s"'$key' $comment")
       }
     }
@@ -368,6 +381,9 @@ class AutoTuner(
       if (recomRecord.originalValue.isEmpty) {
         // add missing comment if any
         appendMissingComment(key)
+      } else {
+        // add updated comment if any
+        appendUpdatedComment(key)
       }
       // add the persistent comment if any.
       appendPersistentComment(key)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -702,6 +702,16 @@ class AutoTuner(
             "com.nvidia.spark.rapids.GpuKryoRegistrator"
           }
           appendRecommendation("spark.kryo.registrator", regToUse)
+          // set the maxBuffer to prevent OOMs
+          getPropertyValue("spark.kryoserializer.buffer.max") match {
+            case Some(f) =>
+              val kryoBufferMax = StringUtils.convertToMB(f)
+              if (kryoBufferMax < 512) { // incrrease it to 512m
+                appendRecommendation("spark.kryoserializer.buffer.max", "512m")
+              }
+            case None =>
+              appendRecommendation("spark.kryoserializer.buffer.max", "512m")
+          }
         case None =>
           // do nothing
       }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -2917,6 +2917,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.kryo.registrator=com.nvidia.spark.rapids.GpuKryoRegistrator
+          |--conf spark.kryoserializer.buffer.max=512m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -2942,6 +2943,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.kryo.registrator' should include GpuKryoRegistrator when using Kryo serialization.
+          |- 'spark.kryoserializer.buffer.max' increasing the max buffer to prevent out-of-memory errors.
           |- 'spark.rapids.memory.pinnedPool.size' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
@@ -2991,6 +2993,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.kryo.registrator=org.apache.SomeRegistrator,org.apache.SomeOtherRegistrator,com.nvidia.spark.rapids.GpuKryoRegistrator
+          |--conf spark.kryoserializer.buffer.max=512m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -3016,6 +3019,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.kryo.registrator' GpuKryoRegistrator must be appended to the existing value when using Kryo serialization.
+          |- 'spark.kryoserializer.buffer.max' increasing the max buffer to prevent out-of-memory errors.
           |- 'spark.rapids.memory.pinnedPool.size' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
@@ -3065,6 +3069,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |--conf spark.executor.memory=32768m
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.kryo.registrator=com.nvidia.spark.rapids.GpuKryoRegistrator
+          |--conf spark.kryoserializer.buffer.max=512m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4096m
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -3090,6 +3095,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.kryo.registrator' GpuKryoRegistrator must be appended to the existing value when using Kryo serialization.
+          |- 'spark.kryoserializer.buffer.max' increasing the max buffer to prevent out-of-memory errors.
           |- 'spark.rapids.memory.pinnedPool.size' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -2941,7 +2941,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
-          |- 'spark.kryo.registrator' was not set.
+          |- 'spark.kryo.registrator' should include GpuKryoRegistrator when using Kryo serialization.
           |- 'spark.rapids.memory.pinnedPool.size' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
@@ -3015,6 +3015,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.kryo.registrator' GpuKryoRegistrator must be appended to the existing value when using Kryo serialization.
           |- 'spark.rapids.memory.pinnedPool.size' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
@@ -3088,6 +3089,7 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
           |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.kryo.registrator' GpuKryoRegistrator must be appended to the existing value when using Kryo serialization.
           |- 'spark.rapids.memory.pinnedPool.size' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1572

- The Kryo settings were not listed in the boostrap conf.
- Reformatted the tuningTable.yaml file to wrap long strings on multiple lines.
- Added a method to automate comments on updated values.
- Set the keryoserializer max buffer size to 512M to prevent OOM.
- fixed unit tests.