### PR TITLE
AutoTuner: Fix executor memory recommendation by accounting for off-heap usage and container reservations

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/ClusterConfigurationStrategy.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/ClusterConfigurationStrategy.scala
@@ -271,15 +271,15 @@ class EventLogBasedStrategy(
    * this method returns the memory per node.
    *
    * Reference:
-   * https://github.com/apache/spark/blob/branch-3.5/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala#L536
+   * https://spark.apache.org/docs/3.5.5/configuration.html#:~:text=spark.executor.memoryOverhead,pyspark.memory.
    */
   // scalastyle:on line.size.limit
   override def getMemoryPerNodeMb: Long = {
     val heapMemMB = clusterInfoFromEventLog.executorHeapMemory
     val overheadMemMB = platform.getExecutorOverheadMemoryMB(sparkProperties)
-    // This includes spark.memory.offHeap.size and spark.executor.pyspark.memor
-    val offHeapMemMB = platform.getTotalOffHeapMemoryMB(sparkProperties)
-    heapMemMB + overheadMemMB + offHeapMemMB
+    val sparkOffHeapMemMB = platform.getSparkOffHeapMemoryMB(sparkProperties).getOrElse(0L)
+    val pySparkMemMB = platform.getPySparkMemoryMB(sparkProperties).getOrElse(0L)
+    heapMemMB + overheadMemMB + sparkOffHeapMemMB + pySparkMemMB
   }
 
   override def calculateInitialNumExecutors: Int = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/ClusterConfigurationStrategy.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/ClusterConfigurationStrategy.scala
@@ -265,12 +265,21 @@ class EventLogBasedStrategy(
       throw new IllegalArgumentException("Cluster information from event log must be defined"))
   }
 
-  // For onprem or cases where a matching CSP instance type is unavailable,
-  // Returns the memory per node
+  // scalastyle:off line.size.limit
+  /**
+   * For onprem or cases where a matching CSP instance type is unavailable,
+   * this method returns the memory per node.
+   *
+   * Reference:
+   * https://github.com/apache/spark/blob/branch-3.5/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala#L536
+   */
+  // scalastyle:on line.size.limit
   override def getMemoryPerNodeMb: Long = {
     val heapMemMB = clusterInfoFromEventLog.executorHeapMemory
     val overheadMemMB = platform.getExecutorOverheadMemoryMB(sparkProperties)
-    heapMemMB + overheadMemMB
+    // This includes spark.memory.offHeap.size and spark.executor.pyspark.memor
+    val offHeapMemMB = platform.getTotalOffHeapMemoryMB(sparkProperties)
+    heapMemMB + overheadMemMB + offHeapMemMB
   }
 
   override def calculateInitialNumExecutors: Int = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -222,7 +222,6 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
    */
   def fractionOfAvailableMemory: Double = 1.0
 
-
   val sparkVersionLabel: String = "Spark version"
 
   // It's not deal to use vars here but to minimize changes and

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -217,10 +217,10 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
 
   /**
    * Fraction of the system’s total memory that is available for executor use.
-   * This value should be adjusted based on the platform to account for memory
+   * This value should be set based on the platform to account for memory
    * reserved by the resource managers (e.g., YARN).
    */
-  def fractionOfAvailableMemory: Double = 1.0
+  def fractionOfSystemMemoryForExecutors: Double
 
   val sparkVersionLabel: String = "Spark version"
 
@@ -414,28 +414,23 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
     }
   }
 
