### PR TITLE
Packaging tools jar with whl file

### DIFF
--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -102,7 +102,7 @@ where = ["src"]
 [tool.setuptools.dynamic]
 version = {attr = "spark_rapids_pytools.__version__"}
 [tool.setuptools.package-data]
-"*"= ["*.json", "*.yaml", "*.ms", "*.sh", "*.tgz", "*.properties"]
+"*"= ["*.json", "*.yaml", "*.ms", "*.sh", "*.tgz", "*.properties","*.jar"]
 [tool.poetry]
 repository = "https://github.com/NVIDIA/spark-rapids-tools/tree/main"
 [project.optional-dependencies]

--- a/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
@@ -145,24 +145,9 @@ class ToolContext(YAMLPropertiesContainer):
         self.logger.info('Dependencies are generated locally in local disk as: %s', dep_folder)
         self.logger.info('Local output folder is set as: %s', exec_root_dir)
 
-    # def _identify_fat_wheel_jar(self, resource_files: List[str]) -> None:
-    #     """
-    #     Identifies the tools JAR file from resource files in fat wheel mode and sets its name in the context.
-    #     :param resource_files: List of resource files to search for the tools JAR file.
-    #     :raises AssertionError: If the number of matching files is not exactly one.
-    #     """
-    #     tools_jar_regex_str = self.get_value('sparkRapids', 'toolsJarRegex')
-    #     tools_jar_regex = re.compile(tools_jar_regex_str)
-    #     matched_files = [f for f in resource_files if tools_jar_regex.search(f)]
-    #     assert len(matched_files) == 1, \
-    #         (f'Expected exactly one tools JAR file, found {len(matched_files)}. '
-    #          'Rebuild the wheel package with the correct tools JAR file.')
-    #     # set the tools JAR file name in the context
-    #     self.set_ctxt('fatWheelModeJarFileName', FSUtil.get_resource_name(matched_files[0]))
-
     def _identify_tools_wheel_jar(self, resource_files: List[str]) -> None:
         """
-        Identifies the tools JAR file from resource files in fat wheel mode and sets its name in the context.
+        Identifies the tools JAR file from resource files and sets its name in the context.
         :param resource_files: List of resource files to search for the tools JAR file.
         :raises AssertionError: If the number of matching files is not exactly one.
         """
@@ -181,12 +166,17 @@ class ToolContext(YAMLPropertiesContainer):
         Checks if the packaging includes the CSP dependencies. If so, it moves the dependencies
         into the tmp folder. This allows the tool to pick the resources from cache folder.
         """
-        for tools_related_files in self.tools_resources:
+        for tools_related_files in self.tools_resource_path:
+            # This function uses a regex based comparison to identify the tools jar file
+            # from the tools-resources directory. The jar is pre-packed in the wheel file
+            # and moved to the work directory when user runs the tool.
+            self.logger.info("Checking for tools related files in %s", tools_related_files)
             if os.path.exists(tools_related_files):
                 FSUtil.copy_resource(tools_related_files, self.get_cache_folder())
                 self._identify_tools_wheel_jar(FSUtil.get_all_files(tools_related_files))
 
         if not self.are_resources_prepackaged():
+            self.logger.info('No prepackaged resources found.')
             return
 
         self.set_ctxt('fatWheelModeEnabled', True)
@@ -216,15 +206,8 @@ class ToolContext(YAMLPropertiesContainer):
         return self.get_local('depFolder')
 
     def get_rapids_jar_url(self) -> str:
-        self.logger.info('Fetching the Rapids Jar URL')
-        # get the version from the package, instead of the yaml file
-        # jar_version = self.get_value('sparkRapids', 'version')
-        # if self.is_fat_wheel_mode():
+        self.logger.info('Fetching the Rapids Jar URL from local context')
         return self._get_tools_jar()
-        # mvn_base_url = self.get_value('sparkRapids', 'mvnUrl')
-        # jar_version = Utilities.get_latest_mvn_jar_from_metadata(mvn_base_url)
-        # rapids_url = self.get_value('sparkRapids', 'repoUrl').format(mvn_base_url, jar_version, jar_version)
-        # return rapids_url
 
     def get_tool_main_class(self) -> str:
         return self.get_value('sparkRapids', 'mainClass')
@@ -260,26 +243,6 @@ class ToolContext(YAMLPropertiesContainer):
         """
         return CspEnv.pretty_print(self.platform.type_id)
 
