### PR TITLE
AutoTuner: Fix incorrect memoryOverheadFactor recommendation for YARN and k8s and add default master handling in unit tests

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -634,6 +634,10 @@ class AutoTuner(
           calcOverallMemory(executorHeapExpr, execCores, availableMemPerExecExpr)
         appendRecommendationForMemoryMB("spark.rapids.memory.pinnedPool.size", s"$pinnedMemory")
         appendRecommendationForMemoryMB("spark.executor.memory", s"$finalExecutorHeap")
+        // scalastyle:off line.size.limit
+        // For YARN and Kubernetes, we need to set the executor memory overhead
+        // Ref: https://spark.apache.org/docs/latest/configuration.html#:~:text=This%20option%20is%20currently%20supported%20on%20YARN%20and%20Kubernetes.
+        // scalastyle:on line.size.limit
         if (sparkMaster.contains(Yarn) || sparkMaster.contains(Kubernetes)) {
           appendRecommendationForMemoryMB("spark.executor.memoryOverhead", s"$memoryOverhead")
         }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -109,7 +109,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
   }
 
   /**
@@ -133,7 +133,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -232,7 +232,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
 
   test("Load cluster properties with CPU cores 0") {
     val dataprocWorkerInfo = buildGpuWorkerInfoAsString(None, Some(0))
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, getGpuAppMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -269,7 +269,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(workerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.ONPREM, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(workerInfo,
+    val autoTuner = buildAutoTunerForTests(workerInfo,
         getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -279,7 +279,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
 
   test("Load cluster properties with CPU memory missing") {
     val workerInfo = buildGpuWorkerInfoAsString(None, Some(32), None)
-    val autoTuner = createAutoTunerFromProps(workerInfo, getGpuAppMockInfoProvider)
+    val autoTuner = buildAutoTunerForTests(workerInfo, getGpuAppMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -316,7 +316,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo,
       getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -383,7 +383,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo,
       getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -462,7 +462,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo,
       getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -531,7 +531,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo,
       getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -597,7 +597,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo,
       getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -657,7 +657,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo,
       getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -722,7 +722,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo,
       getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -774,7 +774,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo,
       getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -890,7 +890,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo,
       getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -955,7 +955,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo,
       getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -1022,7 +1022,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo,
       getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -1067,7 +1067,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1150,7 +1150,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1224,7 +1224,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val infoProvider = getMockInfoProvider(8126464.0, Seq(0), Seq(0.004), logEventsProps,
       Some(testSparkVersion))
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1309,7 +1309,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1396,7 +1396,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo,
         getMockInfoProvider(3.7449728E7, Seq(0, 0), Seq(0.01, 0.0), logEventsProps,
           Some(testSparkVersion)), platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
@@ -1483,7 +1483,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1563,7 +1563,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1630,7 +1630,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo,
         getGpuAppMockInfoWithJars(rapidsJars), platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -1803,7 +1803,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1885,7 +1885,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1938,7 +1938,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(databricksWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATABRICKS_AWS, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(databricksWorkerInfo,
+    val autoTuner = buildAutoTunerForTests(databricksWorkerInfo,
         getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
 
@@ -1986,7 +1986,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
         .loadClusterPropertiesFromContent(dataprocWorkerInfo)
       val platform = PlatformFactory.createInstance(PlatformNames.ONPREM, clusterPropsOpt)
-      val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform,
+      val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform,
         sparkMaster)
       val (_, comments) = autoTuner.getRecommendedProperties()
       val expectedComment = "'spark.executor.memoryOverhead' was not set."
@@ -2191,7 +2191,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -2272,7 +2272,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     assert(expectedLines.forall(line => autoTunerOutput.contains(line)),
@@ -2338,7 +2338,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATABRICKS_AWS, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -2404,7 +2404,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
         DatabricksParseHelper.PROP_TAG_CLUSTER_SPARK_VERSION_KEY -> databricksVersion),
       Some(databricksVersion), Seq())
     // Do not set the platform as DB to see if it can work correctly irrespective
-    val autoTuner = createAutoTunerFromProps(databricksWorkerInfo,
+    val autoTuner = buildAutoTunerForTests(databricksWorkerInfo,
         infoProvider, PlatformFactory.createInstance(PlatformNames.DATABRICKS_AWS))
     // Assert shuffle manager string for DB 11.3 tag
     verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion = "330db")
@@ -2417,7 +2417,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin"),
       Some(sparkVersion), Seq())
-    val autoTuner = createAutoTunerFromProps(workerInfo,
+    val autoTuner = buildAutoTunerForTests(workerInfo,
         infoProvider, PlatformFactory.createInstance())
     // Assert shuffle manager string for supported Spark v3.3.0
     verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion = "330")
@@ -2430,7 +2430,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin"),
       Some(customSparkVersion), Seq())
-    val autoTuner = createAutoTunerFromProps(workerInfo,
+    val autoTuner = buildAutoTunerForTests(workerInfo,
         infoProvider, PlatformFactory.createInstance())
     // Assert shuffle manager string for supported custom Spark v3.3.0
     verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion = "330")
@@ -2461,7 +2461,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
         DatabricksParseHelper.PROP_TAG_CLUSTER_SPARK_VERSION_KEY -> databricksVersion),
       Some(databricksVersion), Seq())
     // Do not set the platform as DB to see if it can work correctly irrespective
-    val autoTuner = createAutoTunerFromProps(databricksWorkerInfo,
+    val autoTuner = buildAutoTunerForTests(databricksWorkerInfo,
         infoProvider, PlatformFactory.createInstance(PlatformNames.DATABRICKS_AWS))
     verifyUnsupportedSparkVersionForShuffleManager(autoTuner, databricksVersion)
   }
@@ -2473,7 +2473,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin"),
       Some(sparkVersion), Seq())
-    val autoTuner = createAutoTunerFromProps(workerInfo,
+    val autoTuner = buildAutoTunerForTests(workerInfo,
         infoProvider, PlatformFactory.createInstance())
     verifyUnsupportedSparkVersionForShuffleManager(autoTuner, sparkVersion)
   }
@@ -2485,7 +2485,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin"),
       Some(customSparkVersion), Seq())
-    val autoTuner = createAutoTunerFromProps(workerInfo,
+    val autoTuner = buildAutoTunerForTests(workerInfo,
         infoProvider, PlatformFactory.createInstance())
     verifyUnsupportedSparkVersionForShuffleManager(autoTuner, customSparkVersion)
   }
@@ -2496,7 +2496,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin"),
       None, Seq())
-    val autoTuner = createAutoTunerFromProps(workerInfo,
+    val autoTuner = buildAutoTunerForTests(workerInfo,
         infoProvider, PlatformFactory.createInstance())
     // Verify that the shuffle manager is not recommended for missing Spark version
     autoTuner.getShuffleManagerClassName match {
@@ -2538,7 +2538,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -2622,7 +2622,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -2919,7 +2919,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(emrWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.EMR, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(emrWorkerInfo, infoProvider, platform)
+    val autoTuner = buildAutoTunerForTests(emrWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -3133,7 +3133,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
         .loadClusterPropertiesFromContent(dataprocWorkerInfo)
       val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-      val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+      val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
       val (properties, comments) = autoTuner.getRecommendedProperties()
       val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
       // scalastyle:off line.size.limit
@@ -3264,7 +3264,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -3342,7 +3342,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.rapids.tool.util.{FSUtils, WebCrawlerUtil}
  */
 class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
 
