### PR TITLE
Adding 'Not Recommended Reason' to qualification summary

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -347,8 +347,7 @@ class Qualification(RapidsJarTool):
         # Also processes the SpeedUp assigned using some eligibility conditions present in the qualification-conf.yaml
         # in case that needs to be updated
         df_final_result = speedup_category_ob.build_category_column(apps_with_runtime_df)
-        # Rename the column name to Not Recommended Reason and fill the missing values with N/A
-        df_final_result.rename(columns={'Reason': 'Not Recommended Reason'}, inplace=True)
+        # Fill the missing values in 'Not Recommended Reason' with N/A
         df_final_result['Not Recommended Reason'] = df_final_result['Not Recommended Reason'].fillna('N/A')
 
         reshaped_notes = self.__generate_cluster_shape_report()

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -298,15 +298,15 @@ class Qualification(RapidsJarTool):
         return None
 
     def __build_global_report_summary(self,
-                                      all_apps: pd.DataFrame,
+                                      processed_apps: pd.DataFrame,
                                       total_apps: pd.DataFrame,
                                       unsupported_ops_df: pd.DataFrame,
                                       output_files_info: JSONPropertiesContainer) -> QualificationSummary:
         # TODO: This method does a lot of critical but unrelated work. Refactor this into smaller steps/methods
         #  to improve readability and maintainability.
-        if all_apps.empty:
+        if processed_apps.empty:
             # No need to run saving estimator or process the data frames.
-            return QualificationSummary(total_apps=total_apps, tools_processed_apps=all_apps)
+            return QualificationSummary(total_apps=total_apps, tools_processed_apps=processed_apps)
 
         # Generate the statistics report
         try:
@@ -315,10 +315,13 @@ class Qualification(RapidsJarTool):
         except Exception as e:  # pylint: disable=broad-except
             self.logger.error('Failed to generate the statistics report: %s', e)
 
-        # Calculate unsupported operators stage duration before grouping
+        # Calculate unsupported operators stage duration
+        # This returns a DF with the following additional columns:
+        # 1. Unsupported Operators Stage Duration: Total duration of stages with unsupported operators
+        # 2. Unsupported Operators Stage Duration Percent: Percentage of unsupported operators stage duration
         unsupported_ops_obj = UnsupportedOpsStageDuration(
             self.ctxt.get_value('local', 'output', 'unsupportedOperators'))
-        all_apps = unsupported_ops_obj.prepare_apps_with_unsupported_stages(all_apps, unsupported_ops_df)
+        all_apps = unsupported_ops_obj.prepare_apps_with_unsupported_stages(processed_apps, unsupported_ops_df)
         apps_pruned_df = self.__remap_columns_and_prune(all_apps)
 
         # Apply additional heuristics to skip apps not suitable for GPU acceleration
@@ -326,19 +329,28 @@ class Qualification(RapidsJarTool):
             props=self.ctxt.get_value('local', 'output', 'additionalHeuristics'),
             tools_output_dir=self.ctxt.get_rapids_output_folder(),
             output_file=output_files_info.get_value('intermediateOutput', 'files', 'heuristics', 'path'))
+        # The apply heuristics will return DF with two additional columns:
+        # 1. Skip by heuristics: True/False
+        # 2. Reason: the reason why the app was skipped
         apps_pruned_df = heuristics_ob.apply_heuristics(apps_pruned_df)
 
         # Group the applications and recalculate metrics
         apps_grouped_df, group_notes = self.__group_apps_by_name(apps_pruned_df)
 
         # Assign the runtime type (Spark/Photon etc.) and speedup categories (Small/Medium/Large) to each application.
-        # Note: Strategy for speedup categorization will be based on the execution engine of the application.
+        # Note: Based on the assigned runtime, the speedup category conditions vary.
+        # Refer qualification-conf.yaml for exact speedUp category conditions/runtime type.
         apps_with_runtime_df = self._assign_spark_runtime_to_apps(apps_grouped_df)
         speedup_category_confs = self.ctxt.get_value('local', 'output', 'speedupCategories')
         speedup_category_ob = SpeedupCategory(speedup_category_confs)
+        # Adds the Speedup Category Column to the DataFrame.
+        # Also processes the SpeedUp assigned using some eligibility conditions present in the qualification-conf.yaml
+        # in case that needs to be updated
         df_final_result = speedup_category_ob.build_category_column(apps_with_runtime_df)
+        # Rename the column name to Not Recommended Reason and fill the missing values with N/A
+        df_final_result.rename(columns={'Reason': 'Not Recommended Reason'}, inplace=True)
+        df_final_result['Not Recommended Reason'] = df_final_result['Not Recommended Reason'].fillna('N/A')
 
-        # Generate the cluster shape report
         reshaped_notes = self.__generate_cluster_shape_report()
         report_comments = [group_notes] if group_notes else []
         if reshaped_notes:

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -226,7 +226,6 @@ local:
         - 'App Duration'
         - 'Stage ID'
         - 'Stage Duration'
-        - 'Unsupported Operator'
       groupingColumns:
         max:
           - 'App ID'
@@ -292,7 +291,7 @@ local:
             - columnName: 'Estimated GPU Speedup'
               lowerBound: 1.3
               upperBound: 1000000.0
