### PR TITLE
Integrate Qualx train_and_evaluate into spark_rapids CLI with docs

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/qualx/train_and_evaluate.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualx/train_and_evaluate.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/user_tools/src/spark_rapids_pytools/rapids/qualx/train_and_evaluate.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualx/train_and_evaluate.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation class representing wrapper around the RAPIDS acceleration QualX training tool."""
+
+from dataclasses import dataclass
+
+from spark_rapids_pytools.rapids.qualx.qualx_tool import QualXTool
+from spark_rapids_tools.tools.qualx.qualx_pipeline import train_and_evaluate
+
+
+@dataclass
+class TrainAndEvaluate(QualXTool):
+    """
+    Wrapper layer around QualX pipeline.
+
+    Attributes
+    ----------
+    config:
+        Path to YAML config file containing training parameters.
+    """
+
+    config: str = None
+
+    name = 'train_and_evaluate'
+
+    def _run_rapids_tool(self):
+        """
+        Runs the QualX pipeline.
+        """
+        try:
+            train_and_evaluate(config=self.config)
+            self.logger.info('QualX pipeline completed successfully.')
+        except Exception as e:  # pylint: disable=broad-except
+            self.logger.error('QualX pipeline failed with error: %s', e)
+            raise e

--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -737,6 +737,24 @@ class TrainUserArgModel(AbsToolUserArgModel):
 
 
 @dataclass
+@register_tool_arg_validator('train_and_evaluate')
+class TrainAndEvaluateUserArgModel(AbsToolUserArgModel):
+    """
+    Represents the arguments collected by the user to run the train and evaluate tool.
+    """
+    config: str = None
+
+    def build_tools_args(self) -> dict:
+        runtime_platform = CspEnv.fromstring(self.platform)
+        return {
+            'runtimePlatform': runtime_platform,
+            'config': self.config,
+            'output_folder': self.output_folder,
+            'platformOpts': {},
+        }
+
+
+@dataclass
 @register_tool_arg_validator('stats')
 class StatsUserArgModel(AbsToolUserArgModel):
     """

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -25,6 +25,7 @@ from spark_rapids_pytools.rapids.qualx.prediction import Prediction
 from spark_rapids_pytools.rapids.profiling import ProfilingAsLocal
 from spark_rapids_pytools.rapids.qualification import QualificationAsLocal
 from spark_rapids_pytools.rapids.qualx.train import Train
+from spark_rapids_pytools.rapids.qualx.train_and_evaluate import TrainAndEvaluate
 
 
 class ToolsCLI(object):  # pylint: disable=too-few-public-methods
@@ -290,6 +291,27 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                          base_model=base_model,
                          features_csv_dir=features_csv_dir,
                          wrapper_options=train_args)
+        tool_obj.launch()
+
+    def train_and_evaluate(self, config: str = None):
+        """The Train and Evaluate cmd trains an XGBoost model and evaluates it using matched CPU and GPU eventlogs.
+
+        This API supports online training by allowing multiple invocations with new data.
+        Each invocation will create a new dataset JSON file with an incrementing number.
+
+        :param config: Path to YAML config file containing the required training parameters.
+        """
+        # Since pipeline is an internal tool with frequent output, we enable debug mode by default
+        ToolLogging.enable_debug_mode()
+        init_environment('train_and_evaluate')
+
+        pipeline_args = AbsToolUserArgModel.create_tool_args('train_and_evaluate',
+                                                             platform=CspEnv.get_default(),
+                                                             config=config)
+
+        tool_obj = TrainAndEvaluate(platform_type=pipeline_args['runtimePlatform'],
+                                    config=config,
+                                    wrapper_options=pipeline_args)
         tool_obj.launch()
 
 

--- a/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
@@ -46,19 +46,17 @@ _modifiers = None  # global cache of modifiers
 
 def get_alignment() -> pd.DataFrame:
     """Get alignment_df from alignment_file, including historical alignments."""
-    alignment_file = get_config().alignment_file
+    alignment_dir = get_config().alignment_dir
 
-    if alignment_file is None:
+    if alignment_dir is None:
         return pd.DataFrame()
 
-    abs_path = get_abs_path(alignment_file)
+    abs_path = get_abs_path(alignment_dir)
     if not abs_path:
-        raise ValueError(f'Alignment file not found: {alignment_file}')
+        raise ValueError(f'Alignment directory not found: {alignment_dir}')
 
     # concatenate all CSV files in alignment_file directory
-    parent_dir = Path(abs_path).parent
-    base_name = Path(abs_path).stem
-    csv_files = glob.glob(f'{parent_dir}/{base_name}*.*')
+    csv_files = glob.glob(f'{abs_path}/*.csv')
 
     chunk_size = 100
     alignment_dfs = []

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_config.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_config.py
@@ -129,10 +129,13 @@ class QualxPipelineConfig(QualxConfig):
         description='Platform supported by Profiler and Qualification tools.',
         examples=['onprem'])
 