+  val autoTunerConfigsProvider: AutoTunerConfigsProvider = ProfilingAutoTunerConfigsProvider
   private val profilingLogDir = ToolTestUtils.getTestResourcePath("spark-events-profiling")
 
   /**
@@ -82,14 +83,14 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       gpuCount, gpuMemory, gpuDevice)
   }
 
-  private def getGpuAppMockInfoProvider: AppSummaryInfoBaseProvider = {
+  private def getGpuAppMockInfoProvider: AppInfoProviderMockTest = {
     getMockInfoProvider(0, Seq(0), Seq(0.0),
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin"),
       Some(testSparkVersion), Seq())
   }
 
-  private def getGpuAppMockInfoWithJars(rapidsJars: Seq[String]): AppSummaryInfoBaseProvider = {
+  private def getGpuAppMockInfoWithJars(rapidsJars: Seq[String]): AppInfoProviderMockTest = {
     getMockInfoProvider(0, Seq(0), Seq(0.0),
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin"),
@@ -108,8 +109,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    ProfilingAutoTunerConfigsProvider.buildAutoTunerFromProps(
-      dataprocWorkerInfo, infoProvider, platform)
+    createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
   }
 
   /**
@@ -133,8 +133,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -233,8 +232,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
 
   test("Load cluster properties with CPU cores 0") {
     val dataprocWorkerInfo = buildGpuWorkerInfoAsString(None, Some(0))
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -267,12 +265,11 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
   }
 
   test("Load cluster properties with memory to cores ratio to small") {
-    val dataprocWorkerInfo = buildGpuWorkerInfoAsString(None, Some(8), Some("14000MiB"))
+    val workerInfo = buildGpuWorkerInfoAsString(None, Some(8), Some("14000MiB"))
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
-      .loadClusterPropertiesFromContent(dataprocWorkerInfo)
+      .loadClusterPropertiesFromContent(workerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.ONPREM, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo,
+    val autoTuner = createAutoTunerFromProps(workerInfo,
         getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -281,9 +278,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
   }
 
   test("Load cluster properties with CPU memory missing") {
-    val dataprocWorkerInfo = buildGpuWorkerInfoAsString(None, Some(32), None)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider)
+    val workerInfo = buildGpuWorkerInfoAsString(None, Some(32), None)
+    val autoTuner = createAutoTunerFromProps(workerInfo, getGpuAppMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -320,9 +316,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider,
-        platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+      getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -388,9 +383,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider,
-        platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+      getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -468,9 +462,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider,
-        platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+      getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -538,9 +531,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider,
-        platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+      getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -605,9 +597,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider,
-        platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+      getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -666,9 +657,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider,
-        platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+      getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -732,9 +722,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider,
-        platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+      getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -785,9 +774,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider,
-        platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+      getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -902,9 +890,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider,
-        platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+      getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     compareOutput(expectedResults, autoTunerOutput)
@@ -968,9 +955,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider,
-        platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+      getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     compareOutput(expectedResults, autoTunerOutput)
@@ -1036,9 +1022,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, getGpuAppMockInfoProvider,
-        platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
+      getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     compareOutput(expectedResults, autoTunerOutput)
@@ -1082,8 +1067,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1166,8 +1150,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1241,8 +1224,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
     val infoProvider = getMockInfoProvider(8126464.0, Seq(0), Seq(0.004), logEventsProps,
       Some(testSparkVersion))
-    val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1327,8 +1309,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1415,8 +1396,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo,
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
         getMockInfoProvider(3.7449728E7, Seq(0, 0), Seq(0.01, 0.0), logEventsProps,
           Some(testSparkVersion)), platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
@@ -1503,8 +1483,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1584,8 +1563,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1652,8 +1630,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo,
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo,
         getGpuAppMockInfoWithJars(rapidsJars), platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -1826,8 +1803,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1909,8 +1885,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -1963,8 +1938,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(databricksWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATABRICKS_AWS, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(databricksWorkerInfo,
+    val autoTuner = createAutoTunerFromProps(databricksWorkerInfo,
         getGpuAppMockInfoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
 
@@ -1974,28 +1948,26 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     assert(comments.map(_.comment).forall(autoTuner.platform.isValidComment))
   }
 
-  // When spark is running as a standalone, the memoryOverhead should not be listed as a
-  // recommendation: issue-553.
-  test("memoryOverhead should not be recommended for Spark Standalone") {
-    // This UT sets a custom spark-property "spark.master" pointing to a spark-standalone value
-    // The Autotuner should detect that the spark-master is standalone and refrains from
-    // recommending memoryOverhead value
-    val customProps = mutable.LinkedHashMap(
-      "spark.executor.cores" -> "8",
-      "spark.executor.memory" -> "47222m",
-      "spark.rapids.shuffle.multiThreaded.reader.threads" -> "8",
-      "spark.rapids.shuffle.multiThreaded.writer.threads" -> "8",
-      "spark.rapids.sql.concurrentGpuTasks" -> "2",
-      "spark.rapids.sql.multiThreadedRead.numThreads" -> "20",
-      "spark.shuffle.manager" ->
-        s"com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager",
-      "spark.task.resource.gpu.amount" -> "0.001")
-    // mock the properties loaded from eventLog
-    val logEventsProps: mutable.Map[String, String] =
-      mutable.LinkedHashMap[String, String](
-        "spark.master" -> "spark://HOST_NAME:7077",
+  // Test cases for memory overhead configuration based on Spark Master
+  private val MEMORY_OVERHEAD_TEST_CASES = Table(
+    ("sparkMaster", "shouldIncludeMemoryOverhead"),
+    // memoryOverhead should be included for yarn and k8s
+    (Some(Yarn), true),
+    (Some(Kubernetes), true),
+    // memoryOverhead should be excluded for standalone and local
+    (Some(Standalone), false),
+    (Some(Local), false),
+    // memoryOverhead should be excluded for other sparkMaster values
+    (None, false)
+  )
+
+  forAll(MEMORY_OVERHEAD_TEST_CASES) {
+    (sparkMaster: Option[SparkMaster], shouldIncludeMemoryOverhead: Boolean) =>
+    test("memoryOverhead comment is " +
+      s"${if (shouldIncludeMemoryOverhead) "included" else "excluded"} " +
+      s"for sparkMaster=${sparkMaster.getOrElse("undefined")}") {
+      val logEventsProps = mutable.LinkedHashMap[String, String](
         "spark.executor.cores" -> "16",
-        "spark.executor.instances" -> "1",
         "spark.executor.memory" -> "80g",
         "spark.executor.resource.gpu.amount" -> "1",
         "spark.executor.instances" -> "1",
@@ -2005,238 +1977,28 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
         "spark.rapids.memory.pinnedPool.size" -> "5g",
         "spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
-        "spark.rapids.sql.concurrentGpuTasks" -> "4")
-    val dataprocWorkerInfo = buildGpuWorkerInfoAsString(Some(customProps), Some(32),
-      Some("212992MiB"), Some(5), Some(4), Some(T4Gpu.getMemory), Some(T4Gpu.toString))
-    val infoProvider = getMockInfoProvider(8126464.0, Seq(0), Seq(0.004), logEventsProps,
-      Some(testSparkVersion))
-    val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
-      .loadClusterPropertiesFromContent(dataprocWorkerInfo)
-    val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
-    val (properties, comments) = autoTuner.getRecommendedProperties()
-    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
-    // scalastyle:off line.size.limit
-    val expectedResults =
-      s"""|
-          |Spark Properties:
-          |--conf spark.dataproc.enhanced.execution.enabled=false
-          |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=10
-          |--conf spark.executor.memory=32g
-          |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
-          |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
-          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
-          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
-          |--conf spark.rapids.sql.concurrentGpuTasks=2
-          |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
-          |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
-          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
-          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
-          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
-          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
-          |--conf spark.sql.files.maxPartitionBytes=4g
-          |
-          |Comments:
-          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
-          |- 'spark.dataproc.enhanced.execution.enabled' was not set.
-          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
-          |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
-          |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
-          |- 'spark.rapids.sql.batchSizeBytes' was not set.
-          |- 'spark.rapids.sql.format.parquet.multithreaded.combine.waitTime' was not set.
-          |- 'spark.rapids.sql.reader.multithreaded.combine.sizeBytes' was not set.
-          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
-          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
-          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
-          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
-          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
-          |""".stripMargin
-    // scalastyle:on line.size.limit
-    compareOutput(expectedResults, autoTunerOutput)
-  }
+        "spark.rapids.sql.concurrentGpuTasks" -> "4"
+      )
 
-  // Map of `Spark Version` -> `memoryOverheadLabel`
-  private val MISSING_MEMORY_OVERHEAD_k8s_TEST_CASES = Seq(
-    "3.5.0" -> "spark.executor.memoryOverheadFactor",
-    "3.2.1" -> "spark.kubernetes.memoryOverheadFactor"
-  )
-
-  // This UT sets a custom spark-property "spark.master" pointing to a spark
-  // k8s value. The Autotuner should detect that the spark-master is k8s and
-  // comments on the missing memoryOverhead value since pinned pool is set.
-  MISSING_MEMORY_OVERHEAD_k8s_TEST_CASES.foreach { case (sparkVersion, memoryOverheadLabel) =>
-    test(s"missing memoryOverhead comment is included for k8s with pinned pool " +
-      s"[sparkVersion=$sparkVersion]") {
-      val logEventsProps: mutable.Map[String, String] =
-        mutable.LinkedHashMap[String, String](
-          "spark.master" -> "k8s://https://my-cluster-endpoint.example.com:6443",
-          "spark.executor.cores" -> "16",
-          "spark.executor.instances" -> "1",
-          "spark.executor.memory" -> "80g",
-          "spark.executor.resource.gpu.amount" -> "1",
-          "spark.executor.instances" -> "1",
-          "spark.sql.shuffle.partitions" -> "200",
-          "spark.sql.files.maxPartitionBytes" -> "1g",
-          "spark.task.resource.gpu.amount" -> "0.001",
-          "spark.rapids.memory.pinnedPool.size" -> "5g",
-          "spark.rapids.sql.enabled" -> "true",
-          "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
-          "spark.rapids.sql.concurrentGpuTasks" -> "4")
       val dataprocWorkerInfo = buildGpuWorkerInfoAsString()
-      val infoProvider = getMockInfoProvider(8126464.0, Seq(0), Seq(0.004), logEventsProps,
-        Some(sparkVersion))
+      val infoProvider = getMockInfoProvider(8126464.0, Seq(0),
+        Seq(0.004), logEventsProps, Some(testSparkVersion))
       val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
         .loadClusterPropertiesFromContent(dataprocWorkerInfo)
       val platform = PlatformFactory.createInstance(PlatformNames.ONPREM, clusterPropsOpt)
-      val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-        .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+      val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform,
+        sparkMaster)
       val (_, comments) = autoTuner.getRecommendedProperties()
-      val expectedComment =
-        s"'$memoryOverheadLabel' must be set if using 'spark.rapids.memory.pinnedPool.size'."
-      assert(comments.exists(_.comment == expectedComment))
+      val expectedComment = "'spark.executor.memoryOverhead' was not set."
+
+      if (shouldIncludeMemoryOverhead) {
+        assert(comments.exists(_.comment == expectedComment),
+          s"Expected comment '$expectedComment' not found")
+      } else {
+        assert(comments.forall(_.comment != expectedComment),
+          s"Unexpected comment '$expectedComment' found")
+      }
     }
-  }
-
-  // This UT sets a custom spark-property "spark.master" pointing to a spark
-  // k8s value. The Autotuner should detect that the spark-master is k8s and
-  // should not comment on the missing memoryOverhead value since pinned pool is not set.
-  test(s"missing memoryOverhead comment is not included for k8s without pinned pool " +
-    s"[sparkVersion=$testSparkVersion]") {
-    val sparkMaster = "k8s://https://my-cluster-endpoint.example.com:6443"
-    val logEventsProps: mutable.Map[String, String] =
-      mutable.LinkedHashMap[String, String](
-        "spark.master" -> sparkMaster,
-        "spark.executor.cores" -> "16",
-        "spark.executor.instances" -> "1",
-        "spark.executor.memory" -> "80g",
-        "spark.executor.resource.gpu.amount" -> "1",
-        "spark.executor.instances" -> "1",
-        "spark.sql.shuffle.partitions" -> "200",
-        "spark.sql.files.maxPartitionBytes" -> "1g",
-        "spark.task.resource.gpu.amount" -> "0.001",
-        "spark.rapids.sql.enabled" -> "true",
-        "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
-        "spark.rapids.sql.concurrentGpuTasks" -> "4")
-    val dataprocWorkerInfo = buildGpuWorkerInfoAsString()
-    val infoProvider = getMockInfoProvider(8126464.0, Seq(0), Seq(0.004), logEventsProps,
-      Some(testSparkVersion))
-    val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
-      .loadClusterPropertiesFromContent(dataprocWorkerInfo)
-    val platform = PlatformFactory.createInstance(PlatformNames.ONPREM, clusterPropsOpt)
-    val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
-    val (properties, comments) = autoTuner.getRecommendedProperties()
-    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
-    val memoryOverheadLabel = ProfilingAutoTunerConfigsProvider.getMemoryOverheadLabel(
-      SparkMaster(Some(sparkMaster)), Some(testSparkVersion))
-    // scalastyle:off line.size.limit
-    val expectedResults =
-      s"""|
-          |Spark Properties:
-          |--conf spark.executor.instances=8
-          |--conf spark.executor.memory=32g
-          |--conf $memoryOverheadLabel=13516m
-          |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
-          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
-          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=24
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
-          |--conf spark.rapids.sql.concurrentGpuTasks=2
-          |--conf spark.rapids.sql.multiThreadedRead.numThreads=32
-          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
-          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
-          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
-          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
-          |--conf spark.sql.files.maxPartitionBytes=4g
-          |
-          |Comments:
-          |- '$memoryOverheadLabel' was not set.
-          |- 'spark.rapids.memory.pinnedPool.size' was not set.
-          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
-          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
-          |- 'spark.rapids.sql.batchSizeBytes' was not set.
-          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
-          |- 'spark.shuffle.manager' was not set.
-          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
-          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
-          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
-          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
-          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
-          |""".stripMargin
-    // scalastyle:on line.size.limit
-    compareOutput(expectedResults, autoTunerOutput)
-  }
-
-  // This UT sets a custom spark-property "spark.master" pointing to a yarn
-  // value. The Autotuner should detect that the spark-master is yarn and
-  // should not comment on the missing memoryOverhead value even though pinned
-  // pool is set.
-  test("missing memoryOverhead comment is not included for yarn " +
-    s"[sparkVersion=$testSparkVersion]") {
-    val logEventsProps: mutable.Map[String, String] =
-      mutable.LinkedHashMap[String, String](
-        "spark.master" -> "yarn",
-        "spark.executor.cores" -> "16",
-        "spark.executor.instances" -> "1",
-        "spark.executor.memory" -> "80g",
-        "spark.executor.resource.gpu.amount" -> "1",
-        "spark.executor.instances" -> "1",
-        "spark.sql.shuffle.partitions" -> "200",
-        "spark.sql.files.maxPartitionBytes" -> "1g",
-        "spark.task.resource.gpu.amount" -> "0.001",
-        "spark.rapids.memory.pinnedPool.size" -> "5g",
-        "spark.rapids.sql.enabled" -> "true",
-        "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
-        "spark.rapids.sql.concurrentGpuTasks" -> "4")
-    val dataprocWorkerInfo = buildGpuWorkerInfoAsString()
-    val infoProvider = getMockInfoProvider(8126464.0, Seq(0), Seq(0.004), logEventsProps,
-      Some(testSparkVersion))
-    val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
-      .loadClusterPropertiesFromContent(dataprocWorkerInfo)
-    val platform = PlatformFactory.createInstance(PlatformNames.ONPREM, clusterPropsOpt)
-    val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
-    val (properties, comments) = autoTuner.getRecommendedProperties()
-    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
-    // scalastyle:off line.size.limit
-    val expectedResults =
-      s"""|
-          |Spark Properties:
-          |--conf spark.executor.instances=8
-          |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=13516m
-          |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
-          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
-          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=24
-          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
-          |--conf spark.rapids.sql.concurrentGpuTasks=2
-          |--conf spark.rapids.sql.multiThreadedRead.numThreads=32
-          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
-          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
-          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
-          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
-          |--conf spark.sql.files.maxPartitionBytes=4g
-          |
-          |Comments:
-          |- 'spark.executor.memoryOverhead' was not set.
-          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
-          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
-          |- 'spark.rapids.sql.batchSizeBytes' was not set.
-          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
-          |- 'spark.shuffle.manager' was not set.
-          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
-          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
-          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
-          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
-          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
-          |""".stripMargin
-    // scalastyle:on line.size.limit
-    compareOutput(expectedResults, autoTunerOutput)
   }
 
   test("Recommendations generated for unsupported operators from driver logs only") {
@@ -2309,7 +2071,6 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=4
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=13516m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
@@ -2325,7 +2086,6 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |
           |Comments:
           |- 'spark.executor.instances' was not set.
-          |- 'spark.executor.memoryOverhead' was not set.
           |- 'spark.rapids.memory.pinnedPool.size' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
@@ -2431,8 +2191,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -2513,8 +2272,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     assert(expectedLines.forall(line => autoTunerOutput.contains(line)),
@@ -2580,8 +2338,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATABRICKS_AWS, clusterPropsOpt)
-    val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -2647,8 +2404,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
         DatabricksParseHelper.PROP_TAG_CLUSTER_SPARK_VERSION_KEY -> databricksVersion),
       Some(databricksVersion), Seq())
     // Do not set the platform as DB to see if it can work correctly irrespective
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(databricksWorkerInfo,
+    val autoTuner = createAutoTunerFromProps(databricksWorkerInfo,
         infoProvider, PlatformFactory.createInstance(PlatformNames.DATABRICKS_AWS))
     // Assert shuffle manager string for DB 11.3 tag
     verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion = "330db")
@@ -2661,8 +2417,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin"),
       Some(sparkVersion), Seq())
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(workerInfo,
+    val autoTuner = createAutoTunerFromProps(workerInfo,
         infoProvider, PlatformFactory.createInstance())
     // Assert shuffle manager string for supported Spark v3.3.0
     verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion = "330")
@@ -2675,8 +2430,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin"),
       Some(customSparkVersion), Seq())
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(workerInfo,
+    val autoTuner = createAutoTunerFromProps(workerInfo,
         infoProvider, PlatformFactory.createInstance())
     // Assert shuffle manager string for supported custom Spark v3.3.0
     verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion = "330")
@@ -2707,8 +2461,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
         DatabricksParseHelper.PROP_TAG_CLUSTER_SPARK_VERSION_KEY -> databricksVersion),
       Some(databricksVersion), Seq())
     // Do not set the platform as DB to see if it can work correctly irrespective
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(databricksWorkerInfo,
+    val autoTuner = createAutoTunerFromProps(databricksWorkerInfo,
         infoProvider, PlatformFactory.createInstance(PlatformNames.DATABRICKS_AWS))
     verifyUnsupportedSparkVersionForShuffleManager(autoTuner, databricksVersion)
   }
@@ -2720,8 +2473,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin"),
       Some(sparkVersion), Seq())
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(workerInfo,
+    val autoTuner = createAutoTunerFromProps(workerInfo,
         infoProvider, PlatformFactory.createInstance())
     verifyUnsupportedSparkVersionForShuffleManager(autoTuner, sparkVersion)
   }
@@ -2733,8 +2485,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin"),
       Some(customSparkVersion), Seq())
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(workerInfo,
+    val autoTuner = createAutoTunerFromProps(workerInfo,
         infoProvider, PlatformFactory.createInstance())
     verifyUnsupportedSparkVersionForShuffleManager(autoTuner, customSparkVersion)
   }
@@ -2745,8 +2496,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       mutable.Map("spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin"),
       None, Seq())
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(workerInfo,
+    val autoTuner = createAutoTunerFromProps(workerInfo,
         infoProvider, PlatformFactory.createInstance())
     // Verify that the shuffle manager is not recommended for missing Spark version
     autoTuner.getShuffleManagerClassName match {
@@ -2788,8 +2538,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -2873,8 +2622,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -3171,9 +2919,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(emrWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.EMR, clusterPropsOpt)
-    val autoTuner: AutoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(emrWorkerInfo, infoProvider,
-        platform)
+    val autoTuner = createAutoTunerFromProps(emrWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -3387,8 +3133,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
         .loadClusterPropertiesFromContent(dataprocWorkerInfo)
       val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-      val autoTuner = ProfilingAutoTunerConfigsProvider
-        .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+      val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
       val (properties, comments) = autoTuner.getRecommendedProperties()
       val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
       // scalastyle:off line.size.limit
@@ -3519,8 +3264,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -3598,8 +3342,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = ProfilingAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(dataprocWorkerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
-    val autoTuner = ProfilingAutoTunerConfigsProvider
-      .buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
+    val autoTuner = createAutoTunerFromProps(dataprocWorkerInfo, infoProvider, platform)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -63,7 +63,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = QualificationAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(workerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.EMR, clusterPropsOpt)
-    createAutoTunerFromProps(workerInfo, infoProvider, platform)
+    buildAutoTunerForTests(workerInfo, infoProvider, platform)
   }
 
   test("test AutoTuner for Qualification sets batch size to 1GB") {

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -26,10 +26,12 @@ import com.nvidia.spark.rapids.tool.profiling.Profiler
  */
 class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
 