-  private def getExecutorOffHeapMemoryMB(sparkProperties: Map[String, String]): Long = {
-    val offHeapEnabled = sparkProperties.getOrElse("spark.memory.offHeap.enabled", "false")
-      .toBoolean
-    if (offHeapEnabled) {
-      sparkProperties.get("spark.memory.offHeap.size").map {
-        size => StringUtils.convertToMB(size, Some(ByteUnit.BYTE))
-      }.getOrElse(0L)
-    } else {
-      0L
+  def getSparkOffHeapMemoryMB(sparkProperties: Map[String, String]): Option[Long] = {
+    // Return if offHeap is not enabled
+    if (!sparkProperties.getOrElse("spark.memory.offHeap.enabled", "false").toBoolean) {
+      return None
+    }
+
+    sparkProperties.get("spark.memory.offHeap.size").map { size =>
+      StringUtils.convertToMB(size, Some(ByteUnit.BYTE))
     }
   }
 
-  private def getPySparkMemoryMB(sparkProperties: Map[String, String]): Long = {
+  def getPySparkMemoryMB(sparkProperties: Map[String, String]): Option[Long] = {
     // Avoiding explicitly checking if it is PySpark app, if the user has set
     // the memory for PySpark, we will use that.
     sparkProperties.get("spark.executor.pyspark.memory").map {
       size => StringUtils.convertToMB(size, Some(ByteUnit.MiB))
-    }.getOrElse(0L)
-  }
-
-  def getTotalOffHeapMemoryMB(sparkProperties: Map[String, String]): Long = {
-    getExecutorOffHeapMemoryMB(sparkProperties) + getPySparkMemoryMB(sparkProperties)
+    }
   }
 
   def getExecutorOverheadMemoryMB(sparkProperties: Map[String, String]): Long = {
@@ -669,6 +664,12 @@ class DatabricksAwsPlatform(gpuDevice: Option[GpuDevice],
   override def getInstanceMapByName: Map[NodeInstanceMapKey, InstanceInfo] = {
     PlatformInstanceTypes.DATABRICKS_AWS_BY_INSTANCE_NAME
   }
+
+  /**
+   * Could not find public documentation for this. This was determined based on
+   * manual inspection of Databricks AWS configurations.
+   */
+  override def fractionOfSystemMemoryForExecutors = 0.65
 }
 
 class DatabricksAzurePlatform(gpuDevice: Option[GpuDevice],
@@ -683,6 +684,12 @@ class DatabricksAzurePlatform(gpuDevice: Option[GpuDevice],
   override def getInstanceMapByName: Map[NodeInstanceMapKey, InstanceInfo] = {
     PlatformInstanceTypes.AZURE_NCAS_T4_V3_BY_INSTANCE_NAME
   }
+
+  /**
+   * Could not find public documentation for this. This was determined based on
+   * manual inspection of Databricks Azure configurations.
+   */
+  override def fractionOfSystemMemoryForExecutors = 0.7
 }
 
 class DataprocPlatform(gpuDevice: Option[GpuDevice],
@@ -701,7 +708,7 @@ class DataprocPlatform(gpuDevice: Option[GpuDevice],
    * Reference: https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/autoscaling#hadoop_yarn_metrics
    */
   // scalastyle:on line.size.limit
-  override def fractionOfAvailableMemory: Double = 0.8
+  override def fractionOfSystemMemoryForExecutors: Double = 0.8
 
   override val recommendationsToInclude: Seq[(String, String)] = Seq(
     // Keep disabled. This property does not work well with GPU clusters.
@@ -752,7 +759,7 @@ class EmrPlatform(gpuDevice: Option[GpuDevice],
    * Reference: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-hadoop-task-config.html#emr-hadoop-task-config-g6
    */
   // scalastyle:on line.size.limit
-  override def fractionOfAvailableMemory: Double = 0.7
+  override def fractionOfSystemMemoryForExecutors: Double = 0.7
 
   override def isPlatformCSP: Boolean = true
   override def requirePathRecommendations: Boolean = false
@@ -795,6 +802,14 @@ class OnPremPlatform(gpuDevice: Option[GpuDevice],
   // on prem is hard since we don't know what node configurations they have
   // assume 1 for now. We should have them pass this information in the future.
   override lazy val maxGpusSupported: Int = 1
+
+  /**
+   * For OnPrem, setting this value to 1.0 since we are calculating the
+   * overall memory by ourselves or it is provided by the user.
+   *
+   * See `getMemoryPerNodeMb()` in [[com.nvidia.spark.rapids.tool.ClusterConfigurationStrategy]]
+   */
+  def fractionOfSystemMemoryForExecutors: Double = 1.0
 }
 
 object Platform {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -534,12 +534,12 @@ class AutoTuner(
       // Add a warning comment indicating that the current setup is not optimal
       // and no memory-related tunings are recommended.
       // TODO: For CSPs, we should recommend a different instance type.
-      val minExecutorContainerMem = (
+      val minTotalExecMemRequired = (
         // Estimate total executor memory by reversing the memory fraction adjustment.
         // This accounts for memory reserved by the container manager (e.g., YARN).
         (executorHeap + minOverhead + offHeapMemSetByUser) / platform.fractionOfAvailableMemory
       ).toLong
-      Left(autoTunerConfigsProvider.notEnoughMemComment(minExecutorContainerMem))
+      Left(autoTunerConfigsProvider.notEnoughMemComment(minTotalExecMemRequired))
     }
   }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -1520,8 +1520,8 @@ trait AutoTunerConfigsProvider extends Logging {
     s"""
        |This node/worker configuration is not ideal for using the RAPIDS Accelerator
        |for Apache Spark because it doesn't have enough memory for the executors.
-       |We recommend using nodes/workers with more memory. Need at least $minSizeInMB MB
-       |memory per executor.
+       |We recommend using nodes/workers with more memory or reduce 'spark.memory.offHeap.size'.
+       |Need at least $minSizeInMB MB memory per executor.
        |""".stripMargin.trim.replaceAll("\n", "\n  ")
   }
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
@@ -55,6 +55,7 @@ class AppInfoProviderMockTest(val maxInput: Double,
   override def getMeanShuffleRead: Double = meanShuffleRead
   override def getSpilledMetrics: Seq[Long] = spilledMetrics
   override def getJvmGCFractions: Seq[Double] = jvmGCFractions
+  override def getAllProperties: Map[String, String] = propsFromLog.toMap
   override def getRapidsProperty(propKey: String): Option[String] = propsFromLog.get(propKey)
   override def getSparkProperty(propKey: String): Option[String] = propsFromLog.get(propKey)
   override def getSystemProperty(propKey: String): Option[String] = propsFromLog.get(propKey)

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -157,7 +157,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=2
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -285,15 +285,48 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
-    val expectedResults = Seq(
-      "--conf spark.executor.memory=[FILL_IN_VALUE]",
-      "--conf spark.rapids.memory.pinnedPool.size=[FILL_IN_VALUE]",
-      s"- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.executor.memory")}",
-      s"- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.rapids.memory.pinnedPool.size")}",
-      s"- ${ProfilingAutoTunerConfigsProvider.notEnoughMemComment(42188)}"
-    )
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.executor.cores=16
+          |--conf spark.executor.instances=8
+          |--conf spark.executor.memory=[FILL_IN_VALUE]
+          |--conf spark.locality.wait=0
+          |--conf spark.rapids.memory.pinnedPool.size=[FILL_IN_VALUE]
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=24
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
+          |--conf spark.rapids.sql.concurrentGpuTasks=2
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=32
+          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
+          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
+          |--conf spark.sql.files.maxPartitionBytes=512m
+          |--conf spark.task.resource.gpu.amount=0.001
+          |
+          |Comments:
+          |- 'spark.executor.cores' was not set.
+          |- 'spark.executor.instances' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- 'spark.rapids.sql.concurrentGpuTasks' was not set.
+          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
+          |- 'spark.shuffle.manager' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+          |- 'spark.sql.files.maxPartitionBytes' was not set.
+          |- 'spark.task.resource.gpu.amount' was not set.
+          |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.executor.memory")}
+          |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.rapids.memory.pinnedPool.size")}
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
+          |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemComment(40140)}
+          |""".stripMargin
     // scalastyle:on line.size.limit
-    assert(expectedResults.forall(autoTunerOutput.contains))
+    compareOutput(expectedResults, autoTunerOutput)
   }
 
   test("Load cluster properties with CPU memory missing") {
@@ -347,7 +380,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=8
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -413,7 +446,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=2
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -489,7 +522,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=4
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
@@ -557,7 +590,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
@@ -622,7 +655,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
@@ -681,7 +714,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
@@ -745,7 +778,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
@@ -799,7 +832,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=4
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -859,7 +892,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=8
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -960,9 +993,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -1042,9 +1074,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -1115,9 +1146,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -1199,9 +1229,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -1287,9 +1316,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -1371,9 +1399,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -1450,9 +1477,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -1523,7 +1549,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
@@ -1569,7 +1595,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
@@ -1617,7 +1643,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
@@ -1688,9 +1714,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.filecache.enabled=true
           |--conf spark.rapids.memory.pinnedPool.size=4g
@@ -1769,9 +1794,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -2068,9 +2092,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -2419,9 +2442,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -2502,9 +2524,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -2566,9 +2587,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.kryo.registrator=com.nvidia.spark.rapids.GpuKryoRegistrator
           |--conf spark.kryoserializer.buffer.max=512m
           |--conf spark.locality.wait=0
@@ -2642,9 +2662,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.kryo.registrator=org.apache.SomeRegistrator,org.apache.SomeOtherRegistrator,com.nvidia.spark.rapids.GpuKryoRegistrator
           |--conf spark.kryoserializer.buffer.max=512m
           |--conf spark.locality.wait=0
@@ -2718,9 +2737,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.kryo.registrator=com.nvidia.spark.rapids.GpuKryoRegistrator
           |--conf spark.kryoserializer.buffer.max=512m
           |--conf spark.locality.wait=0
@@ -2797,11 +2815,10 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       s"""|
           |Spark Properties:
           |--conf spark.executor.cores=16
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=13106m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=2867m
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -2862,9 +2879,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -2932,9 +2948,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       s"""|
           |Spark Properties:
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
-          |--conf spark.executor.instances=20
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -3010,9 +3025,8 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
             |Spark Properties:
             |--conf spark.dataproc.enhanced.execution.enabled=false
             |--conf spark.dataproc.enhanced.optimizer.enabled=false
-            |--conf spark.executor.instances=8
             |--conf spark.executor.memory=32g
-            |--conf spark.executor.memoryOverhead=17612m
+            |--conf spark.executor.memoryOverhead=15564m
             |--conf spark.locality.wait=0
             |--conf spark.rapids.memory.pinnedPool.size=4g
             |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -3107,7 +3121,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
             |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.executor.memory")}
             |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.rapids.memory.pinnedPool.size")}
             |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
-            |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemComment(42188)}
+            |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemComment(40140)}
             |""".stripMargin.trim
       // scalastyle:on line.size.limit
       compareOutput(expectedResults, actualResults)
@@ -3148,7 +3162,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -3227,7 +3241,7 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=17612m
+          |--conf spark.executor.memoryOverhead=15564m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -3375,20 +3389,20 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
   // Test cases for memory overhead configuration
   testMemoryOverhead(
     testName = "Test memory overhead with unit should be skipped when appropriate",
-    initialValue = "17612m",
+    initialValue = "15564m",
     expectedValue = None
   )
 
   testMemoryOverhead(
     testName = "Test memory overhead without unit should be skipped when appropriate",
-    initialValue = "17612",
+    initialValue = "15564",
     expectedValue = None
   )
 
   testMemoryOverhead(
     testName = "Test memory overhead without unit should be updated and set",
     initialValue = "8712",
-    expectedValue = Some("17612m")
+    expectedValue = Some("15564m")
   )
 
   // Test cases for Kryo buffer configuration
@@ -3410,8 +3424,9 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     expectedValue = Some("512m")
   )
 
-  test("Test AutoTuner considers off heap memory in memory calculations - " +
-    "sufficient memory available") {
+  // Verifies that AutoTuner accounts for off-heap memory and recommends
+  // memory configurations when sufficient memory is available for the executor.
+  test("AutoTuner recommends memory configs when executor memory is sufficient after off-heap") {
     // mock the properties loaded from eventLog
     val logEventsProps: mutable.Map[String, String] =
       mutable.LinkedHashMap[String, String](
@@ -3487,8 +3502,11 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     compareOutput(expectedResults, autoTunerOutput)
   }
 
-  test("Test AutoTuner considers off heap memory in memory calculations - " +
-    "not enough memory") {
+  // Verifies that AutoTuner accounts for high off-heap memory and skips
+  // recommendations for memory configurations when sufficient memory is
+  // not available for the executor.
+  test("AutoTuner warns and skips memory configs when executor memory is " +
+    "not sufficient after off-heap") {
     // mock the properties loaded from eventLog
     val logEventsProps: mutable.Map[String, String] =
       mutable.LinkedHashMap[String, String](

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -20,7 +20,7 @@ import java.io.{File, FileNotFoundException}
 
 import scala.collection.mutable
 
-import com.nvidia.spark.rapids.tool.{A100Gpu, AppSummaryInfoBaseProvider, GpuDevice, Platform, PlatformFactory, PlatformNames, T4Gpu, ToolTestUtils}
+import com.nvidia.spark.rapids.tool.{A100Gpu, AppSummaryInfoBaseProvider, GpuDevice, InstanceInfo, NodeInstanceMapKey, Platform, PlatformFactory, PlatformInstanceTypes, PlatformNames, T4Gpu, ToolTestUtils}
 import com.nvidia.spark.rapids.tool.planparser.DatabricksParseHelper
 import com.nvidia.spark.rapids.tool.profiling.{DriverLogUnsupportedOperators, ProfileArgs, ProfileMain, Profiler}
 import org.scalatest.prop.TableDrivenPropertyChecks._
@@ -81,6 +81,20 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
       gpuDevice: Option[String] = Some(GpuDevice.DEFAULT.toString)): String = {
     buildWorkerInfoAsString(customProps, numCores, systemMemory, numWorkers,
       gpuCount, gpuMemory, gpuDevice)
+  }
+
+  protected def buildGpuWorkerInfoFromInstanceType(
+    instanceInfo: InstanceInfo,
+    numWorkers: Option[Int] = Some(4),
+    customProps: Option[mutable.Map[String, String]] = None): String = {
+    buildGpuWorkerInfoAsString(
+      customProps,
+      Some(instanceInfo.cores),
+      Some(instanceInfo.memoryMB.toString),
+      numWorkers,
+      Some(instanceInfo.numGpus),
+      Some(instanceInfo.gpuDevice.getMemory),
+      Some(instanceInfo.gpuDevice.toString))
   }
 
   private def getGpuAppMockInfoProvider: AppInfoProviderMockTest = {
@@ -3395,4 +3409,160 @@ class ProfilingAutoTunerSuite extends BaseAutoTunerSuite {
     initialValue = "128",
     expectedValue = Some("512m")
   )
+
+  test("Test AutoTuner considers off heap memory in memory calculations - " +
+    "sufficient memory available") {
+    // mock the properties loaded from eventLog
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "16",
+        "spark.executor.instances" -> "1",
+        "spark.executor.memory" -> "30g",
+        "spark.memory.offHeap.enabled" -> "true",
+        "spark.memory.offHeap.size" -> "10g",
+        "spark.executor.resource.gpu.amount" -> "1",
+        "spark.executor.instances" -> "1",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin"
+      )
+    val instanceMapKey = NodeInstanceMapKey("g2-standard-16")
+    val gpuInstance = PlatformInstanceTypes.DATAPROC_BY_INSTANCE_NAME(instanceMapKey)
+    val dataprocWorkerInfo = buildGpuWorkerInfoFromInstanceType(gpuInstance, Some(4))
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
+      logEventsProps, Some(testSparkVersion))
+    val clusterPropsOpt = PropertiesLoader[ClusterProperties].loadFromContent(dataprocWorkerInfo)
+    val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
+          |--conf spark.executor.memory=32g
+          |--conf spark.executor.memoryOverhead=9420m
+          |--conf spark.locality.wait=0
+          |--conf spark.rapids.memory.pinnedPool.size=3g
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
+          |--conf spark.rapids.sql.concurrentGpuTasks=3
+          |--conf spark.rapids.sql.enabled=true
+          |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
+          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
+          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
+          |--conf spark.sql.files.maxPartitionBytes=512m
+          |--conf spark.task.resource.gpu.amount=0.001
+          |
+          |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
+          |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.rapids.memory.pinnedPool.size' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- 'spark.rapids.sql.concurrentGpuTasks' was not set.
+          |- 'spark.rapids.sql.enabled' was not set.
+          |- 'spark.rapids.sql.format.parquet.multithreaded.combine.waitTime' was not set.
+          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
+          |- 'spark.rapids.sql.reader.multithreaded.combine.sizeBytes' was not set.
+          |- 'spark.shuffle.manager' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+          |- 'spark.sql.files.maxPartitionBytes' was not set.
+          |- 'spark.task.resource.gpu.amount' was not set.
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    compareOutput(expectedResults, autoTunerOutput)
+  }
+
+  test("Test AutoTuner considers off heap memory in memory calculations - " +
+    "not enough memory") {
+    // mock the properties loaded from eventLog
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "16",
+        "spark.executor.instances" -> "1",
+        "spark.executor.memory" -> "30g",
+        "spark.memory.offHeap.enabled" -> "true",
+        "spark.memory.offHeap.size" -> "20g",
+        "spark.executor.resource.gpu.amount" -> "1",
+        "spark.executor.instances" -> "1",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin"
+      )
+    val instanceMapKey = NodeInstanceMapKey("g2-standard-16")
+    val gpuInstance = PlatformInstanceTypes.DATAPROC_BY_INSTANCE_NAME(instanceMapKey)
+    val dataprocWorkerInfo = buildGpuWorkerInfoFromInstanceType(gpuInstance, Some(4))
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
+      logEventsProps, Some(testSparkVersion))
+    val clusterPropsOpt = PropertiesLoader[ClusterProperties].loadFromContent(dataprocWorkerInfo)
+    val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
+          |--conf spark.executor.memory=[FILL_IN_VALUE]
+          |--conf spark.executor.memoryOverhead=[FILL_IN_VALUE]
+          |--conf spark.locality.wait=0
+          |--conf spark.rapids.memory.pinnedPool.size=[FILL_IN_VALUE]
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
+          |--conf spark.rapids.sql.concurrentGpuTasks=3
+          |--conf spark.rapids.sql.enabled=true
+          |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
+          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
+          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
+          |--conf spark.sql.files.maxPartitionBytes=512m
+          |--conf spark.task.resource.gpu.amount=0.001
+          |
+          |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- 'spark.rapids.sql.concurrentGpuTasks' was not set.
+          |- 'spark.rapids.sql.enabled' was not set.
+          |- 'spark.rapids.sql.format.parquet.multithreaded.combine.waitTime' was not set.
+          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
+          |- 'spark.rapids.sql.reader.multithreaded.combine.sizeBytes' was not set.
+          |- 'spark.shuffle.manager' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+          |- 'spark.sql.files.maxPartitionBytes' was not set.
+          |- 'spark.task.resource.gpu.amount' was not set.
+          |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.executor.memory")}
+          |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.executor.memoryOverhead")}
+          |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.rapids.memory.pinnedPool.size")}
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
+          |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemComment(75775)}
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    compareOutput(expectedResults, autoTunerOutput)
+  }
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -128,14 +128,14 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
         s"- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.executor.memory")}",
         s"- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.executor.memoryOverhead")}",
         s"- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.rapids.memory.pinnedPool.size")}",
