### PR TITLE
Add support for Bit operations

### DIFF
--- a/core/src/main/resources/operatorsScore-databricks-aws-a10G.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws-a10G.csv
@@ -315,3 +315,7 @@ HyperLogLogPlusPlus,1.5
 ArrayPosition,1.5
 Sha1,1.5
 ArrayDistinct,1.5
+BitwiseCount,1.5
+BitAndAgg,1.5
+BitOrAgg,1.5
+BitXorAgg,1.5

--- a/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
@@ -315,3 +315,7 @@ HyperLogLogPlusPlus,1.5
 ArrayPosition,1.5
 Sha1,1.5
 ArrayDistinct,1.5
+BitwiseCount,1.5
+BitAndAgg,1.5
+BitOrAgg,1.5
+BitXorAgg,1.5

--- a/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
@@ -303,3 +303,7 @@ HyperLogLogPlusPlus,1.5
 ArrayPosition,1.5
 Sha1,1.5
 ArrayDistinct,1.5
+BitwiseCount,1.5
+BitAndAgg,1.5
+BitOrAgg,1.5
+BitXorAgg,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
@@ -297,3 +297,7 @@ HyperLogLogPlusPlus,1.5
 ArrayPosition,1.5
 Sha1,1.5
 ArrayDistinct,1.5
+BitwiseCount,1.5
+BitAndAgg,1.5
+BitOrAgg,1.5
+BitXorAgg,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
@@ -297,3 +297,7 @@ HyperLogLogPlusPlus,1.5
 ArrayPosition,1.5
 Sha1,1.5
 ArrayDistinct,1.5
+BitwiseCount,1.5
+BitAndAgg,1.5
+BitOrAgg,1.5
+BitXorAgg,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-l4.csv
@@ -303,3 +303,7 @@ HyperLogLogPlusPlus,1.5
 ArrayPosition,1.5
 Sha1,1.5
 ArrayDistinct,1.5
+BitwiseCount,1.5
+BitAndAgg,1.5
+BitOrAgg,1.5
+BitXorAgg,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
@@ -297,3 +297,7 @@ HyperLogLogPlusPlus,1.5
 ArrayPosition,1.5
 Sha1,1.5
 ArrayDistinct,1.5
+BitwiseCount,1.5
+BitAndAgg,1.5
+BitOrAgg,1.5
+BitXorAgg,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-t4.csv
@@ -303,3 +303,7 @@ HyperLogLogPlusPlus,1.5
 ArrayPosition,1.5
 Sha1,1.5
 ArrayDistinct,1.5
+BitwiseCount,1.5
+BitAndAgg,1.5
+BitOrAgg,1.5
+BitXorAgg,1.5

--- a/core/src/main/resources/operatorsScore-emr-a10.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10.csv
@@ -303,3 +303,7 @@ HyperLogLogPlusPlus,1.5
 ArrayPosition,1.5
 Sha1,1.5
 ArrayDistinct,1.5
+BitwiseCount,1.5
+BitAndAgg,1.5
+BitOrAgg,1.5
+BitXorAgg,1.5

--- a/core/src/main/resources/operatorsScore-emr-a10G.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10G.csv
@@ -303,3 +303,7 @@ HyperLogLogPlusPlus,1.5
 ArrayPosition,1.5
 Sha1,1.5
 ArrayDistinct,1.5
+BitwiseCount,1.5
+BitAndAgg,1.5
+BitOrAgg,1.5
+BitXorAgg,1.5

--- a/core/src/main/resources/operatorsScore-emr-t4.csv
+++ b/core/src/main/resources/operatorsScore-emr-t4.csv
@@ -303,3 +303,7 @@ HyperLogLogPlusPlus,1.5
 ArrayPosition,1.5
 Sha1,1.5
 ArrayDistinct,1.5
+BitwiseCount,1.5
+BitAndAgg,1.5
+BitOrAgg,1.5
+BitXorAgg,1.5

--- a/core/src/main/resources/operatorsScore-onprem-a100.csv
+++ b/core/src/main/resources/operatorsScore-onprem-a100.csv
@@ -315,3 +315,7 @@ HyperLogLogPlusPlus,1.5
 ArrayPosition,1.5
 Sha1,1.5
 ArrayDistinct,1.5
+BitwiseCount,1.5
+BitAndAgg,1.5
+BitOrAgg,1.5
+BitXorAgg,1.5

--- a/core/src/main/resources/supportedExprs.csv
+++ b/core/src/main/resources/supportedExprs.csv
@@ -107,6 +107,8 @@ BitwiseAnd,S,`&`,None,project,result,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 BitwiseAnd,S,`&`,None,AST,lhs,NA,NS,NS,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 BitwiseAnd,S,`&`,None,AST,rhs,NA,NS,NS,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 BitwiseAnd,S,`&`,None,AST,result,NA,NS,NS,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+BitwiseCount,S,`bit_count`,None,project,input,S,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+BitwiseCount,S,`bit_count`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 BitwiseNot,S,`~`,None,project,input,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 BitwiseNot,S,`~`,None,project,result,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 BitwiseNot,S,`~`,None,AST,input,NA,NS,NS,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
@@ -123,6 +125,18 @@ BitwiseXor,S,`^`,None,project,result,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 BitwiseXor,S,`^`,None,AST,lhs,NA,NS,NS,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 BitwiseXor,S,`^`,None,AST,rhs,NA,NS,NS,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 BitwiseXor,S,`^`,None,AST,result,NA,NS,NS,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+BitAndAgg,S,`bit_and`,None,aggregation,input,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+BitAndAgg,S,`bit_and`,None,aggregation,result,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+BitAndAgg,S,`bit_and`,None,reduction,input,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+BitAndAgg,S,`bit_and`,None,reduction,result,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+BitOrAgg,S,`bit_or`,None,aggregation,input,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+BitOrAgg,S,`bit_or`,None,aggregation,result,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+BitOrAgg,S,`bit_or`,None,reduction,input,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+BitOrAgg,S,`bit_or`,None,reduction,result,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+BitXorAgg,S,`bit_xor`,None,aggregation,input,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+BitXorAgg,S,`bit_xor`,None,aggregation,result,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+BitXorAgg,S,`bit_xor`,None,reduction,input,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+BitXorAgg,S,`bit_xor`,None,reduction,result,NA,S,S,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 BloomFilterMightContain,S,`might_contain`,None,project,lhs,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,S,NA,NA,NA,NA,NA,NA,NA
 BloomFilterMightContain,S,`might_contain`,None,project,rhs,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA
 BloomFilterMightContain,S,`might_contain`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1686

Add support for Bit operations:
- `BitwiseCount`
- `BitAndAgg`
- `BitOrAgg`
- `BitXorAgg`
