### PR TITLE
Improve qualx hash algorithm for rewritten plans

### DIFF
--- a/user_tools/src/spark_rapids_pytools/resources/qualx-hash-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualx-hash-conf.yaml
@@ -22,6 +22,7 @@ remove_nodes_prefix:
   - ColumnarToRow  # only appears in CPU plans
   - InputAdapter  # only appears in CPU plans
   - ReusedExchange  # only appears in CPU plans
+  - WindowSort # only appears in CPU plans
   - WholeStageCodegen  # only appears in CPU plans
   # GPU
   - GpuCoalesceBatches  # only appears in GPU plans


### PR DESCRIPTION
This PR addresses followup item 6 from #1650 to improve the hashing algorithm for cases where the GPU plugin rewrites/re-orders the query plan in ways that are not directly mappable to the original CPU query plan.

The most common case is for `BroadcastHashJoin` subtrees.  The solution was to greatly reduce/simplify the subtrees by removing nodes that are typically moved or re-ordered.

**Changes**:
- Added the following "stages" to `normalize_plan` to handle `BroadcastHashJoin` plans
  - `normalize_broadcast_hash_join` - removes any `Project/BroadcastHashJoin/BroadcastExchange/SortMergeJoin` nodes from a `BroadcastHashJoin` subtree.
  - `normalize_sort_merge_join` - removes any `SortMergeJoin/Project/BroadcastHashJoin` nodes from a `SortMergeJoin` subtree.
- Modified `normalize_node` to remove any `SubqueryAdaptiveBroadcast` children.
- Modified `path_match` to match any subtree/branch (instead of only linear "trunks").
- Added a `remove_nodes` function (to remove any node in a tree, including nodes with multiple children).
- Removed `WindowSort` nodes.
- Sorted the `Project` fields before taking first N fields for hashing.

**Tests**:
- Compared hashes for datasets where sqlID alignments were known/given.
- For dataset A: hash match rate went from 93% -> 98%.
- For dataset B: hash match rate went from 64% -> 90% (with a lot of BroadcastHashJoin plans).

