### PR TITLE
Use qual_tool_filter config to enable/disable stage-filtering in Qualx

### DIFF
--- a/user_tools/docs/qualx.md
+++ b/user_tools/docs/qualx.md
@@ -20,6 +20,7 @@ Arguments:
 - qual_output: Path to a directory containing qualification tool output.
 - output_folder: Path to store the output.
 - custom_model_file: (OPTIONAL) Path to a custom-trained model.json file.
+- config: (OPTIONAL) Path to a qualx-conf.yaml file containing configuration options for the qualx model.
 
 Output files:
 - prediction.csv: per-application speedup predictions.
@@ -124,6 +125,7 @@ Arguments:
 - n_trials: (OPTIONAL) Number of trials for hyperparameter search, default: 200.
 - base_model: (OPTIONAL) Path to pre-trained model to serve as a base for fine-tuning/continued-training.
 - features_csv_dir: (OPTIONAL) Path to a directory containing one or more features.csv files to augment the training dataset.
+- config: (OPTIONAL) Path to a qualx-conf.yaml file containing configuration options for the qualx model.
 
 Continuing the example from above, we would use:
 ```bash

--- a/user_tools/src/spark_rapids_pytools/rapids/qualx/prediction.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualx/prediction.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/user_tools/src/spark_rapids_pytools/rapids/qualx/prediction.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualx/prediction.py
@@ -65,10 +65,12 @@ class Prediction(QualXTool):
                 custom_model_file = estimation_model_args['customModelFile']
             else:
                 custom_model_file = None
+            config = self.wrapper_options.get('config')
             df = predict(platform=self.platform_type.map_to_java_arg(),
                          qual=self.qual_output,
                          output_info=output_info,
-                         model=custom_model_file)
+                         model=custom_model_file,
+                         config=config)
             if not df.empty:
                 print_summary(df)
                 print_speedup_summary(df)

--- a/user_tools/src/spark_rapids_pytools/rapids/qualx/train.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualx/train.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/user_tools/src/spark_rapids_pytools/rapids/qualx/train.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualx/train.py
@@ -54,15 +54,16 @@ class Train(QualXTool):
         """
         try:
             train(
-                dataset=self.dataset,
-                model=self.model,
                 output_dir=self.output_folder,
-                n_trials=self.n_trials,
-                base_model=self.base_model,
-                features_csv_dir=self.features_csv_dir,
+                dataset=self.wrapper_options['dataset'],
+                model=self.wrapper_options['model'],
+                n_trials=self.wrapper_options['n_trials'],
+                base_model=self.wrapper_options['base_model'],
+                features_csv_dir=self.wrapper_options['features_csv_dir'],
+                config=self.wrapper_options['config'],
             )
             self.logger.info('Training completed successfully.')
-            self.logger.info('Trained XGBoost model is saved at: %s', self.model)
+            self.logger.info('Trained XGBoost model is saved at: %s', self.wrapper_options['model'])
             self.logger.info('Training results are generated at: %s', self.output_folder)
         except Exception as e:  # pylint: disable=broad-except
             self.logger.error('Training failed with error: %s', e)

--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -691,7 +691,7 @@ class PredictUserArgModel(AbsToolUserArgModel):
     This is used as doing preliminary validation against some of the common pattern
     """
     qual_output: str = None
-    prof_output: str = None
+    config: Optional[str] = None
     estimation_model_args: Optional[Dict] = dataclasses.field(default_factory=dict)
 
     def build_tools_args(self) -> dict:
@@ -703,8 +703,8 @@ class PredictUserArgModel(AbsToolUserArgModel):
         return {
             'runtimePlatform': self.platform,
             'qual_output': self.qual_output,
-            'prof_output': self.prof_output,
             'output_folder': self.output_folder,
+            'config': self.config,
             'estimationModelArgs': self.p_args['toolArgs']['estimationModelArgs'],
             'platformOpts': {}
         }
@@ -721,6 +721,7 @@ class TrainUserArgModel(AbsToolUserArgModel):
     n_trials: Optional[int] = None
     base_model: Optional[str] = None
     features_csv_dir: Optional[str] = None
+    config: Optional[str] = None
 
     def build_tools_args(self) -> dict:
         runtime_platform = CspEnv.fromstring(self.platform)
@@ -732,6 +733,7 @@ class TrainUserArgModel(AbsToolUserArgModel):
             'n_trials': self.n_trials,
             'base_model': self.base_model,
             'features_csv_dir': self.features_csv_dir,
+            'config': self.config,
             'platformOpts': {},
         }
 

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -211,7 +211,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                    qual_output: str = None,
                    output_folder: str = None,
                    custom_model_file: str = None,
-                   platform: str = 'onprem') -> None:
+                   platform: str = 'onprem',
+                   config: str = None) -> None:
         """The Prediction cmd takes existing qualification tool output and runs the
         estimation model in the qualification tools for GPU speedups.
 
@@ -223,6 +224,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                 or remote cloud storage url.
         :param platform: defines one of the following "onprem", "dataproc", "databricks-aws",
                          and "databricks-azure", "emr", default to "onprem".
+        :param config: Path to a qualx-conf.yaml file to use for configuration.
         """
         # Since prediction is an internal tool with frequent output, we enable debug mode by default
         ToolLogging.enable_debug_mode()
@@ -241,7 +243,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                                             platform=platform,
                                                             qual_output=qual_output,
                                                             output_folder=output_folder,
-                                                            estimation_model_args=estimation_model_args)
+                                                            estimation_model_args=estimation_model_args,
+                                                            config=config)
 
         if predict_args:
             tool_obj = Prediction(platform_type=predict_args['runtimePlatform'],
@@ -255,9 +258,10 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
               dataset: str = None,
               model: str = None,
               output_folder: str = None,
-              n_trials: int = 200,
+              n_trials: int = None,
               base_model: str = None,
-              features_csv_dir: str = None):
+              features_csv_dir: str = None,
+              config: str = None):
         """The Train cmd trains an XGBoost model on the input data to estimate the speedup of a
          Spark CPU application.
 
@@ -269,6 +273,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         :param features_csv_dir: Path to a folder containing one or more features.csv files.  These files are
                                  produced during prediction, and must be manually edited to provide a label column
                                  (Duration_speedup) and value.
+        :param config: Path to YAML config file containing the required training parameters.
         """
         # Since train is an internal tool with frequent output, we enable debug mode by default
         ToolLogging.enable_debug_mode()
@@ -281,15 +286,11 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                                           output_folder=output_folder,
                                                           n_trials=n_trials,
                                                           base_model=base_model,
-                                                          features_csv_dir=features_csv_dir)
+                                                          features_csv_dir=features_csv_dir,
+                                                          config=config)
 
         tool_obj = Train(platform_type=train_args['runtimePlatform'],
-                         dataset=dataset,
-                         model=model,
                          output_folder=output_folder,
-                         n_trials=n_trials,
-                         base_model=base_model,
-                         features_csv_dir=features_csv_dir,
                          wrapper_options=train_args)
         tool_obj.launch()
 

--- a/user_tools/src/spark_rapids_tools/tools/qualx/featurizers/default.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/featurizers/default.py
@@ -710,7 +710,7 @@ def load_csv_files(
                 sql_ops_metrics = sql_ops_metrics.loc[
                     sql_ops_metrics['Exec Is Supported']
                 ].drop(columns=['Exec Is Supported'])
-            else:  # qual_tool_filter_by = 'sqlId'
+            elif qualtool_filter == 'sqlId':
                 sql_level_supp = (
                     node_level_supp.groupby(['App ID', 'SQL ID'])['Exec Is Supported']
                     .agg('all')
@@ -726,6 +726,9 @@ def load_csv_files(
                 sql_app_metrics = sql_app_metrics.drop(
                     columns=['Exec Is Supported', 'App ID', 'SQL ID']
                 )
+            else:
+                # don't filter out unsupported ops
+                pass
 
     # sql ids to drop due to failures meeting below criteria
     sqls_to_drop = set()

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -491,7 +491,7 @@ def train(
     dataset: str,
     model: Optional[str] = 'xgb_model.json',
     output_dir: Optional[str] = 'train',
-    n_trials: Optional[int] = 200,
+    n_trials: Optional[int] = None,
     base_model: Optional[str] = None,
     features_csv_dir: Optional[str] = None,
     config: Optional[str] = None,
@@ -519,7 +519,10 @@ def train(
         Path to a qualx-conf.yaml file to use for configuration.
     """
     # load config from command line argument, or use default
-    get_config(config)
+    cfg = get_config(config)
+    model_type = cfg.model_type
+    model_config = cfg.__dict__.get(model_type, {})
+    trials = n_trials if n_trials else model_config.get('n_trials', 200)
 
     datasets, profile_df = load_datasets(dataset)
     dataset_list = sorted(list(datasets.keys()))
@@ -576,7 +579,7 @@ def train(
             feature_cols = xgb_base_model.feature_names   # align features to base model
         else:
             raise ValueError(f'Existing model not found for fine-tuning: {base_model}')
-    xgb_model = train_model(features, feature_cols, label_col, n_trials=n_trials, base_model=xgb_base_model)
+    xgb_model = train_model(features, feature_cols, label_col, n_trials=trials, base_model=xgb_base_model)
 
     # save model and params
     ensure_directory(model, parent=True)
@@ -619,7 +622,7 @@ def predict(
     output_info: dict,
     *,
     model: Optional[str] = None,
-    qual_tool_filter: Optional[str] = 'stage',
+    qual_tool_filter: Optional[str] = None,
     config: Optional[str] = None,
 ) -> pd.DataFrame:
     """Predict GPU speedup given CPU logs.
@@ -635,14 +638,18 @@ def predict(
     model:
         Name of a pre-trained model or path to a model on disk to use for prediction.
     qual_tool_filter:
-        Filter to apply to the qualification tool output, default: 'stage'
+        Filter to apply to the qualification tool output: 'stage' (default), 'sqlId', or 'none'.
     config:
         Path to a qualx-conf.yaml file to use for configuration.
     """
     # load config from command line argument, or use default
-    get_config(config)
+    cfg = get_config(config)
+    model_type = cfg.model_type
+    model_config = cfg.__dict__.get(model_type, {})
+    qual_filter = qual_tool_filter if qual_tool_filter else model_config.get('qual_tool_filter', 'stage')
 
     node_level_supp, qual_tool_output, qual_metrics = _get_qual_data(qual)
+
     # create a DataFrame with default predictions for all app IDs.
     # this will be used for apps without predictions.
     default_preds_df = qual_tool_output.apply(create_row_with_default_speedup, axis=1)
@@ -667,7 +674,7 @@ def predict(
     profile_df = load_profiles(
         datasets=datasets,
         node_level_supp=node_level_supp,
-        qual_tool_filter=qual_tool_filter,
+        qual_tool_filter=qual_filter,
         qual_tool_output=qual_tool_output,
         remove_failed_sql=False,
     )
@@ -777,7 +784,7 @@ def _predict_cli(
     eventlogs: Optional[str] = None,
     qual_output: Optional[str] = None,
     model: Optional[str] = None,
-    qual_tool_filter: Optional[str] = 'stage',
+    qual_tool_filter: Optional[str] = None,
     config: Optional[str] = None,
 ) -> None:
     """Predict GPU speedup given CPU logs.
@@ -803,13 +810,16 @@ def _predict_cli(
         Either a model name corresponding to a platform/pre-trained model, or the path to an XGBoost
         model on disk.
     qual_tool_filter: str
-        Set to either 'sqlID' or 'stage' (default) to apply model to supported sqlIDs or stages, based on qual tool
-        output.  A sqlID or stage is fully supported if all execs are respectively fully supported.
+        Set to either 'stage' (default), 'sqlId', or 'none', where 'stage' applies model to supported stages,
+        'sqlId' applies model to supported sqlIDs, and 'none' applies model to all sqlIDs and stages.
     config:
         Path to a qualx-conf.yaml file to use for configuration.
     """
     # load config from command line argument, or use default
-    get_config(config)
+    cfg = get_config(config)
+    model_type = cfg.model_type
+    model_config = cfg.__dict__.get(model_type, {})
+    qual_filter = qual_tool_filter if qual_tool_filter else model_config.get('qual_tool_filter', 'stage')
 
     # Note this function is for internal usage only. `spark_rapids predict` cmd is the public interface.
     assert eventlogs or qual_output, 'Please specify either --eventlogs or --qual_output.'
@@ -839,7 +849,7 @@ def _predict_cli(
         output_info=output_info,
         qual=qual,
         model=model,
-        qual_tool_filter=qual_tool_filter,
+        qual_tool_filter=qual_filter,
     )
 
 


### PR DESCRIPTION
This PR fixes #1724 by using the existing `qual_tool_filter` config in the qualx-conf.yaml to enable/disable stage filtering.

The default value for `qual_tool_filter` is "stage", which enables stage-filtering (QXS).  Setting this config to "none" will now disable QXS and report the raw QX predictions.

**Changes**
- Added `--config` option to the `prediction` and `train` CLIs to support external qualx-conf.yaml files.
- Connected `qual_tool_filter` and `n_trials` from the config file to the qualx code.

**Tests**
Following CMDs have been tested:
spark_rapids prediction
spark_rapids train

Internal Usage:
python qualx_main.py preprocess
python qualx_main.py train
python qualx_main.py predict
python qualx_main.py evaluate