### PR TITLE
Enable tool-specific cluster sizing strategies for Qualification and Profiling tool

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -501,13 +501,13 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
    */
   def createRecommendedGpuClusterInfo(
       sparkProperties: Map[String, String],
-      recommendedClusterShapeStrategy: ClusterShapeStrategy): Unit = {
+      recommendedClusterSizingStrategy: ClusterSizingStrategy): Unit = {
     // Get the appropriate cluster configuration strategy (either
     // 'ClusterPropertyBasedStrategy' based on cluster properties or
     // 'EventLogBasedStrategy' based on the event log).
     val configurationStrategyOpt = ClusterConfigurationStrategy.getStrategy(
       platform = this, sparkProperties = sparkProperties,
-      recommendedClusterShapeStrategy = recommendedClusterShapeStrategy)
+      recommendedClusterSizingStrategy = recommendedClusterSizingStrategy)
 
     configurationStrategyOpt match {
       case Some(strategy) =>

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -499,12 +499,15 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
    * @return Optional `RecommendedClusterInfo` containing the GPU cluster configuration
    *         recommendation.
    */
-  def createRecommendedGpuClusterInfo(sparkProperties: Map[String, String]): Unit = {
+  def createRecommendedGpuClusterInfo(
+      sparkProperties: Map[String, String],
+      recommendedClusterShapeStrategy: ClusterShapeStrategy): Unit = {
     // Get the appropriate cluster configuration strategy (either
     // 'ClusterPropertyBasedStrategy' based on cluster properties or
     // 'EventLogBasedStrategy' based on the event log).
     val configurationStrategyOpt = ClusterConfigurationStrategy.getStrategy(
-      platform = this, sparkProperties = sparkProperties)
+      platform = this, sparkProperties = sparkProperties,
+      recommendedClusterShapeStrategy = recommendedClusterShapeStrategy)
 
     configurationStrategyOpt match {
       case Some(strategy) =>
@@ -620,6 +623,8 @@ class DatabricksAwsPlatform(gpuDevice: Option[GpuDevice],
     Some(NodeInstanceMapKey(instanceType = "g5.8xlarge"))
   }
 
+  override def maxGpusSupported: Int = 4
+
   override def getInstanceMapByName: Map[NodeInstanceMapKey, InstanceInfo] = {
     PlatformInstanceTypes.DATABRICKS_AWS_BY_INSTANCE_NAME
   }
@@ -694,6 +699,7 @@ class EmrPlatform(gpuDevice: Option[GpuDevice],
   }
 
   override def isPlatformCSP: Boolean = true
+  override def maxGpusSupported: Int = 4
   override def requirePathRecommendations: Boolean = false
 
   override def getRetainedSystemProps: Set[String] = Set("EMR_CLUSTER_ID")

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -257,6 +257,10 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
     recommendedNodeInstanceInfo.map(_.gpuDevice).getOrElse(defaultGpuDevice)
   }
 
+  final def recommendedNumGpus: Int = {
+    recommendedNodeInstanceInfo.map(_.numGpus).getOrElse(defaultNumGpus)
+  }
+
   // Default runtime for the platform
   val defaultRuntime: SparkRuntime.SparkRuntime = SparkRuntime.SPARK
   // Set of supported runtimes for the platform

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable
 import scala.util.control.NonFatal
 import scala.util.matching.Regex
 
-import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, ClusterShapeStrategy, GpuDevice, KeepTotalGpuCountStrategy, Platform, PlatformFactory}
+import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, ClusterSizingStrategy, GpuDevice, MaintainGpuCountStrategy, Platform, PlatformFactory}
 import com.nvidia.spark.rapids.tool.profiling._
 import org.yaml.snakeyaml.constructor.ConstructorException
 
