### PR TITLE
Adding QualCoreHandler to the context instead of passing to individual functions

### DIFF
--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -41,4 +41,4 @@ jobs:
           python -m pip install --pre tox-gh-actions
 
       - name: Run tox test
-        run: cd user_tools && tox
+        run: cd user_tools && tox -e behave -- -v --no-capture

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -41,4 +41,4 @@ jobs:
           python -m pip install --pre tox-gh-actions
 
       - name: Run tox test
-        run: cd user_tools && tox -e behave -- -v --no-capture
+        run: cd user_tools && tox

--- a/core/src/main/resources/configs/qualOutputTable.yaml
+++ b/core/src/main/resources/configs/qualOutputTable.yaml
@@ -15,80 +15,80 @@
 qualTableDefinitions:
   - label: qualCoreCSVStatus
     description: >-
-      TBA
+      Status of each event log passed to the qualification tool
     fileName: status.csv
     scope: global
     columns:
       - name: Event Log
         dataType: String
         description: >-
-          TBA
+          Event Log Path(local/remote)
       - name: Status
         dataType: String
         description: >-
-          TBA
+          Status whether the event log processed successfully or not
       - name: App ID
         dataType: String
         description: >-
-          TBA
+          ID of the app associated with the event log
       - name: Description
         dataType: String
         description: >-
-          TBA
+          Total processing time of the event log
   - label: qualCoreCSVSummary
     description: >-
-      TBA
+      Summary of each event log processed by the qualification tool
     fileName: apps_summary.csv
     scope: global
     columns:
       - name: App Name
         dataType: String
         description: >-
-          TBA
+          Name of application associated with the event log
       - name: App ID
         dataType: String
         description: >-
-          TBA
+          ID of the app associated with the event log
       - name: Attempt ID
         dataType: String
         description: >-
-          TBA
+          Attempt ID of the app associated with the event log
       - name: App Duration
         dataType: String
         description: >-
-          TBA
+          Total runtime of the app
       - name: Executor CPU Time Percent
         dataType: float
         description: >-
-          TBA
+          Total CPU time consumed by executors in percentage
       - name: SQL Ids with Failures
         dataType: String
         description: >-
-          TBA
+          SQL Ids with failures
       - name: Unsupported Read File Formats and Types
         dataType: String
         description: >-
-          TBA
+          Formats and types of files that are not supported for reading
       - name: Unsupported Write Data Format
         dataType: String
         description: >-
-          TBA
+          Format of the data that is not supported for writing
       - name: Complex Types
         dataType: String
         description: >-
-          TBA
+          Types of data types that are not supported for writing
       - name: Nested Complex Types
         dataType: String
         description: >-
-          TBA
+          Types of data types that are not supported for writing
       - name: Potential Problems
         dataType: String
         description: >-
-          TBA
+          Potential problems with the app
       - name: Longest SQL Duration
         dataType: Long
         description: >-
-          TBA
+          The longest SQL duration in the app
       - name: SQL Stage Durations Sum
         dataType: Long
         description: >-
@@ -97,173 +97,174 @@ qualTableDefinitions:
       - name: App Duration Estimated
         dataType: Boolean
         description: >-
-          TBA
+          Whether the app duration is estimated or not(true/false)
       - name: Total Core Seconds
         dataType: Long
         description: >-
-          TBA
+          The total core seconds of the app
   # the following table seems to be useless
   - label: perSqlCSVReport
-    description:
+    description: >-
+      Report containing the details of each SQL in the app
     fileName: persql.csv
     scope: per-app
     columns:
       - name: Root SQL ID
         dataType: Long
         description: >-
-          TBA
+          The root SQL ID for each triggered SQL
       - name: SQL ID
         dataType: Long
         description: >-
-          TBA
+          The SQL ID for each triggered SQL(root SQL ID is the parent SQL ID)
       - name: SQL Description
         dataType: String
         description: >-
-          TBA
+          The description of the SQL
       - name: SQL DF Duration
         dataType: Long
         description: >-
-          TBA
+          The duration of the SQL
       - name: GPU Opportunity
         dataType: Long
         description: >-