-              skippingReason: 'GPU SpeedUp < 1.3'
+              skippingReason: 'GPU SpeedUp < 30%'
             - columnName: 'Unsupported Operators Stage Duration Percent'
               lowerBound: 0.0
               upperBound: 25.0

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -314,9 +314,11 @@ local:
             - columnName: 'Estimated GPU Speedup'
               lowerBound: 1.0
               upperBound: 1000000.0
+              skippingReason: 'GPU SpeedUp < 30%'
             - columnName: 'Unsupported Operators Stage Duration Percent'
               lowerBound: 0.0
               upperBound: 25.0
+              skippingReason: 'Unsupported Operators Stage Duration Percent > 25%. Refer r4s_qualification_output/r4s_unsupportedOperators.csv for details'
     additionalHeuristics:
       appInfo:
         fileName: 'application_information.csv'

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -289,13 +289,13 @@ local:
               upperBound: 1000000.0
           eligibilityConditions:
             - columnName: 'Estimated GPU Speedup'
-              lowerBound: 1.3
-              upperBound: 1000000.0
-              skippingReason: 'GPU SpeedUp < 30%'
+              lowerBound: !ENV ${RAPIDS_USER_TOOLS_GPU_SPEEDUP_SPARK_LOWER_BOUND:1.3}
+              upperBound: !ENV ${RAPIDS_USER_TOOLS_GPU_SPEEDUP_SPARK_UPPER_BOUND:1000000.0}
+              skippingReason: 'GPU SpeedUp < Qualifying Threshold (More is qualified)'
             - columnName: 'Unsupported Operators Stage Duration Percent'
-              lowerBound: 0.0
-              upperBound: 25.0
-              skippingReason: 'Unsupported Operators Stage Duration Percent > 25%. Refer r4s_qualification_output/r4s_unsupportedOperators.csv for details'
+              lowerBound: !ENV ${RAPIDS_USER_TOOLS_UNSUPPORTED_OPERATORS_SPARK_LOWER_BOUND:0.0}
+              upperBound: !ENV ${RAPIDS_USER_TOOLS_UNSUPPORTED_OPERATORS_SPARK_UPPER_BOUND:25.0}
+              skippingReason: 'Unsupported Operators Stage Duration Percent > Qualifying Threshold (Less is qualified)'
         photon:  # Photon specific speedup categories
           categories:
             - title: 'Not Applicable'
@@ -312,13 +312,13 @@ local:
               upperBound: 1000000.0
           eligibilityConditions:
             - columnName: 'Estimated GPU Speedup'
-              lowerBound: 1.0
-              upperBound: 1000000.0
-              skippingReason: 'GPU SpeedUp < 1%'
+              lowerBound: !ENV ${RAPIDS_USER_TOOLS_GPU_SPEEDUP_PHOTON_LOWER_BOUND:1.0}
+              upperBound: !ENV ${RAPIDS_USER_TOOLS_GPU_SPEEDUP_PHOTON_UPPER_BOUND:1000000.0}
+              skippingReason: 'GPU SpeedUp < Qualifying Threshold (Less is qualified)'
             - columnName: 'Unsupported Operators Stage Duration Percent'
-              lowerBound: 0.0
-              upperBound: 25.0
-              skippingReason: 'Unsupported Operators Stage Duration Percent > 25%. Refer r4s_qualification_output/r4s_unsupportedOperators.csv for details'
+              lowerBound: !ENV ${RAPIDS_USER_TOOLS_UNSUPPORTED_OPERATORS_PHOTON_LOWER_BOUND:0.0}
+              upperBound: !ENV ${RAPIDS_USER_TOOLS_UNSUPPORTED_OPERATORS_PHOTON_UPPER_BOUND:25.0}
+              skippingReason: 'Unsupported Operators Stage Duration Percent > Qualifying Threshold (Less is qualified)'
     additionalHeuristics:
       appInfo:
         fileName: 'application_information.csv'

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -226,6 +226,7 @@ local:
         - 'App Duration'
         - 'Stage ID'
         - 'Stage Duration'
+        - 'Unsupported Operator'
       groupingColumns:
         max:
           - 'App ID'
@@ -291,9 +292,11 @@ local:
             - columnName: 'Estimated GPU Speedup'
               lowerBound: 1.3
               upperBound: 1000000.0
+              skippingReason: 'GPU SpeedUp < 1.3'
             - columnName: 'Unsupported Operators Stage Duration Percent'
               lowerBound: 0.0
               upperBound: 25.0
+              skippingReason: 'Unsupported Operators Stage Duration Percent > 25%'
         photon:  # Photon specific speedup categories
           categories:
             - title: 'Not Applicable'

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -325,7 +325,7 @@ local:
       resultCols:
         - 'App ID'
         - 'Skip by Heuristics'
-        - 'Reason'
+        - 'Not Recommended Reason'
       spillBased:
         stageAggMetrics:
           fileName: 'stage_level_aggregated_task_metrics.csv'

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -314,7 +314,7 @@ local:
             - columnName: 'Estimated GPU Speedup'
               lowerBound: 1.0
               upperBound: 1000000.0
-              skippingReason: 'GPU SpeedUp < 30%'
+              skippingReason: 'GPU SpeedUp < 1%'
             - columnName: 'Unsupported Operators Stage Duration Percent'
               lowerBound: 0.0
               upperBound: 25.0

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -295,7 +295,7 @@ local:
             - columnName: 'Unsupported Operators Stage Duration Percent'
               lowerBound: 0.0
               upperBound: 25.0
