### PR TITLE
Prevent empty file creation in case of `sql_info_json_pre_aqe` generation

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileOutputWriter.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileOutputWriter.scala
@@ -87,14 +87,16 @@ class ProfileOutputWriter(outputDir: String, filePrefix: String, numOutputRows: 
    * @param outRows The sequence of profile results to write.
   */
   def writeJsonL(headerText: String, outRows: Seq[ProfileResult]): Unit = {
-    val fileName = headerText.replace(" ", "_").toLowerCase
-    val jsonWriter = new ToolTextFileWriter(outputDir, s"${fileName}.json", s"$headerText JSON:")
-    try {
-      outRows.foreach { row =>
-        jsonWriter.write(Serialization.write(row) + "\n")
+    if (outRows.nonEmpty) {
+      val fileName = headerText.replace(" ", "_").toLowerCase
+      val jsonWriter = new ToolTextFileWriter(outputDir, s"${fileName}.json", s"$headerText JSON:")
+      try {
+        outRows.foreach { row =>
+          jsonWriter.write(Serialization.write(row) + "\n")
+        }
+      } finally {
+        jsonWriter.close()
       }
-    } finally {
-      jsonWriter.close()
     }
   }
 


### PR DESCRIPTION
Fixes #1644 

This tools update the writeJsonL function to only create a file in case output is non empty.