### PR TITLE
Patches the python unit tests with the new per-app changes

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/ProfSparkMetricsAnalyzer.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/ProfSparkMetricsAnalyzer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,6 @@ package com.nvidia.spark.rapids.tool.analysis
 // Currently, the difference is not significant because `ProfAppIndexMapperTrait` handles the
 // extraction of AppIndex from ApplicationInfo. However, in the future this object can be used
 // to provide customized logic for the Profiler (i.e., handle metrics specific to GPU eventlogs)
-object ProfSparkMetricsAnalyzer extends AppSparkMetricsAggTrait with ProfAppIndexMapperTrait {
+object ProfSparkMetricsAggregator extends AppSparkMetricsAggTrait with ProfAppIndexMapperTrait {
 
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/QualSparkMetricsAnalyzer.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/analysis/QualSparkMetricsAnalyzer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package com.nvidia.spark.rapids.tool.analysis
 
-object QualSparkMetricsAnalyzer extends AppSparkMetricsAggTrait with QualAppIndexMapperTrait {
+object QualSparkMetricsAggregator extends AppSparkMetricsAggTrait with QualAppIndexMapperTrait {
   // This object is kept to provide the aggregation of the application data for the Qualification.
-  // In future, we might need to provide customized logic for the Qualification
+  // In the future, we might need to provide customized logic for the Qualification
   // (i.e., handle metrics; or filter; ..etc)
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TunerContext.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TunerContext.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.tool.tuning
 import scala.util.{Failure, Success, Try}
 
 import com.nvidia.spark.rapids.tool.Platform
-import com.nvidia.spark.rapids.tool.analysis.{AppSQLPlanAnalyzer, QualSparkMetricsAnalyzer}
+import com.nvidia.spark.rapids.tool.analysis.{AppSQLPlanAnalyzer, QualSparkMetricsAggregator}
 import com.nvidia.spark.rapids.tool.profiling.{DataSourceProfileResult, RecommendedCommentResult, RecommendedPropertyResult}
 import com.nvidia.spark.rapids.tool.views.qualification.QualReportGenConfProvider
 import org.apache.hadoop.conf.Configuration
@@ -56,7 +56,7 @@ case class TunerContext (
       platform: Platform): Option[TuningResult] = {
     val sqlAnalyzer = AppSQLPlanAnalyzer(appInfo)
     val rawAggMetrics =
-      QualSparkMetricsAnalyzer.getAggRawMetrics(appInfo, appIndex, Some(sqlAnalyzer))
+      QualSparkMetricsAggregator.getAggRawMetrics(appInfo, appIndex, Some(sqlAnalyzer))
     QualificationAutoTunerRunner(appInfo, appAggStats, this, rawAggMetrics, dsInfo).collect {
       case qualTuner =>
         Try {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/QualRawReportGenerator.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/QualRawReportGenerator.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids.tool.views
 
-import com.nvidia.spark.rapids.tool.analysis.{AggRawMetricsResult, AppSQLPlanAnalyzer, QualSparkMetricsAnalyzer}
+import com.nvidia.spark.rapids.tool.analysis.{AggRawMetricsResult, AppSQLPlanAnalyzer, QualSparkMetricsAggregator}
 import com.nvidia.spark.rapids.tool.profiling.{DataSourceProfileResult, ProfileOutputWriter, ProfileResult, SQLAccumProfileResults}
 
 import org.apache.spark.internal.Logging
@@ -100,7 +100,7 @@ object QualRawReportGenerator extends Logging {
         SystemQualPropertiesView.getRawView(Seq(app)),
         Some(SystemQualPropertiesView.getDescription))
       pWriter.writeText("\n### B. Analysis ###\n")
-      constructLabelsMaps(QualSparkMetricsAnalyzer.
+      constructLabelsMaps(QualSparkMetricsAggregator.
         getAggRawMetrics(
           app, sqlAnalyzer = Some(sqlPlanAnalyzer))).foreach { case (label, metrics) =>
           if (label == STAGE_DIAGNOSTICS_LABEL) {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/RawMetricProfView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/RawMetricProfView.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids.tool.views
 
-import com.nvidia.spark.rapids.tool.analysis.ProfSparkMetricsAnalyzer
+import com.nvidia.spark.rapids.tool.analysis.ProfSparkMetricsAggregator
 import com.nvidia.spark.rapids.tool.profiling.{IOAnalysisProfileResult, JobAggTaskMetricsProfileResult, ShuffleSkewProfileResult, SQLDurationExecutorTimeProfileResult, SQLMaxTaskInputSizes, SQLTaskAggMetricsProfileResult, StageAggTaskMetricsProfileResult, StageDiagnosticResult}
 
 import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
@@ -35,7 +35,7 @@ case class ProfilerAggregatedView(
 
 object RawMetricProfilerView  {
   def getAggMetrics(apps: Seq[ApplicationInfo]): ProfilerAggregatedView = {
-    val aggMetricsResults = ProfSparkMetricsAnalyzer.getAggregateRawMetrics(apps)
+    val aggMetricsResults = ProfSparkMetricsAggregator.getAggregateRawMetrics(apps)
     ProfilerAggregatedView(
       AggMetricsResultSorter.sortJobSparkMetrics(aggMetricsResults.jobAggs),
       AggMetricsResultSorter.sortJobSparkMetrics(aggMetricsResults.stageAggs),

--- a/user_tools/docs/qualx.md
+++ b/user_tools/docs/qualx.md
@@ -38,14 +38,24 @@ To train an XGBoost model on a specific dataset, follow these steps below. Refer
 Training requires the following environment variables to be set:
 ```bash
 export SPARK_HOME=/path/to/spark
-export SPARK_RAPIDS_TOOLS_JAR=/path/to/rapids-4-spark-tools-0.1.0-SNAPSHOT.jar
 export QUALX_DATA_DIR=/path/to/qualx/datasets
-export QUALX_CACHE_DIR=/path/to/qualx/cache
 ```
+
+Since training internally uses the Profiling and Qualification tools, it requires the core tools jar as a dependency.
+By default, QualX automatically locates and uses the bundled core tools jar from the package resources.
 
 Notes:
 - `QUALX_DATA_DIR` should be a valid local path containing the training data.
-- `QUALX_CACHE_DIR` stores intermediate files generated during processing (e.g., profiling output). It will be created automatically if it does not exist.  The directory can be deleted to invalidate the cache.
+
+##### Advanced Environment Setup
+
+For advanced users or specific deployment scenarios, user can override the embedded core tools jar that is pre-packaged
+with user_tools.  To do this, user can set the following environment variable:
+```bash
+export SPARK_RAPIDS_TOOLS_JAR=/path/to/custom/tools.jar
+```
+
+- For users building from source or needing custom jar builds, refer to the [user-tools README](../README.md#building-from-source) for build instructions.
 
 #### Data Collection
 

--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
 ]
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 # see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for list of supported licenses
 dependencies = [
     # numpy-2.0.0 supports python [3.9, 3.13]. numpy2.1.0 drooped support for Python 3.9.

--- a/user_tools/src/spark_rapids_pytools/common/prop_manager.py
+++ b/user_tools/src/spark_rapids_pytools/common/prop_manager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -77,11 +77,25 @@ class AbstractPropertiesContainer(object):
     def _init_fields(self):
         pass
 
+    def _validate_file_exists(self, file_path: Union[str, Path]) -> None:
+        """
+        Validate that the file exists before attempting to load it.
+        :param file_path: Path to the file to validate
+        :raises FileNotFoundError: If the file does not exist
+        """
+        path_obj = Path(file_path)
+        if not path_obj.exists():
+            raise FileNotFoundError(f'Property file does not exist: {file_path}. '
+                                    f'Please ensure the file path is correct and the file is accessible.')
+
     def _load_properties_from_file(self):
         """
         In some case, we want to be able to accept both json and yaml format when the properties are saved as a file.
         :return:
         """
+        # Validate file exists before attempting to load
+        self._validate_file_exists(self.prop_arg)
+
         file_suffix = Path(self.prop_arg).suffix
         if file_suffix in ('.yaml', '.yml'):
             # this is a yaml property

--- a/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
@@ -164,11 +164,10 @@ class ToolContext(YAMLPropertiesContainer):
         self.set_ctxt('useLocalToolsJar', True)
         self.set_ctxt('toolsJarFileName', FSUtil.get_resource_name(matched_files[0]))
 
-    def load_prepackaged_resources(self):
+    def load_tools_jar_resources(self):
         """
-        Checks for the tools jar and adds it to context
-        Checks if the packaging includes the CSP dependencies. If so, it moves the dependencies
-        into the tmp folder. This allows the tool to pick the resources from cache folder.
+        Checks for the tools jar and identifies it from the tools-resources directory.
+        This method handles only the tools jar identification part without loading other prepackaged resources.
         """
         for tools_related_files in self.tools_resource_path:
             # This function uses a regex based comparison to identify the tools jar file
@@ -178,6 +177,14 @@ class ToolContext(YAMLPropertiesContainer):
             if os.path.exists(tools_related_files):
                 FSUtil.copy_resource(tools_related_files, self.get_cache_folder())
                 self._identify_tools_wheel_jar(FSUtil.get_all_files(tools_related_files))
+
+    def load_prepackaged_resources(self):
+        """
+        Checks for the tools jar and adds it to context
+        Checks if the packaging includes the CSP dependencies. If so, it moves the dependencies
+        into the tmp folder. This allows the tool to pick the resources from cache folder.
+        """
+        self.load_tools_jar_resources()
 
         if not self.are_resources_prepackaged():
             self.logger.info('No prepackaged resources found.')

--- a/user_tools/src/spark_rapids_tools/tools/core/qual_table_loader.py
+++ b/user_tools/src/spark_rapids_tools/tools/core/qual_table_loader.py
@@ -40,7 +40,11 @@ class QualCoreTableLoader:
         if self._table_definitions is not None:
             return self._table_definitions
 
-        yaml_container = YAMLPropertiesContainer(prop_arg=self.yaml_file_path)
+        try:
+            yaml_container = YAMLPropertiesContainer(prop_arg=self.yaml_file_path)
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(f'qualOutputTable.yaml not found at: {self.yaml_file_path}') from exc
+
         qual_table_definitions = yaml_container.get_value('qualTableDefinitions')
 
         if qual_table_definitions is None:

--- a/user_tools/tests/spark_rapids_tools_e2e/features/environment.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/environment.py
@@ -21,7 +21,6 @@ import shutil
 import tempfile
 from glob import glob
 
-from spark_rapids_tools.utils import Utilities
 from steps.e2e_utils import E2ETestUtils
 
 """ Define behave hooks for the tests. These hooks are automatically called by behave. """
@@ -87,19 +86,14 @@ def _set_environment_variables(context) -> None:
     """
     Set environment variables needed for the virtual environment setup.
     """
-    tools_version = Utilities.get_base_release()
-    scala_version = context.config.userdata.get('scala_version')
     venv_name = context.config.userdata.get('venv_name')
-    jar_filename = f'rapids-4-spark-tools_{scala_version}-{tools_version}-SNAPSHOT.jar'
-    build_jar_value = context.config.userdata.get('build_jar')
-    build_jar = build_jar_value.lower() in ['true', '1', 'yes']
+    build_wheel_value = context.config.userdata.get('build_wheel')
+    build_wheel = build_wheel_value.lower() in ['true', '1', 'yes']
 
     os.environ['E2E_TEST_TOOLS_DIR'] = E2ETestUtils.get_tools_root_path()
     os.environ['E2E_TEST_SCRIPTS_DIR'] = os.path.join(E2ETestUtils.get_e2e_tests_resource_path(), 'scripts')
-    os.environ['E2E_TEST_TOOLS_JAR_PATH'] = os.path.join(os.environ['E2E_TEST_TOOLS_DIR'],
-                                                         f'core/target/{jar_filename}')
     os.environ['E2E_TEST_VENV_DIR'] = os.path.join(context.temp_dir, venv_name)
-    os.environ['E2E_TEST_BUILD_JAR'] = 'true' if build_jar else 'false'
+    os.environ['E2E_TEST_BUILD_WHEEL'] = 'true' if build_wheel else 'false'
     os.environ['E2E_TEST_SPARK_BUILD_VERSION'] = context.config.userdata.get('buildver')
     os.environ['E2E_TEST_HADOOP_VERSION'] = context.config.userdata.get('hadoop.version')
     os.environ['E2E_TEST_TMP_DIR'] = context.config.userdata.get('e2e_tests_tmp_dir')
@@ -107,14 +101,14 @@ def _set_environment_variables(context) -> None:
 
 def _setup_env(context) -> None:
     """
-    Build the JAR and set up the virtual environment for the tests.
+    Build the wheel and set up the virtual environment for the tests.
     """
     script_file_name = context.config.userdata.get('setup_script_file')
     script = os.path.join(os.environ['E2E_TEST_SCRIPTS_DIR'], script_file_name)
     try:
         warning_msg = "Setting up the virtual environment for the tests. This may take a while."
-        if os.environ.get('E2E_TEST_BUILD_JAR') == 'true':
-            warning_msg = f'Building JAR and {warning_msg}'
+        if os.environ.get('E2E_TEST_BUILD_WHEEL') == 'true':
+            warning_msg = f'Building wheel and {warning_msg}'
         logger.warning(warning_msg)
         result = E2ETestUtils.run_sys_cmd([script])
         E2ETestUtils.assert_sys_cmd_return_code(result,

--- a/user_tools/tests/spark_rapids_tools_e2e/features/preprocess.feature
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/preprocess.feature
@@ -18,8 +18,7 @@ Feature: Testing preprocessing functionality
   So that I can reliably process Spark event logs
 
   Background:
-    Given SPARK_RAPIDS_TOOLS_JAR environment variable is set
-    And SPARK_HOME environment variable is set
+    Given SPARK_HOME environment variable is set
     And QUALX_DATA_DIR environment variable is set
     And QUALX_CACHE_DIR environment variable is set
     And sample event logs in the QUALX_DATA_DIR

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/e2e_utils.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/e2e_utils.py
@@ -83,7 +83,6 @@ class E2ETestUtils:
             '--platform', platform,
             '--eventlogs', ','.join(event_logs),
             '-o', output_dir,
-            '--tools_jar', cls.get_tools_jar_file(),
             '--verbose',
             '--filter_apps', filter_apps
         ]

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/preprocess_steps.py
@@ -35,15 +35,6 @@ def set_spark_home_env(context):
     assert 'SPARK_HOME' in os.environ
 
 
-@given('SPARK_RAPIDS_TOOLS_JAR environment variable is set')
-def set_tools_jar_env(context):
-    """Set the SPARK_RAPIDS_TOOLS_JAR environment variable using tools jar file."""
-    tools_jar = E2ETestUtils.get_tools_jar_file()
-    os.environ['SPARK_RAPIDS_TOOLS_JAR'] = tools_jar
-    assert 'SPARK_RAPIDS_TOOLS_JAR' in os.environ
-    assert os.path.exists(os.environ['SPARK_RAPIDS_TOOLS_JAR'])
-
-
 @given('QUALX_DATA_DIR environment variable is set')
 def set_qualx_data_dir_env(context):
     """Set the QUALX_DATA_DIR environment variable using test resources directory."""

--- a/user_tools/tox.ini
+++ b/user_tools/tox.ini
@@ -101,5 +101,5 @@ hadoop.version = 3.3.6
 scala_version = 2.12
 venv_name = spark_rapids_tools_e2e_tests_venv
 setup_script_file = setup_env.sh
-build_jar = true
+build_wheel = true
 e2e_tests_tmp_dir = /tmp/spark_rapids_tools_e2e_tests


### PR DESCRIPTION
This PR adds the changes for making the python unit tests work for the per-app branch.
Major changes introduced ->
* `build.sh` now accepts maven arguments
* `behave` tests now use the build script to setup the environment and test the behave tests
* Removes the usages of TOOLS_JAR param as it is now packaged with the wheel
* Updates the props manager and qual_table_loader to have validation for file before loading resources
