### PR TITLE
Add more qualx unit tests

### DIFF
--- a/user_tools/src/spark_rapids_tools/tools/qualx/hash_util.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/hash_util.py
@@ -233,6 +233,7 @@ def hash_plan(plan):
                     fields = [field.strip() for field in fields if not re.search(r'\(|\[', field)]
                     # take a max of N fields (to try to avoid truncated fields)
                     fields = fields[:n_fields]
+                    fields = sorted(fields)
                 else:
                     fields = ''
 

--- a/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
@@ -58,7 +58,7 @@ def get_alignment() -> pd.DataFrame:
     # concatenate all CSV files in alignment_file directory
     parent_dir = Path(abs_path).parent
     base_name = Path(abs_path).stem
-    csv_files = glob.glob(f'{parent_dir}/{base_name}_*.*')
+    csv_files = glob.glob(f'{parent_dir}/{base_name}*.*')
 
     chunk_size = 100
     alignment_dfs = []

--- a/user_tools/src/spark_rapids_tools/tools/qualx/split_functions/split_stratified.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/split_functions/split_stratified.py
@@ -25,10 +25,12 @@ def split_function(features: pd.DataFrame, **kwargs) -> pd.DataFrame:
     ----------
     features: pd.DataFrame
         Input dataframe
-    seed: int
-        Seed for random number generator
+    label_col: str
+        Label column name
     threshold: float
         Threshold for true positive
+    seed: int
+        Seed for random number generator
     test_pct: float
         Percentage of all rows to use for test
     val_pct: float
@@ -42,12 +44,17 @@ def split_function(features: pd.DataFrame, **kwargs) -> pd.DataFrame:
     threshold = kwargs.get('threshold', 1.0)
     test_pct = kwargs.get('test_pct', 0.2)
     val_pct = kwargs.get('val_pct', 0.2)
+    label_col = kwargs.get('label_col', 'Duration_speedup')
 
-    df = features.copy()
+    # ensure 'split' column is present
+    if 'split' not in features.columns:
+        # add empty split column
+        features['split'] = ''
+
     rand = random.Random(seed)
-    label_col = 'duration_sum_speedup'
 
-    if label_col in df.columns:  # QXS does not have a label column
+    if label_col in features.columns:  # QXS does not have a label column
+        df = features.copy()
         # stratified split by positives / negatives
         df['true_positive'] = df[label_col] > threshold
         positives = df.loc[df['true_positive']]
@@ -82,5 +89,6 @@ def split_function(features: pd.DataFrame, **kwargs) -> pd.DataFrame:
         # merge positives and negatives
         df.update(positives)
         df.update(negatives)
+        features.update(df)
 
-    return df
+    return features

--- a/user_tools/src/spark_rapids_tools/tools/qualx/util.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/util.py
@@ -168,9 +168,8 @@ def get_abs_path(path: str, subdir: Optional[Union[str, List[str]]] = None) -> s
         search_paths_with_subdir = [os.path.join(search_path, subdir_path) for search_path in search_paths]
 
         for search_path in search_paths_with_subdir:
-            if os.path.exists(os.path.join(search_path, path)):
-                # path in the source directory
-                abs_path = os.path.join(search_path, path)
+            abs_path = os.path.join(search_path, path)
+            if os.path.exists(abs_path):
                 return abs_path
 
     raise ValueError(f'{path} not found')

--- a/user_tools/tests/spark_rapids_tools_e2e/features/preprocess.feature
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/preprocess.feature
@@ -30,6 +30,7 @@ Feature: Testing preprocessing functionality
     When preprocessing the event logs
     Then preprocessing should complete successfully
     And preprocessed data should contain the expected features for label "<label>"
+    And sqlID hashes should align between CPU and GPU runs
 
     Examples:
       | label        |

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
@@ -16,6 +16,7 @@ import glob
 import os
 from behave import given, when, then
 from spark_rapids_tools.tools.qualx.config import get_config