-        s"- ${QualificationAutoTunerConfigsProvider.notEnoughMemComment(42188)}"
+        s"- ${QualificationAutoTunerConfigsProvider.notEnoughMemComment(40140)}"
       )),
     ("sufficient memory available for executors",
       "44g",
       Seq(
         "--conf spark.executor.memory=32g",
-        "--conf spark.executor.memoryOverhead=12g",
-        "--conf spark.rapids.memory.pinnedPool.size=3482m"
+        "--conf spark.executor.memoryOverhead=11468m",
+        "--conf spark.rapids.memory.pinnedPool.size=4g"
       ))
   )
   // scalastyle:on line.size.limit


### PR DESCRIPTION
Fixes #1689
Fixes #1694 

## Issue
- Off-heap memory (`spark.memory.offHeap.size`, `spark.executor.pyspark.memory`) is not currently excluded from executor memory calculations, which may cause total memory requests to exceed container limits.
- Executor memory is calculated using full system memory, ignoring container manager reservations (e.g., YARN), which may lead to over-allocation.

## Changes

This PR improves memory calculations in the AutoTuner:
- Updated `calcOverallMemory`:
  - Subtracts off-heap memory (`spark.memory.offHeap.size`, `spark.executor.pyspark.memory`) from the total memory available to executors.
  - Applies a platform-specific memory fraction to account for memory reserved by resource managers (e.g., YARN).
