### PR TITLE
Remove toml deprecation and update build and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ target/
 
 # prepackage locations
 csp-resources*
+tools-resources/
 
 # precommit files
 *-E

--- a/user_tools/build.sh
+++ b/user_tools/build.sh
@@ -150,8 +150,12 @@ remove_web_dependencies() {
 
 # Pre-build setup
 pre_build() {
+  echo "upgrade pip"
+  pip install --upgrade pip
+  echo "rm previous build and dist directories"
   rm -rf build/ dist/
-  pip install build -e .
+  echo "install build dependencies using pip"
+  pip install build -e .[qualx,test]
 }
 
 # Build process

--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -30,9 +30,11 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
+# see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for list of supported licenses
+license = "Apache-2.0 AND MIT"
+license-files = ["LICENSE"]
 dependencies = [
     # numpy-2.0.0 supports python [3.9, 3.13]. numpy2.1.0 drooped support for Python 3.9.
     "numpy>=2.0.0",


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1697

- remove license from toml classifiers
- in build.sh: automatically upgrade pip in the pre-build, and add test/qualx for optional dependecnies
- add the tools-resources to the gitignore
