### PR TITLE
Improve memory allocations in ProfileResults classes

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids.tool.profiling
 import scala.collection.Map
 
 import com.nvidia.spark.rapids.tool.analysis.StatisticsMetrics
+import com.nvidia.spark.rapids.tool.views.OutHeaderRegistry
 
 import org.apache.spark.resource.{ExecutorResourceRequest, TaskResourceRequest}
 import org.apache.spark.sql.rapids.tool.store.{AccumMetaRef, SparkPlanInfoTruncated}
@@ -29,9 +30,9 @@ import org.apache.spark.sql.rapids.tool.util.{SparkRuntime, StringUtils}
  * used for profiling and qualification.
  */
 trait ProfileResult {
-  val outputHeaders: Seq[String]
-  def convertToSeq: Seq[String]
-  def convertToCSVSeq: Seq[String]
+  def outputHeaders: Array[String] = Array.empty[String]
+  def convertToSeq(): Array[String]
+  def convertToCSVSeq(): Array[String]
 }
 
 case class ExecutorInfoProfileResult(resourceProfileId: Int,
@@ -40,21 +41,19 @@ case class ExecutorInfoProfileResult(resourceProfileId: Int,
     executorOffHeap: Option[Long], taskCpu: Option[Double],
     taskGpu: Option[Double]) extends ProfileResult {
 
-  override val outputHeaders: Seq[String] = {
-    Seq("resourceProfileId", "numExecutors", "executorCores",
-      "maxMem", "maxOnHeapMem", "maxOffHeapMem", "executorMemory", "numGpusPerExecutor",
-      "executorOffHeap", "taskCpu", "taskGpu")
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("ExecutorInfoProfileResult")
   }
-  override def convertToSeq: Seq[String] = {
-    Seq(resourceProfileId.toString, numExecutors.toString,
+
+  override def convertToSeq(): Array[String] = {
+    Array(resourceProfileId.toString, numExecutors.toString,
       executorCores.toString, maxMem.toString, maxOnHeapMem.toString,
       maxOffHeapMem.toString, executorMemory.map(_.toString).orNull,
       numGpusPerExecutor.map(_.toString).orNull,
       executorOffHeap.map(_.toString).orNull, taskCpu.map(_.toString).orNull,
       taskGpu.map(_.toString).orNull)
   }
-  override def convertToCSVSeq: Seq[String] = convertToSeq
-
+  override def convertToCSVSeq(): Array[String] = convertToSeq()
 }
 
 class JobInfoClass(val jobID: Int,
@@ -75,26 +74,22 @@ case class JobInfoProfileResult(
     startTime: Long,
     endTime: Option[Long]) extends ProfileResult {
 
-  override val outputHeaders: Seq[String] = {
-    Seq("jobID",
-      "stageIds",
-      "sqlID",
-      "startTime",
-      "endTime")
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("JobInfoProfileResult")
   }
 
-  override def convertToSeq: Seq[String] = {
+  override def convertToSeq(): Array[String] = {
     val stageIdStr = s"[${stageIds.mkString(",")}]"
-    Seq(jobID.toString,
+    Array(jobID.toString,
       stageIdStr,
       sqlID.map(_.toString).orNull,
       startTime.toString,
       endTime.map(_.toString).orNull)
   }
 
-  override def convertToCSVSeq: Seq[String] = {
+  override def convertToCSVSeq(): Array[String] = {
     val stageIdStr = s"[${stageIds.mkString(",")}]"
-    Seq(jobID.toString,
+    Array(jobID.toString,
       StringUtils.reformatCSVString(stageIdStr),
       sqlID.map(_.toString).orNull,
       startTime.toString,
@@ -104,12 +99,14 @@ case class JobInfoProfileResult(
 
 case class SQLCleanAndAlignIdsProfileResult(
     sqlID: Long) extends ProfileResult {
-  override val outputHeaders: Seq[String] = Seq("sqlID")
-
-  override def convertToSeq: Seq[String] = {
-    Seq(sqlID.toString)
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("SQLCleanAndAlignIdsProfileResult")
   }
-  override def convertToCSVSeq: Seq[String] = convertToSeq
+
+  override def convertToSeq(): Array[String] = {
+    Array(sqlID.toString)
+  }
+  override def convertToCSVSeq(): Array[String] = convertToSeq()
 }
 
 /**
@@ -121,14 +118,16 @@ case class SQLCleanAndAlignIdsProfileResult(
  */
 case class SQLPlanInfoProfileResult(sqlID: Long, sparkPlanInfo: SparkPlanInfoTruncated)
   extends ProfileResult {
-  override val outputHeaders: Seq[String] = Seq("sqlID", "SparkPlanInfoTruncated")
-
-  override def convertToSeq: Seq[String] = {
-    Seq(sqlID.toString, sparkPlanInfo.toString)
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("SQLPlanInfoProfileResult")
   }
 
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(sqlID.toString, StringUtils.reformatCSVString(sparkPlanInfo.toString))
+  override def convertToSeq(): Array[String] = {
+    Array(sqlID.toString, sparkPlanInfo.toString)
+  }
+
+  override def convertToCSVSeq(): Array[String] = {
+    Array(sqlID.toString, StringUtils.reformatCSVString(sparkPlanInfo.toString))
   }
 }
 
@@ -139,48 +138,49 @@ case class SQLStageInfoProfileResult(
     stageAttemptId: Int,
     duration: Option[Long],
     nodeNames: Seq[String]) extends ProfileResult {
-  override val outputHeaders: Seq[String] = Seq("sqlID", "jobID", "stageId",
-    "stageAttemptId", "Stage Duration", "SQL Nodes(IDs)")
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("SQLStageInfoProfileResult")
+  }
 
-  override def convertToSeq: Seq[String] = {
-    Seq(sqlID.toString, jobID.toString, stageId.toString,
+  override def convertToSeq(): Array[String] = {
+    Array(sqlID.toString, jobID.toString, stageId.toString,
       stageAttemptId.toString, duration.map(_.toString).orNull,
       nodeNames.mkString(","))
   }
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(sqlID.toString, jobID.toString, stageId.toString,
+  override def convertToCSVSeq(): Array[String] = {
+    Array(sqlID.toString, jobID.toString, stageId.toString,
       stageAttemptId.toString, duration.map(_.toString).orNull,
       StringUtils.reformatCSVString(nodeNames.mkString(",")))
   }
 }
 
 case class RapidsJarProfileResult(jar: String)  extends ProfileResult {
-  override val outputHeaders: Seq[String] = Seq("Rapids4Spark jars")
-  override def convertToSeq: Seq[String] = {
-    Seq(jar)
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("RapidsJarProfileResult")
   }
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(StringUtils.reformatCSVString(jar))
+  override def convertToSeq(): Array[String] = {
+    Array(jar)
+  }
+  override def convertToCSVSeq(): Array[String] = {
+    Array(StringUtils.reformatCSVString(jar))
   }
 }
 
 case class DataSourceProfileResult(sqlID: Long, version: Int, nodeId: Long,
     format: String, buffer_time: Long, scan_time: Long, data_size: Long,
     decode_time: Long, location: String, pushedFilters: String, schema: String,
-    dataFilters: String, partitionFilters: String, fromFinalPlan: Boolean)
-extends ProfileResult {
-  override val outputHeaders: Seq[String] =
-    Seq("sqlID", "sql_plan_version", "nodeId", "format", "buffer_time", "scan_time",
-      "data_size", "decode_time", "location", "pushedFilters", "schema", "data_filters",
-      "partition_filters", "from_final_plan")
+    dataFilters: String, partitionFilters: String, fromFinalPlan: Boolean) extends ProfileResult {
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("DataSourceProfileResult")
+  }
 
-  override def convertToSeq: Seq[String] = {
-    Seq(sqlID.toString, version.toString, nodeId.toString, format,
+  override def convertToSeq(): Array[String] = {
+    Array(sqlID.toString, version.toString, nodeId.toString, format,
       buffer_time.toString, scan_time.toString, data_size.toString, decode_time.toString,
       location, pushedFilters, schema, dataFilters, partitionFilters, fromFinalPlan.toString)
   }
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(sqlID.toString, version.toString, nodeId.toString,
+  override def convertToCSVSeq(): Array[String] = {
+    Array(sqlID.toString, version.toString, nodeId.toString,
       StringUtils.reformatCSVString(format), buffer_time.toString, scan_time.toString,
       data_size.toString, decode_time.toString, StringUtils.reformatCSVString(location),
       StringUtils.reformatCSVString(pushedFilters), StringUtils.reformatCSVString(schema),
@@ -191,14 +191,16 @@ extends ProfileResult {
 
 case class DriverLogUnsupportedOperators(
     operatorName: String, count: Int, reason: String) extends ProfileResult {
-  override val outputHeaders: Seq[String] = Seq("operatorName", "count", "reason")
-
-  override def convertToSeq: Seq[String] = {
-    Seq(operatorName, count.toString, reason)
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("DriverLogUnsupportedOperators")
   }
 
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(StringUtils.reformatCSVString(operatorName), count.toString,
+  override def convertToSeq(): Array[String] = {
+    Array(operatorName, count.toString, reason)
+  }
+
+  override def convertToCSVSeq(): Array[String] = {
+    Array(StringUtils.reformatCSVString(operatorName), count.toString,
       StringUtils.reformatCSVString(reason))
   }
 }
@@ -209,13 +211,15 @@ case class AppStatusResult(
     status: String,
     appId: String = "",
     message: String = "") extends ProfileResult {
-  override val outputHeaders: Seq[String] = Seq("Event Log", "Status", "AppID", "Description")
-
-  override def convertToSeq: Seq[String] = {
-    Seq(path, status, appId, message)
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("AppStatusResult")
   }
 
-  override def convertToCSVSeq: Seq[String] = convertToSeq
+  override def convertToSeq(): Array[String] = {
+    Array(path, status, appId, message)
+  }
+
+  override def convertToCSVSeq(): Array[String] = convertToSeq()
 }
 
 // note that some things might not be set until after sqlMetricsAggregation called
@@ -249,22 +253,12 @@ case class SQLAccumProfileResults(
 
   private val stageIdsStr = stageIds.mkString(",")
 
-  override val outputHeaders: Seq[String] = {
-    Seq("sqlID",
-      "nodeID",
-      "nodeName",
-      "accumulatorId",
-      "name",
-      "min",
-      "median",
-      "max",
-      "total",
-      "metricType",
-      "stageIds")
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("SQLAccumProfileResults")
   }
 
-  override def convertToSeq: Seq[String] = {
-    Seq(sqlID.toString,
+  override def convertToSeq(): Array[String] = {
+    Array(sqlID.toString,
       nodeID.toString,
       nodeName,
       accumulatorId.toString,
@@ -277,8 +271,8 @@ case class SQLAccumProfileResults(
       stageIdsStr)
   }
 
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(sqlID.toString,
+  override def convertToCSVSeq(): Array[String] = {
+    Array(sqlID.toString,
       nodeID.toString,
       StringUtils.reformatCSVString(nodeName),
       accumulatorId.toString,
@@ -300,18 +294,12 @@ case class AccumProfileResults(
     max: Long,
     total: Long) extends ProfileResult {
 
-  override val outputHeaders: Seq[String] = {
-    Seq("stageId",
-      "accumulatorId",
-      "name",
-      "min",
-      "median",
-      "max",
-      "total")
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("AccumProfileResults")
   }
 
-  override def convertToSeq: Seq[String] = {
-    Seq(stageId.toString,
+  override def convertToSeq(): Array[String] = {
+    Array(stageId.toString,
       accMetaRef.id.toString,
       accMetaRef.getName(),
       min.toString,
@@ -320,8 +308,8 @@ case class AccumProfileResults(
       total.toString)
   }
 
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(stageId.toString,
+  override def convertToCSVSeq(): Array[String] = {
+    Array(stageId.toString,
       accMetaRef.id.toString,
       accMetaRef.name.csvValue,
       min.toString,
@@ -341,24 +329,28 @@ case class BlockManagerRemovedCase(
 
 case class BlockManagerRemovedProfileResult(
     executorId: String, time: Long) extends ProfileResult {
-  override val outputHeaders: Seq[String] = Seq("executorId", "time")
-  override def convertToSeq: Seq[String] = {
-    Seq(executorId, time.toString)
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("BlockManagerRemovedProfileResult")
   }
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(StringUtils.reformatCSVString(executorId), time.toString)
+  override def convertToSeq(): Array[String] = {
+    Array(executorId, time.toString)
+  }
+  override def convertToCSVSeq(): Array[String] = {
+    Array(StringUtils.reformatCSVString(executorId), time.toString)
   }
 }
 
 case class ExecutorsRemovedProfileResult(
     executorId: String, time: Long, reason: String) extends ProfileResult {
-  override val outputHeaders: Seq[String] = Seq("executorId", "time", "reason")
-
-  override def convertToSeq: Seq[String] = {
-    Seq(executorId, time.toString, reason)
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("ExecutorsRemovedProfileResult")
   }
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(StringUtils.reformatCSVString(executorId), time.toString,
+
+  override def convertToSeq(): Array[String] = {
+    Array(executorId, time.toString, reason)
+  }
+  override def convertToCSVSeq(): Array[String] = {
+    Array(StringUtils.reformatCSVString(executorId), time.toString,
       StringUtils.reformatCSVString(reason))
   }
 }
@@ -366,15 +358,16 @@ case class ExecutorsRemovedProfileResult(
 case class UnsupportedOpsProfileResult(
     sqlID: Long, nodeID: Long, nodeName: String, nodeDescription: String,
     reason: String) extends ProfileResult {
-  override val outputHeaders: Seq[String] = Seq("sqlID", "nodeID", "nodeName",
-    "nodeDescription", "reason")
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("UnsupportedOpsProfileResult")
+  }
 
-  override def convertToSeq: Seq[String] = {
-    Seq(sqlID.toString, nodeID.toString, nodeName,
+  override def convertToSeq(): Array[String] = {
+    Array(sqlID.toString, nodeID.toString, nodeName,
       nodeDescription, reason)
   }
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(sqlID.toString, nodeID.toString, StringUtils.reformatCSVString(nodeName),
+  override def convertToCSVSeq(): Array[String] = {
+    Array(sqlID.toString, nodeID.toString, StringUtils.reformatCSVString(nodeName),
       StringUtils.reformatCSVString(nodeDescription), StringUtils.reformatCSVString(reason))
   }
 }
@@ -387,9 +380,9 @@ case class AppInfoProfileResults(
     startTime: Long, endTime: Option[Long], duration: Option[Long],
     durationStr: String, sparkRuntime: SparkRuntime.SparkRuntime, sparkVersion: String,
     pluginEnabled: Boolean)  extends ProfileResult {
-  override val outputHeaders: Seq[String] = Seq("appName", "appId", "attemptId",
-    "sparkUser", "startTime", "endTime", "duration", "durationStr",
-    "sparkRuntime", "sparkVersion", "pluginEnabled")
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("AppInfoProfileResults")
+  }
 
   private def endTimeToStr: String = {
     endTime match {
@@ -419,14 +412,14 @@ case class AppInfoProfileResults(
     }
   }
 
-  override def convertToSeq: Seq[String] = {
-    Seq(appName, appIdToStr, attemptIdToStr,
+  override def convertToSeq(): Array[String] = {
+    Array(appName, appIdToStr, attemptIdToStr,
       sparkUser, startTime.toString, endTimeToStr, durToStr,
       durationStr, sparkRuntime.toString, sparkVersion, pluginEnabled.toString)
   }
 
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(StringUtils.reformatCSVString(appName),
+  override def convertToCSVSeq(): Array[String] = {
+    Array(StringUtils.reformatCSVString(appName),
       StringUtils.reformatCSVString(appIdToStr),
       StringUtils.reformatCSVString(attemptIdToStr),
       StringUtils.reformatCSVString(sparkUser),
@@ -438,14 +431,15 @@ case class AppInfoProfileResults(
 
 case class AppLogPathProfileResults(
     appName: String, appId: Option[String], eventLogPath: String)  extends ProfileResult {
-  override val outputHeaders: Seq[String] = Seq("appName", "appId", "eventLogPath")
-
-  override def convertToSeq: Seq[String] = {
-    Seq(appName, appId.getOrElse(""),
-      eventLogPath)
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("AppLogPathProfileResults")
   }
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(StringUtils.reformatCSVString(appName),
+
+  override def convertToSeq(): Array[String] = {
+    Array(appName, appId.getOrElse(""), eventLogPath)
+  }
+  override def convertToCSVSeq(): Array[String] = {
+    Array(StringUtils.reformatCSVString(appName),
       StringUtils.reformatCSVString(appId.getOrElse("")),
       StringUtils.reformatCSVString(eventLogPath))
   }
@@ -478,14 +472,15 @@ case class UnsupportedSQLPlan(sqlID: Long, nodeID: Long, nodeName: String,
 case class FailedTaskProfileResults(
     stageId: Int, stageAttemptId: Int,
     taskId: Long, taskAttemptId: Int, endReason: String) extends ProfileResult {
-  override val outputHeaders: Seq[String] = Seq("stageId", "stageAttemptId", "taskId",
-    "attempt", "failureReason")
-  override def convertToSeq: Seq[String] = {
-    Seq(stageId.toString, stageAttemptId.toString, taskId.toString,
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("FailedTaskProfileResults")
+  }
+  override def convertToSeq(): Array[String] = {
+    Array(stageId.toString, stageAttemptId.toString, taskId.toString,
       taskAttemptId.toString, StringUtils.renderStr(endReason, doEscapeMetaCharacters = true))
   }
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(stageId.toString, stageAttemptId.toString, taskId.toString,
+  override def convertToCSVSeq(): Array[String] = {
+    Array(stageId.toString, stageAttemptId.toString, taskId.toString,
       taskAttemptId.toString,
       StringUtils.reformatCSVString(
         StringUtils.renderStr(endReason, doEscapeMetaCharacters = true, maxLength = 0)))
@@ -495,15 +490,16 @@ case class FailedTaskProfileResults(
 case class FailedStagesProfileResults(
     stageId: Int, stageAttemptId: Int,
     name: String, numTasks: Int, endReason: String) extends ProfileResult {
-  override val outputHeaders: Seq[String] = Seq("stageId", "attemptId", "name",
-    "numTasks", "failureReason")
-  override def convertToSeq: Seq[String] = {
-    Seq(stageId.toString, stageAttemptId.toString,
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("FailedStagesProfileResults")
+  }
+  override def convertToSeq(): Array[String] = {
+    Array(stageId.toString, stageAttemptId.toString,
       name, numTasks.toString,
       StringUtils.renderStr(endReason, doEscapeMetaCharacters = true))
   }
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(stageId.toString, stageAttemptId.toString,
+  override def convertToCSVSeq(): Array[String] = {
+    Array(stageId.toString, stageAttemptId.toString,
       StringUtils.reformatCSVString(name), numTasks.toString,
       StringUtils.reformatCSVString(StringUtils.renderStr(endReason, doEscapeMetaCharacters = true,
         maxLength = 0)))
@@ -515,16 +511,18 @@ case class FailedJobsProfileResults(
     sqlID: Option[Long],  // sqlID is optional because Jobs might not have a SQL (i.e., RDDs)
     jobResult: String,
     endReason: String) extends ProfileResult {
-  override val outputHeaders: Seq[String] = Seq("jobID", "sqlID", "jobResult", "failureReason")
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("FailedJobsProfileResults")
+  }
 
-  override def convertToSeq: Seq[String] = {
-    Seq(jobId.toString,
+  override def convertToSeq(): Array[String] = {
+    Array(jobId.toString,
       sqlID.map(_.toString).orNull,
       jobResult,
       StringUtils.renderStr(endReason, doEscapeMetaCharacters = true))
   }
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(jobId.toString,
+  override def convertToCSVSeq(): Array[String] = {
+    Array(jobId.toString,
       sqlID.map(_.toString).orNull,
       StringUtils.reformatCSVString(jobResult),
       StringUtils.reformatCSVString(
@@ -567,47 +565,13 @@ trait BaseJobStageAggTaskMetricsProfileResult extends ProfileResult {
 
   def idHeader: String
 
-  override val outputHeaders: Seq[String] = {
-    Seq(idHeader,
-      "numTasks",
-      "Duration",
-      "diskBytesSpilled_sum",
-      "duration_sum",
-      "duration_max",
-      "duration_min",
-      "duration_avg",
-      "executorCPUTime_sum",
-      "executorDeserializeCPUTime_sum",
-      "executorDeserializeTime_sum",
-      "executorRunTime_sum",
-      "input_bytesRead_sum",
-      "input_recordsRead_sum",
-      "jvmGCTime_sum",
-      "memoryBytesSpilled_sum",
-      "output_bytesWritten_sum",
-      "output_recordsWritten_sum",
-      "peakExecutionMemory_max",
-      "resultSerializationTime_sum",
-      "resultSize_max",
-      "sr_fetchWaitTime_sum",
-      "sr_localBlocksFetched_sum",
-      "sr_localBytesRead_sum",
-      "sr_remoteBlocksFetched_sum",
-      "sr_remoteBytesRead_sum",
-      "sr_remoteBytesReadToDisk_sum",
-      "sr_totalBytesRead_sum",
-      "sw_bytesWritten_sum",
-      "sw_recordsWritten_sum",
-      "sw_writeTime_sum")
-  }
-
   private def durStr: String = duration match {
     case Some(dur) => dur.toString
     case None => "null"
   }
 
-  override def convertToSeq: Seq[String] = {
-    Seq(id.toString,
+  override def convertToSeq(): Array[String] = {
+    Array(id.toString,
       numTasks.toString,
       durStr,
       diskBytesSpilledSum.toString,
@@ -640,7 +604,7 @@ trait BaseJobStageAggTaskMetricsProfileResult extends ProfileResult {
       swWriteTimeSum.toString)
   }
 
-  override def convertToCSVSeq: Seq[String] = convertToSeq
+  override def convertToCSVSeq(): Array[String] = convertToSeq()
 }
 
 case class JobAggTaskMetricsProfileResult(
@@ -677,6 +641,10 @@ case class JobAggTaskMetricsProfileResult(
     swWriteTimeSum: Long // milliseconds
   ) extends BaseJobStageAggTaskMetricsProfileResult {
   override def idHeader = "jobId"
+
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("JobAggTaskMetricsProfileResult")
+  }
 }
 
 case class StageAggTaskMetricsProfileResult(
@@ -771,6 +739,10 @@ case class StageAggTaskMetricsProfileResult(
   }
 
   override def idHeader = "stageId"
+
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("StageAggTaskMetricsProfileResult")
+  }
 }
 
 /**
@@ -816,50 +788,12 @@ case class StageDiagnosticResult(
     case None => "null"
   }
 
-  override val outputHeaders: Seq[String] = {
-    Seq("appName",
-      "appId",
-      "stageId",
-      "stageDurationMs",
-      "numTasks",
-      "memoryBytesSpilledMBMin",
-      "memoryBytesSpilledMBMedian",
-      "memoryBytesSpilledMBMax",
-      "memoryBytesSpilledMBTotal",
-      "diskBytesSpilledMBMin",
-      "diskBytesSpilledMBMedian",
-      "diskBytesSpilledMBMax",
-      "diskBytesSpilledMBTotal",
-      "inputBytesReadMin",
-      "inputBytesReadMedian",
-      "inputBytesReadMax",
-      "inputBytesReadTotal",
-      "outputBytesWrittenMin",
-      "outputBytesWrittenMedian",
-      "outputBytesWrittenMax",
-      "outputBytesWrittenTotal",
-      "shuffleReadBytesMin",
-      "shuffleReadBytesMedian",
-      "shuffleReadBytesMax",
-      "shuffleReadBytesTotal",
-      "shuffleWriteBytesMin",
-      "shuffleWriteBytesMedian",
-      "shuffleWriteBytesMax",
-      "shuffleWriteBytesTotal",
-      "shuffleReadFetchWaitTimeMin",
-      "shuffleReadFetchWaitTimeMedian",
-      "shuffleReadFetchWaitTimeMax",
-      "shuffleReadFetchWaitTimeTotal",
-      "shuffleWriteWriteTimeMin",
-      "shuffleWriteWriteTimeMedian",
-      "shuffleWriteWriteTimeMax",
-      "shuffleWriteWriteTimeTotal",
-      "gpuSemaphoreWaitTimeTotal",
-      "SQL Nodes(IDs)")
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("StageDiagnosticResult")
   }
 
-  override def convertToSeq: Seq[String] = {
-    Seq(appName,
+  override def convertToSeq(): Array[String] = {
+    Array(appName,
       appId,
       stageId.toString,
       durStr,
@@ -900,8 +834,8 @@ case class StageDiagnosticResult(
       nodeNames.mkString(","))
   }
 
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(appName,
+  override def convertToCSVSeq(): Array[String] = {
+    Array(appName,
       appId,
       stageId.toString,
       durStr,
@@ -988,41 +922,8 @@ case class SQLTaskAggMetricsProfileResult(
     swWriteTimeSum: Long // milliseconds
   ) extends ProfileResult {
 
-  override val outputHeaders: Seq[String] = {
-    Seq("appID",
-      "sqlID",
-      "description",
-      "numTasks",
-      "Duration",
-      "executorCPURatio",
-      "diskBytesSpilled_sum",
-      "duration_sum",
-      "duration_max",
-      "duration_min",
-      "duration_avg",
-      "executorCPUTime_sum",
-      "executorDeserializeCPUTime_sum",
-      "executorDeserializeTime_sum",
-      "executorRunTime_sum",
-      "input_bytesRead_sum",
-      "input_recordsRead_sum",
-      "jvmGCTime_sum",
-      "memoryBytesSpilled_sum",
-      "output_bytesWritten_sum",
-      "output_recordsWritten_sum",
-      "peakExecutionMemory_max",
-      "resultSerializationTime_sum",
-      "resultSize_max",
-      "sr_fetchWaitTime_sum",
-      "sr_localBlocksFetched_sum",
-      "sr_localBytesRead_sum",
-      "sr_remoteBlocksFetched_sum",
-      "sr_remoteBytesRead_sum",
-      "sr_remoteBytesReadToDisk_sum",
-      "sr_totalBytesRead_sum",
-      "sw_bytesWritten_sum",
-      "sw_recordsWritten_sum",
-      "sw_writeTime_sum")
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("SQLTaskAggMetricsProfileResult")
   }
 
   private def durStr: String = duration match {
@@ -1030,8 +931,8 @@ case class SQLTaskAggMetricsProfileResult(
     case None => ""
   }
 
-  override def convertToSeq: Seq[String] = {
-    Seq(appId,
+  override def convertToSeq(): Array[String] = {
+    Array(appId,
       sqlId.toString,
       description,
       numTasks.toString,
@@ -1066,8 +967,8 @@ case class SQLTaskAggMetricsProfileResult(
       swRecordsWrittenSum.toString,
       swWriteTimeSum.toString)
   }
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(StringUtils.reformatCSVString(appId),
+  override def convertToCSVSeq(): Array[String] = {
+    Array(StringUtils.reformatCSVString(appId),
       sqlId.toString,
       StringUtils.reformatCSVString(description),
       numTasks.toString,
@@ -1132,46 +1033,12 @@ case class IODiagnosticResult(
     fetchWaitTime: StatisticsMetrics,
     gpuDecodeTime: StatisticsMetrics) extends ProfileResult {
 
-  override val outputHeaders: Seq[String] = {
-    Seq("appName",
-      "appId",
-      "sqlId",
-      "stageId",
-      "stageDurationMs",
-      "nodeId",
-      "nodeName",
-      "outputRowsMin",
-      "outputRowsMedian",
-      "outputRowsMax",
-      "outputRowsTotal",
-      "scanTimeMin",
-      "scanTimeMedian",
-      "scanTimeMax",
-      "scanTimeTotal",
-      "outputBatchesMin",
-      "outputBatchesMedian",
-      "outputBatchesMax",
-      "outputBatchesTotal",
-      "bufferTimeMin",
-      "bufferTimeMedian",
-      "bufferTimeMax",
-      "bufferTimeTotal",
-      "shuffleWriteTimeMin",
-      "shuffleWriteTimeMedian",
-      "shuffleWriteTimeMax",
-      "shuffleWriteTimeTotal",
-      "fetchWaitTimeMin",
-      "fetchWaitTimeMedian",
-      "fetchWaitTimeMax",
-      "fetchWaitTimeTotal",
-      "gpuDecodeTimeMin",
-      "gpuDecodeTimeMedian",
-      "gpuDecodeTimeMax",
-      "gpuDecodeTimeTotal")
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("IODiagnosticResult")
   }
 
-  override def convertToSeq: Seq[String] = {
-    Seq(appName,
+  override def convertToSeq(): Array[String] = {
+    Array(appName,
       appId,
       sqlId.toString,
       stageId.toString,
@@ -1208,8 +1075,8 @@ case class IODiagnosticResult(
       gpuDecodeTime.total.toString)
   }
 
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(appName,
+  override def convertToCSVSeq(): Array[String] = {
+    Array(appName,
       appId,
       sqlId.toString,
       stageId.toString,
@@ -1259,13 +1126,12 @@ case class IOAnalysisProfileResult(
     srTotalBytesReadSum: Long,
     swTotalBytesWriteSum: Long) extends ProfileResult {
 
-  override val outputHeaders: Seq[String] = Seq("appID", "sqlID", "input_bytesRead_sum",
-    "input_recordsRead_sum", "output_bytesWritten_sum", "output_recordsWritten_sum",
-    "diskBytesSpilled_sum", "memoryBytesSpilled_sum", "sr_totalBytesRead_sum",
-    "sw_bytesWritten_sum")
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("IOAnalysisProfileResult")
+  }
 
-  override def convertToSeq: Seq[String] = {
-    Seq(appId,
+  override def convertToSeq(): Array[String] = {
+    Array(appId,
       sqlId.toString,
       inputBytesReadSum.toString,
       inputRecordsReadSum.toString,
@@ -1276,8 +1142,8 @@ case class IOAnalysisProfileResult(
       srTotalBytesReadSum.toString,
       swTotalBytesWriteSum.toString)
   }
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(StringUtils.reformatCSVString(appId),
+  override def convertToCSVSeq(): Array[String] = {
+    Array(StringUtils.reformatCSVString(appId),
       sqlId.toString,
       inputBytesReadSum.toString,
       inputRecordsReadSum.toString,
@@ -1299,15 +1165,8 @@ case class SQLDurationExecutorTimeProfileResult(
     appDuration: Option[Long],
     potentialProbs: String,
     executorCpuRatio: Double) extends ProfileResult {
-  override val outputHeaders: Seq[String] = {
-    Seq("App ID",
-      "RootSqlID",
-      "sqlID",
-      "SQL Duration",
-      "Contains Dataset or RDD Op",
-      "App Duration",
-      "Potential Problems",
-      "Executor CPU Time Percent")
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("SQLDurationExecutorTimeProfileResult")
   }
   private def durStr: String = duration match {
     case Some(dur) => dur.toString
@@ -1328,8 +1187,8 @@ case class SQLDurationExecutorTimeProfileResult(
     potentialProbs
   }
 
-  override def convertToSeq: Seq[String] = {
-    Seq(rootsqlID.getOrElse("").toString,
+  override def convertToSeq(): Array[String] = {
+    Array(rootsqlID.getOrElse("").toString,
       appId,
       sqlID.toString,
       durStr,
@@ -1339,8 +1198,8 @@ case class SQLDurationExecutorTimeProfileResult(
       execCpuTimePercent)
   }
 
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(StringUtils.reformatCSVString(appId),
+  override def convertToCSVSeq(): Array[String] = {
+    Array(StringUtils.reformatCSVString(appId),
       rootsqlID.getOrElse("").toString,
       sqlID.toString,
       durStr,
@@ -1355,12 +1214,12 @@ case class ShuffleSkewProfileResult(stageId: Long, stageAttemptId: Long,
     taskId: Long, taskAttemptId: Long, taskDuration: Long, avgDuration: Double,
     taskShuffleReadMB: Long, avgShuffleReadMB: Double, taskPeakMemoryMB: Long,
     successful: Boolean, reason: String) extends ProfileResult {
-  override val outputHeaders: Seq[String] = Seq("stageId", "stageAttemptId", "taskId", "attempt",
-    "taskDurationSec", "avgDurationSec", "taskShuffleReadMB", "avgShuffleReadMB",
-    "taskPeakMemoryMB", "successful", "reason")
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("ShuffleSkewProfileResult")
+  }
 
-  override def convertToSeq: Seq[String] = {
-    Seq(stageId.toString,
+  override def convertToSeq(): Array[String] = {
+    Array(stageId.toString,
       stageAttemptId.toString,
       taskId.toString,
       taskAttemptId.toString,
@@ -1372,8 +1231,8 @@ case class ShuffleSkewProfileResult(stageId: Long, stageAttemptId: Long,
       successful.toString,
       StringUtils.renderStr(reason, doEscapeMetaCharacters = true))
   }
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(stageId.toString,
+  override def convertToCSVSeq(): Array[String] = {
+    Array(stageId.toString,
       stageAttemptId.toString,
       taskId.toString,
       taskAttemptId.toString,
@@ -1383,19 +1242,19 @@ case class ShuffleSkewProfileResult(stageId: Long, stageAttemptId: Long,
       f"${avgShuffleReadMB / 1024 / 1024}%1.2f",
       f"${taskPeakMemoryMB.toDouble / 1024 / 1024}%1.2f",
       successful.toString,
-      // truncate this field because it might be a very long string and it is already
+      // truncate this field because it might be a very long string, and it is already
       // fully displayed in failed_* files
       StringUtils.reformatCSVString(
         StringUtils.renderStr(reason, doEscapeMetaCharacters = true)))
   }
 }
 
-case class RapidsPropertyProfileResult(key: String, outputHeadersIn: Seq[String],
-    rows: Seq[String]) extends ProfileResult {
-
-  override val outputHeaders: Seq[String] = outputHeadersIn
-  override def convertToSeq: Seq[String] = rows
-  override def convertToCSVSeq: Seq[String] = {
+case class RapidsPropertyProfileResult(key: String, rows: Array[String]) extends ProfileResult {
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("RapidsPropertyProfileResult")
+  }
+  override def convertToSeq(): Array[String] = rows
+  override def convertToCSVSeq(): Array[String] = {
     rows.map(StringUtils.reformatCSVString)
   }
 }
@@ -1405,19 +1264,19 @@ case class WholeStageCodeGenResults(
     nodeID: Long,
     parent: String,
     child: String,
-    childNodeID: Long
-) extends ProfileResult {
-  override val outputHeaders: Seq[String] = Seq("sqlID", "nodeID", "SQL Node",
-    "Child Node", "Child NodeID")
-  override def convertToSeq: Seq[String] = {
-    Seq(sqlID.toString,
+    childNodeID: Long) extends ProfileResult {
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("WholeStageCodeGenResults")
+  }
+  override def convertToSeq(): Array[String] = {
+    Array(sqlID.toString,
       nodeID.toString,
       parent,
       child,
       childNodeID.toString)
   }
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(sqlID.toString,
+  override def convertToCSVSeq(): Array[String] = {
+    Array(sqlID.toString,
       nodeID.toString,
       StringUtils.reformatCSVString(parent),
       StringUtils.reformatCSVString(child),

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileOutputWriter.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileOutputWriter.scala
@@ -44,7 +44,7 @@ class ProfileOutputWriter(outputDir: String, filePrefix: String, numOutputRows: 
 
     if (outRows.nonEmpty) {
       val outStr = ProfileOutputWriter.makeFormattedString(numOutputRows, 0,
-        outRows.head.outputHeaders, outRows.map(_.convertToSeq))
+        outRows.head.outputHeaders, outRows.map(_.convertToSeq()))
       textFileWriter.write(outStr)
     } else {
       val finalEmptyText = emptyText match {
@@ -122,7 +122,7 @@ object ProfileOutputWriter {
       try {
         val headerString = outRows.head.outputHeaders.mkString(CSVDelimiter)
         csvWriter.write(headerString + "\n")
-        val rows = outRows.map(_.convertToCSVSeq)
+        val rows = outRows.map(_.convertToCSVSeq())
         rows.foreach { row =>
           val formattedRow = row.map(stringIfempty)
           val outStr = formattedRow.mkString(CSVDelimiter)
@@ -169,7 +169,7 @@ object ProfileOutputWriter {
       _numRows: Int,
       truncate: Int = 20,
       schema: Seq[String],
-      rows: Seq[Seq[String]]): String = {
+      rows: Seq[Array[String]]): String = {
     val numRows = _numRows.max(0).min(2147483632 - 1)
     val hasMoreData = rows.length - 1 > numRows
 
@@ -181,7 +181,7 @@ object ProfileOutputWriter {
     // Initialise the width of each column to a minimum value
     val colWidths = Array.fill(numCols)(minimumColWidth)
 
-    if (rows.nonEmpty && schema.size != rows.head.size) {
+    if (rows.nonEmpty && schema.size != rows.head.length) {
       throw new IllegalArgumentException("schema must be same size as data!")
     }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/OutHeaderRegistry.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/OutHeaderRegistry.scala
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.views
+
+/**
+ * This class is used to register the output headers for each view.
+ * This centralized registration is a memory optimization to avoid creating a copy of the header
+ * for each object instantiation.
+ * The utility object is a centralized way to compared to creating a separate companion object for
+ * each case class.
+ * Note that the key lookup depends on literal strings for performance reasons.
+ * The idea that we do not want to use reflections such as classForName
+ * (or more broadly, classOf[YourClass].getName). the latter would impose a significant performance
+ * hit considering the number of rows to be processed for each file.
+ */
+object OutHeaderRegistry {
+  val outputHeaders: Map[String, Array[String]] = Map(
+    "ExecutorInfoProfileResult" ->
+      Array("resourceProfileId", "numExecutors", "executorCores", "maxMem", "maxOnHeapMem",
+        "maxOffHeapMem", "executorMemory", "numGpusPerExecutor", "executorOffHeap", "taskCpu",
+        "taskGpu"),
+    "JobInfoProfileResult" ->
+      Array("jobID", "stageIds", "sqlID", "startTime", "endTime"),
+    "SQLCleanAndAlignIdsProfileResult" ->
+      Array("sqlID"),
+    "SQLPlanInfoProfileResult" ->
+      Array("sqlID", "SparkPlanInfoTruncated"),
+    "SQLStageInfoProfileResult" ->
+      Array("sqlID", "jobID", "stageId", "stageAttemptId", "Stage Duration", "SQL Nodes(IDs)"),
+    "RapidsJarProfileResult" ->
+      Array("Rapids4Spark jars"),
+    "DataSourceProfileResult" ->
+      Array("sqlID", "sql_plan_version", "nodeId", "format", "buffer_time", "scan_time",
+        "data_size", "decode_time", "location", "pushedFilters", "schema", "data_filters",
+        "partition_filters", "from_final_plan"),
+    "DriverLogUnsupportedOperators" ->
+      Array("operatorName", "count", "reason"),
+    "AppStatusResult" ->
+      Array("Event Log", "Status", "AppID", "Description"),
+    "SQLAccumProfileResults" ->
+      Array("sqlID", "nodeID", "nodeName", "accumulatorId", "name", "min", "median", "max",
+        "total", "metricType", "stageIds"),
+    "AccumProfileResults" ->
+      Array("stageId", "accumulatorId", "name", "min", "median", "max", "total"),
+    "BlockManagerRemovedProfileResult" ->
+      Array("executorId", "time"),
+    "ExecutorsRemovedProfileResult" ->
+      Array("executorId", "time", "reason"),
+    "UnsupportedOpsProfileResult" ->
+      Array("sqlID", "nodeID", "nodeName", "nodeDescription", "reason"),
+    "AppInfoProfileResults" ->
+      Array("appName", "appId", "attemptId", "sparkUser", "startTime", "endTime", "duration",
+        "durationStr", "sparkRuntime", "sparkVersion", "pluginEnabled"),
+    "AppLogPathProfileResults" ->
+      Array("appName", "appId", "eventLogPath"),
+    "FailedTaskProfileResults" ->
+      Array("stageId", "stageAttemptId", "taskId", "attempt", "failureReason"),
+    "FailedStagesProfileResults" ->
+      Array("stageId", "attemptId", "name", "numTasks", "failureReason"),
+    "FailedJobsProfileResults" ->
+      Array("jobID", "sqlID", "jobResult", "failureReason"),
+    "JobAggTaskMetricsProfileResult" ->
+      Array("jobId",
+        "numTasks",
+        "Duration",
+        "diskBytesSpilled_sum",
+        "duration_sum",
+        "duration_max",
+        "duration_min",
+        "duration_avg",
+        "executorCPUTime_sum",
+        "executorDeserializeCPUTime_sum",
+        "executorDeserializeTime_sum",
+        "executorRunTime_sum",
+        "input_bytesRead_sum",
+        "input_recordsRead_sum",
+        "jvmGCTime_sum",
+        "memoryBytesSpilled_sum",
+        "output_bytesWritten_sum",
+        "output_recordsWritten_sum",
+        "peakExecutionMemory_max",
+        "resultSerializationTime_sum",
+        "resultSize_max",
+        "sr_fetchWaitTime_sum",
+        "sr_localBlocksFetched_sum",
+        "sr_localBytesRead_sum",
+        "sr_remoteBlocksFetched_sum",
+        "sr_remoteBytesRead_sum",
+        "sr_remoteBytesReadToDisk_sum",
+        "sr_totalBytesRead_sum",
+        "sw_bytesWritten_sum",
+        "sw_recordsWritten_sum",
+        "sw_writeTime_sum"),
+    "StageAggTaskMetricsProfileResult" ->
+      Array("stageId",
+        "numTasks",
+        "Duration",
+        "diskBytesSpilled_sum",
+        "duration_sum",
+        "duration_max",
+        "duration_min",
+        "duration_avg",
+        "executorCPUTime_sum",
+        "executorDeserializeCPUTime_sum",
+        "executorDeserializeTime_sum",
+        "executorRunTime_sum",
+        "input_bytesRead_sum",
+        "input_recordsRead_sum",
+        "jvmGCTime_sum",
+        "memoryBytesSpilled_sum",
+        "output_bytesWritten_sum",
+        "output_recordsWritten_sum",
+        "peakExecutionMemory_max",
+        "resultSerializationTime_sum",
+        "resultSize_max",
+        "sr_fetchWaitTime_sum",
+        "sr_localBlocksFetched_sum",
+        "sr_localBytesRead_sum",
+        "sr_remoteBlocksFetched_sum",
+        "sr_remoteBytesRead_sum",
+        "sr_remoteBytesReadToDisk_sum",
+        "sr_totalBytesRead_sum",
+        "sw_bytesWritten_sum",
+        "sw_recordsWritten_sum",
+        "sw_writeTime_sum"),
+    "StageDiagnosticResult" ->
+      Array("appName",
+        "appId",
+        "stageId",
+        "stageDurationMs",
+        "numTasks",
+        "memoryBytesSpilledMBMin",
+        "memoryBytesSpilledMBMedian",
+        "memoryBytesSpilledMBMax",
+        "memoryBytesSpilledMBTotal",
+        "diskBytesSpilledMBMin",
+        "diskBytesSpilledMBMedian",
+        "diskBytesSpilledMBMax",
+        "diskBytesSpilledMBTotal",
+        "inputBytesReadMin",
+        "inputBytesReadMedian",
+        "inputBytesReadMax",
+        "inputBytesReadTotal",
+        "outputBytesWrittenMin",
+        "outputBytesWrittenMedian",
+        "outputBytesWrittenMax",
+        "outputBytesWrittenTotal",
+        "shuffleReadBytesMin",
+        "shuffleReadBytesMedian",
+        "shuffleReadBytesMax",
+        "shuffleReadBytesTotal",
+        "shuffleWriteBytesMin",
+        "shuffleWriteBytesMedian",
+        "shuffleWriteBytesMax",
+        "shuffleWriteBytesTotal",
+        "shuffleReadFetchWaitTimeMin",
+        "shuffleReadFetchWaitTimeMedian",
+        "shuffleReadFetchWaitTimeMax",
+        "shuffleReadFetchWaitTimeTotal",
+        "shuffleWriteWriteTimeMin",
+        "shuffleWriteWriteTimeMedian",
+        "shuffleWriteWriteTimeMax",
+        "shuffleWriteWriteTimeTotal",
+        "gpuSemaphoreWaitTimeTotal",
+        "SQL Nodes(IDs)"),
+    "SQLTaskAggMetricsProfileResult" ->
+      Array("appID",
+        "sqlID",
+        "description",
+        "numTasks",
+        "Duration",
+        "executorCPURatio",
+        "diskBytesSpilled_sum",
+        "duration_sum",
+        "duration_max",
+        "duration_min",
+        "duration_avg",
+        "executorCPUTime_sum",
+        "executorDeserializeCPUTime_sum",
+        "executorDeserializeTime_sum",
+        "executorRunTime_sum",
+        "input_bytesRead_sum",
+        "input_recordsRead_sum",
+        "jvmGCTime_sum",
+        "memoryBytesSpilled_sum",
+        "output_bytesWritten_sum",
+        "output_recordsWritten_sum",
+        "peakExecutionMemory_max",
+        "resultSerializationTime_sum",
+        "resultSize_max",
+        "sr_fetchWaitTime_sum",
+        "sr_localBlocksFetched_sum",
+        "sr_localBytesRead_sum",
+        "sr_remoteBlocksFetched_sum",
+        "sr_remoteBytesRead_sum",
+        "sr_remoteBytesReadToDisk_sum",
+        "sr_totalBytesRead_sum",
+        "sw_bytesWritten_sum",
+        "sw_recordsWritten_sum",
+        "sw_writeTime_sum"),
+    "IODiagnosticResult" ->
+      Array("appName",
+        "appId",
+        "sqlId",
+        "stageId",
+        "stageDurationMs",
+        "nodeId",
+        "nodeName",
+        "outputRowsMin",
+        "outputRowsMedian",
+        "outputRowsMax",
+        "outputRowsTotal",
+        "scanTimeMin",
+        "scanTimeMedian",
+        "scanTimeMax",
+        "scanTimeTotal",
+        "outputBatchesMin",
+        "outputBatchesMedian",
+        "outputBatchesMax",
+        "outputBatchesTotal",
+        "bufferTimeMin",
+        "bufferTimeMedian",
+        "bufferTimeMax",
+        "bufferTimeTotal",
+        "shuffleWriteTimeMin",
+        "shuffleWriteTimeMedian",
+        "shuffleWriteTimeMax",
+        "shuffleWriteTimeTotal",
+        "fetchWaitTimeMin",
+        "fetchWaitTimeMedian",
+        "fetchWaitTimeMax",
+        "fetchWaitTimeTotal",
+        "gpuDecodeTimeMin",
+        "gpuDecodeTimeMedian",
+        "gpuDecodeTimeMax",
+        "gpuDecodeTimeTotal"),
+    "IOAnalysisProfileResult" ->
+      Array("appID", "sqlID", "input_bytesRead_sum", "input_recordsRead_sum",
+        "output_bytesWritten_sum", "output_recordsWritten_sum", "diskBytesSpilled_sum",
+        "memoryBytesSpilled_sum", "sr_totalBytesRead_sum", "sw_bytesWritten_sum"),
+    "SQLDurationExecutorTimeProfileResult" ->
+      Array("App ID",
+        "RootSqlID",
+        "sqlID",
+        "SQL Duration",
+        "Contains Dataset or RDD Op",
+        "App Duration",
+        "Potential Problems",
+        "Executor CPU Time Percent"),
+    "ShuffleSkewProfileResult" ->
+      Array("stageId", "stageAttemptId", "taskId", "attempt",
+        "taskDurationSec", "avgDurationSec", "taskShuffleReadMB", "avgShuffleReadMB",
+        "taskPeakMemoryMB", "successful", "reason"),
+    "RapidsPropertyProfileResult" ->
+      Array("propertyName", "propertyValue"),
+    "WholeStageCodeGenResults" ->
+      Array("sqlID", "nodeID", "SQL Node", "Child Node", "Child NodeID"),
+    "WriteOpProfileResult" ->
+      Array("sqlID", "sqlPlanVersion", "nodeId", "fromFinalPlan", "execName", "format",
+          "location", "tableName", "dataBase", "outputColumns", "writeMode",
+          "partitionColumns", "fullDescription")
+  ) // End of outputHeaders map initialization
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/PropertiesView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/PropertiesView.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,12 +61,11 @@ trait AppPropertiesViewTrait extends ViewableTrait[RapidsPropertyProfileResult] 
   def getRelevantProperties(app: AppBase): Map[String, String]
 
   def getRawView(app: AppBase, index: Int): Seq[RapidsPropertyProfileResult] = {
-    val outputHeaders = ArrayBuffer("propertyName", s"appIndex_$index")
     val props = mutable.HashMap[String, ArrayBuffer[String]]()
     val propsToKeep = getRelevantProperties(app)
     addNewProps(props, propsToKeep)
     val allRows = props.map { case (k, v) => Seq(k) ++ v }.toSeq
-    val resRows = allRows.map(r => RapidsPropertyProfileResult(r.head, outputHeaders, r))
+    val resRows = allRows.map(r => RapidsPropertyProfileResult(r.head, r.toArray))
     resRows
   }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/WriteOpsView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/WriteOpsView.scala
@@ -37,18 +37,16 @@ case class WriteOpProfileResult(record: WriteOperationRecord) extends ProfileRes
   /**
    * Defines the headers for the output display.
    */
-  override val outputHeaders: Seq[String] = {
-    Seq("sqlID", "sqlPlanVersion", "nodeId", "fromFinalPlan", "execName", "format",
-      "location", "tableName", "dataBase", "outputColumns", "writeMode",
-      "partitionColumns", "fullDescription")
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("WriteOpProfileResult")
   }
 
   /**
    * Converts the profiling result into a sequence of strings for display.
    * Escapes special characters in the description and truncates long strings.
    */
-  override def convertToSeq: Seq[String] = {
-    Seq(record.sqlID.toString,
+  override def convertToSeq(): Array[String] = {
+    Array(record.sqlID.toString,
       record.version.toString,
       record.nodeId.toString,
       record.fromFinalPlan.toString,
@@ -70,8 +68,8 @@ case class WriteOpProfileResult(record: WriteOperationRecord) extends ProfileRes
    * Converts the profiling result into a sequence of strings formatted for CSV output.
    * Escapes special characters and truncates long descriptions to a maximum length.
    */
-  override def convertToCSVSeq: Seq[String] = {
-    Seq(record.sqlID.toString,
+  override def convertToCSVSeq(): Array[String] = {
+    Array(record.sqlID.toString,
       record.version.toString,
       record.nodeId.toString,
       record.fromFinalPlan.toString,

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
@@ -233,15 +233,15 @@ class ToolUtilsSuite extends FunSuite with Logging {
 
   case class MockProfileResults(appID: String, nonEnglishField: String,
       parentIDs: String) extends ProfileResult {
-    override val outputHeaders: Seq[String] = Seq("appID", "nonEnglishField",
+    override val outputHeaders: Array[String] = Array("appID", "nonEnglishField",
       "parentIDs")
 
-    override def convertToSeq: Seq[String] = {
-      Seq(appID, nonEnglishField, parentIDs)
+    override def convertToSeq(): Array[String] = {
+      Array(appID, nonEnglishField, parentIDs)
     }
 
-    override def convertToCSVSeq: Seq[String] = {
-      Seq(appID, StringUtils.reformatCSVString(nonEnglishField),
+    override def convertToCSVSeq(): Array[String] = {
+      Array(appID, StringUtils.reformatCSVString(nonEnglishField),
         StringUtils.reformatCSVString(parentIDs))
     }
   }


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1625

This code change aims at removing the overhead icurred from defining the outputHeaders as a `val` in each case-class. This meant that each new instance will have its own copy of the same constant list of strings. Clearly, this adds unecessary stress on memory allocations considering the number of instances created per type.

- create a `HeaderRegistry` object to hold a centralized map of output headers.
- change the type of outputHeaders to `def:array`. Arrays are more optimized for the purpose of this functionality compared to `Seq`.
- the properties files column has changed from `appIndex_1` to `propertyValue` since we have no app index any more.
- change return type of `convertToSeq` to Array to improve performance.

This pull request introduces several changes to improve performance, consistency, and maintainability in the profiling and views components of the codebase. Key updates include standardizing data structures for output headers, centralizing header definitions for memory optimization, and updating method signatures for clarity and consistency.