- Modified `getMemoryPerNodeMb` in `ClusterConfigurationStrategy` to include off-heap memory in its calculation.
   - This is needed for OnPrem (for CSPs we get total memory from the instance map).
- Added helper methods in `Platform`:
  - `getExecutorOffHeapMemoryMB`
  - `getPySparkMemoryMB`  

## Testing

- Added unit tests in the Profiling suite to validate memory calculations and off-heap handling.

## Examples

- Reference: https://spark.apache.org/docs/3.5.5/configuration.html#:~:text=spark.executor.memoryOverhead,pyspark.memory.
- The total memory for the executor is the sum of:
   - executorHeap + memoryOverhead + offHeap.size + pyspark.memory
- Note: In the below examples, `0.8` is the fraction of the physical system memory that is available to Spark executors (0.2 is reserved by Dataproc YARN0

### Example 1: g2-standard-8 machine (32 GB total memory) — Just enough memory
```
  - actualMemForExec =  32 GB * 0.8 = 25.6 GB
  - executorHeap = 16 GB
  - sparkOffHeapMemMB = 4 GB
  - execMemLeft = 25.6 GB - 16 GB - 4 GB = 5.6 GB
  - minOverhead = 1.6 GB (10% of executor heap) + 2 GB (min pinned) + 2 GB (min spill) = 5.6 GB
  - Since execMemLeft (5.6 GB) == minOverhead (5.6 GB), proceed with minimum memory recommendations:
  - Recommendation:  
      - executorHeap = 16 GB, executorMemOverhead = 5.6 GB (with pinnedMem = 2 GB and spillMem = 2 GB)
```

### Example 2: g2-standard-16 machine (64 GB total memory) — Not enough memory
```
  - actualMemForExec = 64 GB * 0.8 = 51.2 GB
  - executorHeap = 32 GB
  - sparkOffHeapMemMB = 20 GB
  - execMemLeft = 51.2 GB - 32 GB - 20 GB = -0.8 GB
  - minOverhead = 2 GB (min pinned) + 2 GB (min spill) + 3.2 GB (10% of executor heap) = 7.2 GB
  - Since execMemLeft (-0.8 GB) < minOverhead (7.2 GB), do not proceed with recommendations
      - Add a warning comment indicating that the current setup is not optimal
          - minTotalExecMemRequired = (32 GB + 20 GB + 7.2 GB) / 0.8 = (59.2 GB / 0.8) = 74 GB (as we are using 80% of system memory)
          - Reduce off-heap size or use a larger machine with at least 74 GB system memory.
```

### Example 3: g2-standard-16 machine (64 GB total memory) — More memory available
```
  - actualMemForExec = 64 GB * 0.8 = 51.2 GB
  - executorHeap = 32 GB
  - sparkOffHeapMemMB = 10 GB
  - execMemLeft = 51.2 GB - 32 GB - 10 GB = 9.2 GB
  - minOverhead = 2 GB (min pinned) + 2 GB (min spill) + 3.2 GB (10% of executor heap) = 7.2 GB
  - Since execMemLeft (9.2 GB) > minOverhead (7.2 GB), proceed with recommendations.
      - Increase pinned and spill memory based on remaining memory (up to 4 GB max)
      - executorMemOverhead = 3 GB (pinned) + 3 GB (spill) + 3.2 GB = 9.2 GB
  - Recommendation:
      - executorHeap = 32 GB, executorMemOverhead = 9.2 GB (with pinnedMem = 3 GB and spillMem = 3 GB)
```