-              skippingReason: 'Unsupported Operators Stage Duration Percent > 25%'
+              skippingReason: 'Unsupported Operators Stage Duration Percent > 25%. Refer r4s_qualification_output/r4s_unsupportedOperators.csv for details'
         photon:  # Photon specific speedup categories
           categories:
             - title: 'Not Applicable'

--- a/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
+++ b/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
@@ -128,7 +128,7 @@ class AdditionalHeuristics:
         if not relevant_stages_with_spills.empty:
             stages_str = '; '.join(relevant_stages_with_spills['stageId'].astype(str))
             spill_threshold_human_readable = Utilities.bytes_to_human_readable(spill_threshold_bytes)
-            reason = f'Skipping due to spills in stages [{stages_str}] exceeding {spill_threshold_human_readable}.'
+            reason = f'Skipping due to total data spill in stages exceeding {spill_threshold_human_readable}.'
             return True, reason
         return False, ''
 

--- a/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
+++ b/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
@@ -126,7 +126,6 @@ class AdditionalHeuristics:
             lambda x: isinstance(x, str) and bool(re.search(pattern, x)))]
         # If there are any stages with spills caused by non-allowed Execs, skip the application
         if not relevant_stages_with_spills.empty:
-            stages_str = '; '.join(relevant_stages_with_spills['stageId'].astype(str))
             spill_threshold_human_readable = Utilities.bytes_to_human_readable(spill_threshold_bytes)
             reason = f'Skipping due to total data spill in stages exceeding {spill_threshold_human_readable}.'
             return True, reason

--- a/user_tools/src/spark_rapids_tools/tools/speedup_category.py
+++ b/user_tools/src/spark_rapids_tools/tools/speedup_category.py
@@ -119,12 +119,12 @@ class SpeedupCategory:
                 # If the row does not match the eligibility criteria, set the category to `Not Recommended`.
                 # The reason for 'Not Recommended' will be added to the `Reason` column.
                 if not lower_bound <= col_value <= upper_bound:
-                    existing_reason = single_row.get('Reason', '')
+                    existing_reason = single_row.get('Not Recommended Reason', '')
                     heuristic_skipping_reason = entry.get('skippingReason')
                     if existing_reason and heuristic_skipping_reason:
-                        single_row['Reason'] = existing_reason + f'; {heuristic_skipping_reason}'
+                        single_row['Not Recommended Reason'] = existing_reason + f'; {heuristic_skipping_reason}'
                     elif heuristic_skipping_reason:
-                        single_row['Reason'] = heuristic_skipping_reason
+                        single_row['Not Recommended Reason'] = heuristic_skipping_reason
                     single_row[category_col_name] = self.props.get('defaultCategory')
                 # If the row was already marked to be skipped due to heuristics, set the category to `Not Recommended`
                 # in case not already set. The reason to be skipped due to heuristic will already be there

--- a/user_tools/src/spark_rapids_tools/tools/speedup_category.py
+++ b/user_tools/src/spark_rapids_tools/tools/speedup_category.py
@@ -117,7 +117,12 @@ class SpeedupCategory:
                 # If the row does not match the eligibility criteria, set the category to `Not Recommended`.
                 # The reason for 'Not Recommended' will be added to the `Reason` column.
                 if not entry.get('lowerBound') <= col_value <= entry.get('upperBound'):
-                    single_row['Reason'] = single_row.get('Reason', '') + f"; {entry.get('skippingReason')}"
+                    existing_reason = single_row.get('Reason', '')
+                    heuristic_skipping_reason = entry.get('skippingReason')
+                    if existing_reason and heuristic_skipping_reason:
+                        single_row['Reason'] = existing_reason + f"; {heuristic_skipping_reason}"
+                    elif heuristic_skipping_reason:
+                        single_row['Reason'] = heuristic_skipping_reason
                     assigned_category = self.props.get('defaultCategory')
                 # If the row was already marked to be skipped due to heuristics, set the category to `Not Recommended`
                 # in case not already set. The reason to be skipped due to heuristic will already be there

--- a/user_tools/src/spark_rapids_tools/tools/speedup_category.py
+++ b/user_tools/src/spark_rapids_tools/tools/speedup_category.py
@@ -120,7 +120,7 @@ class SpeedupCategory:
                     existing_reason = single_row.get('Reason', '')
                     heuristic_skipping_reason = entry.get('skippingReason')
                     if existing_reason and heuristic_skipping_reason:
-                        single_row['Reason'] = existing_reason + f"; {heuristic_skipping_reason}"
+                        single_row['Reason'] = existing_reason + f'; {heuristic_skipping_reason}'
                     elif heuristic_skipping_reason:
                         single_row['Reason'] = heuristic_skipping_reason
                     assigned_category = self.props.get('defaultCategory')

--- a/user_tools/src/spark_rapids_tools/tools/speedup_category.py
+++ b/user_tools/src/spark_rapids_tools/tools/speedup_category.py
@@ -117,7 +117,7 @@ class SpeedupCategory:
                 lower_bound = float(entry.get('lowerBound'))
                 upper_bound = float(entry.get('upperBound'))
                 # If the row does not match the eligibility criteria, set the category to `Not Recommended`.
-                # The reason for 'Not Recommended' will be added to the `Not Recommended` column.
+                # The reason for 'Not Recommended' will be added to the `Not Recommended Reason` column.
                 if not lower_bound <= col_value <= upper_bound:
                     existing_reason = single_row.get('Not Recommended Reason', '')
                     heuristic_skipping_reason = entry.get('skippingReason')

