### PR TITLE
Improve unit handling for memory-related configs in AutoTuner

### DIFF
--- a/core/src/main/resources/bootstrap/tuningTable.yaml
+++ b/core/src/main/resources/bootstrap/tuningTable.yaml
@@ -19,11 +19,15 @@ tuningDefinitions:
     enabled: true
     level: job
     category: tuning
+    confType:
+      name: boolean
   - label: spark.dataproc.enhanced.execution.enabled
     description: Enables enhanced execution. Turning this on might cause the accelerated dataproc cluster to hang.
     enabled: true
     level: job
     category: tuning
+    confType:
+      name: boolean
     comments:
       persistent: >-
         should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
@@ -32,6 +36,8 @@ tuningDefinitions:
     enabled: true
     level: job
     category: tuning
+    confType:
+      name: boolean
     comments:
       persistent: >-
         should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
@@ -40,19 +46,25 @@ tuningDefinitions:
     enabled: true
     level: cluster
     category: tuning
+    confType:
+      name: int
   - label: spark.executor.instances
     description: >-
       Controls parallelism level. It is recommended to be set to (cpuCoresPerNode * numWorkers) / spark.executor.cores.
     enabled: true
     level: cluster
     category: tuning
+    confType:
+      name: int
   - label: spark.executor.memory
     description: >-
       Amount of memory to use per executor process. This is tuned based on the available CPU memory on worker node.
     enabled: true
     level: cluster
     category: tuning
-    defaultMemoryUnit: MiB
+    confType:
+      name: byte
+      defaultUnit: MiB
   - label: spark.executor.memoryOverhead
     description: >-
       Amount of additional memory to be allocated per executor process, in MiB unless otherwise specified.
@@ -61,7 +73,9 @@ tuningDefinitions:
     enabled: true
     level: cluster
     category: tuning
-    defaultMemoryUnit: MiB
+    confType:
+      name: byte
+      defaultUnit: MiB
   - label: spark.executor.memoryOverheadFactor
     description: >-
       Fraction of executor memory to be allocated as additional non-heap memory per executor process.
@@ -70,6 +84,8 @@ tuningDefinitions:
     enabled: true
     level: cluster
     category: tuning
+    confType:
+      name: double
   - label: spark.kryo.registrator
     description: >-
       Fraction of executor memory to be allocated as additional non-heap memory per executor process.
@@ -78,6 +94,8 @@ tuningDefinitions:
     enabled: true
     level: job
     category: functionality
+    confType:
+      name: string
     comments:
       missing: should include GpuKryoRegistrator when using Kryo serialization.
       updated: GpuKryoRegistrator must be appended to the existing value when using Kryo serialization.
@@ -89,7 +107,9 @@ tuningDefinitions:
     level: job
     category: tuning
     defaultSpark: "64MB"
-    defaultMemoryUnit: MiB
+    confType:
+      name: byte
+      defaultUnit: MiB
     comments:
       missing: setting the max buffer to prevent out-of-memory errors.
       updated: increasing the max buffer to prevent out-of-memory errors.
@@ -99,6 +119,8 @@ tuningDefinitions:
     enabled: true
     level: cluster
     category: tuning
+    confType:
+      name: double
   - label: spark.locality.wait
     description: >-
       The time to wait to launch a data-local task before giving up and launching it on a less-local node.
@@ -107,6 +129,9 @@ tuningDefinitions:
     level: cluster
     category: tuning
     defaultSpark: "3s"
+    confType:
+      name: time
+      unit: "ms"
   - label: spark.rapids.filecache.enabled
     description: >-
       Enables RAPIDS file cache. The file cache stores data locally in the same local directories
@@ -114,12 +139,16 @@ tuningDefinitions:
     enabled: true
     level: job
     category: tuning
+    confType:
+      name: boolean
   - label: spark.rapids.memory.pinnedPool.size
     description: The size of the pinned memory pool in bytes unless otherwise specified. Use 0 to disable the pool.
     enabled: true
     level: cluster
     category: tuning
-    defaultMemoryUnit: Byte
+    confType:
+      name: byte
+      defaultUnit: Byte
   - label: spark.rapids.shuffle.multiThreaded.maxBytesInFlight
     description: >-
       This property controls the amount of bytes we allow in flight per Spark task.
@@ -128,7 +157,9 @@ tuningDefinitions:
     enabled: true
     level: cluster
     category: tuning
-    defaultMemoryUnit: Byte
+    confType:
+      name: byte
+      defaultUnit: Byte
   - label: spark.rapids.shuffle.multiThreaded.reader.threads
     description: >-
       The shuffle reader is a single implementation irrespective of the number of partitions.
@@ -136,6 +167,8 @@ tuningDefinitions:
     enabled: true
     level: cluster
     category: tuning
+    confType:
+      name: int
   - label: spark.rapids.shuffle.multiThreaded.writer.threads
     description: >-
       Controls the number of threads used for writing shuffle data in a multi-threaded shuffle writer
@@ -143,13 +176,17 @@ tuningDefinitions:
     enabled: true
     level: cluster
     category: tuning
+    confType:
+      name: int
   - label: spark.rapids.sql.batchSizeBytes
     description: >-
       Set the target number of bytes for a GPU batch. Splits sizes for input data is covered by separate configs.
     enabled: true
     level: job
     category: tuning
-    defaultMemoryUnit: Byte
+    confType:
+      name: byte
+      defaultUnit: Byte
   - label: spark.rapids.sql.concurrentGpuTasks
     description: >-
       Set the number of tasks that can execute concurrently per GPU. Tasks may temporarily block when the number of
@@ -158,6 +195,8 @@ tuningDefinitions:
     enabled: true
     level: cluster
     category: tuning
+    confType:
+      name: int
   - label: spark.rapids.sql.format.parquet.multithreaded.combine.waitTime
     description: >-
       When using the multithreaded parquet reader with combine mode, how long to wait, in milliseconds,
@@ -167,16 +206,22 @@ tuningDefinitions:
     enabled: true
     level: cluster
     category: tuning
+    confType:
+      name: int
   - label: spark.rapids.sql.enabled
     description: Should be true to enable SQL operations on the GPU.
     enabled: true
     level: cluster
     category: functionality
+    confType:
+      name: boolean
   - label: spark.rapids.sql.multiThreadedRead.numThreads
     description: The maximum number of threads on each executor to use for reading small files in parallel.
     enabled: true
     level: cluster
     category: tuning
+    confType:
+      name: int
   - label: spark.rapids.sql.reader.multithreaded.combine.sizeBytes
     description: >-
       The target size in bytes to combine multiple small files together when using the MULTITHREADED
@@ -185,7 +230,9 @@ tuningDefinitions:
     enabled: true
     level: job
     category: tuning
-    defaultMemoryUnit: Byte
+    confType:
+      name: byte
+      defaultUnit: Byte
   - label: spark.serializer
     description: >-
       Specifies which serialization mechanism to use when serializing objects during distributed computation.
@@ -194,6 +241,8 @@ tuningDefinitions:
     enabled: true
     level: job
     category: tuning
+    confType:
+      name: string
   - label: spark.shuffle.manager
     description: >-
       The RAPIDS Shuffle Manager is an implementation of the ShuffleManager interface in Apache Spark that
@@ -202,6 +251,8 @@ tuningDefinitions:
     enabled: true
     level: cluster
     category: tuning
+    confType:
+      name: string
   - label: spark.sql.adaptive.enabled
     description: >-
       When true, enable adaptive query execution, which re-optimizes the query plan in the middle of
@@ -210,6 +261,8 @@ tuningDefinitions:
     level: job
     category: tuning
     defaultSpark: "true"
+    confType:
+      name: boolean
   - label: spark.sql.adaptive.advisoryPartitionSizeInBytes
     description: >-
       The advisory size in bytes of the shuffle partition during adaptive optimization