-          TBA
+          The expected duration of the SQL on GPU
   - label: execCSVReport
     description: >-
-        TBA
+        Report containing the details of each executor in the SQL
     fileName: execs.csv
     scope: per-app
     columns:
       - name: SQL ID
         dataType: Long
         description: >-
-          TBA
+          The associated SQL ID for the executor
       - name: Exec Name
         dataType: String
         description: >-
-          TBA
+          The name of the executor
       - name: Expression Name
         dataType: String
         description: >-
-          TBA
+          The name of the expression in the executor
       - name: Exec Duration
         dataType: Long
         description: >-
-          TBA
+          The duration of the executor
       - name: SQL Node Id
         dataType: Long
         description: >-
-          TBA
+          The Node ID of the associated SQL with the exec
       - name: Exec Is Supported
         dataType: Boolean
         description: >-
-          TBA
+          Whether the executor is supported or not(true/false)
       - name: Exec Stages
         dataType: String
         description: >-
-          TBA
+          The stages of the executor
       - name: Exec Children
         dataType: String
         description: >-
-          TBA
+          The children of the executor
       - name: Exec Children Node Ids
         dataType: String
         description: >-
-          TBA
+          The Node IDs of the children of the executor
       - name: Exec Should Remove
         dataType: Boolean
         description: >-
-          TBA
+          Whether the executor should be removed or not(true/false)
       - name: Exec Should Ignore
         dataType: Boolean
         description: >-
-          TBA
+          Whether the executor should be ignored or not(true/false)
       - name: Action
         dataType: String
         description: >-
-          TBA
+          The action to be taken for the executor
   - label: unsupportedOpsCSVReport
     description: >-
-      TBA
+      Report containing the details of each unsupported operator in the SQL
     fileName: unsupported_operators.csv
     scope: per-app
     columns:
       - name: SQL ID
         dataType: Long
         description: >-
-          TBA
+          The associated SQL ID for the unsupported operator
       - name: Stage ID
         dataType: Long
         description: >-
-          TBA
+          The associated stage ID for the unsupported operator
       - name: ExecId
         dataType: Long
         description: >-
-          TBA
+          The associated executor ID for the unsupported operator
       - name: Unsupported Type
         dataType: String
         description: >-
-          TBA
+          The type of the unsupported operator
       - name: Unsupported Operator
         dataType: String
         description: >-
-          TBA
+          The details of the unsupported operator
       - name: Details
         dataType: String
         description: >-
-          TBA
+          The details of the unsupported operator
       - name: Stage Duration
         dataType: Long
         description: >-
-          STAGE_WALLCLOCK_DUR_STR
+          The duration of the stage
       - name: App Duration
         dataType: Long
         description: >-
-          TBA
+          The duration of the app
       - name: Action
         dataType: String
         description: >-
-          TBA
+          The action to be taken for the unsupported operator
   - label: operatorsStatsCSVReport
     description: >-
-      TBA
+      Report containing the details of each operator in the SQL
     fileName: operators_stats.csv
     scope: per-app
     columns:
       - name: SQL ID
         dataType: Long
         description: >-
-          TBA
+          The associated SQL ID for the operator
       - name: Operator Type
         dataType: String
         description: >-
-          TBA
+          The type of the operator
       - name: Operator Name
         dataType: String
         description: >-
-          TBA
+          The name of the operator
       - name: Count
         dataType: Long
         description: >-
-          TBA
+          The total count of the operator
       - name: Supported
         dataType: Boolean
         description: >-
-          TBA
+          Whether the operator is supported or not(true/false)
       - name: Stages
         dataType: String
         description: >-
-          TBA
+          Colon separated list of the stages of the operator
   - label: stagesCSVReport
     description: >-
-      TBA
+      Report containing the details of each stage in the SQL
     fileName: stages.csv
     scope: per-app
     columns:
       - name: Stage ID
         dataType: Long
         description: >-
-          TBA
+          The associated stage ID for the stage
       - name: Stage Task Duration
         dataType: Long
         description: >-
@@ -271,14 +272,14 @@ qualTableDefinitions:
       - name: Unsupported Task Duration
         dataType: Long
         description: >-