@@ -434,7 +434,7 @@ class AutoTuner(
    */
   private def configureGPURecommendedInstanceType(): Unit = {
     platform.createRecommendedGpuClusterInfo(getAllProperties.toMap,
-      autoTunerConfigsProvider.recommendedClusterShapeStrategy)
+      autoTunerConfigsProvider.recommendedClusterSizingStrategy)
     platform.recommendedClusterInfo.foreach { gpuClusterRec =>
       // TODO: Should we skip recommendation if cores per executor is lower than a min value?
       appendRecommendation("spark.executor.cores", gpuClusterRec.coresPerExecutor)
@@ -1344,9 +1344,9 @@ trait AutoTunerConfigsProvider extends Logging {
 
   /**
    * Default strategy for cluster shape recommendation.
-   * See [[com.nvidia.spark.rapids.tool.ClusterShapeStrategy]] for different strategies.
+   * See [[com.nvidia.spark.rapids.tool.ClusterSizingStrategy]] for different strategies.
    */
-  val recommendedClusterShapeStrategy: ClusterShapeStrategy = KeepTotalGpuCountStrategy
+  val recommendedClusterSizingStrategy: ClusterSizingStrategy = MaintainGpuCountStrategy
 
   val commentsForMissingMemoryProps: Map[String, String] = Map(
     "spark.executor.memory" ->

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -1346,7 +1346,7 @@ trait AutoTunerConfigsProvider extends Logging {
    * Default strategy for cluster shape recommendation.
    * See [[com.nvidia.spark.rapids.tool.ClusterSizingStrategy]] for different strategies.
    */
-  val recommendedClusterSizingStrategy: ClusterSizingStrategy = MaintainGpuCountStrategy
+  lazy val recommendedClusterSizingStrategy: ClusterSizingStrategy = MaintainGpuCountStrategy
 
   val commentsForMissingMemoryProps: Map[String, String] = Map(
     "spark.executor.memory" ->

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable
 import scala.util.control.NonFatal
 import scala.util.matching.Regex
 
-import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, GpuDevice, Platform, PlatformFactory}
+import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, ClusterShapeStrategy, GpuDevice, KeepTotalGpuCountStrategy, Platform, PlatformFactory}
 import com.nvidia.spark.rapids.tool.profiling._
 import org.yaml.snakeyaml.constructor.ConstructorException
 
@@ -433,7 +433,8 @@ class AutoTuner(
    * Returns None if the platform doesn't support specific instance types.
    */
   private def configureGPURecommendedInstanceType(): Unit = {
-    platform.createRecommendedGpuClusterInfo(getAllProperties.toMap)
+    platform.createRecommendedGpuClusterInfo(getAllProperties.toMap,
+      autoTunerConfigsProvider.recommendedClusterShapeStrategy)
     platform.recommendedClusterInfo.foreach { gpuClusterRec =>
       // TODO: Should we skip recommendation if cores per executor is lower than a min value?
       appendRecommendation("spark.executor.cores", gpuClusterRec.coresPerExecutor)
@@ -1340,6 +1341,12 @@ trait AutoTunerConfigsProvider extends Logging {
   val filteredPropKeys: Set[String] = Set(
     "spark.app.id"
   )
+
+  /**
+   * Default strategy for cluster shape recommendation.
+   * See [[com.nvidia.spark.rapids.tool.ClusterShapeStrategy]] for different strategies.
+   */
+  val recommendedClusterShapeStrategy: ClusterShapeStrategy = KeepTotalGpuCountStrategy
 
   val commentsForMissingMemoryProps: Map[String, String] = Map(
     "spark.executor.memory" ->

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable
 import scala.util.control.NonFatal
 import scala.util.matching.Regex
 
-import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, ClusterSizingStrategy, GpuDevice, MaintainGpuCountStrategy, Platform, PlatformFactory}
+import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, ClusterSizingStrategy, ConstantGpuCountStrategy, GpuDevice, Platform, PlatformFactory}
 import com.nvidia.spark.rapids.tool.profiling._
 import org.yaml.snakeyaml.constructor.ConstructorException
 
@@ -1346,7 +1346,7 @@ trait AutoTunerConfigsProvider extends Logging {
    * Default strategy for cluster shape recommendation.
    * See [[com.nvidia.spark.rapids.tool.ClusterSizingStrategy]] for different strategies.
    */
-  lazy val recommendedClusterSizingStrategy: ClusterSizingStrategy = MaintainGpuCountStrategy
+  lazy val recommendedClusterSizingStrategy: ClusterSizingStrategy = ConstantGpuCountStrategy
 
   val commentsForMissingMemoryProps: Map[String, String] = Map(
     "spark.executor.memory" ->

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTuner.scala
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids.tool.tuning
 
 import scala.collection.mutable
 
-import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, Platform}
+import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, ClusterShapeStrategy, KeepTotalCoresStrategy, Platform}
 import com.nvidia.spark.rapids.tool.profiling.DriverLogInfoProvider
 
 /**
@@ -50,6 +50,8 @@ object QualificationAutoTunerConfigsProvider extends AutoTunerConfigsProvider {
   // For qualification tool's auto-tuner, the batch size to be recommended is 1GB
   // See https://github.com/NVIDIA/spark-rapids-tools/issues/1399
   override val BATCH_SIZE_BYTES = 1073741824
+
+  override val recommendedClusterShapeStrategy: ClusterShapeStrategy = KeepTotalCoresStrategy
 
   override def createAutoTunerInstance(
       clusterProps: ClusterProperties,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTuner.scala
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids.tool.tuning
 
 import scala.collection.mutable
 
-import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, ClusterSizingStrategy, MaintainCoresStrategy, Platform}
+import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, ClusterSizingStrategy, ConstantTotalCoresStrategy, Platform}
 import com.nvidia.spark.rapids.tool.profiling.DriverLogInfoProvider
 
 /**
@@ -51,7 +51,12 @@ object QualificationAutoTunerConfigsProvider extends AutoTunerConfigsProvider {
   // See https://github.com/NVIDIA/spark-rapids-tools/issues/1399
   override val BATCH_SIZE_BYTES = 1073741824
 
-  override lazy val recommendedClusterSizingStrategy: ClusterSizingStrategy = MaintainCoresStrategy
+  /**
+   * For the Qualification Tool's recommendation for cluster sizing, we want to keep
+   * the total number of CPU cores between the source and target clusters constant.
+   */
+  override lazy val recommendedClusterSizingStrategy: ClusterSizingStrategy =
+    ConstantTotalCoresStrategy
 
   override def createAutoTunerInstance(
       clusterProps: ClusterProperties,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTuner.scala
@@ -51,7 +51,7 @@ object QualificationAutoTunerConfigsProvider extends AutoTunerConfigsProvider {
   // See https://github.com/NVIDIA/spark-rapids-tools/issues/1399
   override val BATCH_SIZE_BYTES = 1073741824
 
-  override val recommendedClusterSizingStrategy: ClusterSizingStrategy = MaintainCoresStrategy
+  override lazy val recommendedClusterSizingStrategy: ClusterSizingStrategy = MaintainCoresStrategy
 
   override def createAutoTunerInstance(
       clusterProps: ClusterProperties,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTuner.scala
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids.tool.tuning
 
 import scala.collection.mutable
 
-import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, ClusterShapeStrategy, KeepTotalCoresStrategy, Platform}
+import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, ClusterSizingStrategy, MaintainCoresStrategy, Platform}
 import com.nvidia.spark.rapids.tool.profiling.DriverLogInfoProvider
 
 /**
@@ -51,7 +51,7 @@ object QualificationAutoTunerConfigsProvider extends AutoTunerConfigsProvider {
   // See https://github.com/NVIDIA/spark-rapids-tools/issues/1399
   override val BATCH_SIZE_BYTES = 1073741824
 
-  override val recommendedClusterShapeStrategy: ClusterShapeStrategy = KeepTotalCoresStrategy
+  override val recommendedClusterSizingStrategy: ClusterSizingStrategy = MaintainCoresStrategy
 
   override def createAutoTunerInstance(
       clusterProps: ClusterProperties,

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ClusterRecommendationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ClusterRecommendationSuite.scala
@@ -103,9 +103,9 @@ class ClusterRecommendationSuite extends FunSuite with Logging with TableDrivenP
       RecommendedClusterInfo(
         vendor = PlatformNames.EMR,
         coresPerExecutor = 32,
-        numWorkerNodes = 4,
+        numWorkerNodes = 8,
         numGpusPerNode = 1,
-        numExecutors = 4,
+        numExecutors = 8,
         gpuDevice = GpuTypes.L4,
         dynamicAllocationEnabled = false,
         dynamicAllocationMaxExecutors = "N/A",
@@ -120,9 +120,9 @@ class ClusterRecommendationSuite extends FunSuite with Logging with TableDrivenP
       RecommendedClusterInfo(
         vendor = PlatformNames.DATABRICKS_AWS,
         coresPerExecutor = 32,
-        numWorkerNodes = 4,
+        numWorkerNodes = 8,
         numGpusPerNode = 1,
-        numExecutors = 4,
+        numExecutors = 8,
         gpuDevice = GpuTypes.A10G,
         dynamicAllocationEnabled = false,
         dynamicAllocationMaxExecutors = "N/A",


### PR DESCRIPTION
Fixes #1677 

## Feature Request

We want to use different strategies for recommending cluster shapes in the Qualification and Profiling tools (see issue description for reasoning). This PR introduces a new abstraction to support this.

## Changes

- Introduced an abstract base class `ClusterSizingStrategy` with the following implementations:
  1. `MaintainCoresStrategy` - Maintains the total number of CPU cores between the source and target clusters. It adjusts the number of executors (and hence GPUs) accordingly.
     
  2. `MaintainGpuCountStrategy`- Maintains the total number of GPUs between the source and target clusters. The number of executors remains unchanged.

- Tool-specific strategies:
  - Profiling Tool (AutoTuner) uses `MaintainGpuCountStrategy`.
  - Qualification Tool (Bootstrap) uses `MaintainCoresStrategy`.

## Output

CMD
```bash
 spark_rapids profiling \
  --platform $PLATFORM \
  --eventlogs $EVENT_LOG \
  --target-cluster-info $PATH_TO_TARGET_YAML 
```

with 
```yaml
workerInfo:
  instanceType: g2-standard-16
```

#### Previous Output (keeping total cores between source and target constant)

<details>
<summary>Cluster Information</summary>
<pre>
[ {
  "appName" : "app-test",
  "appId" : "application_xxx_0001",
  "eventLogPath" : "/path/to/log",
  "sourceClusterInfo" : {
    "vendor" : "dataproc",
    "coresPerExecutor" : 7,
    "numExecsPerNode" : -1,
    "numExecutors" : 30,
    "numWorkerNodes" : 30,
    "executorHeapMemory" : 40960,
    "dynamicAllocationEnabled" : true,
    "dynamicAllocationMaxExecutors" : "10000",
    "dynamicAllocationMinExecutors" : "1",
    "dynamicAllocationInitialExecutors" : "2",
    "driverHost" : "xxx.yyy.zzz.internal"
  },
  "recommendedClusterInfo" : {
    "vendor" : "dataproc",
    "coresPerExecutor" : 16,
    "numWorkerNodes" : 14,
    "numGpusPerNode" : 1,
    "numExecutors" : 14,
    "gpuDevice" : "l4",
    "dynamicAllocationEnabled" : true,
    "dynamicAllocationMaxExecutors" : "10000",
    "dynamicAllocationMinExecutors" : "1",
    "dynamicAllocationInitialExecutors" : "2",
    "workerNodeType" : "g2-standard-16"
  }
} ]
</pre>
</details>

#### After this change (keeping total num GPUs between source and target constant)

<details>
<summary>Cluster Information</summary>
<pre>
[ {
  "appName" : "app-test",
  "appId" : "application_xxx_0001",
  "eventLogPath" : "/path/to/log",
  "sourceClusterInfo" : {
    "vendor" : "dataproc",
    "coresPerExecutor" : 7,
    "numExecsPerNode" : -1,
    "numExecutors" : 30,
    "numWorkerNodes" : 30,
    "executorHeapMemory" : 40960,
    "dynamicAllocationEnabled" : true,
    "dynamicAllocationMaxExecutors" : "10000",
    "dynamicAllocationMinExecutors" : "1",
    "dynamicAllocationInitialExecutors" : "2",
    "driverHost" : "xxx.yyy.zzz.internal"
  },
  "recommendedClusterInfo" : {
    "vendor" : "dataproc",
    "coresPerExecutor" : 16,
    "numWorkerNodes" : 30,
    "numGpusPerNode" : 1,
    "numExecutors" : 30,
    "gpuDevice" : "l4",
    "dynamicAllocationEnabled" : true,
    "dynamicAllocationMaxExecutors" : "10000",
    "dynamicAllocationMinExecutors" : "1",
    "dynamicAllocationInitialExecutors" : "2",
    "workerNodeType" : "g2-standard-16"
  }
} ]
</pre>
</details>


**Note**:
- This PR changes the behaviour only for Profiling Tool.


## Testing

- Updated UTs in `profiling.ProfilingAutoTunerSuite` and `profiling.ClusterRecommendationSuite`  to ensure the recommended number of executors matches the source and keep the GPU count the same as source.