--- a/user_tools/src/spark_rapids_tools/tools/speedup_category.py
+++ b/user_tools/src/spark_rapids_tools/tools/speedup_category.py
@@ -117,7 +117,7 @@ class SpeedupCategory:
                 lower_bound = float(entry.get('lowerBound'))
                 upper_bound = float(entry.get('upperBound'))
                 # If the row does not match the eligibility criteria, set the category to `Not Recommended`.
-                # The reason for 'Not Recommended' will be added to the `Reason` column.
+                # The reason for 'Not Recommended' will be added to the `Not Recommended` column.
                 if not lower_bound <= col_value <= upper_bound:
                     existing_reason = single_row.get('Not Recommended Reason', '')
                     heuristic_skipping_reason = entry.get('skippingReason')

--- a/user_tools/src/spark_rapids_tools/tools/speedup_category.py
+++ b/user_tools/src/spark_rapids_tools/tools/speedup_category.py
@@ -117,12 +117,7 @@ class SpeedupCategory:
                 # If the row does not match the eligibility criteria, set the category to `Not Recommended`.
                 # The reason for 'Not Recommended' will be added to the `Reason` column.
                 if not entry.get('lowerBound') <= col_value <= entry.get('upperBound'):
-                    existing_reason = single_row.get('Reason', '')
-                    eligibility_skip_reason = entry.get('skippingReason')
-                    if existing_reason and eligibility_skip_reason:
-                        single_row['Reason'] = f"{existing_reason}; {eligibility_skip_reason}"
-                    elif eligibility_skip_reason:
-                        single_row['Reason'] = eligibility_skip_reason
+                    single_row['Reason'] = single_row.get('Reason', '') + f"; {entry.get('skippingReason')}"
                     assigned_category = self.props.get('defaultCategory')
                 # If the row was already marked to be skipped due to heuristics, set the category to `Not Recommended`
                 # in case not already set. The reason to be skipped due to heuristic will already be there

--- a/user_tools/src/spark_rapids_tools/tools/speedup_category.py
+++ b/user_tools/src/spark_rapids_tools/tools/speedup_category.py
@@ -117,7 +117,12 @@ class SpeedupCategory:
                 # If the row does not match the eligibility criteria, set the category to `Not Recommended`.
                 # The reason for 'Not Recommended' will be added to the `Reason` column.
                 if not entry.get('lowerBound') <= col_value <= entry.get('upperBound'):
-                    single_row['Reason'] = single_row.get('Reason', '') + f"; {entry.get('skippingReason')}"
+                    existing_reason = single_row.get('Reason', '')
+                    eligibility_skip_reason = entry.get('skippingReason')
+                    if existing_reason and eligibility_skip_reason:
+                        single_row['Reason'] = f"{existing_reason}; {eligibility_skip_reason}"
+                    elif eligibility_skip_reason:
+                        single_row['Reason'] = eligibility_skip_reason
                     assigned_category = self.props.get('defaultCategory')
                 # If the row was already marked to be skipped due to heuristics, set the category to `Not Recommended`
                 # in case not already set. The reason to be skipped due to heuristic will already be there

--- a/user_tools/src/spark_rapids_tools/tools/unsupported_ops_stage_duration.py
+++ b/user_tools/src/spark_rapids_tools/tools/unsupported_ops_stage_duration.py
@@ -62,8 +62,8 @@ class UnsupportedOpsStageDuration:
         Calculates the percentage of all sql stage durations sum for unsupported operators for each application
         """
         # Mask defines a set of conditions to filter which unsupported operators have an impact
-        # on the stage duration. Refer to keys unsupportedOperators/mask in qualification-conf.yaml
-        # for mask conditions
+        # on the stage duration. Refer to key 'local.output.unsupportedOperators.mask' in
+        # qualification-conf.yaml for mask conditions
         mask = self.__create_column_mask(unsupported_ops_df)
         unsupported_ops_df = unsupported_ops_df.loc[mask, self.props.get('inputColumns')]
 

--- a/user_tools/src/spark_rapids_tools/tools/unsupported_ops_stage_duration.py
+++ b/user_tools/src/spark_rapids_tools/tools/unsupported_ops_stage_duration.py
@@ -62,7 +62,8 @@ class UnsupportedOpsStageDuration:
         Calculates the percentage of all sql stage durations sum for unsupported operators for each application
         """
         # Mask defines a set of conditions to filter which unsupported operators have an impact
-        # on the stage duration. Refer - qualification-conf.yaml for mask conditions
+        # on the stage duration. Refer to keys unsupportedOperators/mask in qualification-conf.yaml
+        # for mask conditions
         mask = self.__create_column_mask(unsupported_ops_df)
         unsupported_ops_df = unsupported_ops_df.loc[mask, self.props.get('inputColumns')]
 

