### PR TITLE
Move the local dependency-folder out of output folder

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/bootstrap.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/bootstrap.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ class Bootstrap(RapidsTool):
         if tool_result is not None and any(tool_result):
             # write the result to log file
             # Now create the new folder
-            FSUtil.make_dirs(self.ctxt.get_output_folder(), exist_ok=True)
+            FSUtil.make_dirs(self.ctxt.get_csp_output_path(), exist_ok=True)
             wrapper_out_content_arr = [f'##### BEGIN : RAPIDS bootstrap settings for {exec_cluster.name}']
             for conf_key, conf_val in tool_result.items():
                 wrapper_out_content_arr.append(f'{conf_key}={conf_val}')

--- a/user_tools/src/spark_rapids_pytools/rapids/diagnostic.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/diagnostic.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ class Diagnostic(RapidsTool):
         super()._process_output_args()
 
         # Set remote output folder same as local output folder name
-        output_path = self.ctxt.get_output_folder()
+        output_path = self.ctxt.get_csp_output_path()
         folder_name = FSUtil.get_resource_name(output_path)
         self.ctxt.set_remote('outputFolder', folder_name)
 
@@ -119,7 +119,7 @@ class Diagnostic(RapidsTool):
     def _download_output(self):
         self.logger.info('Downloading results from remote nodes:')
 
-        output_path = self.ctxt.get_output_folder()
+        output_path = self.ctxt.get_csp_output_path()
         remote_output_folder = self.ctxt.get_remote('outputFolder')
         remote_output_result = f'/tmp/{remote_output_folder}*.tgz'
 
@@ -144,7 +144,7 @@ class Diagnostic(RapidsTool):
     def _process_output(self):
         self.logger.info('Processing the collected results.')
 
-        output_path = self.ctxt.get_output_folder()
+        output_path = self.ctxt.get_csp_output_path()
         region = self.exec_cluster.get_region()
         worker_count = self.exec_cluster.get_nodes_cnt(SparkNodeType.WORKER)
 
@@ -167,7 +167,7 @@ class Diagnostic(RapidsTool):
             f.write(f'Worker type: {worker_type}\n')
 
     def _archive_results(self):
-        output_path = self.ctxt.get_output_folder()
+        output_path = self.ctxt.get_csp_output_path()
         Utils.make_archive(output_path, 'tar', output_path)
         self.logger.info("Archive '%s.tar' is successfully created.", output_path)
 

--- a/user_tools/src/spark_rapids_pytools/rapids/profiling.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/profiling.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -175,7 +175,7 @@ class Profiling(RapidsJarTool):
             log_lines.append(f'{sec_comments}')
             recommendations_table.append(row)
         log_file_name = self.ctxt.get_value('local', 'output', 'fileName')
-        summary_file = FSUtil.build_path(self.ctxt.get_output_folder(), log_file_name)
+        summary_file = FSUtil.build_path(self.ctxt.get_csp_output_path(), log_file_name)
         self.logger.info('Writing recommendations into local file %s', summary_file)
         log_file_lines_str = Utils.gen_multiline_str(log_lines)
         with open(summary_file, 'w', encoding='utf-8') as wrapper_summary:

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -515,7 +515,7 @@ class Qualification(RapidsJarTool):
         Build the full output path for the output files.
         """
         files_info = self.ctxt.get_value('local', 'output', 'files')
-        output_folder = self.ctxt.get_output_folder()
+        output_folder = self.ctxt.get_csp_output_path()
         output_files_raw = self.__update_files_info_with_paths(files_info, output_folder)
         return JSONPropertiesContainer(output_files_raw, file_load=False)
 
@@ -524,7 +524,7 @@ class Qualification(RapidsJarTool):
         Build the full output path for the predictions output files
         """
         predictions_info = self.ctxt.get_value('local', 'output', 'predictionModel')
-        output_dir = FSUtil.build_path(self.ctxt.get_output_folder(), predictions_info['outputDirectory'])
+        output_dir = FSUtil.build_path(self.ctxt.get_csp_output_path(), predictions_info['outputDirectory'])
         FSUtil.make_dirs(output_dir)
         return self.__update_files_info_with_paths(predictions_info['files'], output_dir)
 