-    def _get_tools_jar_in_fat_wheel_mode(self) -> str:
-        """
-        Extracts the tools JAR file from the context and returns its path from the cache folder.
-        """
-        jar_filename = self.get_ctxt('fatWheelModeJarFileName')
-        if jar_filename is None:
-            raise ValueError(
-                'In Fat Mode. Tools JAR file name not found in context. '
-                'Rebuild the wheel package or re-run without fat wheel mode.'
-            )
-        # construct the path to the tools JAR file in the cache folder
-        jar_filepath = FSUtil.build_path(self.get_cache_folder(), jar_filename)
-        if not FSUtil.resource_exists(jar_filepath):
-            raise FileNotFoundError(
-                f'In Fat Mode. Tools JAR not found in cache folder: {jar_filepath}. '
-                'Rebuild the wheel package or re-run without fat wheel mode.'
-            )
-        self.logger.info('Using jar from wheel file %s', jar_filepath)
-        return jar_filepath
-
     def _get_tools_jar(self) -> str:
         """
         Extracts the tools JAR file from the context and returns its path from the cache folder.
@@ -287,15 +250,15 @@ class ToolContext(YAMLPropertiesContainer):
         jar_filename = self.get_ctxt('toolsJarFileName')
         if jar_filename is None:
             raise ValueError(
-                'In Fat Mode. Tools JAR file name not found in context. '
-                'Rebuild the wheel package or re-run without fat wheel mode.'
+                'Tools JAR file name not found in context.'
+                'Rebuild the wheel package'
             )
         # construct the path to the tools JAR file in the cache folder
         jar_filepath = FSUtil.build_path(self.get_cache_folder(), jar_filename)
         if not FSUtil.resource_exists(jar_filepath):
             raise FileNotFoundError(
-                f'In Fat Mode. Tools JAR not found in cache folder: {jar_filepath}. '
-                'Rebuild the wheel package or re-run without fat wheel mode.'
+                f'Tools JAR not found in cache folder: {jar_filepath}. '
+                'Rebuild the wheel package'
             )
         self.logger.info('Using jar from wheel file %s', jar_filepath)
         return jar_filepath

--- a/user_tools/src/spark_rapids_pytools/resources/dev/prepackage_mgr.py
+++ b/user_tools/src/spark_rapids_pytools/resources/dev/prepackage_mgr.py
@@ -98,6 +98,8 @@ class PrepackageMgr:   # pylint: disable=too-few-public-methods
     def _fetch_resources(self) -> dict:
         """
         Fetches the resource information from configuration files for each supported platform.
+        Tools jar if passed explicitly is set as a dependency. Else it is build from source
+        and added as a dependency.
         Returns a dictionary of resource details.
         """
         resource_uris = {}
@@ -172,11 +174,19 @@ class PrepackageMgr:   # pylint: disable=too-few-public-methods
     def run(self):
         """
         Main method to fetch and download dependencies.
