### PR TITLE
Fix broken build caused by wheel-package

### DIFF
--- a/user_tools/build.sh
+++ b/user_tools/build.sh
@@ -189,6 +189,13 @@ pre_build() {
   pip install --upgrade pip
   echo "rm previous build and dist directories"
   rm -rf build/ dist/
+  echo "Cleanup pip cache"
+  pip cache purge
+  # enforce wheel package to 0.45.1 to avoid a bug in the package that breaks the wheel on some OS
+  echo "install the wheel-package dependency used to build the wheel"
+  pip install "wheel==0.45.1"
+  echo "install the setuptools to use the latest version"
+  pip install "setuptools>=80.9.0"
   echo "install build dependencies using pip"
   pip install build .[qualx,test]
   # Note: Removed -e .[qualx,test] to avoid overriding existing package installations

--- a/user_tools/pyproject.toml
+++ b/user_tools/pyproject.toml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 [build-system]
-requires = ["setuptools"]
+# set wheel version to 0.45.1 new packages (0.46+) were yanked as the broke the wheel
+# builds on some OS for Python 3.10
+requires = ["wheel==0.45.1", "setuptools>=80.9.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -107,6 +109,8 @@ version = {attr = "spark_rapids_pytools.__version__"}
 repository = "https://github.com/NVIDIA/spark-rapids-tools/tree/main"
 [project.optional-dependencies]
 test = [
+    # make sure that wheel version is available for testing
+    "wheel==0.45.1",
     "tox", 'pytest', 'cli_test_helpers', 'behave',
     # use flak-8 plugin for pydantic
     'flake8-pydantic',

--- a/user_tools/tox.ini
+++ b/user_tools/tox.ini
@@ -34,6 +34,7 @@ python =
 
 [testenv]
 deps =
+    wheel==0.45.1
     pytest
     pytest-cov
     cli_test_helpers


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1774

This pull request introduces changes to address compatibility issues with the `wheel` package and ensures consistent build and testing environments. The most important changes involve pinning the `wheel` package to version `0.45.1` and updating `setuptools` to the latest version, along with corresponding updates to build and test configurations.

### Build system updates:
* [`user_tools/build.sh`](diffhunk://#diff-33b48dfaa0c6bf1bbed25c76e81b86d6c4d3e177f220d0ebf07634c11cedea5fR192-R198): Added a step to purge the pip cache and explicitly installed `wheel==0.45.1` and `setuptools>=80.9.0` to address compatibility issues and ensure the latest features are used.
* [`user_tools/pyproject.toml`](diffhunk://#diff-4567c711bb2a94833399095b675b18e161015821d727f84acb42052a55996616L16-R18): Updated the `[build-system]` requirements to include `wheel==0.45.1` and `setuptools>=80.9.0` for consistent builds across environments.

### Testing configuration updates:
* [`user_tools/pyproject.toml`](diffhunk://#diff-4567c711bb2a94833399095b675b18e161015821d727f84acb42052a55996616R112-R113): Added `wheel==0.45.1` to the `test` optional dependencies to ensure the correct version is available during testing.
* [`user_tools/tox.ini`](diffhunk://#diff-c83303edf712b3edc8532fb2a1cb9dd3cedfae27d7002b146db1e510a82e21b2R37): Included `wheel==0.45.1` in the `deps` section to ensure the correct version is used in test environments.