@@ -552,7 +552,7 @@ class Qualification(RapidsJarTool):
         """
         # Execute the prediction model
         model_name = self.ctxt.platform.get_prediction_model_name()
-        qual_output_dir = self.ctxt.get_local('outputFolder')
+        qual_output_dir = self.ctxt.get_csp_output_path()
         output_info = self.__build_prediction_output_files_info()
         qual_handler = self.ctxt.get_ctxt('qualHandler')
         try:

--- a/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/tool_ctxt.py
@@ -19,7 +19,7 @@ import re
 import tarfile
 from dataclasses import dataclass, field
 from logging import Logger
-from typing import Type, Any, ClassVar, List
+from typing import Type, Any, ClassVar, List, Union
 
 from spark_rapids_pytools.cloud_api.sp_types import PlatformBase
 from spark_rapids_pytools.common.prop_manager import YAMLPropertiesContainer
@@ -129,23 +129,49 @@ class ToolContext(YAMLPropertiesContainer):
     def get_remote(self, key: str):
         return self.props['remoteCtx'].get(key)
 
-    def set_local_workdir(self, parent: str):
+    def _set_local_dep_dir(self) -> None:
+        """
+        Create the dependency folder. It is a subdirectory of temp folders because we cannot
+        store those on remote storage. Especially if this used for the classPath.
+        The directory is going to be in 'tmp/run_name/work_dir'
+        """
+        cache_folder = self.get_cache_folder()
+        exec_full_name = self.get_ctxt('execFullName')
+
+        dep_folder_name = 'work_dir'
+        self.set_ctxt('depFolderName', dep_folder_name)
+        temp_folder = FSUtil.build_path(cache_folder, exec_full_name)
+        self.set_local('tmpFolder', temp_folder)
+        dep_folder = FSUtil.build_path(temp_folder, dep_folder_name)
+        FSUtil.make_dirs(dep_folder, exist_ok=False)
+        self.logger.info('Dependencies are generated locally in local disk as: %s', dep_folder)
+        self.set_local('depFolder', dep_folder)
+
+    def set_local_directories(self, output_parent_folder: str) -> None:
+        """
+        Creates and initializes local directories used for dependencies and output folder
+        :param output_parent_folder: the directory where the local output is going to be created.
+        """
         short_name = self.get_value('platform', 'shortName')
         exec_dir_name = f'{short_name}_{self.uuid}'
         self.set_ctxt('execFullName', exec_dir_name)
-        exec_root_dir = FSUtil.build_path(parent, exec_dir_name)
-        self.logger.info('Local workdir root folder is set as %s', exec_root_dir)
-        # It should never happen that the exec_root_dir exists
-        FSUtil.make_dirs(exec_root_dir, exist_ok=False)
-        # Create the dependency folder. It is a subdirectory in the output folder
-        # because we want that same name appear on the remote storage when copying
-        dep_folder_name = 'work_dir'
-        self.set_ctxt('depFolderName', dep_folder_name)
-        dep_folder = FSUtil.build_path(exec_root_dir, dep_folder_name)
-        FSUtil.make_dirs(dep_folder, exist_ok=False)
+        # create the local dependency folder
+        self._set_local_dep_dir()
+        # create the local output folder
+        self.set_local_output_folder(output_parent_folder)
+
+    def set_local_output_folder(self, parent: str) -> None:
+        """
+        create and initialized output folder on local disk. it will be as follows:
+        parent/exec_full_name
+        :param parent: the parent directory that will contain the subdirectory
+        """
+        exec_full_name = self.get_ctxt('execFullName')
+        exec_root_dir = FSUtil.build_path(parent, exec_full_name)
         self.set_local('outputFolder', exec_root_dir)
-        self.set_local('depFolder', dep_folder)
-        self.logger.info('Dependencies are generated locally in local disk as: %s', dep_folder)
+        # For now set the cspOutputPath here
+        self.set_csp_output_path(exec_root_dir)
+        FSUtil.make_dirs(exec_root_dir, exist_ok=False)
         self.logger.info('Local output folder is set as: %s', exec_root_dir)
 
     def _identify_tools_wheel_jar(self, resource_files: List[str]) -> None:
@@ -210,7 +236,7 @@ class ToolContext(YAMLPropertiesContainer):
 
     def get_wrapper_summary_file_path(self) -> str:
         summary_file_name = self.get_value('local', 'output', 'fileName')
-        summary_path = FSUtil.build_path(self.get_output_folder(), summary_file_name)
+        summary_path = FSUtil.build_path(self.get_csp_output_path(), summary_file_name)
         return summary_path
 
     def get_local_work_dir(self) -> str:
@@ -241,7 +267,7 @@ class ToolContext(YAMLPropertiesContainer):
     def get_rapids_output_folder(self) -> str:
         # TODO: Remove the subfolder entry from here as it is not relevant
         #       in the new output folder structure for Qualification
-        root_dir = self.get_local('outputFolder')
+        root_dir = self.get_csp_output_path()
         rapids_subfolder = self.get_value_silent('toolOutput', 'subFolder')
         if rapids_subfolder is None:
             return root_dir
@@ -281,3 +307,21 @@ class ToolContext(YAMLPropertiesContainer):
             )
         self.logger.info('Using jar from wheel file %s', jar_filepath)
         return jar_filepath
+
+    def do_cleanup_tmp_directory(self) -> bool:
+        """
+        checks whether the temp folder created for the run should be deleted at the end or not.
+        :return: True/False if the temp folders hsould be cleaned up
+        """
+        config_val = self.get_value_silent('platform', 'cleanUp')
+        return Utilities.string_to_bool(config_val)
+
+    def get_local_tmp_folder(self) -> str:
+        return self.get_local('tmpFolder')
+
+    def set_csp_output_path(self, path: Union[str, CspPath]) -> None:
+        csp_path = CspPath(path)
+        self.set_ctxt('cspOutputPath', csp_path)
+
+    def get_csp_output_path(self) -> str:
+        return self.get_output_folder()

--- a/user_tools/src/spark_rapids_pytools/resources/profiling-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/profiling-conf.yaml
@@ -78,4 +78,7 @@ local:
 platform:
   shortName: 'prof'
   outputDir: profiling_tool_output
-  cleanUp: true
+  # Whether or not the temp directories should be cleaned up. For example,
+  # the temporary folder for each run will be cleaned-up.
+  # Set that to false if we need to troubleshoot the workdir/dependencies.
+  cleanUp: !ENV ${RAPIDS_USER_TOOLS_CLEAN_UP:true}

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -378,4 +378,7 @@ local:
 platform:
   shortName: 'qual'
   outputDir: qual-tool-output
-  cleanUp: true
+  # Whether or not the temp directories should be cleaned up. For example,
+  # the temporary folder for each run will be cleaned-up.
+  # Set that to false if we need to troubleshoot the workdir/dependencies.
+  cleanUp: !ENV ${RAPIDS_USER_TOOLS_CLEAN_UP:true}

--- a/user_tools/src/spark_rapids_tools/utils/util.py
+++ b/user_tools/src/spark_rapids_tools/utils/util.py
@@ -396,3 +396,20 @@ class Utilities:
                                    format=archive_format,
                                    root_dir=os.path.dirname(source_folder),
                                    base_dir=os.path.basename(source_folder))
+
+    @staticmethod
+    def string_to_bool(s: str = None) -> bool:
+        """
+        Converts a string to a boolean using a dictionary lookup, handling case insensitivity.
+        Maps specific string values to True or False.
+        :param s: The string to convert.
+        :return: The corresponding boolean value.
+        """
+        return {
+            'true': True,
+            'false': False,
+            'on': True,
+            'off': False,
+            'yes': True,
+            'no': False
+        }.get(s.lower(), False)


### PR DESCRIPTION
Fixes #1763

Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

The local dependency folder needs to be moved out of the output folder. This is required in case that the output folder is a remote folder.

This pull request introduces several updates to the RAPIDS tools, focusing on improving output directory handling, adding cleanup functionality, and updating configuration.

### Main Changes

- added new env-variable `RAPIDS_USER_TOOLS_CLEAN_UP` . when set to false, the temporary local folder will be kept for troubleshooting.
- moved the dependency folder to `/var/tmp/spark_rapids_user_tools_cache/RUNTIME_EXEC`
- added new methods to tools_ctxt in order to prepare to use cspPath instead of strings.

### Output Directory Handling Improvements:
* Replaced all instances of `self.ctxt.get_output_folder()` with `self.ctxt.get_csp_output_path()` across multiple files (`bootstrap.py`, `diagnostic.py`, `profiling.py`, `qualification.py`, and `rapids_tool.py`) to standardize the output folder path handling. [[1]](diffhunk://#diff-b67ac4787b3ba1b07e4f6e5c006044baa0d3234c537d3984a3a9b1610c05b73cL77-R77) [[2]](diffhunk://#diff-53756383c7ab4c53664dd96559728640361acfb959422b6c4c110f7194842c7aL71-R71) [[3]](diffhunk://#diff-53756383c7ab4c53664dd96559728640361acfb959422b6c4c110f7194842c7aL122-R122) [[4]](diffhunk://#diff-53756383c7ab4c53664dd96559728640361acfb959422b6c4c110f7194842c7aL147-R147) [[5]](diffhunk://#diff-53756383c7ab4c53664dd96559728640361acfb959422b6c4c110f7194842c7aL170-R170) [[6]](diffhunk://#diff-cff39006d37df8afc418e314455704e314e7635baad4fa773e131fe57ef44285L178-R178) [[7]](diffhunk://#diff-b0a32bd51bc60911ea7a9d91a6794a312db06d32a1df38c5aeac8243a4f4816fL518-R518) [[8]](diffhunk://#diff-b0a32bd51bc60911ea7a9d91a6794a312db06d32a1df38c5aeac8243a4f4816fL527-R527) [[9]](diffhunk://#diff-b0a32bd51bc60911ea7a9d91a6794a312db06d32a1df38c5aeac8243a4f4816fL555-R555) [[10]](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0L234-L238) [[11]](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0L781-R794) [[12]](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0L865-R878) [[13]](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0L992-R1005) [[14]](diffhunk://#diff-478d74668cb7f8438192c9f044fe6312bd2f11df130607745e51223aa039004dL213-R239) [[15]](diffhunk://#diff-478d74668cb7f8438192c9f044fe6312bd2f11df130607745e51223aa039004dL244-R270)
* Introduced methods `set_csp_output_path` and `get_csp_output_path` in `tool_ctxt.py` to streamline the management of cloud storage paths.

### Cleanup Functionality:
* Added a `cleanup_run` method in `rapids_tool.py` to handle temporary directory cleanup after execution or failure. This method is invoked in multiple places, such as during error handling and finalization. [[1]](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0R135-R136) [[2]](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0R218-R228) [[3]](diffhunk://#diff-55690ae7ca276d65ab3f1ed28b6329ba3749b18ac3d5a6b9f22d5b81108390a0R263)
* Introduced a `do_cleanup_tmp_directory` method in `tool_ctxt.py` to determine whether temporary directories should be deleted based on the configuration.
* Updated configuration files (`profiling-conf.yaml`, `qualification-conf.yaml`) to allow environment-based control of the cleanup behavior. [[1]](diffhunk://#diff-288f76442581c0ca5777006664feb82af59a84cb092a2a833bbea5c8e0e626e5L81-R84) [[2]](diffhunk://#diff-22b8de975769653e2557b95d5f322532457b5d98a27e023cf4dac69b5daff963L381-R384)

### Refactoring and Enhancements:
* Refactored local directory initialization in `tool_ctxt.py` by introducing `set_local_directories` and `set_local_output_folder` methods, consolidating logic for creating dependency and output folders. [[1]](diffhunk://#diff-478d74668cb7f8438192c9f044fe6312bd2f11df130607745e51223aa039004dL132-R174) [[2]](diffhunk://#diff-478d74668cb7f8438192c9f044fe6312bd2f11df130607745e51223aa039004dL213-R239)
* Removed the now-unused `set_local_workdir` method from `tool_ctxt.py` as part of the refactoring.

### Copyright Updates:
* Updated copyright years to reflect 2023-2025 across multiple files. [[1]](diffhunk://#diff-b67ac4787b3ba1b07e4f6e5c006044baa0d3234c537d3984a3a9b1610c05b73cL1-R1) [[2]](diffhunk://#diff-53756383c7ab4c53664dd96559728640361acfb959422b6c4c110f7194842c7aL1-R1) [[3]](diffhunk://#diff-cff39006d37df8afc418e314455704e314e7635baad4fa773e131fe57ef44285L1-R1)

### Typing Improvements:
* Enhanced type hints in `tool_ctxt.py` by adding the `Union` type from `typing` to improve code clarity and maintainability.