+        This function goes through the following steps:
+        1. Fetches the resources from the configuration files.
+        2. Downloads the resources to the specified directory.
+        3. Optionally compresses the resources into a tar file.
+        4. Cleans up the resources if compression is enabled.
         """
         resources_to_download = self._fetch_resources()
         self._download_resources(resources_to_download)
-        output_res = self._compress_resources()
-        print(f'CSP-prepackaged resources stored as {output_res}')
+        if self.fetch_all_csp:
+            output_res = self._compress_resources()
+            print(f'CSP-prepackaged resources stored as {output_res}')
+        else:
+            print(f'Packaged with tools resources only.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #1496 

This PR enables changes for packaging the tools jar with the python whl file. This solves for avoiding downloading the latest jar from maven each time any cli command is run.
This packages the jar from source and bundles it in the wheel in the folder tools_resources.

The changes have been tested locally using the --platform onprem. Since there are no platform specific changes  needed, it should be sufficient.

This pull request includes changes to the `user_tools/build.sh` script and related files to add support for a "non-fat" mode, which only downloads necessary resources instead of all dependencies. Additionally, it introduces a new folder structure to separate tools resources from CSP resources.

Build script enhancements:

* [`user_tools/build.sh`](diffhunk://#diff-33b48dfaa0c6bf1bbed25c76e81b86d6c4d3e177f220d0ebf07634c11cedea5fR32): Added a new variable `TOOLS_RESOURCE_FOLDER` to define the tools resources folder and updated the `download_web_dependencies` function to handle both fat and non-fat modes. [[1]](diffhunk://#diff-33b48dfaa0c6bf1bbed25c76e81b86d6c4d3e177f220d0ebf07634c11cedea5fR32) [[2]](diffhunk://#diff-33b48dfaa0c6bf1bbed25c76e81b86d6c4d3e177f220d0ebf07634c11cedea5fL65-R83)
* [`user_tools/build.sh`](diffhunk://#diff-33b48dfaa0c6bf1bbed25c76e81b86d6c4d3e177f220d0ebf07634c11cedea5fR109-R125): Modified the `build` function to incorporate the new build modes and ensure the appropriate resources are downloaded and organized.

Python tool context updates:

* [`user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py`](diffhunk://#diff-478d74668cb7f8438192c9f044fe6312bd2f11df130607745e51223aa039004dR48-R50): Introduced a new class variable `tools_resource_path` to manage tools resources and updated methods to handle the new folder structure and non-fat mode. [[1]](diffhunk://#diff-478d74668cb7f8438192c9f044fe6312bd2f11df130607745e51223aa039004dR48-R50) [[2]](diffhunk://#diff-478d74668cb7f8438192c9f044fe6312bd2f11df130607745e51223aa039004dL145-R150) [[3]](diffhunk://#diff-478d74668cb7f8438192c9f044fe6312bd2f11df130607745e51223aa039004dL158-R181) [[4]](diffhunk://#diff-478d74668cb7f8438192c9f044fe6312bd2f11df130607745e51223aa039004dL176-L181) [[5]](diffhunk://#diff-478d74668cb7f8438192c9f044fe6312bd2f11df130607745e51223aa039004dL196-R210) [[6]](diffhunk://#diff-478d74668cb7f8438192c9f044fe6312bd2f11df130607745e51223aa039004dL240-R261)

Resource manager script changes:

* [`user_tools/src/spark_rapids_pytools/resources/dev/prepackage_mgr.py`](diffhunk://#diff-48f4c8d291d66fc725353b1a3d40b1a126a974b64c6e1daa149f3f765654fdc5L39-R40): Added support for the `fetch_all_csp` flag to control whether all CSP resources are downloaded or just the tools jar. Updated the script to handle the new tools resources directory. [[1]](diffhunk://#diff-48f4c8d291d66fc725353b1a3d40b1a126a974b64c6e1daa149f3f765654fdc5L39-R40) [[2]](diffhunk://#diff-48f4c8d291d66fc725353b1a3d40b1a126a974b64c6e1daa149f3f765654fdc5L73-R87) [[3]](diffhunk://#diff-48f4c8d291d66fc725353b1a3d40b1a126a974b64c6e1daa149f3f765654fdc5R101-R102) [[4]](diffhunk://#diff-48f4c8d291d66fc725353b1a3d40b1a126a974b64c6e1daa149f3f765654fdc5L113-R123) [[5]](diffhunk://#diff-48f4c8d291d66fc725353b1a3d40b1a126a974b64c6e1daa149f3f765654fdc5L127-R151) [[6]](diffhunk://#diff-48f4c8d291d66fc725353b1a3d40b1a126a974b64c6e1daa149f3f765654fdc5R177-R189)

Other minor changes:

* [`user_tools/pyproject.toml`](diffhunk://#diff-4567c711bb2a94833399095b675b18e161015821d727f84acb42052a55996616L105-R105): Added `*.jar` to the package data to ensure the tools jar is included in the package.