### PR TITLE
AutoTuner recommends increasing shuffle partitions when shuffle stages have OOM failures on YARN

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -1458,4 +1458,13 @@ object SparkRapidsOomExceptions {
   val gpuExceptionClassNames: Set[String] = {
     Set("GpuSplitAndRetryOOM", "GpuRetryOOM")
   }
+
+  val gpuShuffleClassName: String = "GpuShuffleExchangeExec"
+}
+
+/**
+ * Helper object to store the exit codes for a UNIX process.
+ */
+object UnixExitCode {
+  val FORCE_KILLED = 137
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
@@ -47,7 +47,8 @@ class AppInfoProviderMockTest(val maxInput: Double,
     val meanShuffleRead: Double,
     val shuffleStagesWithPosSpilling: Set[Long],
     val shuffleSkewStages: Set[Long],
-    val scanStagesWithGpuOom: Boolean) extends BaseProfilingAppSummaryInfoProvider {
+    val scanStagesWithGpuOom: Boolean,
+    val shuffleStagesWithOom: Boolean) extends BaseProfilingAppSummaryInfoProvider {
   override def isAppInfoAvailable = true
   override def getMaxInput: Double = maxInput
   override def getMeanInput: Double = meanInput
@@ -64,6 +65,7 @@ class AppInfoProviderMockTest(val maxInput: Double,
   override def getShuffleStagesWithPosSpilling: Set[Long] = shuffleStagesWithPosSpilling
   override def getShuffleSkewStages: Set[Long] = shuffleSkewStages
   override def hasScanStagesWithGpuOom: Boolean = scanStagesWithGpuOom
+  override def hasShuffleStagesWithOom: Boolean = shuffleStagesWithOom
 }
 
 /**
@@ -142,10 +144,11 @@ abstract class BaseAutoTunerSuite extends FunSuite with BeforeAndAfterEach with 
       meanShuffleRead: Double = 0.0,
       shuffleStagesWithPosSpilling: Set[Long] = Set(),
       shuffleSkewStages: Set[Long] = Set(),
-      scanStagesWithGpuOom: Boolean = false): AppSummaryInfoBaseProvider = {
+      scanStagesWithGpuOom: Boolean = false,
+      shuffleStagesWithOom: Boolean = false): AppSummaryInfoBaseProvider = {
     new AppInfoProviderMockTest(maxInput, spilledMetrics, jvmGCFractions, propsFromLog,
       sparkVersion, rapidsJars, distinctLocationPct, redundantReadSize, meanInput, meanShuffleRead,
-      shuffleStagesWithPosSpilling, shuffleSkewStages, scanStagesWithGpuOom)
+      shuffleStagesWithPosSpilling, shuffleSkewStages, scanStagesWithGpuOom, shuffleStagesWithOom)
   }
 
   /**

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -3501,4 +3501,164 @@ We recommend using nodes/workers with more memory. Need at least 17496MB memory.
       compareOutput(expectedResults, actualResults)
     }
   }
+
+  test(s"test AutoTuner recommends increasing shuffle partition when shuffle stages " +
+    s"have OOM failures") {
+    // mock the properties loaded from eventLog
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.sql.shuffle.partitions" -> "150",  // AutoTuner should recommend increasing this
+        "spark.executor.cores" -> "16",
+        "spark.executor.instances" -> "1",
+        "spark.executor.memory" -> "80g",
+        "spark.executor.resource.gpu.amount" -> "1",
+        "spark.executor.instances" -> "1",
+        "spark.task.resource.gpu.amount" -> "0.001",
+        "spark.rapids.memory.pinnedPool.size" -> "5g",
+        "spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
+        "spark.rapids.sql.concurrentGpuTasks" -> "4")
+    val dataprocWorkerInfo = buildGpuWorkerInfoAsString()
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
+      logEventsProps, Some(testSparkVersion), shuffleStagesWithOom = true)
+    val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
+      .loadClusterPropertiesFromContent(dataprocWorkerInfo)
+    val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
+    val autoTuner = ProfilingAutoTunerConfigsProvider
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
+          |--conf spark.executor.instances=8
+          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.locality.wait=0
+          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.concurrentGpuTasks=2
+          |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
+          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
+          |--conf spark.sql.files.maxPartitionBytes=512m
+          |--conf spark.sql.shuffle.partitions=300
+          |
+          |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
+          |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- 'spark.rapids.sql.format.parquet.multithreaded.combine.waitTime' was not set.
+          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
+          |- 'spark.rapids.sql.reader.multithreaded.combine.sizeBytes' was not set.
+          |- 'spark.shuffle.manager' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+          |- 'spark.sql.files.maxPartitionBytes' was not set.
+          |- 'spark.sql.shuffle.partitions' should be increased since task OOM occurred in shuffle stages.
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    compareOutput(expectedResults, autoTunerOutput)
+  }
+
+  test(s"test AutoTuner recommends increasing shuffle partition and AQE initial partition num " +
+    s"when shuffle stages have OOM failures") {
+    // mock the properties loaded from eventLog
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.sql.shuffle.partitions" -> "50",  // AutoTuner should recommend increasing this
+        "spark.executor.cores" -> "16",
+        "spark.executor.instances" -> "1",
+        "spark.executor.memory" -> "80g",
+        "spark.executor.resource.gpu.amount" -> "1",
+        "spark.executor.instances" -> "1",
+        "spark.task.resource.gpu.amount" -> "0.001",
+        "spark.rapids.memory.pinnedPool.size" -> "5g",
+        "spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
+        "spark.rapids.sql.concurrentGpuTasks" -> "4")
+    val dataprocWorkerInfo = buildGpuWorkerInfoAsString()
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
+      logEventsProps, Some(testSparkVersion), shuffleStagesWithOom = true,
+      meanInput = 50000, meanShuffleRead = 80000)
+    val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
+      .loadClusterPropertiesFromContent(dataprocWorkerInfo)
+    val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
+    val autoTuner = ProfilingAutoTunerConfigsProvider
+      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
+          |--conf spark.executor.instances=8
+          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.locality.wait=0
+          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.concurrentGpuTasks=2
+          |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=32m
+          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
+          |--conf spark.sql.adaptive.coalescePartitions.initialPartitionNum=800
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
+          |--conf spark.sql.adaptive.coalescePartitions.parallelismFirst=false
+          |--conf spark.sql.files.maxPartitionBytes=512m
+          |--conf spark.sql.shuffle.partitions=800
+          |
+          |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
+          |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- 'spark.rapids.sql.format.parquet.multithreaded.combine.waitTime' was not set.
+          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
+          |- 'spark.rapids.sql.reader.multithreaded.combine.sizeBytes' was not set.
+          |- 'spark.shuffle.manager' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.coalescePartitions.initialPartitionNum' was not set.
+          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+          |- 'spark.sql.files.maxPartitionBytes' was not set.
+          |- 'spark.sql.shuffle.partitions' should be increased since task OOM occurred in shuffle stages.
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    compareOutput(expectedResults, autoTunerOutput)
+  }
 }


### PR DESCRIPTION
Fixes #1566 

This PR introduces changes to detect if OOM occurred in shuffle stages (exit code 137) and updates the AutoTuner to recommend increasing `spark.sql.shuffle.partitions`.

Note: This check is enabled only if the plugin is enabled (i.e. GPU app) and running on YARN.

## Error Message
```
ExecutorLostFailure (executor 2 exited caused by one of the running tasks) Reason: Container from a bad node: container_e02_17xxx on host: test-cluster-w-0. Exit status: 137
```

## Logic
### 1. For `spark.sql.shuffle.partitions`:
1. Detect OOM Failures: Check for `ExecutorLostFailure` and exit code `137` in task failure reason for shuffle stages
2. Calculate shuffle partition num: Use existing logic based on spills and skew
3. New Logic:
   - If OOM failures detected: Use max(2 × current shuffle partition num, calculated shuffle partition num)
   - Else, use calculated shuffle partition num


### 2. For `spark.sql.adaptive.coalescePartitions.initialPartitionNum`:
1. Use existing logic to calculate `initialPartitionNum` (mean input and mean shuffle size is large)
2. Skip recommending 'initialPartitionNum' when:
   - AutoTuner has already recommended `spark.sql.shuffle.partitions` AND
   - The recommended shuffle partitions value is sufficient (>= `initialPartitionNum`)
     This is because AQE will use the recommended 'spark.sql.shuffle.partitions' by default.
3. Set `initialPartitionNum` when either:
   - AutoTuner has not recommended `spark.sql.shuffle.partitions` OR
   - Recommended shuffle partitions is small (< `initialPartitionNum`)

## Code Changes

### Enhancements to profiling and tuning functionalities:

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala`](diffhunk://#diff-56f8f43c29a4842fda9381a3199ebf71e51ce90491357ce8051d8493d902925bR23-R24): Added a method to check for shuffle stages with OOM errors and updated the `AppInfoGpuOomCheck` trait to include this method. [[1]](diffhunk://#diff-56f8f43c29a4842fda9381a3199ebf71e51ce90491357ce8051d8493d902925bR23-R24) [[2]](diffhunk://#diff-56f8f43c29a4842fda9381a3199ebf71e51ce90491357ce8051d8493d902925bR90) [[3]](diffhunk://#diff-56f8f43c29a4842fda9381a3199ebf71e51ce90491357ce8051d8493d902925bR245-R284)

### Improvements to AQE property recommendations:

* [`core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala`](diffhunk://#diff-ef26e6d4e25cf3134245beb228e7802e2cf3be63e64e0d6e1b98587d0e2d7896R663): Enhanced the recommendation logic for AQE properties, including handling initial partition numbers and shuffle partitions based on shuffle stages with OOM errors. [[1]](diffhunk://#diff-ef26e6d4e25cf3134245beb228e7802e2cf3be63e64e0d6e1b98587d0e2d7896R663) [[2]](diffhunk://#diff-ef26e6d4e25cf3134245beb228e7802e2cf3be63e64e0d6e1b98587d0e2d7896R776) [[3]](diffhunk://#diff-ef26e6d4e25cf3134245beb228e7802e2cf3be63e64e0d6e1b98587d0e2d7896R792) [[4]](diffhunk://#diff-ef26e6d4e25cf3134245beb228e7802e2cf3be63e64e0d6e1b98587d0e2d7896R816) [[5]](diffhunk://#diff-ef26e6d4e25cf3134245beb228e7802e2cf3be63e64e0d6e1b98587d0e2d7896L824-R857) [[6]](diffhunk://#diff-ef26e6d4e25cf3134245beb228e7802e2cf3be63e64e0d6e1b98587d0e2d7896L988-L998) [[7]](diffhunk://#diff-ef26e6d4e25cf3134245beb228e7802e2cf3be63e64e0d6e1b98587d0e2d7896R1032-R1047) [[8]](diffhunk://#diff-ef26e6d4e25cf3134245beb228e7802e2cf3be63e64e0d6e1b98587d0e2d7896R1277-R1297) [[9]](diffhunk://#diff-ef26e6d4e25cf3134245beb228e7802e2cf3be63e64e0d6e1b98587d0e2d7896L1329-R1386)
## Tests

- Added unit tests
- Reproduced this test application locally and copied the event logs to cloud for our internal CICD tests.