### PR TITLE
Remove cast of taskCpu and taskGpu to int in Qualx default.py featurizer

### DIFF
--- a/user_tools/src/spark_rapids_tools/tools/qualx/featurizers/default.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/featurizers/default.py
@@ -230,6 +230,10 @@ def extract_raw_features(
         app_duration_sum = app_duration_sum.rename(columns={'duration_sum': 'appDuration'})
         app_tbl = app_tbl.merge(app_duration_sum, on=['appId'], how='left', suffixes=['_orig', None])
 
+    # ensure task features are valid floats
+    app_task_features = ['taskCpu', 'taskGpu']
+    app_tbl[app_task_features] = app_tbl[app_task_features].fillna(0.0)
+
     # normalize timings from ns to ms
     ns_timing_mask = ops_tbl['metricType'] == 'nsTiming'
     ops_tbl.loc[ns_timing_mask, 'max'] = (

--- a/user_tools/src/spark_rapids_tools/tools/qualx/featurizers/default.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/featurizers/default.py
@@ -230,10 +230,6 @@ def extract_raw_features(
         app_duration_sum = app_duration_sum.rename(columns={'duration_sum': 'appDuration'})
         app_tbl = app_tbl.merge(app_duration_sum, on=['appId'], how='left', suffixes=['_orig', None])
 
-    # normalize dtypes
-    app_int_dtypes = ['taskCpu', 'taskGpu']
-    app_tbl[app_int_dtypes] = app_tbl[app_int_dtypes].fillna(0).astype(int)
-
     # normalize timings from ns to ms
     ns_timing_mask = ops_tbl['metricType'] == 'nsTiming'
     ops_tbl.loc[ns_timing_mask, 'max'] = (


### PR DESCRIPTION
This PR removes the casting of `taskCpu` and `taskGpu` Qualx features to integer types, since `taskGpu` can be a fractional value, e.g. 0.125.

Tests:
- `spark_rapids prediction`
- `python qualx_main.py preprocess`
- `python qualx_main.py train`
- `python qualx_main.py evaluate`
