### PR TITLE
Add support for user enforced spark property overrides in Profiling Tool's AutoTuner

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/ClusterConfigurationStrategy.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/ClusterConfigurationStrategy.scala
@@ -46,13 +46,22 @@ trait ClusterSizingStrategy {
 
   /** Utility method to compute recommended cores per executor. */
   final def computeRecommendedCoresPerExec(platform: Platform, totalCoresCount: Int): Int = {
-    if (platform.isPlatformCSP) {
-      // For CSPs, we already have the recommended cores per executor based on the instance type
-      platform.recommendedCoresPerExec
-    } else {
-      // For onprem, we do want to limit to the total cores count
-      math.min(platform.recommendedCoresPerExec, totalCoresCount)
+    platform.getUserEnforcedSparkProperty("spark.executor.cores").map(_.toInt).getOrElse {
+      if (platform.isPlatformCSP) {
+        // For CSPs, we already have the recommended cores per executor based on the instance type
+        platform.recommendedCoresPerExec
+      } else {
+        // For onprem, we do want to limit to the total cores count
+        math.min(platform.recommendedCoresPerExec, totalCoresCount)
+      }
     }
+  }
+
+  final def computeRecommendedInstances(
+      platform: Platform,
+      computeRecommendedInstancesExpr: () => Int): Int = {
+    platform.getUserEnforcedSparkProperty("spark.executor.instances").map(_.toInt)
+      .getOrElse(computeRecommendedInstancesExpr())
   }
 
   /** Abstract method to compute the recommended cluster configuration. */
@@ -80,8 +89,8 @@ object ConstantTotalCoresStrategy extends ClusterSizingStrategy {
       getRecommendedNumGpus: => Int): RecommendedClusterConfig = {
     val totalCoresCount = initialCoresPerExec * initialNumExecutors
     val recommendedCoresPerExec = computeRecommendedCoresPerExec(platform, totalCoresCount)
-    val recommendedNumExecutors =
-      math.ceil(totalCoresCount.toDouble / recommendedCoresPerExec).toInt
+    val recommendedNumExecutors = computeRecommendedInstances(platform,
+      () => math.ceil(totalCoresCount.toDouble / recommendedCoresPerExec).toInt)
     RecommendedClusterConfig(recommendedNumExecutors, recommendedCoresPerExec,
       getMemoryPerNodeMb, getRecommendedGpuDevice, getRecommendedNumGpus)
   }
@@ -101,7 +110,9 @@ object ConstantGpuCountStrategy extends ClusterSizingStrategy {
       getRecommendedNumGpus: => Int): RecommendedClusterConfig = {
     val totalCoresCount = initialCoresPerExec * initialNumExecutors
     val recommendedCoresPerExec = computeRecommendedCoresPerExec(platform, totalCoresCount)
-    RecommendedClusterConfig(initialNumExecutors, recommendedCoresPerExec,
+    val recommendNumExecutors = computeRecommendedInstances(platform,
+      () => initialNumExecutors)
+    RecommendedClusterConfig(recommendNumExecutors, recommendedCoresPerExec,
       getMemoryPerNodeMb, getRecommendedGpuDevice, getRecommendedNumGpus)
   }
 }
@@ -111,7 +122,7 @@ object ConstantGpuCountStrategy extends ClusterSizingStrategy {
  */
 abstract class ClusterConfigurationStrategy(
     platform: Platform,
-    sparkProperties: Map[String, String],
+    sourceSparkProperties: Map[String, String],
     recommendedClusterSizingStrategy: ClusterSizingStrategy) {
 
   /**
@@ -120,8 +131,8 @@ abstract class ClusterConfigurationStrategy(
   protected def calculateInitialNumExecutors: Int
 
   private def getInitialNumExecutors: Int = {
-    val dynamicAllocationEnabled = Platform.isDynamicAllocationEnabled(sparkProperties)
-    val execInstFromProps = sparkProperties.get("spark.executor.instances")
+    val dynamicAllocationEnabled = Platform.isDynamicAllocationEnabled(sourceSparkProperties)
+    val execInstFromProps = sourceSparkProperties.get("spark.executor.instances")
     // If dynamic allocation is disabled, use spark.executor.instances in precedence
     if (execInstFromProps.isDefined && !dynamicAllocationEnabled) {
       // Spark Properties are in order:
@@ -139,7 +150,7 @@ abstract class ClusterConfigurationStrategy(
   protected def calculateInitialCoresPerExec: Int
 
   private def getInitialCoresPerExec: Int = {
-    val coresFromProps = sparkProperties.get("spark.executor.cores")
+    val coresFromProps = sourceSparkProperties.get("spark.executor.cores")
     // Use spark.executor.cores in precedence
     if (coresFromProps.isDefined) {
       coresFromProps.get.toInt
@@ -148,7 +159,7 @@ abstract class ClusterConfigurationStrategy(
     }
   }
 
-  protected def getMemoryPerNodeMb: Long
+  protected def getRecommendedMemoryPerNodeMb: Long
 
   protected def getSourceNumGpus: Option[Int]
 
@@ -179,7 +190,7 @@ abstract class ClusterConfigurationStrategy(
         platform,
         initialNumExecutors,
         getInitialCoresPerExec,
-        getMemoryPerNodeMb,
+        getRecommendedMemoryPerNodeMb,
         getRecommendedGpuDevice,
         getRecommendedNumGpus
       ))
@@ -192,9 +203,9 @@ abstract class ClusterConfigurationStrategy(
  */
 class ClusterPropertyBasedStrategy(
     platform: Platform,
-    sparkProperties: Map[String, String],
+    sourceSparkProperties: Map[String, String],
     recommendedClusterSizingStrategy: ClusterSizingStrategy)
-  extends ClusterConfigurationStrategy(platform, sparkProperties,
+  extends ClusterConfigurationStrategy(platform, sourceSparkProperties,
     recommendedClusterSizingStrategy) {
 
   private val clusterProperties = platform.clusterProperties.getOrElse(
@@ -226,7 +237,7 @@ class ClusterPropertyBasedStrategy(
     math.ceil(coresPerGpu).toInt
   }
 
-  override protected def getMemoryPerNodeMb: Long = {
+  override protected def getRecommendedMemoryPerNodeMb: Long = {
     StringUtils.convertToMB(clusterProperties.system.getMemory, Some(ByteUnit.BYTE))
   }
 
@@ -255,9 +266,9 @@ class ClusterPropertyBasedStrategy(
  */
 class EventLogBasedStrategy(
     platform: Platform,
-    sparkProperties: Map[String, String],
+    sourceSparkProperties: Map[String, String],
     recommendedClusterSizingStrategy: ClusterSizingStrategy)
-  extends ClusterConfigurationStrategy(platform, sparkProperties,
+  extends ClusterConfigurationStrategy(platform, sourceSparkProperties,
     recommendedClusterSizingStrategy) {
 
   private val clusterInfoFromEventLog: SourceClusterInfo = {
@@ -268,17 +279,23 @@ class EventLogBasedStrategy(
   // scalastyle:off line.size.limit
   /**
    * For onprem or cases where a matching CSP instance type is unavailable,
-   * this method returns the memory per node.
+   * this method returns the memory for the recommended node in MB.
    *
    * Reference:
    * https://spark.apache.org/docs/3.5.5/configuration.html#:~:text=spark.executor.memoryOverhead,pyspark.memory.
    */
   // scalastyle:on line.size.limit
-  override def getMemoryPerNodeMb: Long = {
-    val heapMemMB = clusterInfoFromEventLog.executorHeapMemory
-    val overheadMemMB = platform.getExecutorOverheadMemoryMB(sparkProperties)
-    val sparkOffHeapMemMB = platform.getSparkOffHeapMemoryMB(sparkProperties).getOrElse(0L)
-    val pySparkMemMB = platform.getPySparkMemoryMB(sparkProperties).getOrElse(0L)
+  override def getRecommendedMemoryPerNodeMb: Long = {
+    val heapMemMB = platform.getUserEnforcedSparkProperty("spark.executor.memory")
+      .map(StringUtils.convertToMB(_, Some(ByteUnit.BYTE)))
+      .getOrElse(clusterInfoFromEventLog.executorHeapMemory)
+    // Get a combined spark properties function that includes user enforced properties
+    // and properties from the event log
+    val sparkPropertiesFn = platform.getSparkPropertyWithUserOverrides(sourceSparkProperties)
+    val overheadMemMB = platform.getExecutorOverheadMemoryMB(sparkPropertiesFn)
+    val sparkOffHeapMemMB = platform.getSparkOffHeapMemoryMB(sparkPropertiesFn)
+      .getOrElse(0L)
+    val pySparkMemMB = platform.getPySparkMemoryMB(sparkPropertiesFn).getOrElse(0L)
     heapMemMB + overheadMemMB + sparkOffHeapMemMB + pySparkMemMB
   }
 
@@ -319,16 +336,16 @@ class EventLogBasedStrategy(
 object ClusterConfigurationStrategy {
   def getStrategy(
       platform: Platform,
-      sparkProperties: Map[String, String],
+      sourceSparkProperties: Map[String, String],
       recommendedClusterSizingStrategy: ClusterSizingStrategy)
   : Option[ClusterConfigurationStrategy] = {
     if (platform.clusterProperties.isDefined) {
       // Use strategy based on cluster properties
-      Some(new ClusterPropertyBasedStrategy(platform, sparkProperties,
+      Some(new ClusterPropertyBasedStrategy(platform, sourceSparkProperties,
         recommendedClusterSizingStrategy))
     } else if (platform.clusterInfoFromEventLog.isDefined) {
       // Use strategy based on cluster information from event log
-      Some(new EventLogBasedStrategy(platform, sparkProperties,
+      Some(new EventLogBasedStrategy(platform, sourceSparkProperties,
         recommendedClusterSizingStrategy))
     } else {
       // Neither cluster properties are defined nor cluster information from event log is available

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntry.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntry.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.rapids.tool.util.StringUtils
 abstract class TuningEntryBase(
     override val name: String,
     originalValueRaw: Option[String],
-    tunedValueRaw: Option[String],
+    var tunedValueRaw: Option[String],
     definition: Option[TuningEntryDefinition] = None) extends TuningEntryTrait {
 
   /**
@@ -65,6 +65,11 @@ abstract class TuningEntryBase(
       case None => true
     }
     globalFlag && enabled
+  }
+
+  override def setRecommendedValue(value: String): Unit = {
+    tunedValueRaw = Option(value)
+    super.setRecommendedValue(value)
   }
 
   /////////////////////////

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.tuning
+
+import scala.collection.mutable
+
+import com.nvidia.spark.rapids.tool.{NodeInstanceMapKey, PlatformFactory, PlatformInstanceTypes, PlatformNames, ToolTestUtils}
+import com.nvidia.spark.rapids.tool.profiling.Profiler
+
+import org.apache.spark.sql.rapids.tool.annotation.Since
+import org.apache.spark.sql.rapids.tool.util.PropertiesLoader
+
+/**
+ * Test suite for the Profiling AutoTuner that uses the new target cluster properties format.
+ *
+ * This test suite introduces a cleaner way to specify target cluster configurations by explicitly
+ * separating:
+ * - Target cluster shape (cores, memory, GPU count/type)
+ * - Target Spark properties (enforced configurations)
+ *
+ * This is in contrast to the legacy format in [[ProfilingAutoTunerSuite]] which overloaded the
+ * same format for both source and target cluster properties.
+ */
+@Since("25.04.2")
+class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
+
+  // Test that the properties from the custom target cluster props will be enforced.
+  test("AutoTuner enforces properties from custom target cluster props") {
+    // 1. Mock source cluster info for dataproc
+    val instanceMapKey = NodeInstanceMapKey("g2-standard-16")
+    val gpuInstance = PlatformInstanceTypes.DATAPROC_BY_INSTANCE_NAME(instanceMapKey)
+    val sourceWorkerInfo = buildGpuWorkerInfoFromInstanceType(gpuInstance, Some(4))
+    val sourceClusterInfoOpt =
+      PropertiesLoader[ClusterProperties].loadFromContent(sourceWorkerInfo)
+    // 2. Mock the properties loaded from eventLog
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "8",
+        "spark.executor.instances" -> "2",
+        "spark.rapids.memory.pinnedPool.size" -> "5g",
+        "spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
+        "spark.executor.resource.gpu.amount" -> "1",
+        // Below properties should be overridden by the enforced properties
+        "spark.sql.shuffle.partitions" -> "200",
+        "spark.sql.files.maxPartitionBytes" -> "1g",
+        "spark.task.resource.gpu.amount" -> "0.001",
+        "spark.rapids.sql.concurrentGpuTasks" -> "4"
+      )
+    // 3. Define enforced properties for the target cluster
+    val enforcedSparkProperties = Map(
+      "spark.sql.shuffle.partitions" -> "400",
+      "spark.sql.files.maxPartitionBytes" -> "101m",
+      "spark.task.resource.gpu.amount" -> "0.25",
+      "spark.rapids.sql.concurrentGpuTasks" -> "2"
+    )
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      enforcedSparkProperties = enforcedSparkProperties
+    )
+    val infoProvider = getMockInfoProvider(8126464.0, Seq(0), Seq(0.004), logEventsProps,
+      Some(testSparkVersion))
+    val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC,
+      sourceClusterInfoOpt, Some(targetClusterInfo))
+    val autoTuner = buildAutoTunerForTests(sourceWorkerInfo, infoProvider, platform)
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
+          |--conf spark.executor.cores=16
+          |--conf spark.executor.memory=32g
+          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.locality.wait=0
+          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
+          |--conf spark.rapids.sql.concurrentGpuTasks=2
+          |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
+          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
+          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
+          |--conf spark.sql.files.maxPartitionBytes=101m
+          |--conf spark.sql.shuffle.partitions=400
+          |--conf spark.task.resource.gpu.amount=0.25
+          |
+          |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
+          |- 'spark.executor.memory' was not set.
+          |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- ${ProfilingAutoTunerConfigsProvider.getEnforcedPropertyComment("spark.rapids.sql.concurrentGpuTasks")}
+          |- 'spark.rapids.sql.format.parquet.multithreaded.combine.waitTime' was not set.
+          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
+          |- 'spark.rapids.sql.reader.multithreaded.combine.sizeBytes' was not set.
+          |- 'spark.shuffle.manager' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+          |- ${ProfilingAutoTunerConfigsProvider.getEnforcedPropertyComment("spark.sql.files.maxPartitionBytes")}
+          |- ${ProfilingAutoTunerConfigsProvider.getEnforcedPropertyComment("spark.sql.shuffle.partitions")}
+          |- ${ProfilingAutoTunerConfigsProvider.getEnforcedPropertyComment("spark.task.resource.gpu.amount")}
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    compareOutput(expectedResults, autoTunerOutput)
+  }
+
+  // Test that the executor memory and memory overhead properties from the custom target cluster
+  // props lead to AutoTuner warning about insufficient memory.
+  test("AutoTuner warns about insufficient memory with executor heap and" +
+    " memory overhead override") {
+    // 1. Mock source cluster info for dataproc
+    val instanceMapKey = NodeInstanceMapKey("g2-standard-16")
+    val gpuInstance = PlatformInstanceTypes.DATAPROC_BY_INSTANCE_NAME(instanceMapKey)
+    val sourceWorkerInfo = buildGpuWorkerInfoFromInstanceType(gpuInstance, Some(4))
+    val sourceClusterInfoOpt =
+      PropertiesLoader[ClusterProperties].loadFromContent(sourceWorkerInfo)
+    // 2. Mock the properties loaded from eventLog
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "8",
+        "spark.executor.instances" -> "2",
+        "spark.rapids.memory.pinnedPool.size" -> "5g",
+        "spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
+        "spark.executor.resource.gpu.amount" -> "1"
+      )
+    // 3. Define enforced properties for the target cluster
+    // Note: These values should cause insufficient memory warning
+    val enforcedSparkProperties = Map(
+      "spark.executor.memory" -> "40g",
+      "spark.executor.memoryOverhead" -> "30g"
+    )
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      enforcedSparkProperties = enforcedSparkProperties
+    )
+    val infoProvider = getMockInfoProvider(8126464.0, Seq(0), Seq(0.004), logEventsProps,
+      Some(testSparkVersion))
+    val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC,
+      sourceClusterInfoOpt, Some(targetClusterInfo))
+    val autoTuner = buildAutoTunerForTests(sourceWorkerInfo, infoProvider, platform)
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
+          |--conf spark.executor.cores=16
+          |--conf spark.executor.memory=[FILL_IN_VALUE]
+          |--conf spark.executor.memoryOverhead=[FILL_IN_VALUE]
+          |--conf spark.locality.wait=0
+          |--conf spark.rapids.memory.pinnedPool.size=[FILL_IN_VALUE]
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
+          |--conf spark.rapids.sql.concurrentGpuTasks=3
+          |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
+          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
+          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
+          |--conf spark.sql.files.maxPartitionBytes=4g
+          |--conf spark.task.resource.gpu.amount=0.001
+          |
+          |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
+          |- ${ProfilingAutoTunerConfigsProvider.getEnforcedPropertyComment("spark.executor.memory")}
+          |- ${ProfilingAutoTunerConfigsProvider.getEnforcedPropertyComment("spark.executor.memoryOverhead")}
+          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- 'spark.rapids.sql.concurrentGpuTasks' was not set.
+          |- 'spark.rapids.sql.format.parquet.multithreaded.combine.waitTime' was not set.
+          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
+          |- 'spark.rapids.sql.reader.multithreaded.combine.sizeBytes' was not set.
+          |- 'spark.shuffle.manager' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+          |- 'spark.sql.files.maxPartitionBytes' was not set.
+          |- 'spark.task.resource.gpu.amount' was not set.
+          |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.executor.memory")}
+          |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.executor.memoryOverhead")}
+          |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.rapids.memory.pinnedPool.size")}
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
+          |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemComment(89600)}
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    compareOutput(expectedResults, autoTunerOutput)
+  }
+
+  // Test that the pinned pool property from the custom target cluster
+  // props lead to AutoTuner warning about insufficient memory.
+  test("AutoTuner warns about insufficient memory with pinned pool override") {
+    // 1. Mock source cluster info for dataproc
+    val instanceMapKey = NodeInstanceMapKey("g2-standard-16")
+    val gpuInstance = PlatformInstanceTypes.DATAPROC_BY_INSTANCE_NAME(instanceMapKey)
+    val sourceWorkerInfo = buildGpuWorkerInfoFromInstanceType(gpuInstance, Some(4))
+    val sourceClusterInfoOpt =
+      PropertiesLoader[ClusterProperties].loadFromContent(sourceWorkerInfo)
+    // 2. Mock the properties loaded from eventLog
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "8",
+        "spark.executor.instances" -> "2",
+        "spark.rapids.memory.pinnedPool.size" -> "5g",
+        "spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
+        "spark.executor.resource.gpu.amount" -> "1"
+      )
+    // 3. Define enforced properties for the target cluster
+    val enforcedSparkProperties = Map(
+      "spark.rapids.memory.pinnedPool.size" -> "30g", // Should cause insufficient memory warning
+      "spark.sql.files.maxPartitionBytes" -> "101m"   // Should be enforced
+    )
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      enforcedSparkProperties = enforcedSparkProperties
+    )
+    val infoProvider = getMockInfoProvider(8126464.0, Seq(0), Seq(0.004), logEventsProps,
+      Some(testSparkVersion))
+    val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC,
+      sourceClusterInfoOpt, Some(targetClusterInfo))
+    val autoTuner = buildAutoTunerForTests(sourceWorkerInfo, infoProvider, platform)
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
+          |--conf spark.executor.cores=16
+          |--conf spark.executor.memory=[FILL_IN_VALUE]
+          |--conf spark.executor.memoryOverhead=[FILL_IN_VALUE]
+          |--conf spark.locality.wait=0
+          |--conf spark.rapids.memory.pinnedPool.size=[FILL_IN_VALUE]
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
+          |--conf spark.rapids.sql.concurrentGpuTasks=3
+          |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
+          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
+          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
+          |--conf spark.sql.files.maxPartitionBytes=101m
+          |--conf spark.task.resource.gpu.amount=0.001
+          |
+          |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
+          |- ${ProfilingAutoTunerConfigsProvider.getEnforcedPropertyComment("spark.rapids.memory.pinnedPool.size")}
+          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- 'spark.rapids.sql.concurrentGpuTasks' was not set.
+          |- 'spark.rapids.sql.format.parquet.multithreaded.combine.waitTime' was not set.
+          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
+          |- 'spark.rapids.sql.reader.multithreaded.combine.sizeBytes' was not set.
+          |- 'spark.shuffle.manager' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+          |- ${ProfilingAutoTunerConfigsProvider.getEnforcedPropertyComment("spark.sql.files.maxPartitionBytes")}
+          |- 'spark.task.resource.gpu.amount' was not set.
+          |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.executor.memory")}
+          |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.executor.memoryOverhead")}
+          |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemCommentForKey("spark.rapids.memory.pinnedPool.size")}
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
+          |- ${ProfilingAutoTunerConfigsProvider.notEnoughMemComment(126975)}
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    compareOutput(expectedResults, autoTunerOutput)
+  }
+}


### PR DESCRIPTION
Fixes #1526 

This MR adds support for user-enforced Spark property overrides in AutoTuner. This is required in cases where users have more context about their workloads and may wish to override AutoTuner’s default recommendations, which might not always be optimal.

The changes in this PR handle the interaction between the user enforced properties and how it would affect the recommendation logic for other properties or how it would affect the recommended cluster shape. 

For example: 
- User enforced value of memoryOverhead can be too large that might exceed the available memory limits. 
    - See UTs added in `ProfilingAutoTunerSuiteV2` for these cases.
- User enforced value of `spark.executor.instances` might affect the recommended cluster shape. 
    - See UTs added in `ClusterRecommendationSuite` for these cases.
 

### Usage via Python CLI
1. Build and install the Python CLI in non-fat mode

```shell
$ cd spark-rapids-tools/user_tools
$ ./build.sh non-fat
$ pip install dist/spark_rapids_user_tools-25.4.2-py3-none-any.whl
```

2. Create a target cluster YAML file
```yaml
workerInfo:
  instanceType: g2-standard-8
sparkProperties:
  enforced:
    spark.sql.shuffle.partitions: 400
    spark.sql.files.maxPartitionBytes: 100m
    spark.task.resource.gpu.amount: 0.25
    spark.rapids.sql.concurrentGpuTasks: 2
```

4. Run the Profile CLI as:
```shell
spark_rapids profiling \
  --platform $PLATFORM \
  --eventlogs $EVENT_LOG \
  --target-cluster-info $PATH_TO_TARGET_YAML \
```

5. Corresponding AutoTuner recommendations will generated at

<details>
<summary>File: prof_2025xxxx/profiling_summary.log</summary>
<pre>
### Recommended configurations ###
application_1746596730921_0001
	Spark Properties:
	--conf spark.dataproc.enhanced.execution.enabled=false
	--conf spark.dataproc.enhanced.optimizer.enabled=false
	--conf spark.executor.cores=8
	--conf spark.executor.instances=300
	--conf spark.executor.memory=16g
	--conf spark.executor.memoryOverhead=9830m
	--conf spark.locality.wait=0
	--conf spark.rapids.memory.pinnedPool.size=4g
	--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
	--conf spark.rapids.shuffle.multiThreaded.writer.threads=20
	--conf spark.rapids.sql.batchSizeBytes=2147483647b
	--conf spark.rapids.sql.concurrentGpuTasks=2
	--conf spark.rapids.sql.enabled=true
	--conf spark.rapids.sql.multiThreadedRead.numThreads=40
	--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark353.RapidsShuffleManager
	--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
	--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
	--conf spark.sql.adaptive.coalescePartitions.parallelismFirst=false
	--conf spark.sql.files.maxPartitionBytes=100m
	--conf spark.sql.shuffle.partitions=400
	--conf spark.task.resource.gpu.amount=0.25
	Comments:
	- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
	- 'spark.dataproc.enhanced.execution.enabled' was not set.
	- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
	- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
	- 'spark.executor.memoryOverhead' was not set.
	- 'spark.rapids.memory.pinnedPool.size' was not set.
	- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
	- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
	- 'spark.rapids.sql.batchSizeBytes' was not set.
	- 'spark.rapids.sql.concurrentGpuTasks' was user-enforced in the target cluster properties.
	- 'spark.rapids.sql.enabled' was not set.
	- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
	- 'spark.shuffle.manager' was not set.
	- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
	- 'spark.sql.adaptive.enabled' should be enabled for better performance.
	- 'spark.sql.files.maxPartitionBytes' was user-enforced in the target cluster properties.
	- 'spark.sql.shuffle.partitions' was user-enforced in the target cluster properties.
	- 'spark.task.resource.gpu.amount' was user-enforced in the target cluster properties.
	- A newer RAPIDS Accelerator for Apache Spark plugin is available:
	https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/25.04.0/rapids-4-spark_2.12-25.04.0.jar
	Version used in application is 24.12.0.
	- The RAPIDS Shuffle Manager requires spark.driver.extraClassPath
	and spark.executor.extraClassPath settings to include the
	path to the Spark RAPIDS plugin jar.
	If the Spark RAPIDS jar is being bundled with your Spark
	distribution, this step is not needed.
</pre>
</details>

## Changes

- `TargetClusterProps.scala`
  - Added support for a new `sparkProperties` section.
  - Handled user-enforced Spark properties through the `enforced` field.
- `Platform.scala`
  - Introduced `getUserEnforcedSparkProperty()` to retrieve user-overridden Spark configs.
  - Refactored property access to use a function `sparkPropertiesFn`, (which prioritizes user-enforced values over source values)
- `AutoTuner.scala`
  - <ins> Updated `calcOverallMemory()` to account for user-enforced Spark properties when computing memory-related recommendations. </ins>
    - For example, user-provided memory overhead or pinned memory pool sizes may now exceed container limits.
    -  Unit tests covering these scenarios added to `ProfilingAutoTunerSuiteV2`.
  - Added `getAllSourceProperties` and `getPropertyValueFromSource()` to clearly distinguish between source and enforced property origins.
  - For all user-enforced properties, AutoTuner would include a comment as
     - `'spark.task.resource.gpu.amount' was user-enforced in the target cluster properties.`
- `ClusterConfigurationStrategy.scala`
  - <ins>Integrated user-enforced values like `spark.executor.cores` and `spark.executor.instances` into cluster configuration logic</ins>
    - For example, `spark.executor.instances` affect number of GPUs and thus the number of worker nodes.
    - Unit tests covering these scenarios added to `ClusterRecommendationSuite`.

## Tests
- Added unit tests for tuning overrides in `ProfilingAutoTunerSuiteV2`.
- Added unit tests validating the interaction between tuning overrides and cluster shape in `ClusterRecommendationSuite`.
- Added a note in `ProfilingAutoTunerSuite` indicating that no new AutoTuner tests should be added to this class
   - It uses the legacy worker info properties format, which is overloaded to be used for both source and target cluster properties. 
   - These tests need to be migrated to use the new target cluster info format, which explicitly specifies target cluster shape and Spark properties.
   -  Till then, all new Profiling AutoTuner tests should be added in `ProfilingAutoTunerSuiteV2`