+from spark_rapids_tools.tools.qualx.modifiers.align_sql_id import compute_alignment_from_raw_features
 from spark_rapids_tools.tools.qualx.preprocess import (
     load_datasets,
     expected_raw_features
@@ -72,7 +73,7 @@ def check_sample_event_logs(context):
     """Verify sample event logs exist in test resources."""
     assert os.path.exists(context.qualx_data_dir)
     event_logs = glob.glob(os.path.join(context.qualx_data_dir, '**', '*.zstd'), recursive=True)
-    assert len(event_logs) > 0, "No event logs found in the QUALX_DATA_DIR"
+    assert len(event_logs) > 0, 'No event logs found in the QUALX_DATA_DIR'
 
 
 @given('dataset JSON files in the datasets directory')
@@ -80,7 +81,7 @@ def check_dataset_json(context):
     """Verify dataset JSON file exists in test resources."""
     context.dataset_path = os.path.join(E2ETestUtils.get_e2e_tests_resource_path(), 'datasets')
     dataset_json = glob.glob(os.path.join(context.dataset_path, '**', '*.json'), recursive=True)
-    assert len(dataset_json) > 0, "No dataset JSON files found in the datasets directory"
+    assert len(dataset_json) > 0, 'No dataset JSON files found in the datasets directory'
 
 
 @when('preprocessing the event logs')
@@ -99,9 +100,9 @@ def verify_preprocessing_success(context):
     """Verify that preprocessing completed without errors."""
     assert context.preprocessing_success, \
         f"Preprocessing failed with error: {getattr(context, 'preprocessing_error', 'Unknown error')}"
-    assert context.datasets is not None, "Datasets dictionary should not be None"
-    assert not context.profile_df.empty, "Profile DataFrame should not be empty"
-    assert len(context.profile_df) == 194, "Profile DataFrame should have 194 rows"
+    assert context.datasets is not None, 'Datasets dictionary should not be None'
+    assert not context.profile_df.empty, 'Profile DataFrame should not be empty'
+    assert len(context.profile_df) == 194, 'Profile DataFrame should have 194 rows'
 
 
 @then('preprocessed data should contain the expected features for label "{label}"')
@@ -112,8 +113,26 @@ def verify_expected_features(context, label):
     missing_features = expected_features - actual_features
     extra_features = actual_features - expected_features
 
-    assert label in actual_features, f"Label {label} should be in the expected features"
-    assert not missing_features, f"Missing expected features: {missing_features}"
-    assert not extra_features, f"Found unexpected features: {extra_features}"
+    assert label in actual_features, f'Label {label} should be in the expected features'
+    assert not missing_features, f'Missing expected features: {missing_features}'
+    assert not extra_features, f'Found unexpected features: {extra_features}'
 
-    assert len(context.profile_df) == 194, "Profile DataFrame should have 194 rows"
+    assert len(context.profile_df) == 194, 'Profile DataFrame should have 194 rows'
+
+
+@then('sqlID hashes should align between CPU and GPU runs')
+def verify_sql_id_alignment(context):
+    """Verify that SQL IDs are properly aligned between CPU and GPU runs."""
+    df = context.profile_df.copy()
+
+    assert 'hash' in df.columns, 'hash column should be in the DataFrame'
+    assert df['hash'].notna().all(), 'hash column should not contain any NaN values'
+
+    alignment_df = compute_alignment_from_raw_features(df)
+    alignment_df.to_csv('test_alignment_df.csv', index=False)
+
+    assert not alignment_df.empty, 'Alignment DataFrame should not be empty'
+
+    # these are specific to the test eventlogs
+    assert len(alignment_df) >= 46, 'Alignment DataFrame should have at least 46 rows'
+    assert all(alignment_df.sqlID_cpu == alignment_df.sqlID_gpu), 'sqlID_cpu should match sqlID_gpu'

--- a/user_tools/tests/spark_rapids_tools_ut/qualx/test_modifiers.py
+++ b/user_tools/tests/spark_rapids_tools_ut/qualx/test_modifiers.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for qualx modifiers."""
+
+import pytest  # pylint: disable=import-error
+import pandas as pd
+from spark_rapids_tools.tools.qualx.config import get_config
+from spark_rapids_tools.tools.qualx.modifiers.align_sql_id import (
+    compute_alignment_from_raw_features,
+    compute_alignment_from_app_pairs,
+    modify
+)
+from ..conftest import SparkRapidsToolsUT
+
+
+@pytest.fixture(name='raw_features')
+def _raw_features():
+    return pd.DataFrame(
+        [
+            # appName, runType, appId, sqlID, hash
+            ('test1', 'CPU', 'app1', 1, 'hash1'),
+            ('test1', 'CPU', 'app1', 2, 'hash2'),
+            ('test1', 'GPU', 'app2', 1, 'hash1'),
+            ('test1', 'GPU', 'app2', 2, 'hash3'),
+            ('test2', 'CPU', 'app3', 1, 'hash4'),
+            ('test2', 'GPU', 'app4', 2, 'hash4')
+        ],
+        columns=['appName', 'runType', 'appId', 'sqlID', 'hash']
+    )
+
+
+class TestModifiers(SparkRapidsToolsUT):
+    """Test class for qualx_modifiers module"""
+    def test_compute_alignment_from_raw_features(self, raw_features):
+        alignment_df = compute_alignment_from_raw_features(raw_features)
+
+        # Verify the structure of the output
+        assert isinstance(alignment_df, pd.DataFrame)
+        assert all(col in alignment_df.columns for col in ['appId_cpu', 'appId_gpu', 'sqlID_cpu', 'sqlID_gpu', 'hash'])
+
+        # Verify specific alignments
+        assert len(alignment_df) > 0
+
+        assert alignment_df['appId_cpu'].iloc[0] == 'app1'
+        assert alignment_df['appId_gpu'].iloc[0] == 'app2'
+        assert alignment_df['sqlID_cpu'].iloc[0] == 1
+        assert alignment_df['sqlID_gpu'].iloc[0] == 1
+        assert alignment_df['hash'].iloc[0] == 'hash1'
+
+        assert alignment_df['appId_cpu'].iloc[1] == 'app3'
+        assert alignment_df['appId_gpu'].iloc[1] == 'app4'
+        assert alignment_df['sqlID_cpu'].iloc[1] == 1
+        assert alignment_df['sqlID_gpu'].iloc[1] == 2
+        assert alignment_df['hash'].iloc[1] == 'hash4'
+
+    def test_compute_alignment_from_app_pairs(self, raw_features):
+        app_pairs = pd.DataFrame(
+            [
+                ('app1', 'app2'),
+                ('app3', 'app4')
+            ],
+            columns=['appId_cpu', 'appId_gpu']
+        )
+
+        alignment_df = compute_alignment_from_app_pairs(raw_features, app_pairs)
+
+        # Verify the structure of the output
+        assert isinstance(alignment_df, pd.DataFrame)
+        assert all(col in alignment_df.columns for col in ['appId_cpu', 'appId_gpu', 'sqlID_cpu', 'sqlID_gpu', 'hash'])
+
+        # Verify specific alignments
+        assert len(alignment_df) > 0
+        assert alignment_df['appId_cpu'].iloc[0] == 'app1'
+        assert alignment_df['appId_gpu'].iloc[0] == 'app2'
+        assert alignment_df['sqlID_cpu'].iloc[0] == 1
+        assert alignment_df['sqlID_gpu'].iloc[0] == 1
+        assert alignment_df['hash'].iloc[0] == 'hash1'
+
+    def test_modify_with_provided_alignment(self, raw_features):
+        # Create sample alignment data using row-based representation
+        alignment_df = pd.DataFrame(
+            [
+                ('app1', 'app2', 1, 1, 'hash1'),
+                ('app3', 'app4', 1, 2, 'hash4')
+            ],
+            columns=['appId_cpu', 'appId_gpu', 'sqlID_cpu', 'sqlID_gpu', 'hash']
+        )
+
+        config = get_config(reload=True)
+
+        raw_features['description'] = 'dummy'
+        result = modify(raw_features, config, alignment_df)
+
+        # Verify the structure of the output
+        assert isinstance(result, pd.DataFrame)
+
+        # Verify CPU row descriptions have been updated to the GPU appId
+        cpu_rows = result[result['runType'] == 'CPU']
+        assert all(cpu_rows['description'] == cpu_rows['appId'])
+
+        # Verify GPU row descriptions have been updated to the CPU appId
+        # Verify the alignment is correct
+        assert all(result.loc[(result.appId == 'app2') & (result.hash == 'hash1'), 'sqlID'] == 1)
+        assert all(result.loc[(result.appId == 'app2') & (result.hash == 'hash3'), 'sqlID'] == -1)
+        assert all(result.loc[(result.appId == 'app4') & (result.hash == 'hash4'), 'sqlID'] == 1)

--- a/user_tools/tests/spark_rapids_tools_ut/qualx/test_preprocess.py
+++ b/user_tools/tests/spark_rapids_tools_ut/qualx/test_preprocess.py
@@ -13,11 +13,23 @@
 # limitations under the License.
 
 """Test qualx_preprocess module"""
+import os
+import json
+import tempfile
+from unittest.mock import patch
+
 import pandas as pd
 
+from spark_rapids_tools.tools.qualx.config import get_config
 from spark_rapids_tools.tools.qualx.preprocess import (
     expected_raw_features,
-    impute
+    impute,
+    get_alignment,
+    get_featurizers,
+    get_modifiers,
+    infer_app_meta,
+    load_qtool_execs,
+    load_datasets
 )
 from ..conftest import SparkRapidsToolsUT
 
@@ -47,3 +59,166 @@ class TestPreprocess(SparkRapidsToolsUT):
 
         # all other columns should be 0.0
         assert imputed_df[list(df_columns - {'fraction_supported'})].iloc[0].sum() == 0.0
+
+    def test_get_alignment(self):
+        # Test get_alignment function
+        with patch('spark_rapids_tools.tools.qualx.preprocess.get_config') as mock_config:
+            # Create temporary alignment CSV file
+            test_alignment = pd.DataFrame({'appId': ['app1', 'app2'], 'sqlId': ['sql1', 'sql2']})
+            with tempfile.NamedTemporaryFile(prefix='alignment_', suffix='.csv', mode='w') as f:
+                test_alignment.to_csv(f.name, index=False)
+
+                mock_config.return_value.alignment_file = f.name
+
+                # Call function
+                align_df = get_alignment()
+
+                # Verify results
+                assert isinstance(align_df, pd.DataFrame)
+                assert len(align_df) == 2
+                assert list(align_df.columns) == ['appId', 'sqlId']
+                assert list(align_df['appId']) == ['app1', 'app2']
+                assert list(align_df['sqlId']) == ['sql1', 'sql2']
+
+    def test_get_featurizers(self):
+        # Test get_featurizers function
+        get_config(reload=True)
+        result = get_featurizers()
+
+        # Verify results
+        assert isinstance(result, list)
+        assert len(result) >= 2
+        assert all(callable(f.extract_raw_features) for f in result)
+
+        # Test caching
+        with patch('spark_rapids_tools.tools.qualx.util.load_plugin') as mock_load_plugin:
+            result2 = get_featurizers()
+            mock_load_plugin.assert_not_called()
+            assert result == result2
+
+    def test_get_modifiers(self):
+        # Test get_modifiers function
+        with patch('spark_rapids_tools.tools.qualx.preprocess.get_config') as mock_config:
+            mock_config.return_value.modifiers = ['align_sql_id.py']
+            result = get_modifiers()
+
+            # Verify results
+            assert isinstance(result, list)
+            assert len(result) >= 1
+            assert all(callable(f.modify) for f in result)
+
+            # Test caching
+            with patch('spark_rapids_tools.tools.qualx.util.load_plugin') as mock_load_plugin:
+                result2 = get_modifiers()
+                mock_load_plugin.assert_not_called()
+                assert result == result2
+
+    def test_infer_app_meta(self):
+        # Test infer_app_meta function
+        with patch('spark_rapids_tools.tools.qualx.preprocess.find_eventlogs') as mock_find_eventlogs:
+            # Setup mock eventlogs
+            mock_find_eventlogs.return_value = [
+                '/path/to/job1/eventlogs/CPU/app1',
+                '/path/to/job1/eventlogs/GPU/app2',
+                '/path/to/job2/eventlogs/CPU/app3',
+                '/path/to/job2/eventlogs/GPU/app4',
+            ]
+
+            # Call function
+            result = infer_app_meta(['/path/to/job1', '/path/to/job2'])
+
+            # Verify results
+            assert isinstance(result, dict)
+            assert len(result) == 4
+            assert result['app1'] == {
+                'jobName': 'job1',
+                'runType': 'CPU',
+                'scaleFactor': 1
+            }
+            assert result['app2'] == {
+                'jobName': 'job1',
+                'runType': 'GPU',
+                'scaleFactor': 1
+            }
+            assert result['app3'] == {
+                'jobName': 'job2',
+                'runType': 'CPU',
+                'scaleFactor': 1
+            }
+            assert result['app4'] == {
+                'jobName': 'job2',
+                'runType': 'GPU',
+                'scaleFactor': 1
+            }
+
+    def test_load_qtool_execs(self):
+        # Test load_qtool_execs function
+        # Create test data
+        test_data = pd.DataFrame([
+            ['app1', 'sql1', 'node1', True, '', 'Exec1'],
+            ['app1', 'sql2', 'node2', False, 'IgnoreNoPerf', 'Exec2'],
+            ['app2', 'sql1', 'node1', False, '', 'WholeStageCodegen3'],
+            ['app2', 'sql1', 'node2', False, '', 'Exec4']
+        ], columns=['App ID', 'SQL ID', 'SQL Node Id', 'Exec Is Supported', 'Action', 'Exec Name'])
+
+        # Create temporary CSV file
+        with tempfile.NamedTemporaryFile(suffix='.csv', mode='w') as f:
+            test_data.to_csv(f.name, index=False)
+
+            # Call function
+            result = load_qtool_execs([f.name])
+
+            # Verify results
+            assert isinstance(result, pd.DataFrame)
+            assert list(result.columns) == ['App ID', 'SQL ID', 'SQL Node Id', 'Exec Is Supported']
+            assert len(result) == 4
+            assert result['Exec Is Supported'].tolist() == [True, True, True, False]
+
+    def test_load_datasets(self):
+        """Test load_datasets function"""
+        get_config(reload=True)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create test dataset structure
+            dataset_dir = os.path.join(temp_dir, 'datasets', 'onprem')
+            os.makedirs(dataset_dir)
+
+            # Create test JSON file
+            test_json = {
+                'dataset1': {
+                    'eventlogs': ['/path/to/eventlog1'],
+                    'platform': 'onprem',
+                    'app_meta': {
+                        'app1': {
+                            'runType': 'CPU',
+                            'scaleFactor': 1
+                        }
+                    }
+                }
+            }
+
+            json_path = os.path.join(dataset_dir, 'dummy.json')
+            with open(json_path, 'w', encoding='utf-8') as f:
+                json.dump(test_json, f)
+
+            # Create dummy preprocessed.parquet cache file
+            test_profile = pd.DataFrame([
+                ['dataset1', 'app1', 'sql1', 100, 0.8],
+                ['dataset1', 'app1', 'sql2', 150, 0.6],
+                ['dataset2', 'app2', 'sql1', 200, 0.9],
+                ['dataset2', 'app2', 'sql2', 180, 0.7]
+            ], columns=['appName', 'appId', 'sqlID', 'Duration', 'fraction_supported'])
+            profile_dir = os.path.join(get_config().cache_dir, 'onprem')
+            os.makedirs(profile_dir, exist_ok=True)
+            test_profile.to_parquet(os.path.join(profile_dir, 'preprocessed.parquet'), index=False)
+
+            # Call function
+            datasets, profile_df = load_datasets(dataset_dir)
+
+            # Verify results
+            assert isinstance(datasets, dict)
+            assert 'dataset1' in datasets
+            assert datasets['dataset1']['platform'] == 'onprem'
+
+            assert isinstance(profile_df, pd.DataFrame)
+            assert not profile_df.empty
+            assert len(profile_df) == 2  # only 2 rows correspond to dataset1

--- a/user_tools/tests/spark_rapids_tools_ut/qualx/test_qualx_config.py
+++ b/user_tools/tests/spark_rapids_tools_ut/qualx/test_qualx_config.py
@@ -137,6 +137,31 @@ xgboost:
         assert 'label' in schema['properties']
         assert 'datasets' in schema['properties']
 
+    def test_split_functions_as_dict(self, qualx_config_params):
+        """Test that split_functions can be a dictionary with path and args"""
+        # Create a dictionary version of split_functions
+        split_dict = {
+            'train': {
+                'path': 'split_stratified.py',
+                'args': {'threshold': 2.0, 'test_pct': 0.2, 'val_pct': 0.2}
+            },
+            'test': 'split_all_test.py'
+        }
+
+        # Update the config params with the dictionary version
+        config_params = qualx_config_params.copy()
+        config_params['split_functions'] = split_dict
+
+        # Create config and verify the values
+        config = QualxConfig(**config_params)
+        assert config.split_functions == split_dict
+        assert isinstance(config.split_functions, dict)
+        assert 'train' in config.split_functions
+        assert 'test' in config.split_functions
+        assert config.split_functions['train']['path'] == 'split_stratified.py'
+        assert config.split_functions['train']['args']['threshold'] == 2.0
+        assert config.split_functions['test'] == 'split_all_test.py'
+
 
 class TestQualxPipelineConfig(SparkRapidsToolsUT):
     """Test class for QualxPipelineConfig"""

--- a/user_tools/tests/spark_rapids_tools_ut/qualx/test_split_functions.py
+++ b/user_tools/tests/spark_rapids_tools_ut/qualx/test_split_functions.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for split functions."""
+
+import pytest  # pylint: disable=import-error
+import pandas as pd
+import numpy as np
+from spark_rapids_tools.tools.qualx.split_functions.split_random import split_function as split_random
+from spark_rapids_tools.tools.qualx.split_functions.split_all_test import split_function as split_all_test
+from spark_rapids_tools.tools.qualx.split_functions.split_train_val import split_function as split_train_val
+from spark_rapids_tools.tools.qualx.split_functions.split_stratified import split_function as split_stratified
+
+from ..conftest import SparkRapidsToolsUT
+
+
+@pytest.fixture(name='sample_dataframe')
+def _sample_dataframe():
+    """Create a sample dataframe for testing."""
+    n = 1000
+    return pd.DataFrame({
+        'feature1': np.random.rand(n),
+        'feature2': np.random.rand(n),
+        'Duration_speedup': np.random.rand(n) * 2,  # Values between 0 and 2
+        'duration_sum_speedup': np.random.rand(n) * 2  # Values between 0 and 2
+    })
+
+
+class TestSplitFunctions(SparkRapidsToolsUT):
+    """Test class for split functions."""
+
+    def test_split_random(self, sample_dataframe):
+        """Test random split function."""
+        # Test with default parameters
+        result = split_random(sample_dataframe)
+        assert 'split' in result.columns
+        assert set(result['split'].unique()) == {'train', 'val', 'test'}
+        assert len(result) == len(sample_dataframe)
+
+        counts = result.groupby('split').size()
+        assert counts['test'] / len(result) == pytest.approx(0.2)
+        assert counts['val'] / len(result) == pytest.approx(0.2)
+        assert counts['train'] / len(result) == pytest.approx(0.6)
+
+        # Test with custom parameters
+        result = split_random(sample_dataframe, seed=42, test_pct=0.3, val_pct=0.2)
+        counts = result.groupby('split').size()
+        assert counts['test'] / len(result) == pytest.approx(0.3)
+        assert counts['val'] / len(result) == pytest.approx(0.2)
+        assert counts['train'] / len(result) == pytest.approx(0.5)
+
+    def test_split_all_test(self, sample_dataframe):
+        """Test all-test split function."""
+        result = split_all_test(sample_dataframe)
+        assert 'split' in result.columns
+        assert all(result['split'] == 'test')
+        assert len(result) == len(sample_dataframe)
+
+    def test_split_train_val(self, sample_dataframe):
+        """Test train-val split function."""
+        # Test with default parameters
+        result = split_train_val(sample_dataframe)
+        assert 'split' in result.columns
+        assert set(result['split'].unique()) == {'train', 'val'}
+        assert len(result) == len(sample_dataframe)
+
+        counts = result.groupby('split').size()
+        assert counts['val'] / len(result) == pytest.approx(0.2)
+        assert counts['train'] / len(result) == pytest.approx(0.8)
+
+        # reset split column, since this split function will only modify empty rows
+        sample_dataframe.drop(columns=['split'], inplace=True)
+
+        # Test with custom parameters
+        result = split_train_val(sample_dataframe, seed=42, val_pct=0.5)
+        counts = result.groupby('split').size()
+        assert counts['val'] / len(result) == pytest.approx(0.5)
+        assert counts['train'] / len(result) == pytest.approx(0.5)
+
+    def test_split_stratified(self, sample_dataframe):
+        """Test stratified split function."""
+        # Test with default parameters
+        result = split_stratified(sample_dataframe)
+        assert 'split' in result.columns
+        assert set(result['split'].unique()) == {'train', 'val', 'test'}
+
+        # Test with custom parameters
+        result = split_stratified(
+            sample_dataframe,
+            seed=42,
+            threshold=1.0,
+            test_pct=0.3,
+            val_pct=0.3,
+            label_col='duration_sum_speedup'
+        )
+        assert 'split' in result.columns
+        assert set(result['split'].unique()) == {'train', 'val', 'test'}
+
+        # Test split proportions for positive and negative cases
+        df = result.copy()
+        df['true_positive'] = df['duration_sum_speedup'] > 1.0
+
+        for is_positive in [True, False]:
+            subset = df[df['true_positive'] == is_positive]
+            counts = subset.groupby('split').size()
+            total = len(subset)
+
+            if total > 0:  # Only check if we have samples in this category
+                assert counts['train'] / total == pytest.approx(0.4, abs=0.05)
+                assert counts['val'] / total == pytest.approx(0.3, abs=0.05)
+                assert counts['test'] / total == pytest.approx(0.3, abs=0.05)
+
+    def test_split_random_reproducibility(self, sample_dataframe):
+        """Test that random split produces same results with same seed."""
+        sample1 = sample_dataframe.copy()
+        result1 = split_random(sample1, seed=42)
+        sample2 = sample_dataframe.copy()
+        result2 = split_random(sample2, seed=42)
+        pd.testing.assert_series_equal(result1['split'], result2['split'])
+
+        # test different seed
+        result2 = split_random(sample_dataframe, seed=1234)
+        assert not result1['split'].equals(result2['split'])
+
+    def test_split_train_val_reproducibility(self, sample_dataframe):
+        """Test that train-val split produces same results with same seed."""
+        sample1 = sample_dataframe.copy()
+        result1 = split_train_val(sample1, seed=42)
+        sample2 = sample_dataframe.copy()
+        result2 = split_train_val(sample2, seed=42)
+        pd.testing.assert_series_equal(result1['split'], result2['split'])
+
+        # test different seed
+        result2 = split_train_val(sample_dataframe, seed=1234)
+        assert not result1['split'].equals(result2['split'])
+
+    def test_split_stratified_reproducibility(self, sample_dataframe):
+        """Test that stratified split produces same results with same seed."""
+        sample1 = sample_dataframe.copy()
+        result1 = split_stratified(sample1, seed=42)
+        sample2 = sample_dataframe.copy()
+        result2 = split_stratified(sample2, seed=42)
+        pd.testing.assert_series_equal(result1['split'], result2['split'])
+
+        # test different seed
+        result2 = split_stratified(sample_dataframe, seed=1234)
+        assert not result1['split'].equals(result2['split'])

--- a/user_tools/tests/spark_rapids_tools_ut/qualx/test_utils.py
+++ b/user_tools/tests/spark_rapids_tools_ut/qualx/test_utils.py
@@ -35,6 +35,7 @@ from spark_rapids_tools.tools.qualx.util import (
     create_row_with_default_speedup,
     write_csv_reports,
     log_fallback,
+    get_abs_path,
 )
 from ..conftest import SparkRapidsToolsUT
 
@@ -59,6 +60,25 @@ class TestUtils(SparkRapidsToolsUT):
             mock_glob.return_value = ['/eventlog/log1', '/eventlog/log2']
             result = find_eventlogs('/eventlog/*.log')
             assert result == ['/eventlog/log1', '/eventlog/log2']
+
+    def test_get_abs_path(self):
+        get_config(reload=True)  # reload config
+
+        # Test absolute path case
+        with patch('os.path.isabs') as mock_isabs, \
+             patch('os.path.exists') as mock_exists:
+            mock_isabs.return_value = True
+            mock_exists.return_value = True
+            result = get_abs_path('/absolute/path')
+            assert result == '/absolute/path'
+
+        # Test relative path case
+        result = get_abs_path('util.py')
+        assert os.path.exists(result) and os.path.isabs(result)
+
+        # Test relative path with subdirectory
+        result = get_abs_path('split_all_test.py', 'split_functions')
+        assert os.path.exists(result) and os.path.isabs(result)
 
     def test_get_dataset_platforms(self):
         # supported platforms


### PR DESCRIPTION
This PR adds more unit tests for qualx, and includes the following fixes found during testing:
- sort Project fields in `hash_util.py` to allow for slight re-ordering of fields up to `n_fields`.
- modify globbing of alignment CSV files to include the "current" file without any prefix.
- add a configurable `label_col` argument to `split_stratified.py`.
