### PR TITLE
[WIP] Improve AppSqlPlanAnalyzer for large eventlogs

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DeltaLakeHelper.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/DeltaLakeHelper.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.tool.planparser
 import com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker
 
 import org.apache.spark.sql.execution.ui.{SparkPlanGraphCluster, SparkPlanGraphNode}
-import org.apache.spark.sql.rapids.tool.SqlPlanInfoGraphEntry
+import org.apache.spark.sql.rapids.tool.store.SQLPlanModel
 import org.apache.spark.sql.rapids.tool.util.StringUtils
 
 // A class used to handle the DL writeOps such as:
@@ -189,7 +189,7 @@ object DeltaLakeHelper {
    * @param node the node to check
    * @return true if the node is a Delta meta-data operation
    */
-  def isDeltaOpNode(sqlPIGEntry: SqlPlanInfoGraphEntry,
+  def isDeltaOpNode(sqlPIGEntry: SQLPlanModel,
       sqlDesc: String,
       node: SparkPlanGraphNode): Boolean = {
     node match {
@@ -208,10 +208,10 @@ object DeltaLakeHelper {
             // differences in data between runs
             // Execute MergeIntoCommandEdge (1)
             //   +- MergeIntoCommandEdge (2)
-            sqlPIGEntry.sparkPlanGraph.allNodes.size < 2
+            sqlPIGEntry.getToolsPlanGraph.allNodes.size < 2
           case "LocalTableScan" =>
             sqlDesc.contains("stats_parsed.numRecords") ||
-              sqlPIGEntry.sparkPlanGraph.allNodes.size == 1
+              sqlPIGEntry.getToolsPlanGraph.allNodes.size == 1
           case s if ReadParser.isScanNode(s) =>
             // RAPIDS plugin checks that a node is Delta Scan by looking at the type of the exec
             // "RDDScanExec" and checking for some string patterns in the Relation/schema

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -451,7 +451,9 @@ object SQLPlanParser extends Logging {
       sqlDesc: String,
       checker: PluginTypeChecker,
       app: AppBase): PlanInfo = {
-    val toolsGraph = ToolsPlanGraph.createGraphWithStageClusters(planInfo, app)
+    // Use the tools graph cached in the SQLPlan model.
+    val toolsGraph = app.sqlManager.applyToPlanModel(sqlID)(_.getToolsPlanGraph)
+      .getOrElse(ToolsPlanGraph.createGraphWithStageClusters(planInfo, app))
 
     // Find all the node graphs that should be excluded and send it to the parsePlanNode
     val excludedNodes = buildSkippedReusedNodesForPlan(toolsGraph.sparkGraph)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
@@ -40,7 +40,6 @@ object ProfileMain extends Logging {
    * Entry point for tests
    */
   def mainInternal(appArgs: ProfileArgs, enablePB: Boolean = false): (Int, Int) = {
-
     // Parsing args
     val eventlogPaths = appArgs.eventlog.getOrElse(List.empty[String])
     val driverLog = appArgs.driverlog.getOrElse("")

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
@@ -289,6 +289,8 @@ class RunningQualificationApp(
   // don't aggregate at app level, just sql level
   private def aggregatePerSQLStats(sqlID: Long): Option[EstimatedPerSQLSummaryInfo] = {
     val sqlDesc = sqlIdToInfo.get(sqlID).map(_.description)
+    // build the plan graphs to guarantee that the SQL plans were already created
+    buildPlanGraphsInternal()
     val origPlanInfo = sqlPlans.get(sqlID).map { plan =>
       SQLPlanParser.parseSQLPlan(appId, plan, sqlID, sqlDesc.getOrElse(""), pluginTypeChecker, this)
     }
@@ -309,12 +311,46 @@ class RunningQualificationApp(
     perSqlInfos
   }
 
+  override def buildPlanGraphs(): Unit = {
+    // Do nothing because the events are not parsed yet by the time
+    // this function is called.
+  }
+
+  /**
+   * Whether the plan graphs have already been built.
+   */
+  private var _graphBuilt = false
+
+  /**
+   * Build the plan graphs for all the SQL Plans if any.
+   * It is possible that this method gets called multiple times. For example, aggregateStats
+   * is called by different methods in teh same object and we want to make sure that it does not
+   * create the graphs multiple times.
+   */
+  def buildPlanGraphsInternal(): Unit = {
+    this.synchronized {
+      if (!_graphBuilt) {
+        sqlManager.buildPlanGraph(this)
+        _graphBuilt = true
+      }
+    }
+  }
+
+  override def cleanupSQL(sqlID: Long): Unit = {
+    super.cleanupSQL(sqlID)
+    // reset the graph built flag because the sqlIds were removed.
+    this.synchronized {
+      _graphBuilt = false
+    }
+  }
   /**
    * Aggregate and process the application after reading the events.
    * @return Option of QualificationSummaryInfo, Some if we were able to process the application
    *         otherwise None.
    */
   override def aggregateStats(): Option[QualificationSummaryInfo] = {
+    // build the plan graphs to guarantee that the SQL plans were already created
+    buildPlanGraphsInternal()
     // make sure that the APPSQLAppAnalyzer has processed the running application
     AppSQLPlanAnalyzer(this)
     super.aggregateStats()

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/SQLView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/SQLView.scala
@@ -95,7 +95,7 @@ object ProfSQLPlanAlignedView extends AppSQLPlanNonDeltaOpsViewTrait with ProfAp
     // Create a SQLClassifier object and attach it to the AppInfo
     val sqlPlanTypeAnalysis = new SQLPlanClassifier(app.asInstanceOf[ApplicationInfo])
     // Walk through the SQLPlans to identify the delta-op SQIds
-    sqlPlanTypeAnalysis.walkPlans(app.sqlPlans)
+    sqlPlanTypeAnalysis.walkPlans(app.sqlManager.sqlPlans.values)
     app.sqlPlans.filterKeys(!sqlPlanTypeAnalysis.sqlCategories("deltaOp").contains(_)).
       map { case (sqlID, _) =>
         SQLCleanAndAlignIdsProfileResult(sqlID)

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/FilterAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/FilterAppInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,10 @@ class FilterAppInfo(
   // We are currently processing 2 events. This is used as counter to send true when both the
   // event are processed so that we can stop processing further events.
   var eventsToProcess: Int = 2
+
+  override def buildPlanGraphs(): Unit = {
+    // Do nothing because the filter application does not need to build plans anyway.
+  }
 
   override def processEvent(event: SparkListenerEvent): Boolean = {
     if (event.isInstanceOf[SparkListenerApplicationStart]) {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -16,7 +16,6 @@
 
 package org.apache.spark.sql.rapids.tool
 
-import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 
 import com.nvidia.spark.rapids.tool.Platform
@@ -27,9 +26,8 @@ import org.apache.maven.artifact.versioning.ComparableVersion
 
 import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.execution.SparkPlanInfo
-import org.apache.spark.sql.execution.ui.{SparkPlanGraph, SparkPlanGraphNode}
-import org.apache.spark.sql.rapids.tool.util.{SparkRuntime, ToolsPlanGraph}
+import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
+import org.apache.spark.sql.rapids.tool.util.SparkRuntime
 
 object ToolUtils extends Logging {
   // List of recommended file-encodings on the GPUs.
@@ -469,33 +467,6 @@ class InvalidMemoryUnitFormatException(message: String)
 
 class MatchingInstanceTypeNotFoundException(message: String)
   extends Exception(message)
-
-// Class used a container to hold the information of the Tuple<sqlID, PlanInfo, SparkGraph>
-// to simplify arguments of methods and caching.
-case class SqlPlanInfoGraphEntry(
-    sqlID: Long,
-    planInfo: SparkPlanInfo,
-    sparkPlanGraph: SparkPlanGraph
-)
-
-// A class used to cache the SQLPlanInfoGraphs
-class SqlPlanInfoGraphBuffer {
-  // A set to hold the SqlPlanInfoGraphEntry. LinkedHashSet to maintain the order of insertion.
-  val sqlPlanInfoGraphs = mutable.LinkedHashSet[SqlPlanInfoGraphEntry]()
-  def addSqlPlanInfoGraph(sqlID: Long, planInfo: SparkPlanInfo): SqlPlanInfoGraphEntry = {
-    val newEntry = SqlPlanInfoGraphBuffer.createEntry(sqlID, planInfo)
-    sqlPlanInfoGraphs += newEntry
-    newEntry
-  }
-}
-
-object SqlPlanInfoGraphBuffer {
-  def apply(): SqlPlanInfoGraphBuffer = new SqlPlanInfoGraphBuffer()
-  def createEntry(sqlID: Long, planInfo: SparkPlanInfo): SqlPlanInfoGraphEntry = {
-    val planGraph = ToolsPlanGraph(planInfo)
-    SqlPlanInfoGraphEntry(sqlID, planInfo, planGraph)
-  }
-}
 
 // Case class to represent a failed AppInfo creation
 case class FailureApp(

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModel.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.rapids.tool.store
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.execution.SparkPlanInfo
+import org.apache.spark.sql.rapids.tool.util.ToolsPlanGraph
 
 /**
  * SQLPlanModel is a class to store the information of a SQL Plan including all its versions.
@@ -124,5 +125,13 @@ class SQLPlanModel(val id: Long) {
    */
   def getPrimarySQLPlanInfo: Option[SparkPlanInfo] = {
     planVersions.find(_.version == 0).map(_.planInfo)
+  }
+
+  /**
+   * Get the ToolsPlanGraph from the most recent version of the plan.
+   * @return ToolsPlanGraph of the last version of the plan.
+   */
+  def getToolsPlanGraph: ToolsPlanGraph = {
+    plan.getToolsPlanGraph
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/StageModel.scala
@@ -100,6 +100,14 @@ class StageModel private(sInfo: StageInfo) {
   def getDuration: Long = {
     duration.getOrElse(0L)
   }
+
+  def getId: Int = {
+    stageInfo.stageId
+  }
+
+  def getAttemptId: Int = {
+    stageInfo.attemptNumber()
+  }
 }
 
 object StageModel {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/ToolsPlanGraph.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/ToolsPlanGraph.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ class ToolsPlanGraph(val sparkGraph: SparkPlanGraph,
    * @param node the node to get the stages for
    * @return a set of stageIds or empty if None
    */
-  private def getNodeStagesByAccum(node: SparkPlanGraphNode): Set[Int] = {
+   def getNodeStagesByAccum(node: SparkPlanGraphNode): Set[Int] = {
     val nodeAccums = node.metrics.map(_.accumulatorId)
     accumToStageRetriever.getStageIDsFromAccumIds(nodeAccums)
   }


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1737

- remove redundant checks of `sqlPlanAdaptiveMetrics`
- improve the implementation of `aggregateSQLStageInfo` by changing the dataStructure of the map.
- reduce the overhead of plan analysis by cashing the toolsGraph object in the sqlPlan

### Impact on Performance
For large eventlogs, this PR has a significant impact on runtime.

A large eventlog of 6G compact size 

| property|Before | After |
|-------------|--------|--------|
|runtime| 158.8 minutes | 16 minutes | 
|tool| profiling | profiling |
|xmx| 24G | 24G |
|xms| 16G | 16G |

### Changes in details

This pull request introduces significant changes to the `AppSQLPlanAnalyzer` and related classes to improve performance, simplify data structures, and enhance functionality. The most notable updates include the replacement of `SqlPlanInfoGraphEntry` with `SQLPlanModel`, the introduction of optimized mapping structures for SQL plans and stages, and updates to visitor logic to leverage cached tools graphs. These changes aim to streamline SQL plan analysis and improve memory efficiency.

### Structural changes to SQL plan models:
* Replaced `SqlPlanInfoGraphEntry` with `SQLPlanModel` across multiple files (`AppSQLPlanAnalyzer`, `SparkSQLPlanInfoVisitor`, `DeltaLakeHelper`, etc.), simplifying the representation of SQL plans and enabling direct access to cached tools graphs. [[1]](diffhunk://#diff-d56ed990ec181a2ef118996b608fdff3b53818cf6138baba59b51e4eb407d79eL151-R189) [[2]](diffhunk://#diff-5eb8be83209bd4535310b2b2eb190f5cf7ddb43e100aeb508570b48069ee4ab0L19-R24) [[3]](diffhunk://#diff-96914e2ff13a7ca6242bc95eba12d6269cf1ba19ca7e495fa2f20917f5928683L22-R22)

### Optimized data structures for mapping:
* Updated `sqlPlanNodeIdToStageIds` from a flat `HashMap` to a nested `SortedMap` for faster lookups when mapping SQL IDs and node IDs to stage IDs.
* Added a `constructStageToNodeMap` method to build reverse mappings from stages to nodes, improving retrieval efficiency for stage diagnostics. [[1]](diffhunk://#diff-d56ed990ec181a2ef118996b608fdff3b53818cf6138baba59b51e4eb407d79eR109-R165) [[2]](diffhunk://#diff-d56ed990ec181a2ef118996b608fdff3b53818cf6138baba59b51e4eb407d79eR310-R338)

### Enhanced SQL plan visitor logic:
* Modified `SparkSQLPlanInfoVisitor` to directly use `SQLPlanModel` and its cached tools graph, reducing redundant graph creation and improving traversal performance. [[1]](diffhunk://#diff-5eb8be83209bd4535310b2b2eb190f5cf7ddb43e100aeb508570b48069ee4ab0L37-R52) [[2]](diffhunk://#diff-5eb8be83209bd4535310b2b2eb190f5cf7ddb43e100aeb508570b48069ee4ab0L66-R65)
* Updated `DeltaLakeHelper` and `SQLPlanParser` to utilize cached tools graphs from `SQLPlanModel` instead of creating new ones, enhancing efficiency in node parsing and classification. [[1]](diffhunk://#diff-96914e2ff13a7ca6242bc95eba12d6269cf1ba19ca7e495fa2f20917f5928683L211-R214) [[2]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL454-R456)

### Performance improvements in SQL plan analysis:
* Introduced methods like `buildNodeToStageMap` and `getNodeStages` in `AppSQLPlanAnalyzer` to streamline the mapping process and reduce iteration overhead during SQL plan metric processing. [[1]](diffhunk://#diff-d56ed990ec181a2ef118996b608fdff3b53818cf6138baba59b51e4eb407d79eR109-R165) [[2]](diffhunk://#diff-d56ed990ec181a2ef118996b608fdff3b53818cf6138baba59b51e4eb407d79eL229-R286)
* Improved memory management by selectively updating stage-to-node mappings only when diagnostics are enabled.