### PR TITLE
Fix handling of driver logs in core-tools

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
@@ -79,7 +79,10 @@ object ProfileMain extends Logging {
 
     val profiler = new Profiler(hadoopConf, appArgs, enablePB)
     if (driverLog.nonEmpty) {
-      profiler.profileDriver(driverLog, eventLogFsFiltered.isEmpty)
+      profiler.profileDriver(
+        driverLogInfos = driverLog,
+        hadoopConf = Option(hadoopConf),
+        eventLogsEmpty = eventLogFsFiltered.isEmpty)
     }
     profiler.profile(eventLogFsFiltered)
     (0, filteredLogs.size)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
@@ -87,11 +87,17 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
     ProfileOutputWriter.writeCSVTable("Profiling Status", reportResults, outputDir)
   }
 
-  def profileDriver(driverLogInfos: String, eventLogsEmpty: Boolean): Unit = {
+  def profileDriver(
+      driverLogInfos: String,
+      hadoopConf: Option[Configuration],
+      eventLogsEmpty: Boolean): Unit = {
     val profileOutputWriter = new ProfileOutputWriter(s"$outputDir/driver",
       Profiler.DRIVER_LOG_NAME, numOutputRows, true)
     try {
-      val driverLogProcessor = new DriverLogProcessor(driverLogInfos)
+      val driverLogProcessor =
+        BaseDriverLogInfoProvider(
+          logPath = Option(driverLogInfos),
+          hadoopConf = hadoopConf)
       val unsupportedDriverOperators = driverLogProcessor.getUnsupportedOperators
       profileOutputWriter.write(s"Unsupported operators in driver log",
         unsupportedDriverOperators)

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.rapids.tool.ToolUtils
 
 
 case class DriverInfoProviderMockTest(unsupportedOps: Seq[DriverLogUnsupportedOperators])
-  extends BaseDriverLogInfoProvider(None) {
+  extends BaseDriverLogInfoProvider() {
   override def getUnsupportedOperators: Seq[DriverLogUnsupportedOperators] = unsupportedOps
 }
 


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #698

- Uses hadoop API to handle the driverlog path
- tested with driver log `file:///` and `/home/directory`