### PR TITLE
Use config file and add docs for Qualx hash_util

### DIFF
--- a/user_tools/src/spark_rapids_pytools/resources/qualx-hash-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualx-hash-conf.yaml
@@ -1,0 +1,68 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+remove_nodes_exact:
+  - Exchange  # inconsistent appearance in plans
+  - Sort  # inconsistent appearance in plans
+
+remove_nodes_prefix:
+  # CPU
+  - AdaptiveSparkPlan  # only appears in CPU plans
+  - ColumnarToRow  # only appears in CPU plans
+  - InputAdapter  # only appears in CPU plans
+  - ReusedExchange  # only appears in CPU plans
+  - WholeStageCodegen  # only appears in CPU plans
+  # GPU
+  - GpuCoalesceBatches  # only appears in GPU plans
+  - GpuColumnarExchange  # only appears in GPU plans
+  - GpuColumnarToRow  # only appears in GPU plans
+  - GpuRapidsDeltaWrite  # only appears in GPU plans
+  - GpuRowToColumnar  # only appears in GPU plans
+  - GpuShuffleCoalesce  # only appears in GPU plans
+  - GpuSort  # inconsistent appearance in plans
+  # Velox
+  - RowToVeloxColumnar  # only appears in Velox plans
+  - VeloxColumnarToRowExec  # only appears in Velox plans
+  - VeloxRowToColumnar  # only appears in Velox plans
+
+rename_nodes:
+  # strip suffixes
+  Scan parquet: Scan parquet
+  Scan ExistingRDD Delta Table State: Scan ExistingRDD
+  Scan ExistingRDD Delta Table Checkpoint: Scan parquet
+  # CPU
+  BucketUnion: Union
+  ObjectHashAggregate: HashAggregate
+  ShuffledHashJoin: SortMergeJoin
+  # GPU
+  Execute GpuInsertIntoHadoopFsRelationCommand: Execute InsertIntoHadoopFsRelationCommand
+  Execute GpuInsertIntoHiveTable: Execute InsertIntoHiveTable
+  GpuBroadcastExchange: BroadcastExchange
+  GpuBroadcastHashJoin: BroadcastHashJoin
+  GpuCoalesce: Coalesce
+  CpuCustomShuffleReader: AQEShuffleRead
+  GpuExpand: Expand
+  GpuExecute SaveIntoDataSourceCommand: Execute SaveIntoDataSourceCommand
+  GpuFilter: Filter
+  GpuGenerate: Generate
+  GpuGlobalLimit: GlobalLimit
+  GpuHashAggregate: HashAggregate
+  GpuLocalLimit: LocalLimit
+  GpuProject: Project
+  GpuRunningWindow: Window
+  GpuScan parquet: Scan parquet
+  GpuShuffledHashJoin: SortMergeJoin
+  GpuUnion: Union
+  # Velox
+  ProjectExecTransformer: Project

--- a/user_tools/src/spark_rapids_tools/tools/qualx/hash_config.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/hash_config.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration for hash_util."""
+
+from typing import List, Optional, Union
+from pydantic import Field
+from spark_rapids_tools.configuration.common import BaseConfig
+from spark_rapids_tools.storagelib.csppath import CspPathT
+from spark_rapids_tools.utils.propmanager import AbstractPropContainer
+
+
+class HashConfig(BaseConfig):
+    """Configuration for hash_util."""
+    remove_nodes_exact: List[str] = Field(
+        default=[],
+        description='List of nodes to remove exactly.',
+        examples=['Exchange', 'Sort']
+    )
+    remove_nodes_prefix: List[str] = Field(
+        default=[],
+        description='List of nodes to remove by prefix.',
+        examples=['AdaptiveSparkPlan', 'ColumnarToRow', 'InputAdapter', 'ReusedExchange', 'WholeStageCodegen']
+    )
+    rename_nodes: dict[str, str] = Field(
+        default={},
+        description='Dictionary of nodes to rename by prefix.',
+        examples={
+            'BucketUnion': 'Union',
+            'ObjectHashAggregate': 'HashAggregate',
+            'ShuffledHashJoin': 'SortMergeJoin'
+        }
+    )
+
+    @classmethod
+    def load_from_file(cls, file_path: Union[str, CspPathT]) -> Optional['HashConfig']:
+        """Load the Hash configuration from a file."""
+        prop_container = AbstractPropContainer.load_from_file(file_path)
+        return cls(**prop_container.props)
+
+    @classmethod
+    def get_schema(cls) -> str:
+        """Returns a JSON schema of the Qualx configuration."""
+        return cls.model_json_schema()


### PR DESCRIPTION
This PR addresses items 5, 7, and 8 of #1650.

Changes:
- Moves `remove_nodes_exact`, `remove_nodes_prefix`, and `rename_nodes` to a new `qualx-hash-conf.yaml`.
- Adds a new `hash_config.py` class to represent the YAML file.
- Adds more details to `hash_util` docs.