### PR TITLE
Fix invalid SSD recommendation for g2-standard-16 in cluster shape

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -617,11 +617,15 @@ class DataprocCluster(ClusterBase):
     @classmethod
     def _get_ssd_configuration(cls) -> dict:
         """
-        TODO: We should recommend correct number of SSDs instead a fixed number.
+        Currently, we recommend either `g2-standard` and `n1-standard` series which
+        supports minimum 1 SSD per worker.
+
+        TODO: We should recommend correct number of SSDs instead of a fixed number.
+         See https://github.com/NVIDIA/spark-rapids-tools/issues/657
         """
         return {
             'ssdInfo': {
-                'ssdPerWorker': 2
+                'ssdPerWorker': 1
             }
         }
 


### PR DESCRIPTION
Fixes #1712

In [PR-1673](https://github.com/NVIDIA/spark-rapids-tools/pull/1673), we updated the default Dataproc instance type from `n1-standard-16` to `g2-standard-16`. However, the `g2-standard` series does not support attaching 2 SSDs per worker, which was our previous recommendation.

This PR reduces the default number of SSDs recommended in cluster shape recommendations for Dataproc to 1.

## Note

There is a related issue, [#657](https://github.com/NVIDIA/spark-rapids-tools/issues/657), to improve the recommendation logic for SSDs by analyzing I/O statistics to determine whether SSDs are necessary or not.

## Output

### CMD

```console
$ spark_rapids qualification --platform dataproc --eventlogs $EVENTLOG
```

### Previously:
```json
[
  {
    "appId": "app_xxx",
    "appName": "custom-app-name",
    "eventLog": "file:/path/to/eventlog",
    "clusterInfo": {
      "platform": "dataproc",
      "sourceCluster": {},
      "recommendedCluster": {
        "driverNodeType": "n1-standard-16",
        "workerNodeType": "g2-standard-16",
        "numWorkerNodes": 10,
        "gpuInfo": {
          "device": "nvidia-l4",
          "gpuPerWorker": 1
        },
        "ssdInfo": {
          "ssdPerWorker": 2
        }
      }
    },
    "sparkRuntime": "SPARK",
    "estimatedGpuSpeedupCategory": "Large",
    "fullClusterConfigRecommendations": "/path/to/qual_20250530162219_9E4627C4/rapids_4_spark_qualification_output/tuning/application_1746588827107_0006.conf",
    "gpuConfigRecommendationBreakdown": "/path/to/qual_20250530162219_9E4627C4/rapids_4_spark_qualification_output/tuning/application_1746588827107_0006.log"
  }
]
```


### After
```json
[
  {
    "appId": "app_xxx",
    "appName": "custom-app-name",
    "eventLog": "file:/path/to/eventlog",
    "clusterInfo": {
      "platform": "dataproc",
      "sourceCluster": {},
      "recommendedCluster": {
        "driverNodeType": "n1-standard-16",
        "workerNodeType": "g2-standard-16",
        "numWorkerNodes": 10,
        "gpuInfo": {
          "device": "nvidia-l4",
          "gpuPerWorker": 1
        },
        "ssdInfo": {
          "ssdPerWorker": 1
        }
      }
    },
    "sparkRuntime": "SPARK",
    "estimatedGpuSpeedupCategory": "Large",
    "fullClusterConfigRecommendations": "/path/to/qual_20250530162219_9E4627C4/rapids_4_spark_qualification_output/tuning/application_1746588827107_0006.conf",
    "gpuConfigRecommendationBreakdown": "/path/to/qual_20250530162219_9E4627C4/rapids_4_spark_qualification_output/tuning/application_1746588827107_0006.log"
  }
]
```