@@ -219,6 +272,9 @@ tuningDefinitions:
     level: job
     category: tuning
     defaultMemoryUnit: Byte
+    confType:
+      name: byte
+      defaultUnit: Byte
   - label: spark.sql.adaptive.coalescePartitions.initialPartitionNum
     description: >-
       The initial number of shuffle partitions before coalescing. If not set, it equals to
@@ -226,6 +282,8 @@ tuningDefinitions:
     enabled: true
     level: job
     category: tuning
+    confType:
+      name: int
   - label: spark.sql.adaptive.coalescePartitions.minPartitionNum
     description: >-
       (deprecated) The suggested (not guaranteed) minimum number of shuffle partitions after coalescing.
@@ -233,6 +291,8 @@ tuningDefinitions:
     enabled: true
     level: job
     category: tuning
+    confType:
+      name: int
   - label: spark.sql.adaptive.coalescePartitions.minPartitionSize
     description: >-
       The minimum size of shuffle partitions after coalescing. This is useful when the adaptively calculated
@@ -242,6 +302,9 @@ tuningDefinitions:
     category: tuning
     defaultSpark: 1m
     defaultMemoryUnit: Byte
+    confType:
+      name: byte
+      defaultUnit: Byte
   - label: spark.sql.adaptive.coalescePartitions.parallelismFirst
     description: >-
       When true, Spark does not respect the target size specified by 'spark.sql.adaptive.advisoryPartitionSizeInBytes'
@@ -251,6 +314,8 @@ tuningDefinitions:
     level: job
     category: tuning
     defaultSpark: "true"
+    confType:
+      name: boolean
   - label: spark.sql.adaptive.autoBroadcastJoinThreshold
     description: >-
       Configures the maximum size in bytes for a table that will be broadcast to all worker nodes when
@@ -259,6 +324,9 @@ tuningDefinitions:
     level: job
     category: tuning
     defaultMemoryUnit: Byte
+    confType:
+      name: byte
+      defaultUnit: Byte
   - label: spark.sql.files.maxPartitionBytes
     description: >-
       The maximum number of bytes to pack into a single partition when reading files.
@@ -267,6 +335,9 @@ tuningDefinitions:
     level: job
     category: tuning
     defaultMemoryUnit: Byte
+    confType:
+      name: byte
+      defaultUnit: Byte
   - label: spark.sql.shuffle.partitions
     description: >-
       The default number of partitions to use when shuffling data for joins or aggregations.
@@ -276,6 +347,8 @@ tuningDefinitions:
     level: job
     category: tuning
     defaultSpark: "200"
+    confType:
+      name: int
   - label: spark.task.resource.gpu.amount
     description: >-
       The GPU resource amount per task when Apache Spark schedules GPU resources.
@@ -283,3 +356,5 @@ tuningDefinitions:
     enabled: true
     level: cluster
     category: tuning
+    confType:
+      name: double

--- a/core/src/main/resources/bootstrap/tuningTable.yaml
+++ b/core/src/main/resources/bootstrap/tuningTable.yaml
@@ -52,6 +52,7 @@ tuningDefinitions:
     enabled: true
     level: cluster
     category: tuning
+    defaultMemoryUnit: MiB
   - label: spark.executor.memoryOverhead
     description: >-
       Amount of additional memory to be allocated per executor process, in MiB unless otherwise specified.
@@ -60,6 +61,7 @@ tuningDefinitions:
     enabled: true
     level: cluster
     category: tuning
+    defaultMemoryUnit: MiB
   - label: spark.executor.memoryOverheadFactor
     description: >-
       Fraction of executor memory to be allocated as additional non-heap memory per executor process.
@@ -87,6 +89,7 @@ tuningDefinitions:
     level: job
     category: tuning
     defaultSpark: "64MB"
+    defaultMemoryUnit: MiB
     comments:
       missing: setting the max buffer to prevent out-of-memory errors.
       updated: increasing the max buffer to prevent out-of-memory errors.
@@ -116,14 +119,16 @@ tuningDefinitions:
     enabled: true
     level: cluster
     category: tuning
+    defaultMemoryUnit: Byte
   - label: spark.rapids.shuffle.multiThreaded.maxBytesInFlight
     description: >-
       This property controls the amount of bytes we allow in flight per Spark task.
       This typically happens on the reader side, when blocks are received from the network,
-      they’re queued onto these threads for decompression and decode.
+      they're queued onto these threads for decompression and decode.
     enabled: true
     level: cluster
     category: tuning
+    defaultMemoryUnit: Byte
   - label: spark.rapids.shuffle.multiThreaded.reader.threads
     description: >-
       The shuffle reader is a single implementation irrespective of the number of partitions.
@@ -144,6 +149,7 @@ tuningDefinitions:
     enabled: true
     level: job
     category: tuning
+    defaultMemoryUnit: Byte
   - label: spark.rapids.sql.concurrentGpuTasks
     description: >-
       Set the number of tasks that can execute concurrently per GPU. Tasks may temporarily block when the number of
@@ -155,7 +161,7 @@ tuningDefinitions:
   - label: spark.rapids.sql.format.parquet.multithreaded.combine.waitTime
     description: >-
       When using the multithreaded parquet reader with combine mode, how long to wait, in milliseconds,
-      for more files to finish if haven’t met the size threshold. Note that this will wait this amount
+      for more files to finish if haven't met the size threshold. Note that this will wait this amount
       of time from when the last file was available, so total wait time could be larger then this.
       DEPRECATED: use spark.rapids.sql.reader.multithreaded.combine.waitTime instead.
     enabled: true
@@ -179,6 +185,7 @@ tuningDefinitions:
     enabled: true
     level: job
     category: tuning
+    defaultMemoryUnit: Byte
   - label: spark.serializer
     description: >-
       Specifies which serialization mechanism to use when serializing objects during distributed computation.
@@ -211,6 +218,7 @@ tuningDefinitions:
     enabled: true
     level: job
     category: tuning
+    defaultMemoryUnit: Byte
   - label: spark.sql.adaptive.coalescePartitions.initialPartitionNum
     description: >-
       The initial number of shuffle partitions before coalescing. If not set, it equals to
@@ -233,6 +241,7 @@ tuningDefinitions:
     level: job
     category: tuning
     defaultSpark: 1m
+    defaultMemoryUnit: Byte
   - label: spark.sql.adaptive.coalescePartitions.parallelismFirst
     description: >-
       When true, Spark does not respect the target size specified by 'spark.sql.adaptive.advisoryPartitionSizeInBytes'
@@ -249,6 +258,7 @@ tuningDefinitions:
     enabled: true
     level: job
     category: tuning
+    defaultMemoryUnit: Byte
   - label: spark.sql.files.maxPartitionBytes
     description: >-
       The maximum number of bytes to pack into a single partition when reading files.
@@ -256,6 +266,7 @@ tuningDefinitions:
     enabled: true
     level: job
     category: tuning
+    defaultMemoryUnit: Byte
   - label: spark.sql.shuffle.partitions
     description: >-
       The default number of partitions to use when shuffling data for joins or aggregations.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/ClusterConfigurationStrategy.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/ClusterConfigurationStrategy.scala
@@ -16,6 +16,7 @@
 
 package com.nvidia.spark.rapids.tool
 
+import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.rapids.tool.ExistingClusterInfo
 import org.apache.spark.sql.rapids.tool.util.StringUtils
 
