### PR TITLE
Improve Profiling AutoTuner to provide cluster-aware configuration recommendations

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/AppSummaryInfoBaseProvider.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/AppSummaryInfoBaseProvider.scala
@@ -17,7 +17,7 @@
 package com.nvidia.spark.rapids.tool
 
 import com.nvidia.spark.rapids.tool.analysis.AggRawMetricsResult
-import com.nvidia.spark.rapids.tool.profiling.{AppInfoJobStageAggMetricsVisitor, AppInfoPropertyGetter, AppInfoReadMetrics, AppInfoSqlTaskAggMetricsVisitor, AppInfoSQLTaskInputSizes, ApplicationSummaryInfo, BaseProfilingAppSummaryInfoProvider, DataSourceProfileResult, SingleAppSummaryInfoProvider}
+import com.nvidia.spark.rapids.tool.profiling.{AppInfoJobStageAggMetricsVisitor, AppInfoPropertyGetter, AppInfoReadMetrics, AppInfoSqlTaskAggMetricsVisitor, AppInfoSQLTaskInputSizes, BaseProfilingAppSummaryInfoProvider, DataSourceProfileResult, ProfilerResult, SingleAppSummaryInfoProvider}
 import com.nvidia.spark.rapids.tool.tuning.QualAppSummaryInfoProvider
 
 import org.apache.spark.sql.rapids.tool.ToolUtils