--- a/user_tools/src/spark_rapids_tools/tools/unsupported_ops_stage_duration.py
+++ b/user_tools/src/spark_rapids_tools/tools/unsupported_ops_stage_duration.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,17 +29,17 @@ class UnsupportedOpsStageDuration:
     """
     props: dict = field(default=None, init=True)
 
-    def prepare_apps_with_unsupported_stages(self, all_apps: pd.DataFrame,
+    def prepare_apps_with_unsupported_stages(self, processed_apps: pd.DataFrame,
                                              unsupported_ops_df: pd.DataFrame) -> pd.DataFrame:
         """
         Transform applications to include additional column having stage durations for unsupported operators
         and its percentage of all sql stage durations sum.
         """
-        unsupported_stage_duration_percentage = self.__calculate_unsupported_stages_duration(unsupported_ops_df)
-        # Note: We might have lost some applications because of masking. Final result should include these
-        # applications with unsupported stage duration percentage as 0.0. Thus implying that
-        # these applications have no stages with unsupported operator.
-        result_df = pd.merge(all_apps, unsupported_stage_duration_percentage, how='left')
+        unsupported_stage_total_duration = self.__calculate_unsupported_stages_duration(unsupported_ops_df)
+        # Note: We might have lost some applications because of masking(filtering based on valid unsupported cond).
+        # Final result should include these applications with unsupported stage duration percentage as 0.0 .
+        # Thus implying that these applications have no stages with unsupported operator.
+        result_df = pd.merge(processed_apps, unsupported_stage_total_duration, how='left')
         result_col_name = self.props.get('resultColumnName')
         result_df[result_col_name] = result_df[result_col_name].fillna(0)
         # Update the percentage column
@@ -57,16 +57,19 @@ class UnsupportedOpsStageDuration:
         """
         Calculates the percentage of all sql stage durations sum for unsupported operators for each application
         """
-        # Define mask to remove rows invalid entries
+        # Mask defines a set of conditions to filter which unsupported operators have an impact
+        # on the stage duration. Refer - qualification-conf.yaml for mask conditions
         mask = self.__create_column_mask(unsupported_ops_df)
         unsupported_ops_df = unsupported_ops_df.loc[mask, self.props.get('inputColumns')]
 
         # Calculate total duration of stages with unsupported operators
         grouping_cols = self.props.get('groupingColumns')
-        unsupported_ops_stage_duration = unsupported_ops_df \
-            .groupby(grouping_cols.get('max'))['Stage Duration'].max().reset_index() \
-            .groupby(grouping_cols.get('sum'))['Stage Duration'].sum().reset_index()
-
+        # De-duping based on stageID and take the max unsupported stage duration
+        unsupported_ops_stage_duration_dedup = (unsupported_ops_df.groupby(grouping_cols.get('max'))
+                                                ['Stage Duration'].max().reset_index())
+        # Sums the unsupported stage duration across stages
+        unsupported_ops_stage_duration = (unsupported_ops_stage_duration_dedup.groupby(grouping_cols.get('sum'))
+                                          ['Stage Duration'].sum().reset_index())
         # Return the calculated unsupported operators stage duration
         return unsupported_ops_stage_duration.rename(columns={'Stage Duration':  self.props.get('resultColumnName')})
 

--- a/user_tools/src/spark_rapids_tools/tools/unsupported_ops_stage_duration.py
+++ b/user_tools/src/spark_rapids_tools/tools/unsupported_ops_stage_duration.py
@@ -32,8 +32,12 @@ class UnsupportedOpsStageDuration:
     def prepare_apps_with_unsupported_stages(self, processed_apps: pd.DataFrame,
                                              unsupported_ops_df: pd.DataFrame) -> pd.DataFrame:
         """
-        Transform applications to include additional column having stage durations for unsupported operators
-        and its percentage of all sql stage durations sum.
+        Transform the given `processed_apps` DataFrame to include an additional column for stage durations
+        of unsupported operators and its percentage of the total SQL stage durations sum.
+
+        :param processed_apps: DataFrame containing application data processed by qualX
+        :param unsupported_ops_df: DataFrame containing unsupported operators data.
+        :return: A DataFrame with updated columns for unsupported stage durations and their percentage.
         """
         unsupported_stage_total_duration = self.__calculate_unsupported_stages_duration(unsupported_ops_df)
         # Note: We might have lost some applications because of masking(filtering based on valid unsupported cond).

--- a/user_tools/tests/spark_rapids_tools_e2e/features/environment.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/environment.py
@@ -19,6 +19,7 @@ This module defines environment setup and teardown functions for the end-to-end 
 import os
 import shutil
 import tempfile
+import re
 
 from spark_rapids_tools.utils import Utilities
 from steps.e2e_utils import E2ETestUtils
@@ -66,6 +67,13 @@ def after_scenario(context, scenario) -> None:
             os.environ['QUALX_LABEL'] = context.original_qualx_label
         else:
             os.environ.pop('QUALX_LABEL', None)
+
+    # Cleaning up the output from previous scenarios if any
+    if hasattr(context, 'temp_dir') and os.path.exists(context.temp_dir):
+        for item in os.listdir(context.temp_dir):
+            item_path = os.path.join(context.temp_dir, item)
+            if os.path.isdir(item_path) and re.match(r'^qual_.*', item):
+                shutil.rmtree(item_path)
 
 
 def _set_verbose_mode(context) -> None:

--- a/user_tools/tests/spark_rapids_tools_e2e/features/environment.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/environment.py
@@ -19,7 +19,7 @@ This module defines environment setup and teardown functions for the end-to-end 
 import os
 import shutil
 import tempfile
-import re
+from glob import glob
 
 from spark_rapids_tools.utils import Utilities
 from steps.e2e_utils import E2ETestUtils
@@ -70,9 +70,8 @@ def after_scenario(context, scenario) -> None:
 
     # Cleaning up the output from previous scenarios if any
     if hasattr(context, 'temp_dir') and os.path.exists(context.temp_dir):
-        for item in os.listdir(context.temp_dir):
-            item_path = os.path.join(context.temp_dir, item)
-            if os.path.isdir(item_path) and re.match(r'^qual_.*', item):
+        for item_path in glob(os.path.join(context.temp_dir, 'qual_*')):
+            if os.path.isdir(item_path):
                 shutil.rmtree(item_path)
 
 

--- a/user_tools/tests/spark_rapids_tools_e2e/features/event_log_processing.feature
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/event_log_processing.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,3 +43,17 @@ Feature: Event Log Processing
       Qualification. Raised an error in phase [Execution]
       """
     And return code is "1"