-          TBA
+          Part of the stage task duration that is not supported
       - name: Stage Estimated
         dataType: Boolean
         description: >-
-          TBA
+          Whether the stage runtime is estimated or not(true/false)
   - label: clusterInfoJSONReport
     description: >-
-      TBA
+      Report containing the details of the cluster
     fileName: cluster_information.json
     fileFormat: JSON
     scope: per-app
@@ -286,71 +287,73 @@ qualTableDefinitions:
       - name: appName
         dataType: String
         description: >-
-          TBA
+          The name of the app for the associated event log
       - name: appId
         dataType: String
         description: >-
-          TBA
+          The ID of the app for the associated event log
       - name: eventLogPath
         dataType: String
         description: >-
-          TBA
+          The path of the event log for the associated app
       - name: sourceClusterInfo
         dataType: Dict
         description: >-
-          TBA
+          The source cluster information for the associated app(dictionary containing the cluster information)
       - name: recommendedClusterInfo
         dataType: Dict
         description: >-
-          TBA
+          The recommended cluster information for the associated app(dictionary containing the cluster information)
   # the following table is databricks specific table
   - label: clusterTagsCSVReport
     description: >-
-      TBA
+      Report containing the details of the cluster tags
     fileName: clusters_tags.csv
     scope: per-app
     columns:
       - name: Property Name
         dataType: String
         description: >-
-          TBA
+          The name of the property
       - name: Property Value
         dataType: String
         description: >-
-          TBA
+          The value of the property
   # the following table is enabled only when ml-functions argument is added to the arguments.
   - label: mlFunctionsCSVReport
-    description:
+    description: >-
+      Report containing the details of the ML functions
     fileName: ml_functions.csv
     scope: per-app
     columns:
       - name: Stage ID
         dataType: Long
         description: >-
-          TBA
+          The stage IDs of the ML functions
       - name: ML Functions
         dataType: String
         description: >-
-          TBA
+          The ML functions in the stage
       - name: Stage WallClock Duration (ms)
         dataType: Long
         description: >-
           Calculated as (submissionTime - completionTime) of the given stage
   # the following table is enabled only when ml-functions argument is added to the arguments.
   - label: mlFunctionsDurationsCSVReport
-    description:
+    description: >-
+      Report containing the details of the ML functions durations
     fileName: ml_functions_durations.csv
     scope: per-app
     columns:
       - name: Stage Ids
         dataType: String
         description: >-
-          TBA
+          The stage IDs of the ML functions
       - name: ML Function Name
         dataType: String
         description: >-
-          TBA
+          The ML functions name in the stage
       - name: Total Duration
         dataType: Long
         description: >-
-          TBA
+          The total duration of the ML functions

--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -32,9 +32,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
 ]
+license = {text = "Apache-2.0"}
 # see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for list of supported licenses