@@ -154,7 +155,7 @@ class ClusterPropertyBasedStrategy(
   }
 
   override protected def getMemoryPerNodeMb: Long = {
-    StringUtils.convertToMB(clusterProperties.system.getMemory)
+    StringUtils.convertToMB(clusterProperties.system.getMemory, Some(ByteUnit.BYTE))
   }
 }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/GpuDevice.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/GpuDevice.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package com.nvidia.spark.rapids.tool
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.rapids.tool.util.StringUtils
 
 object GpuTypes {
@@ -39,7 +40,7 @@ abstract class GpuDevice {
   def getInitialPartitionNum: Option[Int] = None
   // TODO: Improve logic for concurrent tasks
   final def getGpuConcTasks: Long =
-    StringUtils.convertToMB(getMemory) / GpuDevice.DEF_GPU_MEM_PER_TASK_MB
+    StringUtils.convertToMB(getMemory, Some(ByteUnit.BYTE)) / GpuDevice.DEF_GPU_MEM_PER_TASK_MB
 }
 
 case object A100Gpu extends GpuDevice {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -198,11 +198,23 @@ class ClusterProperties(
 /**
  * Represents different Spark master types.
  */
-sealed trait SparkMaster
-case object Local extends SparkMaster
-case object Yarn extends SparkMaster
-case object Kubernetes extends SparkMaster
-case object Standalone extends SparkMaster
+sealed trait SparkMaster {
+  // Default executor memory to use in case not set by the user.
+  val defaultExecutorMemoryMB: Long
+}
+case object Local extends SparkMaster {
+  val defaultExecutorMemoryMB: Long = 0L
+}
+case object Yarn extends SparkMaster {
+  val defaultExecutorMemoryMB: Long = 1024L
+}
+case object Kubernetes extends SparkMaster {
+  val defaultExecutorMemoryMB: Long = 1024L
+}
+case object Standalone extends SparkMaster {
+  // Would be the entire node memory by default
+  val defaultExecutorMemoryMB: Long = 0L
+}
 
 object SparkMaster {
   def apply(master: Option[String]): Option[SparkMaster] = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -34,6 +34,7 @@ import org.yaml.snakeyaml.constructor.{Constructor, ConstructorException}
 import org.yaml.snakeyaml.representer.Representer
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.rapids.tool.ToolUtils
 import org.apache.spark.sql.rapids.tool.util.{StringUtils, WebCrawlerUtil}
 
@@ -378,7 +379,7 @@ class AutoTuner(
     // if the value is not null, then proceed to add the recommendation.
     Option(value).foreach { nonNullValue =>
       recomRecord.setRecommendedValue(nonNullValue)
-      if (recomRecord.originalValue.isEmpty) {
+      if (recomRecord.getOriginalValue.isEmpty) {
         // add missing comment if any
         appendMissingComment(key)
       } else {
@@ -697,7 +698,7 @@ class AutoTuner(
       // set the kryo serializer buffer size to prevent OOMs
       val desiredBufferMax = autoTunerConfigsProvider.KRYO_SERIALIZER_BUFFER_MAX_MB
       val currentBufferMaxMb = getPropertyValue("spark.kryoserializer.buffer.max")
-        .map(StringUtils.convertToMB)
+        .map(StringUtils.convertToMB(_, Some(ByteUnit.MiB)))
         .getOrElse(0L)
       if (currentBufferMaxMb < desiredBufferMax) {
         appendRecommendationForMemoryMB("spark.kryoserializer.buffer.max", s"$desiredBufferMax")
@@ -852,11 +853,11 @@ class AutoTuner(
     // TODO - can we set spark.sql.autoBroadcastJoinThreshold ???
     val autoBroadcastJoinKey = "spark.sql.adaptive.autoBroadcastJoinThreshold"
     val autoBroadcastJoinThresholdProperty =
-      getPropertyValue(autoBroadcastJoinKey).map(StringUtils.convertToMB)
+      getPropertyValue(autoBroadcastJoinKey).map(StringUtils.convertToMB(_, Some(ByteUnit.BYTE)))
     if (autoBroadcastJoinThresholdProperty.isEmpty) {
       appendComment(autoBroadcastJoinKey, s"'$autoBroadcastJoinKey' was not set.")
     } else if (autoBroadcastJoinThresholdProperty.get >
-        StringUtils.convertToMB(autoTunerConfigsProvider.AQE_AUTOBROADCAST_JOIN_THRESHOLD)) {
+        StringUtils.convertToMB(autoTunerConfigsProvider.AQE_AUTOBROADCAST_JOIN_THRESHOLD, None)) {
       appendComment(s"Setting '$autoBroadcastJoinKey' > " +
         s"${autoTunerConfigsProvider.AQE_AUTOBROADCAST_JOIN_THRESHOLD} could " +
         s"lead to performance\n" +
@@ -942,7 +943,7 @@ class AutoTuner(
   protected def calculateMaxPartitionBytesInMB(maxPartitionBytes: String): Option[Long] = {
     // AutoTuner only supports a single app right now, so we get whatever value is here
     val inputBytesMax = appInfoProvider.getMaxInput / 1024 / 1024
-    val maxPartitionBytesNum = StringUtils.convertToMB(maxPartitionBytes)
+    val maxPartitionBytesNum = StringUtils.convertToMB(maxPartitionBytes, Some(ByteUnit.BYTE))
     if (inputBytesMax == 0.0) {
       Some(maxPartitionBytesNum)
     } else {
@@ -996,7 +997,7 @@ class AutoTuner(
       if (isCalculationEnabled("spark.sql.files.maxPartitionBytes")) {
         calculateMaxPartitionBytesInMB(maxPartitionProp).map(_.toString).orNull
       } else {
-        s"${StringUtils.convertToMB(maxPartitionProp)}"
+        s"${StringUtils.convertToMB(maxPartitionProp, Some(ByteUnit.BYTE))}"
       }
     appendRecommendationForMemoryMB("spark.sql.files.maxPartitionBytes", recommended)
   }
@@ -1257,7 +1258,7 @@ class ProfilingAutoTuner(
     getPropertyValue("spark.sql.files.maxPartitionBytes") match {
       case Some(currentValue) if appInfoProvider.hasScanStagesWithGpuOom =>
         // GPU OOM detected. We may want to reduce max partition size.
-        val halvedValue = StringUtils.convertToMB(currentValue) / 2
+        val halvedValue = StringUtils.convertToMB(currentValue, Some(ByteUnit.BYTE)) / 2
         // Choose the minimum between the calculated value and half of the current value.
         calculatedValueFromInputSize match {
           case Some(calculatedValue) => Some(math.min(calculatedValue, halvedValue))

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntry.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntry.scala
@@ -100,7 +100,7 @@ class MemoryUnitTuningEntry(
    * E.g. "MiB" -> ByteUnit.MiB
    */
   private val defaultMemoryUnit: ByteUnit = {
-    val defaultMemoryUnitStr = definition.map(_.defaultMemoryUnit).orNull
+    val defaultMemoryUnitStr = definition.flatMap(_.getConfUnit).orNull
     require(defaultMemoryUnitStr != null,
       "Default memory unit must be specified for memory tuning entries")
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntry.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntry.scala
@@ -17,18 +17,20 @@
 package com.nvidia.spark.rapids.tool.tuning
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.ByteUnit
+import org.apache.spark.sql.rapids.tool.util.StringUtils
 
 /**
  * A wrapper to the hold the tuning entry information.
  * @param name the name of the property
- * @param originalValue the value from the eventlog
- * @param tunedValue the value recommended by the AutoTuner
+ * @param originalValueRaw the value from the eventlog
+ * @param tunedValueRaw the value recommended by the AutoTuner
  * @param definition the definition of the tuning entry.
  */
-class TuningEntry(
+abstract class TuningEntryBase(
     override val name: String,
-    override var originalValue: Option[String],
-    override var tunedValue: Option[String],
+    originalValueRaw: Option[String],
+    tunedValueRaw: Option[String],
     definition: Option[TuningEntryDefinition] = None) extends TuningEntryTrait {
 
   /**
@@ -68,8 +70,83 @@ class TuningEntry(
   /////////////////////////
   // Initialization Code //
   /////////////////////////
+  def init(): Unit = {
+    // Set values through inherited setters which handle normalization
+    originalValue = originalValueRaw
+    tunedValue = tunedValueRaw
+    setOriginalValueFromDefaultSpark()
+  }
+}
 
-  setOriginalValueFromDefaultSpark()
+class TuningEntry(
+    override val name: String,
+    originalValueRaw: Option[String],
+    tunedValueRaw: Option[String],
+    definition: Option[TuningEntryDefinition] = None)
+  extends TuningEntryBase(name, originalValueRaw, tunedValueRaw, definition) {
+
+  init()
+}
+
+class MemoryUnitTuningEntry(
+    override val name: String,
+    originalValueRaw: Option[String],
+    tunedValueRaw: Option[String],
+    definition: Option[TuningEntryDefinition] = None)
+  extends TuningEntryBase(name, originalValueRaw, tunedValueRaw, definition) {
+
+  /**
+   * Parse the default memory unit from the tuning table and store it as a ByteUnit value.
+   * E.g. "MiB" -> ByteUnit.MiB
+   */
+  private val defaultMemoryUnit: ByteUnit = {
+    val defaultMemoryUnitStr = definition.map(_.defaultMemoryUnit).orNull
+    require(defaultMemoryUnitStr != null,
+      "Default memory unit must be specified for memory tuning entries")
+
+    // Map of memory unit strings to ByteUnit values.
+    // This is specific to the default memory unit defined in the tuning table.
+    val memoryUnitsMap = Map[String, ByteUnit](
+      "Byte" -> ByteUnit.BYTE,
+      "KiB" -> ByteUnit.KiB,
+      "MiB" -> ByteUnit.MiB,
+      "GiB" -> ByteUnit.GiB,
+      "TiB" -> ByteUnit.TiB,
+      "PiB" -> ByteUnit.PiB
+    )
+
+    memoryUnitsMap.getOrElse(defaultMemoryUnitStr,
+      throw new IllegalArgumentException(
+        s"Unknown memory unit: $defaultMemoryUnitStr. " +
+          s"Valid units are: ${memoryUnitsMap.keys.mkString(", ")}"))
+  }
+
+  /**
+   * Normalize a memory configuration value by converting it to bytes.
+   * If no unit is provided, the defaultMemoryUnitStr is used.
+   *
+   * @param propValue The original property value, possibly without a unit
+   * @return The normalized string with bytes unit (e.g. "1024b")
+   */
+  override def normalizeValue(propValue: String): String = {
+    val bytes = StringUtils.convertMemorySizeToBytes(propValue, Some(defaultMemoryUnit))
+    s"${bytes}b"
+  }
+
+  /**
+   * Format the output value by converting it to the largest appropriate unit.
+   * This is used to display the value in a human-readable format.
+   *
+   * @param propValue The property value in bytes format (e.g. "1024b")
+   * @return The formatted string with appropriate unit (e.g. "1KiB")
+   */
+  override def formatOutput(propValue: String): String = {
+    // Remove the 'b' suffix and convert to bytes
+    val bytes = propValue.dropRight(1).toLong
+    StringUtils.convertBytesToLargestUnit(bytes)
+  }
+
+  init()
 }
 
 object TuningEntry extends Logging {
@@ -83,13 +160,18 @@ object TuningEntry extends Logging {
   def build(
       name: String,
       originalValue: Option[String],
-      tunedValue: Option[String]): TuningEntry = {
-    // pul the information from Tuning Entry Table
+      tunedValue: Option[String]): TuningEntryBase = {
+    // pull the information from Tuning Entry Table
     val tuningDefinition = TuningEntryDefinition.TUNING_TABLE.get(name)
     // for debugging purpose
     if (tuningDefinition.isEmpty) {
       logInfo("Tuning Entry is not defined for " + name)
     }
-    new TuningEntry(name, originalValue, tunedValue, tuningDefinition)
+    tuningDefinition match {
+      case Some(defn) if defn.isMemoryProperty =>
+        new MemoryUnitTuningEntry(name, originalValue, tunedValue, tuningDefinition)
+      case _ =>
+        new TuningEntry(name, originalValue, tunedValue, tuningDefinition)
+    }
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntryDefinition.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntryDefinition.scala
@@ -42,6 +42,8 @@ import org.apache.spark.sql.rapids.tool.util.UTF8Source
  *                       Default is true.
  * @param defaultSpark The default value of the property in Spark. This is used to set the
  *                     originalValue of the property in case it is not set by the eventlog.
+ * @param defaultMemoryUnit The default memory unit for memory-related properties (e.g., MiB, Byte).
+ *                         When defined, indicates this is a memory property.
  * @param comments The defaults comments to be loaded for the entry. It is a map to represent
  *                 three different types of comments:
  *                 1. "missing" to represent the default comment to be appended to the AutoTuner's
@@ -59,10 +61,11 @@ class TuningEntryDefinition(
     @BeanProperty var category: String,
     @BeanProperty var bootstrapEntry: Boolean,
     @BeanProperty var defaultSpark: String,
+    @BeanProperty var defaultMemoryUnit: String,
     @BeanProperty var comments: util.LinkedHashMap[String, String]) {
   def this() = {
     this(label = "", description = "", enabled = true, level = "", category = "",
-      bootstrapEntry = true, defaultSpark = null,
+      bootstrapEntry = true, defaultSpark = null, defaultMemoryUnit = null,
       comments = new util.LinkedHashMap[String, String]())
   }
 
@@ -71,6 +74,13 @@ class TuningEntryDefinition(
   }
   def isBootstrap(): Boolean = {
     bootstrapEntry || label.startsWith("spark.rapids.")
+  }
+
+  /**
+   * Indicates if the property is a memory-related property.
+   */
+  def isMemoryProperty: Boolean = {
+    defaultMemoryUnit != null
   }
 
   /**

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntryTrait.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntryTrait.scala
@@ -20,17 +20,29 @@ import scala.collection.mutable.ListBuffer
 
 import com.nvidia.spark.rapids.tool.tuning.TuningOpTypes.TuningOpType
 
-import org.apache.spark.sql.rapids.tool.util.StringUtils
-
 /**
  * A trait that defines the behavior of the Tuning Entry.
  */
 trait TuningEntryTrait {
   val name: String
   // The value recommended by the AutoTuner
-  var tunedValue: Option[String]
+  private var _tunedValue: Option[String] = None
+  // Define getter and setter for the tunedValue
+  protected def tunedValue: Option[String] = _tunedValue
+  protected def tunedValue_=(value: Option[String]): Unit = {
+    // Values are normalized before being set.
+    _tunedValue = value.map(normalizeValue)
+  }
+
   // The original value of the property from the event log
-  var originalValue: Option[String]
+  private var _originalValue: Option[String] = None
+  // Define getter and setter for the originalValue
+  protected def originalValue: Option[String] = _originalValue
+  protected def originalValue_=(value: Option[String]): Unit = {
+    // Values are normalized before being set.
+    _originalValue = value.map(normalizeValue)
+  }
+
   var enabled: Boolean = true
 
   // The type of tuning operation to be performed
@@ -81,10 +93,21 @@ trait TuningEntryTrait {
     if (isUnresolved()) {
       fillIfBlank.getOrElse(fillUnresolved.get)
     } else {
-      // It is possible the the propery was not tuned. However, we should not be in that case
+      // It is possible the property was not tuned. However, we should not be in that case
       // because by calling commit we must have copied the tuned from the original.
-      tunedValue.getOrElse(fillIfBlank.getOrElse(originalValue.getOrElse("[UNDEFINED]")))
+      val finalTunedValue = tunedValue.map(formatOutput)
+      val finalOriginalValue = originalValue.map(formatOutput)
+      finalTunedValue.orElse(fillIfBlank).orElse(finalOriginalValue)
+        .getOrElse("[UNDEFINED]")
     }
+  }
+
+  /**
+   * Returns the original value as a string.
+   * @return the value of the property as a string.
+   */
+  def getOriginalValue: Option[String] = {
+    originalValue.map(formatOutput)
   }
 
   /**
@@ -132,23 +155,25 @@ trait TuningEntryTrait {
   def isEnabled(): Boolean
 
   /**
-   * Used to compare between two properties by converting memory units to equivalent
-   * representations.
-   * @param propValue property to be processed.
+   * Returns a normalized representation of a property value, useful for consistent comparison.
+   *
+   * This base implementation returns the property value as-is. Subclasses can override this method
+   * to apply specific normalization logic.
    * @return the uniform representation of property.
-   *         For Memory, the value is converted to bytes.
    */
-  private def getRawValue(propValue: Option[String]): Option[String] = {
-    propValue match {
-      case None => None
-      case Some(value) =>
-        if (StringUtils.isMemorySize(value)) {
-          // if it is memory return the bytes unit
-          Some(s"${StringUtils.convertMemorySizeToBytes(value)}")
-        } else {
-          propValue
-        }
-    }
+  def normalizeValue(propValue: String): String = {
+    propValue
+  }
+
+  /**
+   * Returns a formatted representation of a property value, useful for consistent output.
+   *
+   * This base implementation returns the property value as-is. Subclasses can override this method
+   * to apply specific formatting logic.
+   * @return the formatted representation of property.
+   */
+  def formatOutput(propValue: String): String = {
+    propValue
   }
 
   def setTuningOpType(opType: TuningOpType): Unit = {
@@ -160,9 +185,7 @@ trait TuningEntryTrait {
    */
   def updateOpType(): Unit = {
     if (!(isRemoved() || isUnresolved())) {
-      val originalVal = getRawValue(originalValue)
-      val recommendedVal = getRawValue(tunedValue)
-      (originalVal, recommendedVal) match {
+      (originalValue, tunedValue) match {
         case (None, None) => setTuningOpType(TuningOpTypes.UNKNOWN)
         case (Some(orig), Some(rec)) =>
           if (orig != rec) {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntryTrait.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntryTrait.scala
@@ -25,22 +25,27 @@ import com.nvidia.spark.rapids.tool.tuning.TuningOpTypes.TuningOpType
  */
 trait TuningEntryTrait {
   val name: String
-  // The value recommended by the AutoTuner
-  private var _tunedValue: Option[String] = None
-  // Define getter and setter for the tunedValue
-  protected def tunedValue: Option[String] = _tunedValue
-  protected def tunedValue_=(value: Option[String]): Unit = {
-    // Values are normalized before being set.
-    _tunedValue = value.map(normalizeValue)
+
+  // The original value of the property
+  private var _originalValue: Option[String] = None
+
+  /** Gets the original value */
+  protected def originalValue: Option[String] = _originalValue
+
+  /** Sets the original value after normalizing it */
+  protected def originalValue_=(value: Option[String]): Unit = {
+    _originalValue = value.map(normalizeValue)
   }
 
-  // The original value of the property from the event log
-  private var _originalValue: Option[String] = None
-  // Define getter and setter for the originalValue
-  protected def originalValue: Option[String] = _originalValue
-  protected def originalValue_=(value: Option[String]): Unit = {
-    // Values are normalized before being set.
-    _originalValue = value.map(normalizeValue)
+  // The value recommended by the AutoTuner
+  private var _tunedValue: Option[String] = None
+
+  /** Gets the tuned value */
+  protected def tunedValue: Option[String] = _tunedValue
+
+  /** Sets the tuned value after normalizing it */
+  protected def tunedValue_=(value: Option[String]): Unit = {
+    _tunedValue = value.map(normalizeValue)
   }
 
   var enabled: Boolean = true

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -464,6 +464,9 @@ case class UnsupportedSparkRuntimeException(
     extends AppEventlogProcessException(
      s"Platform '${platform.platformName}' does not support the runtime '$sparkRuntime'")
 
+class InvalidMemoryUnitFormatException(message: String)
+  extends IllegalArgumentException(message)
+
 // Class used a container to hold the information of the Tuple<sqlID, PlanInfo, SparkGraph>
 // to simplify arguments of methods and caching.
 case class SqlPlanInfoGraphEntry(

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -100,8 +100,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
    * Helper method to return an instance of the Profiling AutoTuner with default properties
    * for Dataproc.
    */
-  private def buildDefaultDataprocAutoTuner(
-      logEventsProps: mutable.Map[String, String]): AutoTuner = {
+  def buildDefaultDataprocAutoTuner(logEventsProps: mutable.Map[String, String]): AutoTuner = {
     val dataprocWorkerInfo = buildGpuWorkerInfoAsString(None, Some(32),
       Some("212992MiB"), Some(5), Some(4), Some(T4Gpu.getMemory), Some(T4Gpu.toString))
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
@@ -146,18 +145,18 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=2
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark320.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
@@ -208,7 +207,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       s"""|
           |Spark Properties:
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.files.maxPartitionBytes=512m
           |
@@ -243,7 +242,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       s"""|
           |Spark Properties:
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.files.maxPartitionBytes=512m
           |
@@ -292,7 +291,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       s"""|
           |Spark Properties:
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.files.maxPartitionBytes=512m
           |
@@ -334,18 +333,18 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=8
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
@@ -402,18 +401,18 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=2
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
@@ -486,10 +485,10 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
@@ -556,10 +555,10 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
@@ -623,10 +622,10 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |
           |Comments:
@@ -684,10 +683,10 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
@@ -750,10 +749,10 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
@@ -799,18 +798,18 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=2
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
@@ -877,10 +876,10 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
@@ -943,10 +942,10 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
@@ -987,18 +986,18 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=8
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
@@ -1094,22 +1093,22 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
-          |--conf spark.sql.files.maxPartitionBytes=4096m
+          |--conf spark.sql.files.maxPartitionBytes=4g
           |
           |Comments:
           |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
@@ -1178,22 +1177,22 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=5
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
-          |--conf spark.sql.files.maxPartitionBytes=4096m
+          |--conf spark.sql.files.maxPartitionBytes=4g
           |
           |Comments:
           |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
@@ -1253,24 +1252,24 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.enabled=true
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
-          |--conf spark.sql.files.maxPartitionBytes=4096m
+          |--conf spark.sql.files.maxPartitionBytes=4g
           |
           |Comments:
           |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
@@ -1339,24 +1338,24 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.enabled=true
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
-          |--conf spark.sql.files.maxPartitionBytes=4096m
+          |--conf spark.sql.files.maxPartitionBytes=4g
           |
           |Comments:
           |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
@@ -1403,7 +1402,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
         "spark.rapids.shuffle.multiThreaded.writer.threads" -> "8",
         "spark.rapids.sql.multiThreadedRead.numThreads" -> "20",
         "spark.shuffle.manager" ->
-        s"com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager",
+          s"com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager",
         "spark.sql.shuffle.partitions" -> "1000",
         "spark.sql.files.maxPartitionBytes" -> "1g",
         "spark.task.resource.gpu.amount" -> "0.25",
@@ -1429,18 +1428,18 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.files.maxPartitionBytes=3669m
@@ -1489,7 +1488,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
         "spark.rapids.shuffle.multiThreaded.writer.threads" -> "8",
         "spark.rapids.sql.multiThreadedRead.numThreads" -> "20",
         "spark.shuffle.manager" ->
-        s"com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager",
+          s"com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager",
         "spark.sql.shuffle.partitions" -> "1000",
         "spark.sql.files.maxPartitionBytes" -> "1g",
         "spark.task.resource.gpu.amount" -> "0.25",
@@ -1515,18 +1514,18 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.files.maxPartitionBytes=3669m
@@ -1570,7 +1569,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
         "spark.rapids.shuffle.multiThreaded.writer.threads" -> "8",
         "spark.rapids.sql.multiThreadedRead.numThreads" -> "20",
         "spark.shuffle.manager" ->
-        s"com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager",
+          s"com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager",
         "spark.sql.shuffle.partitions" -> "1000",
         "spark.sql.files.maxPartitionBytes" -> "1g",
         "spark.task.resource.gpu.amount" -> "0.25",
@@ -1596,18 +1595,18 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.files.maxPartitionBytes=3669m
@@ -1675,10 +1674,10 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
@@ -1721,10 +1720,10 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
@@ -1769,10 +1768,10 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
@@ -1838,19 +1837,19 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.filecache.enabled=true
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.files.maxPartitionBytes=3669m
@@ -1921,18 +1920,18 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.files.maxPartitionBytes=3669m
@@ -2025,21 +2024,21 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
-          |--conf spark.sql.files.maxPartitionBytes=4096m
+          |--conf spark.sql.files.maxPartitionBytes=4g
           |
           |Comments:
           |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
@@ -2133,26 +2132,26 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val memoryOverheadLabel = ProfilingAutoTunerConfigsProvider.getMemoryOverheadLabel(
-        SparkMaster(Some(sparkMaster)), Some(testSparkVersion))
+      SparkMaster(Some(sparkMaster)), Some(testSparkVersion))
     // scalastyle:off line.size.limit
     val expectedResults =
       s"""|
           |Spark Properties:
           |--conf spark.executor.instances=8
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf $memoryOverheadLabel=13516m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=24
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=32
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
-          |--conf spark.sql.files.maxPartitionBytes=4096m
+          |--conf spark.sql.files.maxPartitionBytes=4g
           |
           |Comments:
           |- '$memoryOverheadLabel' was not set.
@@ -2208,20 +2207,20 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       s"""|
           |Spark Properties:
           |--conf spark.executor.instances=8
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=13516m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=24
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=32
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
-          |--conf spark.sql.files.maxPartitionBytes=4096m
+          |--conf spark.sql.files.maxPartitionBytes=4g
           |
           |Comments:
           |- 'spark.executor.memoryOverhead' was not set.
@@ -2309,13 +2308,13 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=4
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=13516m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=24
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.incompatibleDateFormats.enabled=true
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=32
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
@@ -2443,22 +2442,22 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
-          |--conf spark.sql.files.maxPartitionBytes=4096m
+          |--conf spark.sql.files.maxPartitionBytes=4g
           |
           |Comments:
           |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
@@ -2566,7 +2565,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
         "spark.rapids.shuffle.multiThreaded.writer.threads" -> "8",
         "spark.rapids.sql.multiThreadedRead.numThreads" -> "20",
         "spark.shuffle.manager" ->
-        s"com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager",
+          s"com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager",
         "spark.sql.shuffle.partitions" -> "1000",
         "spark.sql.files.maxPartitionBytes" -> "1g",
         "spark.task.resource.gpu.amount" -> "0.25",
@@ -2590,17 +2589,17 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       s"""|
           |Spark Properties:
           |--conf spark.databricks.adaptive.autoOptimizeShuffle.enabled=false
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersionDatabricks.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
@@ -2628,8 +2627,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
    * expected version.
    */
   private def verifyRecommendedShuffleManagerVersion(
-      autoTuner: AutoTuner,
-      expectedSmVersion: String): Unit = {
+                                                      autoTuner: AutoTuner,
+                                                      expectedSmVersion: String): Unit = {
     autoTuner.getShuffleManagerClassName match {
       case Right(smClassName) =>
         assert(smClassName == ProfilingAutoTunerConfigsProvider
@@ -2688,8 +2687,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
    * for the unsupported Spark version.
    */
   private def verifyUnsupportedSparkVersionForShuffleManager(
-      autoTuner: AutoTuner,
-      sparkVersion: String): Unit = {
+                                                              autoTuner: AutoTuner,
+                                                              sparkVersion: String): Unit = {
     autoTuner.getShuffleManagerClassName match {
       case Right(smClassName) =>
         fail(s"Expected error comment but got valid RapidsShuffleManager: $smClassName")
@@ -2800,19 +2799,19 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.enabled=true
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.files.maxPartitionBytes=3669m
@@ -2885,19 +2884,19 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.enabled=true
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.files.maxPartitionBytes=3669m
@@ -2949,21 +2948,21 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.kryo.registrator=com.nvidia.spark.rapids.GpuKryoRegistrator
           |--conf spark.kryoserializer.buffer.max=512m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.enabled=true
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
@@ -3025,21 +3024,21 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.kryo.registrator=org.apache.SomeRegistrator,org.apache.SomeOtherRegistrator,com.nvidia.spark.rapids.GpuKryoRegistrator
           |--conf spark.kryoserializer.buffer.max=512m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.enabled=true
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
@@ -3101,21 +3100,21 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.kryo.registrator=com.nvidia.spark.rapids.GpuKryoRegistrator
           |--conf spark.kryoserializer.buffer.max=512m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.enabled=true
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
@@ -3183,19 +3182,19 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.enabled=true
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark341.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
@@ -3248,19 +3247,19 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.enabled=true
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
@@ -3318,19 +3317,19 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.enabled=true
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
@@ -3399,18 +3398,18 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
             |--conf spark.dataproc.enhanced.execution.enabled=false
             |--conf spark.dataproc.enhanced.optimizer.enabled=false
             |--conf spark.executor.instances=8
-            |--conf spark.executor.memory=32768m
+            |--conf spark.executor.memory=32g
             |--conf spark.executor.memoryOverhead=17612m
             |--conf spark.locality.wait=0
-            |--conf spark.rapids.memory.pinnedPool.size=4096m
+            |--conf spark.rapids.memory.pinnedPool.size=4g
             |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
             |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
             |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-            |--conf spark.rapids.sql.batchSizeBytes=2147483647
+            |--conf spark.rapids.sql.batchSizeBytes=2147483647b
             |--conf spark.rapids.sql.concurrentGpuTasks=2
             |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
             |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-            |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+            |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
             |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
             |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
             |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
@@ -3474,7 +3473,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
             |--conf spark.executor.instances=2
             |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
             |--conf spark.rapids.shuffle.multiThreaded.writer.threads=24
-            |--conf spark.rapids.sql.batchSizeBytes=2147483647
+            |--conf spark.rapids.sql.batchSizeBytes=2147483647b
             |--conf spark.rapids.sql.concurrentGpuTasks=3
             |--conf spark.rapids.sql.enabled=true
             |--conf spark.rapids.sql.multiThreadedRead.numThreads=32
@@ -3503,7 +3502,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     // mock the properties loaded from eventLog
     val logEventsProps: mutable.Map[String, String] =
       mutable.LinkedHashMap[String, String](
-        "spark.sql.shuffle.partitions" -> "150",  // AutoTuner should recommend increasing this
+        "spark.sql.shuffle.partitions" -> "150", // AutoTuner should recommend increasing this
         "spark.executor.cores" -> "16",
         "spark.executor.instances" -> "1",
         "spark.executor.memory" -> "80g",
@@ -3531,18 +3530,18 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
@@ -3581,7 +3580,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     // mock the properties loaded from eventLog
     val logEventsProps: mutable.Map[String, String] =
       mutable.LinkedHashMap[String, String](
-        "spark.sql.shuffle.partitions" -> "50",  // AutoTuner should recommend increasing this
+        "spark.sql.shuffle.partitions" -> "50", // AutoTuner should recommend increasing this
         "spark.executor.cores" -> "16",
         "spark.executor.instances" -> "1",
         "spark.executor.memory" -> "80g",
@@ -3610,18 +3609,18 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
-          |--conf spark.executor.memory=32768m
+          |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=17612m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=2
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10485760
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=32m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
@@ -3657,4 +3656,140 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     // scalastyle:on line.size.limit
     compareOutput(expectedResults, autoTunerOutput)
   }
+
+  // ============ Unit Tests for AutoTuner memory configurations ============
+  // It verifies that the AutoTuner correctly handles memory configurations with and without units,
+  // particularly for configurations whose default unit is not Byte (e.g. MB for memory overhead).
+  //
+  // Test Cases:
+  // 1. Configs with explicit units (e.g. "17612m") are handled correctly and skipped if appropriate
+  // 2. Configs without units (e.g. "17612") are handled correctly and skipped when appropriate
+  // 3. Configs without units are properly updated with units when changes are needed
+
+  /**
+   * Helper method to test AutoTuner recommendations for memory configurations.
+   *
+   * @param testName Name of the test case
+   * @param confKey The Spark configuration key to test
+   * @param initialValue Initial value of the configuration (with or without unit)
+   * @param expectedValue Expected value after AutoTuner processing (None if no change expected)
+   * @param extraProps Additional properties needed for the test
+   */
+  private def testAutoTunerConf(
+      testName: String,
+      confKey: String,
+      initialValue: String,
+      expectedValue: Option[String],
+      extraProps: Map[String, String] = Map.empty
+  ): Unit = {
+    test(testName) {
+      val baseProps = Map(
+        "spark.executor.cores" -> "16",
+        "spark.executor.instances" -> "1",
+        "spark.executor.memory" -> "80g",
+        "spark.executor.resource.gpu.amount" -> "1"
+      )
+
+      val testProps = Map(confKey -> initialValue) ++ extraProps
+      val allProps = mutable.LinkedHashMap((baseProps ++ testProps).toSeq: _*)
+      val autoTuner = buildDefaultDataprocAutoTuner(allProps)
+      val (properties, comments) = autoTuner.getRecommendedProperties()
+      val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+
+      def getAssertMessage(expectation: String): String = {
+        s"""|=== Expected ===
+            |$expectation
+            |
+            |=== Actual ===
+            |$autoTunerOutput
+            |""".stripMargin
+      }
+
+      expectedValue match {
+        case Some(expected) =>
+          val expectedLine = s"--conf $confKey=$expected"
+          val hasExpectedLine = autoTunerOutput.contains(expectedLine)
+          assert(hasExpectedLine,
+            getAssertMessage(s"Expected to find '$expectedLine' in output but it was missing"))
+        case None =>
+          val prefix = s"--conf $confKey="
+          val hasPrefix = autoTunerOutput.contains(prefix)
+          assert(!hasPrefix,
+            getAssertMessage(s"Expected NOT to find any conf with '$prefix' but found one"))
+      }
+    }
+  }
+
+  /**
+   * Helper method to test executor memory overhead configurations.
+   * Tests how the AutoTuner handles spark.executor.memoryOverhead with and without units.
+   */
+  private def testMemoryOverhead(
+      testName: String,
+      initialValue: String,
+      expectedValue: Option[String]
+  ): Unit = {
+    testAutoTunerConf(
+      testName = testName,
+      confKey = "spark.executor.memoryOverhead",
+      initialValue = initialValue,
+      expectedValue = expectedValue
+    )
+  }
+
+  /**
+   * Helper method to test Kryo serializer buffer configurations.
+   * Tests how the AutoTuner handles spark.kryoserializer.buffer.max with and without units.
+   */
+  private def testKryoMaxBuffer(
+      testName: String,
+      initialValue: String,
+      expectedValue: Option[String]
+  ): Unit = {
+    testAutoTunerConf(
+      testName = testName,
+      confKey = "spark.kryoserializer.buffer.max",
+      initialValue = initialValue,
+      expectedValue = expectedValue,
+      extraProps = Map("spark.serializer" -> "org.apache.spark.serializer.KryoSerializer")
+    )
+  }
+
+  // Test cases for memory overhead configuration
+  testMemoryOverhead(
+    testName = "Test memory overhead with unit should be skipped when appropriate",
+    initialValue = "17612m",
+    expectedValue = None
+  )
+
+  testMemoryOverhead(
+    testName = "Test memory overhead without unit should be skipped when appropriate",
+    initialValue = "17612",
+    expectedValue = None
+  )
+
+  testMemoryOverhead(
+    testName = "Test memory overhead without unit should be updated and set",
+    initialValue = "8712",
+    expectedValue = Some("17612m")
+  )
+
+  // Test cases for Kryo buffer configuration
+  testKryoMaxBuffer(
+    testName = "Test kryo max buffer with unit should be skipped when appropriate",
+    initialValue = "1024m",
+    expectedValue = None
+  )
+
+  testKryoMaxBuffer(
+    testName = "Test kryo max buffer without unit should be skipped when appropriate",
+    initialValue = "1024",
+    expectedValue = None
+  )
+
+  testKryoMaxBuffer(
+    testName = "Test kryo max buffer without unit should be updated and set",
+    initialValue = "128",
+    expectedValue = Some("512m")
+  )
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -70,7 +70,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults = Seq(
-        "--conf spark.rapids.sql.batchSizeBytes=1073741824",
+        "--conf spark.rapids.sql.batchSizeBytes=1g",
         "- 'spark.rapids.sql.batchSizeBytes' was not set."
     )
     assert(expectedResults.forall(autoTunerOutput.contains))

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
@@ -29,7 +29,9 @@ import org.scalatest.FunSuite
 import org.scalatest.Matchers.{contain, convertToAnyShouldWrapper, equal, not}
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.TrampolineUtil
+import org.apache.spark.sql.rapids.tool.InvalidMemoryUnitFormatException
 import org.apache.spark.sql.rapids.tool.util.{FSUtils, InPlaceMedianArrView, RapidsToolsConfUtil, StringUtils, WebCrawlerUtil}
 
 class ToolUtilsSuite extends FunSuite with Logging {
@@ -229,6 +231,98 @@ class ToolUtilsSuite extends FunSuite with Logging {
         s"Expected: $expectedMedian, " +
         s"Actual: $actualMedian"
     }
+  }
+
+  test("convertMemorySizeToBytes should correctly parse memory sizes") {
+    // Test basic unit conversions with default ByteUnit.BYTE
+    StringUtils.convertMemorySizeToBytes("1024b", None) shouldBe 1024L
+    StringUtils.convertMemorySizeToBytes("1k", None) shouldBe 1024L
+    StringUtils.convertMemorySizeToBytes("1m", None) shouldBe 1024L * 1024
+    StringUtils.convertMemorySizeToBytes("1g", None) shouldBe 1024L * 1024 * 1024
+
+    // Test decimal values
+    StringUtils.convertMemorySizeToBytes("1.5k", None) shouldBe (1.5 * 1024).toLong
+    StringUtils.convertMemorySizeToBytes("2.5g", None) shouldBe (2.5 * 1024 * 1024 * 1024).toLong
+
+    // Test case insensitivity
+    StringUtils.convertMemorySizeToBytes("1K", None) shouldBe 1024L
+    StringUtils.convertMemorySizeToBytes("1KB", None) shouldBe 1024L
+    StringUtils.convertMemorySizeToBytes("1KiB", None) shouldBe 1024L
+    StringUtils.convertMemorySizeToBytes("1M", None) shouldBe 1024L * 1024
+    StringUtils.convertMemorySizeToBytes("1G", None) shouldBe 1024L * 1024 * 1024
+
+    // Test with different default units
+    // When unit is specified in string, defaultUnit should be ignored
+    StringUtils.convertMemorySizeToBytes("1024b", Some(ByteUnit.KiB)) shouldBe 1024L
+    StringUtils.convertMemorySizeToBytes("1k", Some(ByteUnit.MiB)) shouldBe 1024L
+    StringUtils.convertMemorySizeToBytes("1m", Some(ByteUnit.GiB)) shouldBe 1024L * 1024
+
+    // When no unit in string, defaultUnit should be used
+    StringUtils.convertMemorySizeToBytes("1", Some(ByteUnit.KiB)) shouldBe 1024L
+    StringUtils.convertMemorySizeToBytes("1", Some(ByteUnit.MiB)) shouldBe 1024L * 1024
+    StringUtils.convertMemorySizeToBytes("1", Some(ByteUnit.GiB)) shouldBe 1024L * 1024 * 1024
+
+    // Test decimal values with different default units
+    StringUtils.convertMemorySizeToBytes("1.5", Some(ByteUnit.KiB)) shouldBe (
+      1.5 * 1024).toLong
+    StringUtils.convertMemorySizeToBytes("2.5", Some(ByteUnit.GiB)) shouldBe (
+      2.5 * 1024 * 1024 * 1024).toLong
+    StringUtils.convertMemorySizeToBytes("0.5", Some(ByteUnit.TiB)) shouldBe (
+      0.5 * 1024 * 1024 * 1024 * 1024).toLong
+
+    // Test zero values
+    StringUtils.convertMemorySizeToBytes("0b", None) shouldBe 0L
+    StringUtils.convertMemorySizeToBytes("0k", None) shouldBe 0L
+    StringUtils.convertMemorySizeToBytes("0", Some(ByteUnit.GiB)) shouldBe 0L
+  }
+
+  test("convertMemorySizeToBytes should handle invalid input") {
+    intercept[InvalidMemoryUnitFormatException] {
+      StringUtils.convertMemorySizeToBytes("invalid", None)
+    }
+    intercept[InvalidMemoryUnitFormatException] {
+      StringUtils.convertMemorySizeToBytes("invalid", Some(ByteUnit.GiB))
+    }
+    intercept[InvalidMemoryUnitFormatException] {
+      StringUtils.convertMemorySizeToBytes("1z", None)
+    }
+    intercept[InvalidMemoryUnitFormatException] {
+      StringUtils.convertMemorySizeToBytes("-1k", None)
+    }
+    intercept[InvalidMemoryUnitFormatException] {
+      StringUtils.convertMemorySizeToBytes("1.5", None)
+    }
+  }
+
+  test("convertBytesToLargestUnit should convert bytes to appropriate units") {
+    // Test exact conversions that result in whole numbers
+    StringUtils.convertBytesToLargestUnit(1024) shouldBe "1k"
+    StringUtils.convertBytesToLargestUnit(4194304) shouldBe "4m"
+    StringUtils.convertBytesToLargestUnit(2147483648L) shouldBe "2g"
+    StringUtils.convertBytesToLargestUnit(5497558138880L) shouldBe "5t"
+
+    // Test values that should remain in bytes to avoid fractions
+    StringUtils.convertBytesToLargestUnit(1536) shouldBe "1536b"
+    StringUtils.convertBytesToLargestUnit(1) shouldBe "1b"
+    StringUtils.convertBytesToLargestUnit(0) shouldBe "0b"
+
+    // Test falling back to lower units to avoid fractions
+    // 1.5m -> fallback to 1536k
+    StringUtils.convertBytesToLargestUnit(1536 * 1024) shouldBe "1536k"
+    // 1.5g -> fallback to 1536m
+    StringUtils.convertBytesToLargestUnit(1536 * 1024 * 1024) shouldBe "1536m"
+
+    // Test complex fallback cases
+    // 1g + 1 byte -> bytes
+    StringUtils.convertBytesToLargestUnit(1024 * 1024 * 1024 + 1) shouldBe "1073741825b"
+    // 2m + 1k -> k
+    StringUtils.convertBytesToLargestUnit(2048 * 1024 + 1024) shouldBe "2049k"
+    // 3t + 1m -> m
+    StringUtils.convertBytesToLargestUnit(3L * 1024 * 1024 * 1024 * 1024 + 1024 * 1024) shouldBe
+      "3145729m"
+
+    // Test large values that don't perfectly align with units
+    StringUtils.convertBytesToLargestUnit(1234567) shouldBe "1234567b"
   }
 
   case class MockProfileResults(appID: String, nonEnglishField: String,


### PR DESCRIPTION
Fixes #1640 

## Issue
- The current AutoTuner implementation assumes that memory configurations without explicit units are specified in bytes. This is incorrect for some properties—e.g., `spark.executor.memoryOverhead` and `spark.kryoserializer.buffer.max` —which default to MiB ([Ref](https://github.com/apache/spark/blob/335063fc8f888654f6246f667973f4376bff9241/core/src/main/scala/org/apache/spark/internal/config/Kryo.scala#L61-L64)).
- Additionally, several usages of `convertToMB()` incorrectly interpret unit-less values as bytes, which leads to inaccurate processing.

### Recommendation from Tools v25.02.2:
```
--conf spark.executor.memory=3381657600
--conf spark.executor.memoryOverhead=512
--conf spark.kryoserializer.buffer.max=1073741824
--conf spark.rapids.sql.batchSizeBytes=1073741824
--conf spark.sql.adaptive.autoBroadcastJoinThreshold=20971520
```
In the above example,
- Value `3381657600` for `spark.executor.memory` will be interpreted in `Bytes`.
- Value `512` for `spark.executor.memoryOverhead` will be interpreted in `MiB`.
    - It is confusing and one must remember which config has what unit as default.
- Value `1073741824` for `spark.kryoserializer.buffer.max` will be interpreted in `MiB`
    - The combination of issues listed at beginning led to AutoTuner recommending this value. 
    - It is an invalid value for the max buffer and Spark will throw an error (see issue description) 

## Key Improvement
This PR improves the overall handling of memory-related properties in AutoTuner and TuningEntries logic. 
- AutoTuner
   - All usages of `convertToMB()/convertMemorySizeToBytes()` need to specify the default unit incase the value string does not have a unit.
- TuningEntries:
  - It guarantees all memory related configs are stored in `bytes` internally (normalized form).
  - When accessed from outside or as final value it is formatted to the largest unit with whole number value.

### Recommendation after changes 
After this change, all memory config values use the <ins>_largest whole-number unit with an explicit suffix_</ins>:
```
--conf spark.executor.memory=3225m
--conf spark.executor.memoryOverhead=512m
--conf spark.kryoserializer.buffer.max=1g
--conf spark.rapids.sql.batchSizeBytes=1g
--conf spark.sql.adaptive.autoBroadcastJoinThreshold=20m
```


## Detailed Changes
- Added default memory units for relevant configurations in the tuning table.
- Introduced a new `MemoryTuningEntry` class to handle memory-specific tuning logic.
- Improved String utilities:
     - `convertMemorySizeToBytes()` accepts a default unit argument instead of assuming bytes when the unit is unspecified.
      - `convertBytesToLargestUnit()` added for formatting byte values into more human-readable units.
- Updated `TuningEntriesTrait` to use normalized values for originalValue and originalValue.
   - Introduced getter and setter for originalValue and originalValue
   - Values are always stored in bytes

## Testing
- Added unit tests for `convertMemorySizeToBytes()` and `convertBytesToLargestUnit()`
- Added unit tests for cases in Profiling AutoTuner to verify:
   1. Configs with explicit units (e.g. "17612m") are handled correctly and skipped if appropriate
   2. Configs without units (e.g. "17612") are handled correctly and skipped when appropriate
   3. Configs without units are properly updated with units when changes are needed