+
+  @test_id_ELP_0003
+  Scenario Outline: Check for expected output in generated files
+    Given platform is "<platform>"
+    Given RAPIDS_USER_TOOLS_SPILL_BYTES_THRESHOLD environment variable is set to "-1"
+    When spark-rapids tool is executed with "<eventlog>" eventlogs
+    When "<file>" file is generated
+    When "<app_id>" app is not qualified
+    Then not qualified reason is "<expected_reason>"
+    And return code is "0"
+
+    Examples:
+      | platform 	| eventlog                                                    | file                          | app_id                  | expected_reason                                              |
+      | onprem  	| onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | qualification_summary.csv     | app-20231122005806-0064 | Skipping due to total data spill in stages exceeding -1.00 B.|

--- a/user_tools/tests/spark_rapids_tools_e2e/features/event_log_processing.feature
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/event_log_processing.feature
@@ -47,7 +47,7 @@ Feature: Event Log Processing
   @test_id_ELP_0003
   Scenario Outline: Check for expected output in generated files
     Given platform is "<platform>"
-    Given RAPIDS_USER_TOOLS_SPILL_BYTES_THRESHOLD environment variable is set to "-1"
+    Given RAPIDS_USER_TOOLS environment variable "<variable>" is set to "<value>"
     When spark-rapids tool is executed with "<eventlog>" eventlogs
     When "<file>" file is generated
     When "<app_id>" app is not qualified
@@ -55,5 +55,7 @@ Feature: Event Log Processing
     And return code is "0"
 
     Examples:
-      | platform 	| eventlog                                                    | file                          | app_id                  | expected_reason                                              |
-      | onprem  	| onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | qualification_summary.csv     | app-20231122005806-0064 | Skipping due to total data spill in stages exceeding -1.00 B.|
+      | platform 	| variable                                                  | value           |eventlog                                                    | file                          | app_id                  | expected_reason                                              |
+      | onprem  	| RAPIDS_USER_TOOLS_SPILL_BYTES_THRESHOLD                   |   -1            |onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | qualification_summary.csv     | app-20231122005806-0064 | Skipping due to total data spill in stages exceeding -1.00 B.|
+      | onprem  	| RAPIDS_USER_TOOLS_GPU_SPEEDUP_SPARK_LOWER_BOUND           |   20.0          |onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | qualification_summary.csv     | app-20231122005806-0064 | Skipping due to total data spill in stages exceeding -1.00 B.; GPU SpeedUp < Qualifying Threshold (More is qualified) |
+      | onprem  	| RAPIDS_USER_TOOLS_UNSUPPORTED_OPERATORS_SPARK_UPPER_BOUND |   -1            |onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | qualification_summary.csv     | app-20231122005806-0064 | Skipping due to total data spill in stages exceeding -1.00 B.; GPU SpeedUp < Qualifying Threshold (More is qualified); Unsupported Operators Stage Duration Percent > Qualifying Threshold (Less is qualified) |

--- a/user_tools/tests/spark_rapids_tools_e2e/features/event_log_processing.feature
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/event_log_processing.feature
@@ -47,7 +47,7 @@ Feature: Event Log Processing
   @test_id_ELP_0003
   Scenario Outline: Check for expected output in generated files
     Given platform is "<platform>"
-    Given RAPIDS_USER_TOOLS environment variable "<variable>" is set to "<value>"
+    Given environment variable "<variable>" is set to "<value>"
     When spark-rapids tool is executed with "<eventlog>" eventlogs
     When "<file>" file is generated
     When "<app_id>" app is not qualified

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/e2e_utils.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/e2e_utils.py
@@ -19,6 +19,7 @@ This module defines utility functions used by the end-to-end tests using behave.
 import glob
 import logging
 import os
+import pandas as pd
 import subprocess
 from attr import dataclass
 from enum import auto
@@ -171,6 +172,15 @@ class E2ETestUtils:
             format='%(levelname)s: %(message)s'
         )
         return logging.getLogger(__name__)
+
+    @staticmethod
+    def read_csv_as_dataframe(file_path: str) -> pd.DataFrame:
+        """
+        Reads a CSV file from the given file path and returns it as a pandas DataFrame.
+        :param file_path: Path to the CSV file.
+        :return: pandas DataFrame containing the CSV data.
+        """
+        return pd.read_csv(file_path)
 
 
 class HdfsStatus(EnumeratedType):

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
@@ -14,6 +14,7 @@
 
 import glob
 import os
