### PR TITLE
QualX to use the pre-packaged tools_jar as part of whl

### DIFF
--- a/user_tools/docs/qualx.md
+++ b/user_tools/docs/qualx.md
@@ -38,14 +38,11 @@ To train an XGBoost model on a specific dataset, follow these steps below. Refer
 Training requires the following environment variables to be set:
 ```bash
 export SPARK_HOME=/path/to/spark
-export SPARK_RAPIDS_TOOLS_JAR=/path/to/rapids-4-spark-tools-0.1.0-SNAPSHOT.jar
 export QUALX_DATA_DIR=/path/to/qualx/datasets
-export QUALX_CACHE_DIR=/path/to/qualx/cache
 ```
 
 Notes:
 - `QUALX_DATA_DIR` should be a valid local path containing the training data.
-- `QUALX_CACHE_DIR` stores intermediate files generated during processing (e.g., profiling output). It will be created automatically if it does not exist.  The directory can be deleted to invalidate the cache.
 
 #### Data Collection
 

--- a/user_tools/docs/qualx.md
+++ b/user_tools/docs/qualx.md
@@ -41,6 +41,11 @@ export SPARK_HOME=/path/to/spark
 export QUALX_DATA_DIR=/path/to/qualx/datasets
 ```
 
+In case the user wants to use a custom tools jar file, the following environment variable should be set:
+```bash
+export SPARK_RAPIDS_TOOLS_JAR=/path/to/tools.jar
+```
+
 Notes:
 - `QUALX_DATA_DIR` should be a valid local path containing the training data.
 

--- a/user_tools/docs/qualx.md
+++ b/user_tools/docs/qualx.md
@@ -41,13 +41,21 @@ export SPARK_HOME=/path/to/spark
 export QUALX_DATA_DIR=/path/to/qualx/datasets
 ```
 
-In case the user wants to use a custom tools jar file, the following environment variable should be set:
-```bash
-export SPARK_RAPIDS_TOOLS_JAR=/path/to/tools.jar
-```
+Since training internally uses the Profiling and Qualification tools, it requires the core tools jar as a dependency.
+By default, QualX automatically locates and uses the bundled core tools jar from the package resources.
 
 Notes:
 - `QUALX_DATA_DIR` should be a valid local path containing the training data.
+
+##### Advanced Environment Setup
+
+For advanced users or specific deployment scenarios, user can override the embedded core tools jar that is pre-packaged
+with user_tools.  To do this, user can set the following environment variable:
+```bash
+export SPARK_RAPIDS_TOOLS_JAR=/path/to/custom/tools.jar
+```
+
+- For users building from source or needing custom jar builds, refer to the [user-tools README](../README.md#building-from-source) for build instructions.
 
 #### Data Collection
 

--- a/user_tools/src/spark_rapids_pytools/rapids/qualx/qualx_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualx/qualx_tool.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/user_tools/src/spark_rapids_pytools/rapids/qualx/qualx_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualx/qualx_tool.py
@@ -52,7 +52,7 @@ class QualXTool(RapidsTool):
         Process environment variables required for QualX tool execution.
 
         This method ensures that SPARK_RAPIDS_TOOLS_JAR environment variable is set.
-        Priority order:
+        Precedence order:
         1. Existing SPARK_RAPIDS_TOOLS_JAR environment variable (highest priority)
         2. Tools jar from local wheel package resources (fallback)
 
@@ -74,8 +74,6 @@ class QualXTool(RapidsTool):
 
         if self.ctxt.use_local_tools_jar():
             jar_path = self.ctxt.get_rapids_jar_url()
-            self.logger.info('Successfully identified tools jar from resources: %s', jar_path)
-
             os.environ['SPARK_RAPIDS_TOOLS_JAR'] = jar_path
             self.logger.info('Set SPARK_RAPIDS_TOOLS_JAR environment variable to: %s', jar_path)
         else:

--- a/user_tools/src/spark_rapids_pytools/rapids/qualx/qualx_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualx/qualx_tool.py
@@ -47,6 +47,46 @@ class QualXTool(RapidsTool):
                                 prop_arg=self.config_path,
                                 name=self.name)
 
