### PR TITLE
Change core mvn profiles to spark-xyz

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -32,6 +32,14 @@ mvn -Dbuildver=351 clean package
 
 Run `mvn help:all-profiles` to list supported Spark versions.
 
+### Building JAR for release
+
+To build a release JAR file, run the profile `release`
+
+```shell script
+mvn clean package -P release
+```
+
 ### Running tests
 
 The unit tests are run by default when building unless they are explicitly skipped by specifying `-DskipTests`.
@@ -45,8 +53,8 @@ mvn test -Dsuites=com.nvidia.spark.rapids.tool.qualification.QualificationSuite
 
 ### Setting up an Integrated Development Environment
 
-Before proceeding with importing spark-rapids-tools into IDEA or switching to a different Spark release
-profile, execute the install phase with the corresponding `buildver`, e.g. for Spark 3.5.0:
+Before proceeding with importing spark-rapids-tools into IDEA or switching to a different Spark
+profile, execute the installation's phase cmd with the corresponding `buildver`, e.g. for Spark 3.5.0:
 
 ##### Manual Maven Install for a target Spark build
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -71,7 +71,7 @@
     </developers>
     <profiles>
         <profile>
-            <id>release320</id>
+            <id>spark320</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -86,7 +86,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release321</id>
+            <id>spark321</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -101,7 +101,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release322</id>
+            <id>spark322</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -116,7 +116,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release323</id>
+            <id>spark323</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -131,7 +131,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release324</id>
+            <id>spark324</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -146,7 +146,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release325</id>
+            <id>spark325</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -161,7 +161,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release330</id>
+            <id>spark330</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -176,7 +176,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release331</id>
+            <id>spark331</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -191,7 +191,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release332</id>
+            <id>spark332</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -206,7 +206,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release333</id>
+            <id>spark333</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -221,7 +221,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release334</id>
+            <id>spark334</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -236,7 +236,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release335</id>
+            <id>spark335</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -251,7 +251,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release340</id>
+            <id>spark340</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -266,7 +266,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release341</id>
+            <id>spark341</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -281,7 +281,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release342</id>
+            <id>spark342</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -296,7 +296,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release343</id>
+            <id>spark343</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -311,7 +311,22 @@
             </properties>
         </profile>
         <profile>
-            <id>release350</id>
+            <id>spark344</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>344</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>344</buildver>
+                <spark.version>${spark344.version}</spark.version>
+                <delta.core.version>${delta24x.version}</delta.core.version>
+                <hadoop.version>3.3.6</hadoop.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>spark350</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
                 <property>
@@ -328,7 +343,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release351</id>
+            <id>spark351</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -344,7 +359,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release352</id>
+            <id>spark352</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -360,7 +375,55 @@
             </properties>
         </profile>
         <profile>
-            <id>release400</id>
+            <id>spark353</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>353</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>353</buildver>
+                <spark.version>${spark353.version}</spark.version>
+                <delta.core.artifactory>${delta.core.artifactory.post35}</delta.core.artifactory>
+                <delta.core.version>${delta31x.version}</delta.core.version>
+                <hadoop.version>3.3.6</hadoop.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>spark354</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>354</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>354</buildver>
+                <spark.version>${spark354.version}</spark.version>
+                <delta.core.artifactory>${delta.core.artifactory.post35}</delta.core.artifactory>
+                <delta.core.version>${delta31x.version}</delta.core.version>
+                <hadoop.version>3.3.6</hadoop.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>spark355</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>355</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>355</buildver>
+                <spark.version>${spark355.version}</spark.version>
+                <delta.core.artifactory>${delta.core.artifactory.post35}</delta.core.artifactory>
+                <delta.core.version>${delta31x.version}</delta.core.version>
+                <hadoop.version>3.3.6</hadoop.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>spark400</id>
             <activation>
                 <property>
                     <name>buildver</name>
@@ -414,10 +477,14 @@
         <spark340.version>3.4.0</spark340.version>
         <spark341.version>3.4.1</spark341.version>
         <spark342.version>3.4.2</spark342.version>
-        <spark343.version>3.4.3-SNAPSHOT</spark343.version>
+        <spark343.version>3.4.3</spark343.version>
+        <spark344.version>3.4.4</spark344.version>
         <spark350.version>3.5.0</spark350.version>
         <spark351.version>3.5.1</spark351.version>
-        <spark352.version>3.5.2-SNAPSHOT</spark352.version>
+        <spark352.version>3.5.2</spark352.version>
+        <spark353.version>3.5.3</spark353.version>
+        <spark354.version>3.5.4</spark354.version>
+        <spark355.version>3.5.5</spark355.version>
         <spark400.version>4.0.0-SNAPSHOT</spark400.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.plugin.version>4.3.0</scala.plugin.version>


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1679

Changes the mvn profiles from `release-xyz` to `spark-xyz`

- change the names of the profiles
- add missing spark releases profiles 3.5.2+
- update the markdown documentation

This change would help customizing the CI/CD pipeline to create releases/testing stages.