+  val autoTunerConfigsProvider: AutoTunerConfigsProvider = QualificationAutoTunerConfigsProvider
+
   /**
    * Default Spark properties to be used when building the Qualification AutoTuner
    */
-  private val defaultSparkProps: mutable.Map[String, String] = {
+  private def defaultSparkProps: mutable.Map[String, String] = {
     mutable.LinkedHashMap[String, String](
       "spark.executor.cores" -> "32",
       "spark.executor.instances" -> "1",
@@ -61,8 +63,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
     val clusterPropsOpt = QualificationAutoTunerConfigsProvider
       .loadClusterPropertiesFromContent(workerInfo)
     val platform = PlatformFactory.createInstance(PlatformNames.EMR, clusterPropsOpt)
-    QualificationAutoTunerConfigsProvider.buildAutoTunerFromProps(
-      workerInfo, infoProvider, platform)
+    createAutoTunerFromProps(workerInfo, infoProvider, platform)
   }
 
   test("test AutoTuner for Qualification sets batch size to 1GB") {


### PR DESCRIPTION
Fix #1653.

## Issue

Currently, for YARN and k8s, AutoTuner recommends `spark.kubernetes.memoryOverheadFactor` / `spark.executor.memoryOverheadFactor` instead of the correct setting `spark.executor.memoryOverhead`. This led to invalid configurations, such as:
```
--conf spark.kubernetes.memoryOverheadFactor=13516m
```
(Note: `memoryOverheadFactor` expects a fraction, not an absolute value.)

### Additional Investigation
- It is sufficient to recommend only `spark.executor.memoryOverhead` for both k8s and YARN and we should not recommend `memoryOverheadFactor`.
- Our unit tests did not previously specify the spark master the application was running on. 
     - This can cause mismatches in expected recommendations (e.g., Dataproc uses YARN, so expected recommendations should reflect that).

## Changes
This PR fixes the above issues by:
- Removing the recommendation for `memoryOverheadFactor`
- Recommend `spark.executor.memoryOverhead` when running on YARN or k8s.
- Improve unit tests to:
   - Default to appropriate master settings based on the platform (e.g., Dataproc and EMR use YARN, Dataproc Serverless uses Standalone).
   - Allow tests to override the master type when needed (e.g., OnPrem may use local, standalone, or k8s).


## Tests
- Added unit tests to verify that `spark.executor.memoryOverhead` is recommended for YARN and k8s and not recommended for other master types.
 