-    alignment_file: str = Field(
+    alignment_dir: str = Field(
         default=None,
-        description='Path to CPU to GPU appId alignments (and optional sqlID alignments).',
-        examples=['alignment.csv'])
+        description=(
+            'Path to a directory containing CSV files with CPU to GPU appId alignments '
+            '(and optional sqlID alignments).'
+        ),
+        examples=['alignment'])
 
     eventlogs: dict = Field(
         description='Paths to CPU and GPU eventlogs.',

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_config.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_config.py
@@ -81,10 +81,10 @@ class QualxConfig(BaseConfig):
             'qual_tool_filter': 'stage'
         }])
 
-    alignment_file: Optional[str] = Field(
+    alignment_dir: Optional[str] = Field(
         default=None,
-        description='OPTIONAL: Path to alignment file.',
-        examples=['alignment.csv'])
+        description='OPTIONAL: Path to alignment directory.',
+        examples=['alignment'])
 
     @model_validator(mode='after')
     def check_env_overrides(self):
@@ -130,7 +130,6 @@ class QualxPipelineConfig(QualxConfig):
         examples=['onprem'])
 
     alignment_dir: str = Field(
-        default=None,
         description=(
             'Path to a directory containing CSV files with CPU to GPU appId alignments '
             '(and optional sqlID alignments).'

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
@@ -129,8 +129,6 @@ def verify_sql_id_alignment(context):
     assert df['hash'].notna().all(), 'hash column should not contain any NaN values'
 
     alignment_df = compute_alignment_from_raw_features(df)
-    alignment_df.to_csv('test_alignment_df.csv', index=False)
-
     assert not alignment_df.empty, 'Alignment DataFrame should not be empty'
 
     # these are specific to the test eventlogs

--- a/user_tools/tests/spark_rapids_tools_ut/qualx/test_preprocess.py
+++ b/user_tools/tests/spark_rapids_tools_ut/qualx/test_preprocess.py
@@ -65,10 +65,11 @@ class TestPreprocess(SparkRapidsToolsUT):
         with patch('spark_rapids_tools.tools.qualx.preprocess.get_config') as mock_config:
             # Create temporary alignment CSV file
             test_alignment = pd.DataFrame({'appId': ['app1', 'app2'], 'sqlId': ['sql1', 'sql2']})
-            with tempfile.NamedTemporaryFile(prefix='alignment_', suffix='.csv', mode='w') as f:
-                test_alignment.to_csv(f.name, index=False)
+            with tempfile.TemporaryDirectory() as temp_dir:
+                alignment_file = os.path.join(temp_dir, 'alignment.csv')
+                test_alignment.to_csv(alignment_file, index=False)
 
-                mock_config.return_value.alignment_file = f.name
+                mock_config.return_value.alignment_dir = temp_dir
 
                 # Call function
                 align_df = get_alignment()

--- a/user_tools/tests/spark_rapids_tools_ut/qualx/test_qualx_config.py
+++ b/user_tools/tests/spark_rapids_tools_ut/qualx/test_qualx_config.py
@@ -44,6 +44,7 @@ def _qualx_pipeline_config_params(qualx_config_params):
         'platform': 'onprem',
         'eventlogs': {'cpu': ['/path/to/cpu/eventlogs'], 'gpu': ['/path/to/gpu/eventlogs']},
         'output_dir': 'test_output',
+        'alignment_dir': 'alignment',
         **qualx_config_params
     }
 
@@ -56,7 +57,7 @@ class TestQualxConfig(SparkRapidsToolsUT):
         config = QualxConfig(**qualx_config_params)
         assert config.cache_dir == 'qualx_cache'
         assert config.label == 'Duration'
-        assert config.alignment_file is None
+        assert config.alignment_dir is None
 
     def test_environment_variable_overrides(self, monkeypatch, qualx_config_params):
         """Test that environment variables override default values"""
@@ -183,7 +184,7 @@ class TestQualxPipelineConfig(SparkRapidsToolsUT):
             'gpu': ['/path/to/gpu/eventlogs']
         }
         assert config.output_dir == 'test_output'
-        assert config.alignment_file is None  # Default value
+        assert config.alignment_dir == 'alignment'
 
     def test_inheritance(self, qualx_pipeline_config_params):
         """Test that QualxPipelineConfig inherits from QualxConfig"""
@@ -206,3 +207,4 @@ class TestQualxPipelineConfig(SparkRapidsToolsUT):
             'gpu': ['/path/to/gpu/eventlogs']
         }
         assert config.output_dir == 'test_output'
+        assert config.alignment_dir == 'alignment'


### PR DESCRIPTION
This PR integrates the Qualx train_and_evaluate API into spark_rapids CLI and adds associated documentation.  This addresses item 1 of #1650.

Changes:
- Integrates the `train_and_evaluate` command into the `spark_rapids` CLI.
- Changes the `alignment_file` config to `alignment_dir`, since the directory is significant.
- Updates the `qualx.md` docs to describe the `train_and_evaluate` pipeline.

Tests:
- Tested `spark_rapids train_and_evaluate` on existing pipeline.