+    def process_qualx_env_vars(self):
+        """
+        Process environment variables required for QualX tool execution.
+
+        This method ensures that SPARK_RAPIDS_TOOLS_JAR environment variable is set.
+        Priority order:
+        1. Existing SPARK_RAPIDS_TOOLS_JAR environment variable (highest priority)
+        2. Tools jar from local wheel package resources (fallback)
+
+        The environment variable is required by the run_profiler_tool function used during training.
+        """
+        # Priority 1: Check if environment variable is already set - this takes precedence
+        if 'SPARK_RAPIDS_TOOLS_JAR' in os.environ:
+            existing_jar = os.environ['SPARK_RAPIDS_TOOLS_JAR']
+            if os.path.exists(existing_jar):
+                self.logger.info('Using existing SPARK_RAPIDS_TOOLS_JAR environment variable (priority): %s',
+                                 existing_jar)
+                return
+            self.logger.warning('SPARK_RAPIDS_TOOLS_JAR points to non-existent file: %s.'
+                                'Will fallback to resource jar.', existing_jar)
+
+        # Priority 2: Fallback to identifying tools jar from local resources
+        self.logger.info('No valid SPARK_RAPIDS_TOOLS_JAR found. Loading from tools resources...')
+        self.ctxt.load_tools_jar_resources()
+
+        if self.ctxt.use_local_tools_jar():
+            jar_path = self.ctxt.get_rapids_jar_url()
+            self.logger.info('Successfully identified tools jar from resources: %s', jar_path)
+
+            os.environ['SPARK_RAPIDS_TOOLS_JAR'] = jar_path
+            self.logger.info('Set SPARK_RAPIDS_TOOLS_JAR environment variable to: %s', jar_path)
+        else:
+            self.logger.error('Failed to identify tools jar from resources. '
+                              'Please set SPARK_RAPIDS_TOOLS_JAR environment variable manually.')
+            raise RuntimeError('Unable to locate tools jar for QualX execution')
+
+    def _process_rapids_args(self):
+        """Process RAPIDS arguments and environment variables for QualX tool."""
+        self.process_qualx_env_vars()
+
     def _process_output_args(self):
         """
         Sets the `output_folder`, ensures its creation, and updates the context with the folder path.

--- a/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
@@ -164,11 +164,10 @@ class ToolContext(YAMLPropertiesContainer):
         self.set_ctxt('useLocalToolsJar', True)
         self.set_ctxt('toolsJarFileName', FSUtil.get_resource_name(matched_files[0]))
 
-    def load_prepackaged_resources(self):
+    def load_tools_jar_resources(self):
         """
-        Checks for the tools jar and adds it to context
-        Checks if the packaging includes the CSP dependencies. If so, it moves the dependencies
-        into the tmp folder. This allows the tool to pick the resources from cache folder.
+        Checks for the tools jar and identifies it from the tools-resources directory.
+        This method handles only the tools jar identification part without loading other prepackaged resources.
         """
         for tools_related_files in self.tools_resource_path:
             # This function uses a regex based comparison to identify the tools jar file
@@ -178,6 +177,14 @@ class ToolContext(YAMLPropertiesContainer):
             if os.path.exists(tools_related_files):
                 FSUtil.copy_resource(tools_related_files, self.get_cache_folder())
                 self._identify_tools_wheel_jar(FSUtil.get_all_files(tools_related_files))
+
+    def load_prepackaged_resources(self):
+        """
+        Checks for the tools jar and adds it to context
+        Checks if the packaging includes the CSP dependencies. If so, it moves the dependencies
+        into the tmp folder. This allows the tool to pick the resources from cache folder.
+        """
+        self.load_tools_jar_resources()
 
         if not self.are_resources_prepackaged():
             self.logger.info('No prepackaged resources found.')

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -520,7 +520,6 @@ def train(
     """
     # load config from command line argument, or use default
     get_config(config)
-
     datasets, profile_df = load_datasets(dataset)
     dataset_list = sorted(list(datasets.keys()))
     profile_datasets = sorted(list(profile_df['appName'].unique()))


### PR DESCRIPTION
Contributes to #1669 

## Motive
Currently as part of any QualX runs ( train, evaluate ), QualX expects the environment variable `$SPARK_RAPIDS_TOOLS_JAR` to be set.
As as result of #1496 , the whl package now contains the tools_jar which can be use directly with the user_tools commands.
We should start using the packaged jar file instead of expecting the user to set the `SPARK_RAPIDS_TOOLS_JAR` env var

## Changes
This PR uses the existing logic to find core tools jar from resources and updates the required env variables during QualXTool run

## Behavior Updates
- `SPARK_RAPIDS_TOOLS_JAR` env var already set by the user precedes the one being set by using the resource jar
- Validation is added to check if the env var value set already actually points to a jar
- Logs a warning in case not set and goes on to set it from the resources
- In case no jar found in the resources, the run fails

## Testing
This has been locally to run spark_rapids train command with a set of onprem eventlogs and it completes to success