-license = "Apache-2.0 AND MIT"
-license-files = ["LICENSE"]
 dependencies = [
     # numpy-2.0.0 supports python [3.9, 3.13]. numpy2.1.0 drooped support for Python 3.9.
     "numpy>=2.0.0",

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification_stats.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification_stats.py
@@ -74,6 +74,8 @@ class SparkQualStats(RapidsTool):
         FSUtil.make_dirs(self.output_folder, exist_ok=False)
         self.ctxt.set_local('outputFolder', self.output_folder)
         self.logger.info('Local output folder is set as: %s', self.output_folder)
+        # Add QualCoreHandler to the context
+        self.ctxt.set_ctxt('qualHandler', QualCoreHandler(result_path=self.qual_output))
 
     def _run_rapids_tool(self) -> None:
         """
@@ -81,10 +83,7 @@ class SparkQualStats(RapidsTool):
         """
         try:
             self.logger.info('Running Qualification Stats tool')
-            qual_handler = QualCoreHandler(result_path=self.qual_output)
-            if not qual_handler:
-                raise ValueError('No qualification handlers available for stats report')
-            result = SparkQualificationStats(ctxt=self.ctxt, qual_handler=qual_handler)
+            result = SparkQualificationStats(ctxt=self.ctxt)
             result.report_qualification_stats()
             self.logger.info('Qualification Stats tool completed successfully')
         except Exception as e:  # pylint: disable=broad-except

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -151,7 +151,7 @@ local:
             name: 'heuristics_info.csv'
             outputComment: "Heuristics information"
       configRecommendations:
-        name: 'rapids_4_spark_qualification_output/tuning'
+        name: 'qual_core_output/tuning'
         columns:
           - 'Full Cluster Config Recommendations*'
           - 'GPU Config Recommendation Breakdown*'
@@ -168,7 +168,7 @@ local:
           - 'Full Cluster Config Recommendations*'
           - 'GPU Config Recommendation Breakdown*'
       appsStatusReport:
-        name: 'rapids_4_spark_qualification_output/rapids_4_spark_qualification_output_status.csv'
+        name: 'qual_core_output/status.csv'
         outputComment: "Application status report"
     costColumns:
       - 'Savings Based Recommendation'

--- a/user_tools/src/spark_rapids_tools/cmdli/dev_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/dev_cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/user_tools/src/spark_rapids_tools/cmdli/dev_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/dev_cli.py
@@ -69,7 +69,7 @@ class DevCLI(object):  # pylint: disable=too-few-public-methods
         :param output_folder: Path to store the output.
         :param qual_output: path to the directory, which contains the qualification tool output.
                             E.g. user should specify the parent directory $WORK_DIR where
-                            $WORK_DIR/rapids_4_spark_qualification_output exists.
+                            $WORK_DIR/qual_core_output exists.
         """
         ToolLogging.enable_debug_mode()
         init_environment('stats')

--- a/user_tools/tests/spark_rapids_tools_e2e/features/environment.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/environment.py
@@ -113,7 +113,7 @@ def _setup_env(context) -> None:
     script = os.path.join(os.environ['E2E_TEST_SCRIPTS_DIR'], script_file_name)
     try:
         warning_msg = "Setting up the virtual environment for the tests. This may take a while."
-        if os.environ.get('BUILD_JAR') == 'true':
+        if os.environ.get('E2E_TEST_BUILD_JAR') == 'true':
             warning_msg = f'Building JAR and {warning_msg}'
         logger.warning(warning_msg)
         result = E2ETestUtils.run_sys_cmd([script])

--- a/user_tools/tests/spark_rapids_tools_ut/qualx/test_preprocess.py
+++ b/user_tools/tests/spark_rapids_tools_ut/qualx/test_preprocess.py
@@ -161,19 +161,14 @@ class TestPreprocess(SparkRapidsToolsUT):
             ['app2', 'sql1', 'node1', False, '', 'WholeStageCodegen3'],
             ['app2', 'sql1', 'node2', False, '', 'Exec4']
         ], columns=['App ID', 'SQL ID', 'SQL Node Id', 'Exec Is Supported', 'Action', 'Exec Name'])
+        # Call function
+        result = load_qtool_execs(test_data)
 
-        # Create temporary CSV file
-        with tempfile.NamedTemporaryFile(suffix='.csv', mode='w') as f:
-            test_data.to_csv(f.name, index=False)
-
-            # Call function
-            result = load_qtool_execs([f.name])
-
-            # Verify results
-            assert isinstance(result, pd.DataFrame)
-            assert list(result.columns) == ['App ID', 'SQL ID', 'SQL Node Id', 'Exec Is Supported']
-            assert len(result) == 4
-            assert result['Exec Is Supported'].tolist() == [True, True, True, False]
+        # Verify results
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == ['App ID', 'SQL ID', 'SQL Node Id', 'Exec Is Supported']
+        assert len(result) == 4
+        assert result['Exec Is Supported'].tolist() == [True, True, True, False]
 
     def test_load_datasets(self):
         """Test load_datasets function"""


### PR DESCRIPTION
As part of existing patch [PR](https://github.com/NVIDIA/spark-rapids-tools/pull/1735), QualCoreHandler class was introduced which is concerned with all changes related to reading QualCore output

This PR updates the existing code to use the CoreHandler from context rather than passing it around to individual functions.
Also updates the existing definitions in the qualOutputTable for the tables.