### PR TITLE
Fix filtered eventlogs in Profiling tool

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -375,6 +375,30 @@
                 <hadoop.version>3.3.6</hadoop.version>
             </properties>
         </profile>
+        <profile>
+            <!--
+              Define a profile to be used for release. This profile
+              should set the properties accordingly to make the jars suitable for production.
+              For instance, set the elide-level to release to remove scala asserts.
+
+              Release jobs should be using that Profile.
+            -->
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>350</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>350</buildver>
+                <spark.version>${spark350.version}</spark.version>
+                <delta.core.artifactory>${delta.core.artifactory.post35}</delta.core.artifactory>
+                <delta.core.version>${delta31x.version}</delta.core.version>
+                <hadoop.version>3.3.6</hadoop.version>
+                <elide.level>${elide.level.release}</elide.level>
+            </properties>
+        </profile>
     </profiles>
     <properties>
         <spark311.version>3.1.1</spark311.version>
@@ -440,12 +464,12 @@
             For debugging/development and testing, the elide.level should be set to WARNING.
         -->
         <elide.level.release>2001</elide.level.release>
-        <elide.level.dev>MAXIMUM</elide.level.dev>
+        <elide.level.dev>MINIMUM</elide.level.dev>
         <!--
-            Temporarily set the default elid level to RELEASE until we modify the CI/CD release to
-            build with RELEASE profile that disables the Scala asserts.
+            The default elide level to dev A build for RELEASE should overwrite
+            that to disable non-production code (i.e., Scala asserts).
         -->
-        <elide.level>${elide.level.release}</elide.level>
+        <elide.level>${elide.level.dev}</elide.level>
         <java.version>1.8</java.version>
         <platform-encoding>UTF-8</platform-encoding>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -384,12 +384,6 @@
               Release jobs should be using that Profile.
             -->
             <id>release</id>
-            <activation>
-                <property>
-                    <name>buildver</name>
-                    <value>350</value>
-                </property>
-            </activation>
             <properties>
                 <buildver>350</buildver>
                 <spark.version>${spark350.version}</spark.version>

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
@@ -82,9 +82,9 @@ object ProfileMain extends Logging {
       profiler.profileDriver(
         driverLogInfos = driverLog,
         hadoopConf = Option(hadoopConf),
-        eventLogsEmpty = eventLogFsFiltered.isEmpty)
+        eventLogsEmpty = filteredLogs.isEmpty)
     }
-    profiler.profile(eventLogFsFiltered)
+    profiler.profile(filteredLogs)
     (0, filteredLogs.size)
   }
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/ToolTestUtils.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/ToolTestUtils.scala
@@ -36,6 +36,7 @@ object ToolTestUtils extends Logging {
   private val csvStatusFields = Seq(
     (QualOutputWriter.STATUS_REPORT_PATH_STR, StringType),
     (QualOutputWriter.STATUS_REPORT_STATUS_STR, StringType),
+    (QualOutputWriter.STATUS_REPORT_APP_ID, StringType),
     (QualOutputWriter.STATUS_REPORT_DESC_STR, StringType))
 
   val statusReportSchema =
@@ -181,7 +182,9 @@ object ToolTestUtils extends Logging {
         countStatus("FAILURE"),
         countStatus("SKIPPED"),
         countStatus("UNKNOWN"))
-      assert(actualStatusReportCount == expStatusReportCount)
+      assert(actualStatusReportCount == expStatusReportCount,
+        s"Expected status report counts: $expStatusReportCount, " +
+          s"but got: $actualStatusReportCount")
     }
   }
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AppFilterSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AppFilterSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.TrampolineUtil
 import org.apache.spark.sql.rapids.tool.AppFilterImpl
 
 class AppFilterSuite extends BaseTestSuite {
-
+  private val logDir = ToolTestUtils.getTestResourcePath("spark-events-profiling")
   test("illegal args") {
     assertThrows[IllegalArgumentException](AppFilterImpl.parseAppTimePeriod("0"))
     assertThrows[IllegalArgumentException](AppFilterImpl.parseAppTimePeriod("1hd"))
@@ -101,7 +101,8 @@ class AppFilterSuite extends BaseTestSuite {
           "--start-app-time",
           startTimePeriod
         )
-        val appArgs = new ProfileArgs(allArgs ++ Array(elogFile.toString()))
+        val evetlogsPaths = Array(s"$logDir/nds_q66_gpu.zstd", elogFile.toString)
+        val appArgs = new ProfileArgs(allArgs ++ evetlogsPaths)
         val (exit, filteredSize) = ProfileMain.mainInternal(appArgs)
         assert(exit == 0)
         val expectedStatusCount = if (failFilter) {

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -1275,9 +1275,9 @@ class QualificationSuite extends BaseTestSuite {
         // or Json.
         val sqlIdToLookup = allSQLIds.max
         val (csvOut, txtOut) = qualApp.getPerSqlTextAndCSVSummary(sqlIdToLookup)
-        assert(csvOut.contains("collect at ToolTestUtils.scala:67") && csvOut.contains(","),
+        assert(csvOut.contains("collect at ToolTestUtils.scala:68") && csvOut.contains(","),
           s"CSV output was: $csvOut")
-        assert(txtOut.contains("collect at ToolTestUtils.scala:67") && txtOut.contains("|"),
+        assert(txtOut.contains("collect at ToolTestUtils.scala:68") && txtOut.contains("|"),
           s"TXT output was: $txtOut")
         val sqlOut = qualApp.getPerSQLSummary(sqlIdToLookup, ":", true, 5)
         assert(sqlOut.contains("colle:"), s"SQL output was: $sqlOut")


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1616

This code changes fixes the argument passe to the Profiler to process only the filteredEventlogs.

**Changes:**
- fix the argument and the return inside ProfileMain
- fix the unit-tests by adding another eventlog that does not match the criterion to make sure that the old code fails.
- fix the schema definition of the StatusReport as it was missing 1 column
- Add new profile `release` to the pom.xml in order to activate elides during development. This is kinda followup on #1635.