@@ -61,10 +61,17 @@ class AppSummaryInfoBaseProvider extends AppInfoPropertyGetter
 
 
 object AppSummaryInfoBaseProvider {
+  /**
+   * Constructs an application information provider based on the results of Profiler tool.
+   * @param profilerResult  Profiler result containing application information,
+   *                        summary and diagnostics
+   * @return object that can be used by the AutoTuner to calculate the recommendations
+   */
   def fromAppInfo(
-      appInfoInst: Option[ApplicationSummaryInfo]): BaseProfilingAppSummaryInfoProvider = {
-    appInfoInst match {
-      case Some(appSummaryInfo) => new SingleAppSummaryInfoProvider(appSummaryInfo)
+      profilerResult: Option[ProfilerResult]): BaseProfilingAppSummaryInfoProvider = {
+    profilerResult match {
+      case Some(profilerResult) => new SingleAppSummaryInfoProvider(
+        profilerResult.app, profilerResult.summary)
       case _ => new BaseProfilingAppSummaryInfoProvider()
     }
   }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -22,6 +22,7 @@ import com.nvidia.spark.rapids.tool.tuning.{SparkMaster, Yarn}
 import com.nvidia.spark.rapids.tool.views.{IoMetrics, WriteOpProfileResult}
 
 import org.apache.spark.ExecutorLostFailure
+import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
 
 case class ApplicationSummaryInfo(
     appInfo: Seq[AppInfoProfileResults],
@@ -102,9 +103,12 @@ class BaseProfilingAppSummaryInfoProvider
  * [[ApplicationSummaryInfo]].
  * Note that this class does not handle combined mode and assume that the profiling results belong
  * to a single app.
- * @param app the object resulting from profiling a single app.
+ * @param appInfo Info object resulting from profiling a single app.
+ * @param app Summary object resulting from profiling a single app.
  */
-class SingleAppSummaryInfoProvider(val app: ApplicationSummaryInfo)
+class SingleAppSummaryInfoProvider(
+    val appInfo: ApplicationInfo,
+    val app: ApplicationSummaryInfo)
   extends BaseProfilingAppSummaryInfoProvider {
 
   private lazy val distinctLocations = app.dsInfo.groupBy(_.location)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
@@ -19,10 +19,9 @@ package com.nvidia.spark.rapids.tool.profiling
 import java.util.concurrent.{ConcurrentLinkedQueue, TimeUnit}
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.{ArrayBuffer, HashMap}
 import scala.util.control.NonFatal
 
-import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, EventLogInfo, EventLogPathProcessor, FailedEventLog, Platform, PlatformFactory, ToolBase}
+import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, EventLogInfo, EventLogPathProcessor, FailedEventLog, PlatformFactory, ToolBase}
 import com.nvidia.spark.rapids.tool.tuning.{AutoTuner, ProfilingAutoTunerConfigsProvider, TuningEntryTrait}
 import com.nvidia.spark.rapids.tool.views._
 import org.apache.hadoop.conf.Configuration
@@ -31,6 +30,20 @@ import org.apache.spark.sql.rapids.tool.{AppBase, FailureApp, IncorrectAppStatus
 import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
 import org.apache.spark.sql.rapids.tool.ui.ConsoleProgressBar
 import org.apache.spark.sql.rapids.tool.util._
+
+/**
+ * Represents the complete profiling results for a Spark application.
+ * Contains the raw application information, processed summary, and diagnostic data.
+ *
+ * @param app Raw application information including events, metrics, and configuration
+ * @param summary Processed summary information including aggregated metrics,
+ *                health checks, and properties
+ * @param diagnostics Diagnostic information including stage diagnostics and I/O metrics
+ */
+case class ProfilerResult(
+    app: ApplicationInfo,
+    summary: ApplicationSummaryInfo,
+    diagnostics: DiagnosticSummaryInfo)
 
 class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolean)
   extends ToolBase(appArgs.timeout.toOption) {
@@ -43,8 +56,6 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
   private val outputCombined: Boolean = appArgs.combined()
   private val useAutoTuner: Boolean = appArgs.autoTuner()
   private val outputAlignedSQLIds: Boolean = appArgs.outputSqlIdsAligned()
-  // Unlike qualification tool, profiler tool does not require platform per app
-  private val platform: Platform = PlatformFactory.createInstance(appArgs.platform())
 
   override def getNumThreads: Int = appArgs.numThreads.getOrElse(
     Math.ceil(Runtime.getRuntime.availableProcessors() / 4f).toInt)
@@ -81,8 +92,9 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
               val (sums, comparedRes, diagnostics) =
                 processApps(apps, printPlans = false, profileOutputWriter)
               progressBar.foreach(_.reportSuccessfulProcesses(apps.size))
-              writeSafelyToOutput(profileOutputWriter, Seq(sums), false, comparedRes,
-                Seq(diagnostics))
+              writeSafelyToOutput(profileOutputWriter,
+                Seq(ProfilerResult(apps.head, sums, diagnostics)),
+                comparedRes)
             } catch {
               case _: Exception =>
                 progressBar.foreach(_.reportFailedProcesses(apps.size))
@@ -101,8 +113,8 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
         // combine them into single tables in the output.
         val profileOutputWriter = new ProfileOutputWriter(s"$outputDir/combined",
           Profiler.COMBINED_LOG_FILE_NAME_PREFIX, numOutputRows, outputCSV = outputCSV)
-        val (sums, diagnostics) = createAppsAndSummarize(eventLogInfos, profileOutputWriter)
-        writeSafelyToOutput(profileOutputWriter, sums, outputCombined, diagnosticSum = diagnostics)
+        val profilerResults = createAppsAndSummarize(eventLogInfos, profileOutputWriter)
+        writeSafelyToOutput(profileOutputWriter, profilerResults)
         profileOutputWriter.close()
       }
     } else {
@@ -234,15 +246,13 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
   private def createAppsAndSummarize(
       allPaths: Seq[EventLogInfo],
       profileOutputWriter: ProfileOutputWriter)
-    : (Seq[ApplicationSummaryInfo], Seq[DiagnosticSummaryInfo]) = {
-    val allApps = new ConcurrentLinkedQueue[ApplicationSummaryInfo]()
-    val allDiagnostics = new ConcurrentLinkedQueue[DiagnosticSummaryInfo]()
+    : Seq[ProfilerResult] = {
+    val allAppsResultList = new ConcurrentLinkedQueue[ProfilerResult]()
 
     class ProfileThread(path: EventLogInfo, index: Int) extends Runnable {
       def run: Unit = profileApp(path, index, { app =>
         val (s, _, d) = processApps(Seq(app), false, profileOutputWriter)
-        allApps.add(s)
-        allDiagnostics.add(d)
+        allAppsResultList.add(ProfilerResult(app, s, d))
       })
     }
 
@@ -263,7 +273,7 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
         " stopping processing any more event logs")
       threadPool.shutdownNow()
     }
-    (allApps.asScala.toSeq, allDiagnostics.asScala.toSeq)
+    allAppsResultList.asScala.toSeq
   }
 
   private def createAppAndProcess(
@@ -276,8 +286,7 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
         try {
           val (sum, _, diagnostics) =
             processApps(Seq(app), appArgs.printPlans(), profileOutputWriter)
-          writeSafelyToOutput(profileOutputWriter, Seq(sum), false,
-            diagnosticSum = Seq(diagnostics))
+          writeSafelyToOutput(profileOutputWriter, Seq(ProfilerResult(app, sum, diagnostics)))
         } finally {
           profileOutputWriter.close()
         }
@@ -299,6 +308,14 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
     try {
       // These apps only contains 1 app in each loop.
       val startTime = System.currentTimeMillis()
+      // we need a platform per application because it's storing cluster information which could
+      // vary between applications, especially when using dynamic allocation
+      val platform = {
+        val workerInfoPath = appArgs.workerInfo
+          .getOrElse(ProfilingAutoTunerConfigsProvider.DEFAULT_WORKER_INFO_PATH)
+        val clusterPropsOpt = ProfilingAutoTunerConfigsProvider.loadClusterProps(workerInfoPath)
+        PlatformFactory.createInstance(appArgs.platform(), clusterPropsOpt)
+      }
       val app = new ApplicationInfo(hadoopConf, path, index, platform)
       EventLogPathProcessor.logApplicationInfo(app)
       val endTime = System.currentTimeMillis()
@@ -412,22 +429,25 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
 
   /**
    * A wrapper method to run the AutoTuner.
-   * @param appInfo     Summary of the application for tuning.
+   * @param profilerResult     ProfilerResult object storing the app info, summary and diagnostics
    * @param driverInfoProvider Entity that implements APIs needed to extract information from the
    *                           driver log if any
    */
-  private def runAutoTuner(appInfo: Option[ApplicationSummaryInfo],
+  private def runAutoTuner(
+      profilerResult: Option[ProfilerResult],
       driverInfoProvider: DriverLogInfoProvider = BaseDriverLogInfoProvider.noneDriverLog)
   : (Seq[TuningEntryTrait], Seq[RecommendedCommentResult]) = {
     // only run the auto tuner on GPU event logs for profiling tool right now. There are
     // assumptions made in the code
-    if (appInfo.isDefined && appInfo.get.appInfo.head.pluginEnabled) {
-      val appInfoProvider = AppSummaryInfoBaseProvider.fromAppInfo(appInfo)
-      val workerInfoPath = appArgs.workerInfo
-        .getOrElse(ProfilingAutoTunerConfigsProvider.DEFAULT_WORKER_INFO_PATH)
-      val clusterPropsOpt = ProfilingAutoTunerConfigsProvider.loadClusterProps(workerInfoPath)
+    val appInfoFromSummary = profilerResult.flatMap(_.summary.appInfo.headOption)
+    if (appInfoFromSummary.isDefined && appInfoFromSummary.get.pluginEnabled) {
+      val appInfoProvider = AppSummaryInfoBaseProvider.fromAppInfo(profilerResult)
+      val platform = profilerResult.get.app.platform.getOrElse {
+        throw new IllegalStateException("Profiling AutoTuner requires a platform. " +
+          "Please provide a valid platform using --platform option.")
+      }
       val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider.buildAutoTuner(appInfoProvider,
-        PlatformFactory.createInstance(appArgs.platform(), clusterPropsOpt), driverInfoProvider)
+        platform, driverInfoProvider)
 
       // The autotuner allows skipping some properties,
       // e.g., getRecommendedProperties(Some(Seq("spark.executor.instances"))) skips the
@@ -440,78 +460,13 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
     }
   }
 
-  def writeOutput(profileOutputWriter: ProfileOutputWriter,
-      appsSum: Seq[ApplicationSummaryInfo], outputCombined: Boolean,
-      comparedRes: Option[CompareSummaryInfo] = None,
-      diagnosticSum: Seq[DiagnosticSummaryInfo]): Unit = {
+  private def writeOutput(
+      profileOutputWriter: ProfileOutputWriter,
+      profilerResults: Seq[ProfilerResult],
+      comparedRes: Option[CompareSummaryInfo]): Unit = {
 
-    val sums = if (outputCombined) {
-      // the properties table here has the column names as the app indexes so we have to
-      // handle special
-
-      def combineProps(propSource: String,
-          sums: Seq[ApplicationSummaryInfo]): Seq[RapidsPropertyProfileResult] = {
-        var numApps = 0
-        val props = HashMap[String, ArrayBuffer[String]]()
-        val outputHeaders = ArrayBuffer("propertyName")
-        sums.foreach { app =>
-          val inputProps = if (propSource.equals("rapids")) {
-            app.rapidsProps
-          } else if (propSource.equals("spark")) {
-            app.sparkProps
-          } else { // this is for system properties
-            app.sysProps
-          }
-          if (inputProps.nonEmpty) {
-            numApps += 1
-            val appMappedProps = inputProps.map { p =>
-              p.rows(0) -> p.rows(1)
-            }.toMap
-
-            outputHeaders += inputProps.head.outputHeaders(1)
-            CollectInformation.addNewProps(appMappedProps, props, numApps)
-          }
-        }
-        val allRows = props.map { case (k, v) => Seq(k) ++ v }.toSeq
-        val resRows = allRows.map(r => RapidsPropertyProfileResult(r(0), outputHeaders, r))
-        resRows.sortBy(cols => cols.key)
-      }
-      val reduced = ApplicationSummaryInfo(
-        appsSum.flatMap(_.appInfo).sortBy(_.appIndex),
-        appsSum.flatMap(_.dsInfo).sortBy(_.appIndex),
-        appsSum.flatMap(_.execInfo).sortBy(_.appIndex),
-        appsSum.flatMap(_.jobInfo).sortBy(_.appIndex),
-        combineProps("rapids", appsSum).sortBy(_.key),
-        appsSum.flatMap(_.rapidsJar).sortBy(_.appIndex),
-        appsSum.flatMap(_.sqlMetrics).sortBy(_.appIndex),
-        appsSum.flatMap(_.stageMetrics).sortBy(_.appIndex),
-        appsSum.flatMap(_.jobAggMetrics).sortBy(_.appIndex),
-        appsSum.flatMap(_.stageAggMetrics).sortBy(_.appIndex),
-        appsSum.flatMap(_.sqlTaskAggMetrics).sortBy(_.appIndex),
-        appsSum.flatMap(_.durAndCpuMet).sortBy(_.appIndex),
-        appsSum.flatMap(_.skewInfo).sortBy(_.appIndex),
-        appsSum.flatMap(_.failedTasks).sortBy(_.appIndex),
-        appsSum.flatMap(_.failedStages).sortBy(_.appIndex),
-        appsSum.flatMap(_.failedJobs).sortBy(_.appIndex),
-        appsSum.flatMap(_.removedBMs).sortBy(_.appIndex),
-        appsSum.flatMap(_.removedExecutors).sortBy(_.appIndex),
-        appsSum.flatMap(_.unsupportedOps).sortBy(_.appIndex),
-        combineProps("spark", appsSum).sortBy(_.key),
-        appsSum.flatMap(_.sqlStageInfo).sortBy(_.duration)(Ordering[Option[Long]].reverse),
-        appsSum.flatMap(_.wholeStage).sortBy(_.appIndex),
-        appsSum.flatMap(_.maxTaskInputBytesRead).sortBy(_.appIndex),
-        appsSum.flatMap(_.appLogPath).sortBy(_.appIndex),
-        appsSum.flatMap(_.ioMetrics).sortBy(_.appIndex),
-        combineProps("system", appsSum).sortBy(_.key),
-        appsSum.flatMap(_.sqlCleanedAlignedIds).sortBy(_.appIndex),
-        appsSum.flatMap(_.sparkRapidsBuildInfo),
-        appsSum.flatMap(_.writeOpsInfo).sortBy(_.appIndex)
-      )
-      Seq(reduced)
-    } else {
-      appsSum
-    }
-    sums.foreach { app: ApplicationSummaryInfo =>
+    profilerResults.foreach { profilerResult =>
+      val app = profilerResult.summary
       profileOutputWriter.writeText("### A. Information Collected ###")
       profileOutputWriter.write(ProfInformationView.getLabel, app.appInfo)
       profileOutputWriter.write(ProfLogPathView.getLabel, app.appLogPath)
@@ -568,25 +523,17 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
           Some(ProfSQLPlanAlignedView.getDescription))
       }
       if (useAutoTuner) {
-        val (properties, comments) = runAutoTuner(Some(app))
+        val (properties, comments) = runAutoTuner(Some(profilerResult))
         profileOutputWriter.writeText("\n### D. Recommended Configuration ###\n")
         profileOutputWriter.writeText(Profiler.getAutoTunerResultsAsString(properties, comments))
       }
 
       profileOutputWriter.writeSparkRapidsBuildInfo("Spark Rapids Build Info",
         app.sparkRapidsBuildInfo)
-    }
-    // Write diagnostic related results to CSV files
-    val diagnostics = if (outputCombined) {
-      Seq(DiagnosticSummaryInfo(diagnosticSum.flatMap(_.stageDiagnostics),
-        diagnosticSum.flatMap(_.IODiagnostics)))
-    } else {
-      diagnosticSum
-    }
-    diagnostics.foreach { diagnostoic =>
-      profileOutputWriter.writeCSVTable(STAGE_DIAGNOSTICS_LABEL, diagnostoic.stageDiagnostics)
+      profileOutputWriter.writeCSVTable(STAGE_DIAGNOSTICS_LABEL,
+        profilerResult.diagnostics.stageDiagnostics)
       profileOutputWriter.writeCSVTable(ProfIODiagnosticMetricsView.getLabel,
-        diagnostoic.IODiagnostics)
+        profilerResult.diagnostics.IODiagnostics)
     }
   }
 
@@ -595,12 +542,12 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
    * If an exception occurs during the writing process, it will be caught and logged, preventing
    * it from propagating further.
    */
-  private def writeSafelyToOutput(profileOutputWriter: ProfileOutputWriter,
-      appsSum: Seq[ApplicationSummaryInfo], outputCombined: Boolean,
-      comparedRes: Option[CompareSummaryInfo] = None,
-      diagnosticSum: Seq[DiagnosticSummaryInfo]): Unit = {
+  private def writeSafelyToOutput(
+      profileOutputWriter: ProfileOutputWriter,
+      profilerResults: Seq[ProfilerResult],
+      comparedRes: Option[CompareSummaryInfo] = None): Unit = {
     try {
-      writeOutput(profileOutputWriter, appsSum, outputCombined, comparedRes, diagnosticSum)
+      writeOutput(profileOutputWriter, profilerResults, comparedRes)
     } catch {
       case e: Exception =>
         logError("Exception thrown while writing", e)

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -371,11 +371,41 @@ abstract class AppBase(
   }
 
   /**
-   * Builds cluster information based on executor nodes.
+   * Builds cluster information based on executor nodes and sets it in the
+   * platform so that it can be used later.
    * If executor nodes exist, calculates the number of hosts and total cores,
    * and extracts executor and driver instance types (databricks only)
    */
-  protected def buildClusterInfo: Unit = {}
+  def buildClusterInfo(): Unit = {
+    // try to figure out number of executors per node based on the executor info
+    // Group by host name, find max executors per host
+    val execsPerNodeList = executorIdToInfo.values.groupBy(_.host).mapValues(_.size).values
+    // if we have different number of execs per node, then we blank it out to indicate
+    // not applicable (like when dynamic allocation is on in multi-tenant cluster)
+    // Since with dynamic allocation you could end up with more executors on a node then it
+    // has slots, just always set numExecsPerNode to -1 when its enabled.
+    val dynamicAllocEnabled = Platform.isDynamicAllocationEnabled(sparkProperties)
+    val numExecsPerNode = if (!dynamicAllocEnabled && execsPerNodeList.nonEmpty &&
+      execsPerNodeList.forall(_ == execsPerNodeList.head)) {
+      execsPerNodeList.head
+    } else {
+      -1
+    }
+    val execCoreCounts = executorIdToInfo.values.map(_.totalCores)
+    if (execCoreCounts.nonEmpty) {
+      if (execCoreCounts.toSet.size != 1) {
+        logWarning(s"Application $appId: Cluster with variable executor cores detected. " +
+          s"Using maximum value.")
+      }
+      // Create cluster information based on platform type
+      platform.foreach(_.configureClusterInfoFromEventLog(execCoreCounts.max,
+        numExecsPerNode, maxNumExecutorsRunning, maxNumNodesRunning,
+        sparkProperties, systemProperties))
+    } else {
+      logWarning("Could not determine if any executors were allocated or the number of cores " +
+        "used per executor. Can't build existing cluster information!")
+    }
+  }
 
   // The ReadSchema metadata is only in the eventlog for DataSource V1 readers
   def checkMetadataForReadSchema(
@@ -488,10 +518,11 @@ abstract class AppBase(
     }
   }
 
-  protected def postCompletion(): Unit = {
+  private def postCompletion(): Unit = {
     registerAttemptId()
     calculateAppDuration()
     validateSparkRuntime()
+    buildClusterInfo()
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -203,12 +203,6 @@ class ApplicationInfo(
     false
   }
 
-  override def postCompletion(): Unit = {
-    // finally aggregate the Info
-    super.postCompletion()
-    buildClusterInfo
-  }
-
   override def guestimateAppEndTimeCB(): () => Option[Long] = {
     () =>
       val jobEndTimes = jobIdToInfo.map { case (_, jc) => jc.endTime }.filter(_.isDefined)

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -828,48 +828,6 @@ class QualificationAppInfo(
     val unSupportedWriteFormat = pluginTypeChecker.getUnsupportedWriteFormat(writeFormat)
     unSupportedWriteFormat.toSeq
   }
-
-  /**
-   * Builds cluster information based on executor nodes and sets it in the
-   * platform so that it can be used later.
-   * If executor nodes exist, calculates the number of hosts and total cores,
-   * and extracts executor and driver instance types (databricks only)
-   */
-  override def buildClusterInfo: Unit = {
-    // try to figure out number of executors per node based on the executor info
-    // Group by host name, find max executors per host
-    val execsPerNodeList = executorIdToInfo.values.groupBy(_.host).mapValues(_.size).values
-    // if we have different number of execs per node, then we blank it out to indicate
-    // not applicable (like when dynamic allocation is on in multi-tenant cluster)
-    // Since with dynamic allocation you could end up with more executors on a node then it
-    // has slots, just always set numExecsPerNode to -1 when its enabled.
-    val dynamicAllocEnabled = Platform.isDynamicAllocationEnabled(sparkProperties)
-    val numExecsPerNode = if (!dynamicAllocEnabled && execsPerNodeList.size > 0 &&
-      execsPerNodeList.forall(_ == execsPerNodeList.head)) {
-      execsPerNodeList.head
-    } else {
-      -1
-    }
-    val execCoreCounts = executorIdToInfo.values.map(_.totalCores)
-    if (execCoreCounts.size > 0) {
-      if (execCoreCounts.toSet.size != 1) {
-        logWarning(s"Application $appId: Cluster with variable executor cores detected. " +
-          s"Using maximum value.")
-      }
-      // Create cluster information based on platform type
-      platform.configureClusterInfoFromEventLog(execCoreCounts.max,
-        numExecsPerNode, maxNumExecutorsRunning, maxNumNodesRunning,
-        sparkProperties, systemProperties)
-    } else {
-      logWarning("Could not determine if any executors were allocated or the number of cores " +
-        "used per executor. Can't build existing cluster information!")
-    }
-  }
-
-  override def postCompletion(): Unit = {
-    super.postCompletion()
-    buildClusterInfo
-  }
 }
 
 case class MLFunctionReportInfo(


### PR DESCRIPTION
Fixes #1606 

### Issue
Previously, the Profiling AutoTuner was unable to provide certain configuration recommendations that the Qualification Tool could generate, such as:
- Basic executor settings (`spark.executor.instances`, `spark.executor.memory`)
- GPU task configurations (`spark.rapids.sql.concurrentGpuTasks`)
- Advanced Adaptive Query Execution settings (`spark.sql.adaptive.coalescePartitions.initialPartitionNum`)
- Performance optimization parameters (`spark.rapids.sql.multiThreadedRead.numThreads`)

**Reason:**
This was due to a limitation from how cluster information was managed. While the Qualification Tool maintained separate platform objects per event log, the Profiling Tool used a shared platform instance across all event logs. This shared instance prevented the AutoTuner from accessing event-log-specific cluster information needed for calculating optimal configurations.

### Changes
1. Modified the Profiling Tool to maintain separate platform instances per event log.
2. Improved the AutoTuner's context to include both raw ApplicationInfo and platform data
3. Enabled generation of cluster-aware configuration recommendations

### Impact
Previously for a GPU event log, the Profiling Tool would generate basic recommendations as:

```
Spark Properties:
--conf spark.rapids.sql.batchSizeBytes=2147483647
--conf spark.rapids.sql.enabled=true
--conf spark.shuffle.manager=[FILL_IN_VALUE]
--conf spark.sql.files.maxPartitionBytes=2629m

Comments:
- 'spark.executor.cores' should be set to 16.
- 'spark.executor.instances' should be set to (cpuCoresPerNode * numWorkers) / 'spark.executor.cores'.
- 'spark.executor.memory' should be set to at least 2GB/core.
- 'spark.rapids.memory.pinnedPool.size' should be set to 2048m.
- 'spark.rapids.sql.concurrentGpuTasks' should be set to Min(4, (gpuMemory / 7.5G)).
```

After this change, the Profiling AutoTuner generates a comprehensive set of recommendations:

```
Spark Properties:
--conf spark.executor.cores=16
--conf spark.executor.instances=4
--conf spark.executor.memory=32768m
--conf spark.executor.memoryOverhead=17612m
--conf spark.rapids.memory.pinnedPool.size=4096m
--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
--conf spark.rapids.sql.batchSizeBytes=2147483647
--conf spark.rapids.sql.concurrentGpuTasks=2
--conf spark.rapids.sql.enabled=true
--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
--conf spark.rapids.sql.multiThreadedRead.numThreads=80
--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
--conf spark.shuffle.manager=[FILL_IN_VALUE]
--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=32m
--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
--conf spark.sql.adaptive.coalescePartitions.initialPartitionNum=800
--conf spark.sql.adaptive.coalescePartitions.parallelismFirst=false
--conf spark.sql.files.maxPartitionBytes=2629m
--conf spark.sql.shuffle.partitions=800
--conf spark.task.resource.gpu.amount=0.001
```
