### PR TITLE
Fix AutoTuner unit test with dynamic plugin JAR URL value

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -1490,6 +1490,13 @@ trait AutoTunerConfigsProvider extends Logging {
     "Could not recommend RapidsShuffleManager as Spark version cannot be determined."
   }
 
+  def latestPluginJarComment(latestJarMvnUrl: String, currentJarVer: String): String = {
+    s"""
+       |A newer RAPIDS Accelerator for Apache Spark plugin is available:
+       |$latestJarMvnUrl
+       |Version used in application is $currentJarVer.
+       |""".stripMargin.trim.replaceAll("\n", "\n  ")
+  }
 
   /**
    * Find the label of the memory overhead based on the spark master configuration and the spark


### PR DESCRIPTION
This PR fixes a unit test added in PR  #1578. 

The AutoTuner recommendation included recommending the latest plugin JAR which is a dynamic property. This PR introduces helper methods to fetch the latest plugin JAR URL and use that in the recommendation.