+import re
 from behave import given, when, then
 from spark_rapids_tools.tools.qualx.preprocess import (
     load_datasets,
@@ -65,10 +66,15 @@ def step_impl(context, label):
     os.environ['QUALX_LABEL'] = label
 
 
-@given('RAPIDS_USER_TOOLS_SPILL_BYTES_THRESHOLD environment variable is set to "{threshold}"')
-def set_spill_threshold(context, threshold):
-    """Set the QUALX_LABEL environment variable to the specified value."""
-    os.environ['RAPIDS_USER_TOOLS_SPILL_BYTES_THRESHOLD'] = threshold
+@given('RAPIDS_USER_TOOLS environment variable "{variable_name}" is set to "{value}"')
+def set_environment_variable(context, variable_name, value):
+    """Set the specified RAPIDS_USER_TOOLS_* environment variable to the given value."""
+    pattern = r'^RAPIDS_USER_TOOLS_[A-Z_]+$'
+
+    if re.match(pattern, variable_name):
+        os.environ[variable_name] = value
+    else:
+        raise ValueError(f"Environment variable {variable_name} does not match the required pattern: {pattern}")
 
 
 @given('sample event logs in the QUALX_DATA_DIR')

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
@@ -64,6 +64,10 @@ def step_impl(context, label):
     context.qualx_label = label
     os.environ['QUALX_LABEL'] = label
 
+@given('RAPIDS_USER_TOOLS_SPILL_BYTES_THRESHOLD environment variable is set to "{threshold}"')
+def step_impl(context, threshold):
+    """Set the QUALX_LABEL environment variable to the specified value."""
+    os.environ['RAPIDS_USER_TOOLS_SPILL_BYTES_THRESHOLD'] = threshold
 
 @given('sample event logs in the QUALX_DATA_DIR')
 def check_sample_event_logs(context):

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
@@ -14,7 +14,6 @@
 
 import glob
 import os
-import re
 from behave import given, when, then
 from spark_rapids_tools.tools.qualx.preprocess import (
     load_datasets,

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
@@ -66,15 +66,10 @@ def step_impl(context, label):
     os.environ['QUALX_LABEL'] = label
 
 
-@given('RAPIDS_USER_TOOLS environment variable "{variable_name}" is set to "{value}"')
+@given('environment variable "{variable_name}" is set to "{value}"')
 def set_environment_variable(context, variable_name, value):
     """Set the specified RAPIDS_USER_TOOLS_* environment variable to the given value."""
-    pattern = r'^RAPIDS_USER_TOOLS_[A-Z_]+$'
-
-    if re.match(pattern, variable_name):
-        os.environ[variable_name] = value
-    else:
-        raise ValueError(f"Environment variable {variable_name} does not match the required pattern: {pattern}")
+    os.environ[variable_name] = value
 
 
 @given('sample event logs in the QUALX_DATA_DIR')

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
@@ -64,10 +64,12 @@ def step_impl(context, label):
     context.qualx_label = label
     os.environ['QUALX_LABEL'] = label
 
+
 @given('RAPIDS_USER_TOOLS_SPILL_BYTES_THRESHOLD environment variable is set to "{threshold}"')
 def step_impl(context, threshold):
     """Set the QUALX_LABEL environment variable to the specified value."""
     os.environ['RAPIDS_USER_TOOLS_SPILL_BYTES_THRESHOLD'] = threshold
+
 
 @given('sample event logs in the QUALX_DATA_DIR')
 def check_sample_event_logs(context):

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
@@ -66,7 +66,7 @@ def step_impl(context, label):
 
 
 @given('RAPIDS_USER_TOOLS_SPILL_BYTES_THRESHOLD environment variable is set to "{threshold}"')
-def step_impl(context, threshold):
+def set_spill_threshold(context, threshold):
     """Set the QUALX_LABEL environment variable to the specified value."""
     os.environ['RAPIDS_USER_TOOLS_SPILL_BYTES_THRESHOLD'] = threshold
 

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/test_steps.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/test_steps.py
@@ -138,6 +138,7 @@ def step_file_is_generated(context, file) -> None:
     assert file_path is not None, f"File '{file}' was not found in the directory '{context.temp_dir}'"
     context.generated_file_path = file_path
 
+
 @when('spark-rapids tool is executed with "{event_logs}" eventlogs')
 def step_execute_spark_rapids_tool(context, event_logs) -> None:
     event_logs_list = E2ETestUtils.resolve_event_logs(event_logs.split(","))
@@ -147,6 +148,7 @@ def step_execute_spark_rapids_tool(context, event_logs) -> None:
         cmd = E2ETestUtils.create_spark_rapids_cmd(event_logs_list, context.temp_dir)
     context.result = E2ETestUtils.run_sys_cmd(cmd)
 
+
 @when('"{app_id}" app is not qualified')
 def step_verify_gpu_speedup_category(context, app_id) -> None:
     df = E2ETestUtils.read_csv_as_dataframe(context.generated_file_path)
@@ -154,6 +156,7 @@ def step_verify_gpu_speedup_category(context, app_id) -> None:
     row = df[df["App ID"] == app_id]
     assert row["Estimated GPU Speedup Category"].iloc[0] == "Not Recommended", \
         f'Expected "Not Recommended", but found "{row["Estimated GPU Speedup Category"].iloc[0]}"'
+
 
 @then('not qualified reason is "{expected_reason}"')
 def step_verify_not_qualified_reason(context, expected_reason) -> None:
@@ -165,6 +168,7 @@ def step_verify_not_qualified_reason(context, expected_reason) -> None:
     actual_reason = df["Not Recommended Reason"].iloc[0]
     assert actual_reason == expected_reason, f"Expected reason: '{expected_reason}', but found: '{actual_reason}'"
 
+
 @then('stderr contains the following')
 def step_verify_stderr(context) -> None:
     expected_stderr_list = context.text.strip().split(";")
@@ -172,6 +176,7 @@ def step_verify_stderr(context) -> None:
         assert stderr_line in context.result.stderr, \
             (f"Expected stderr line '{stderr_line}' not found\n" +
              E2ETestUtils.get_cmd_output_str(context.result))
+
 
 @then('stdout contains the following')
 def step_verify_stdout(context) -> None:
@@ -181,11 +186,13 @@ def step_verify_stdout(context) -> None:
             (f"Expected stdout line '{stdout_line}' not found\n" +
              E2ETestUtils.get_cmd_output_str(context.result))
 
+
 @then('file output contains the following "{expected_content}"')
 def step_verify_file_contains(context, expected_content) -> None:
     with open(context.generated_file_path, 'r') as file:
         file_content = file.read()
     assert expected_content in file_content, f"Expected content '{expected_content}' not found in the file output."
+
 
 @then('processed applications is "{expected_num_apps}"')
 def step_verify_num_apps(context, expected_num_apps) -> None:

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/test_steps.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/test_steps.py
@@ -157,11 +157,11 @@ def step_execute_spark_rapids_tool(context, event_logs) -> None:
 @when('"{app_id}" app is not qualified')
 def step_verify_gpu_speedup_category(context, app_id) -> None:
     df = E2ETestUtils.read_csv_as_dataframe(context.generated_file_paths['qualification_summary'])
-    logger.info(f"App IDs present in the DataFrame: {df['App ID'].values}")
-    assert app_id in df["App ID"].values, f'App ID "{app_id}" not found in the CSV file.'
-    row = df[df["App ID"] == app_id]
-    assert row["Estimated GPU Speedup Category"].iloc[0] == "Not Recommended", \
-        f'Expected "Not Recommended", but found "{row["Estimated GPU Speedup Category"].iloc[0]}"'
+    row = df.loc[df["App ID"] == app_id]
+    assert not row.empty, f'App ID "{app_id}" not found in the CSV file.'
+    category = row["Estimated GPU Speedup Category"].iloc[0]
+    assert category == "Not Recommended", \
+        f'Expected "Not Recommended", but found "{category}"'
 
 
 @then('not qualified reason is "{expected_reason}"')

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/test_steps.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/test_steps.py
@@ -152,7 +152,7 @@ def step_execute_spark_rapids_tool(context, event_logs) -> None:
 @when('"{app_id}" app is not qualified')
 def step_verify_gpu_speedup_category(context, app_id) -> None:
     df = E2ETestUtils.read_csv_as_dataframe(context.generated_file_path)
-    print(df)
+    logger.info(f"App IDs present in the DataFrame: {df['App ID'].values}")
     assert app_id in df["App ID"].values, f'App ID "{app_id}" not found in the CSV file.'
     row = df[df["App ID"] == app_id]
     assert row["Estimated GPU Speedup Category"].iloc[0] == "Not Recommended", \

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/test_steps.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/test_steps.py
@@ -152,6 +152,7 @@ def step_execute_spark_rapids_tool(context, event_logs) -> None:
 @when('"{app_id}" app is not qualified')
 def step_verify_gpu_speedup_category(context, app_id) -> None:
     df = E2ETestUtils.read_csv_as_dataframe(context.generated_file_path)
+    print(df)
     assert app_id in df["App ID"].values, f'App ID "{app_id}" not found in the CSV file.'
     row = df[df["App ID"] == app_id]
     assert row["Estimated GPU Speedup Category"].iloc[0] == "Not Recommended", \


### PR DESCRIPTION
Fixes #1621 

This PR changes the `qualification_summary.csv` file to include the `Not Recommended Reason` column.

**Output Changes** ->

`qualification_summary.csv` pre-change ->
```
Vendor,Driver Host,App Name,App ID,Estimated GPU Speedup,Estimated GPU Duration,App Duration,SQL Stage Durations Sum,Unsupported Operators Stage Duration,Unsupported Operators Stage Duration Percent,Total Core Seconds,Skip by Heuristics,Spark Runtime,Estimated GPU Speedup Category
<vendor>,<driver>,application_1,6.00,6234174,37381418,37546873,528067,1.41,6727206,False,SPARK,Large
```

`qualification_summary.csv` post-change ->
```
Vendor,Driver Host,App Name,App ID,Estimated GPU Speedup,Estimated GPU Duration,App Duration,SQL Stage Durations Sum,Unsupported Operators Stage Duration,Unsupported Operators Stage Duration Percent,Total Core Seconds,Skip by Heuristics,Not Recommended Reason,Spark Runtime,Estimated GPU Speedup Category
<vendor>,<driver>,application_1,6.00,6234174,37381418,37546873,528067,1.41,6727206,False,N/A,SPARK,Large
```

**Logic Updates** ->
- In case app skipped by Heuristic ( only heuristic is the spilling to disk ), reason is added
- In case GPU speedup not enough, reason is added
- In case unsupported operator % is too high, reason is added

Filtering based on core seconds is only there in the TOP_CANDIDATE view. Hence that is not updated in the `qual_summary.csv` update

**Testing** ->

This PR also adds a behavioral test to verify the 'Not Recommended Reason' in case an app comes up as 'Not Recommended'
The current logic appends to the list of existing reasons, which can easily be verified through the added test