### PR TITLE
Validate custom target cluster info YAML and comment on speedup accuracy in Qual Tool

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -810,10 +810,14 @@ class RapidsJarTool(RapidsTool):
                                                 exec_files=exc_files)
             doc_url = self.ctxt.get_value('sparkRapids', 'outputDocURL')
             out_tree_list.append(f'{indentation}- To learn more about the output details, visit {doc_url}')
-            # if the target worker info is provided, then add a comment about speed up estimation being inaccurate.
+            # If running qualification Tool and the target worker info is provided,
+            # then add a comment about speed up estimation being inaccurate.
             target_worker_info_provided = self.ctxt.get_ctxt('targetWorkerInfoProvided')
-            inaccurate_speedup_comment = self.ctxt.get_value_silent('local', 'output', 'stdout', 'inaccurateSpeedupComment')
-            if target_worker_info_provided and inaccurate_speedup_comment:
+            # Lazy import Qualification to avoid circular import issues
+            from spark_rapids_pytools.rapids.qualification import Qualification  # pylint: disable=import-outside-toplevel
+            if isinstance(self, Qualification) and target_worker_info_provided:
+                inaccurate_speedup_comment =\
+                    self.ctxt.get_value('local', 'output', 'stdout', 'inaccurateSpeedupComment')
                 out_tree_list.append(f'{indentation}- {inaccurate_speedup_comment}')
             return out_tree_list
         return []

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -520,11 +520,12 @@ class RapidsJarTool(RapidsTool):
 
         # If the target cluster info is provided and contains worker info,
         # set the context to indicate that worker info is provided.
-        # This is used later to determine if the Speed up calculation should be skipped in
-        # Qualification Tool
+        # This is used later to determine if the Speed up calculation should be skipped if
+        # running the Qualification Tool.
         target_cluster_info_file = self.rapids_options.get('target_cluster_info')
         target_cluster_info = YAMLPropertiesContainer(target_cluster_info_file) if target_cluster_info_file else None
-        worker_info = target_cluster_info.get_value('workerInfo') if target_cluster_info else None
+        # workerInfo may or may not be present in the target cluster info.
+        worker_info = target_cluster_info.get_value_silent('workerInfo') if target_cluster_info else None
         if worker_info:
             self.ctxt.set_ctxt('targetWorkerInfoProvided', True)
         return arguments_list
@@ -809,10 +810,11 @@ class RapidsJarTool(RapidsTool):
                                                 exec_files=exc_files)
             doc_url = self.ctxt.get_value('sparkRapids', 'outputDocURL')
             out_tree_list.append(f'{indentation}- To learn more about the output details, visit {doc_url}')
-            # if the target worker info is provided, then add a note about speed up estimation.
-            if str(self.ctxt.get_ctxt('targetWorkerInfoProvided')).strip().lower() == 'true':
-                out_tree_list.append(f'{indentation}- Speed up estimations may be inaccurate because '
-                                     'custom worker information was provided.')
+            # if the target worker info is provided, then add a comment about speed up estimation being inaccurate.
+            target_worker_info_provided = self.ctxt.get_ctxt('targetWorkerInfoProvided')
+            inaccurate_speedup_comment = self.ctxt.get_value_silent('local', 'output', 'stdout', 'inaccurateSpeedupComment')
+            if target_worker_info_provided and inaccurate_speedup_comment:
+                out_tree_list.append(f'{indentation}- {inaccurate_speedup_comment}')
             return out_tree_list
         return []
 

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -126,6 +126,8 @@ sparkRapids:
 local:
   output:
     cleanUp: true
+    stdout:
+      inaccurateSpeedupComment: 'Speed up estimations may be inaccurate because custom target worker information was provided.'
     files:
       summary:
         name: qualification_summary.csv

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -119,7 +119,7 @@ sparkRapids:
       - spark-property
       - speedup-factor-file
       - start-app-time
-      - t
+      - target-cluster-info
       - timeout
       - u
       - user-name

--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -407,7 +407,7 @@ class ToolUserArgModel(AbsToolUserArgModel):
                 raise PydanticCustomError(
                     'target_cluster_info',
                     f'Target cluster info file path {self.target_cluster_info} is not valid. '
-                    'It is expected to be a valid YAML file.\n  Error:')
+                    'It is expected to be a valid YAML file.')
             # Using `_` instead of `-` as a later step appropriately converts the arguments for the JAR.
             # See: `spark_rapids_pytools.rapids.rapids_tool.RapidsJarTool._process_tool_args_from_input`
             rapids_options['target_cluster_info'] = self.target_cluster_info

--- a/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/argprocessor.py
@@ -408,6 +408,8 @@ class ToolUserArgModel(AbsToolUserArgModel):
                     'target_cluster_info',
                     f'Target cluster info file path {self.target_cluster_info} is not valid. '
                     'It is expected to be a valid YAML file.\n  Error:')
+            # Using `_` instead of `-` as a later step appropriately converts the arguments for the JAR.
+            # See: `spark_rapids_pytools.rapids.rapids_tool.RapidsJarTool._process_tool_args_from_input`
             rapids_options['target_cluster_info'] = self.target_cluster_info
 
     def init_extra_arg_cases(self) -> list:

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -84,11 +84,13 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                 Default is calculated as a function of the total number of cores and the heap size on the host.
         :param verbose: True or False to enable verbosity of the script.
         :param tools_config_file: Path to a configuration file that contains the tools' options.
-               For sample configuration files, please visit
-               https://github.com/NVIDIA/spark-rapids-tools/tree/main/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid
+                For sample configuration files, please visit
+                https://github.com/NVIDIA/spark-rapids-tools/tree/main/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid
         :param submission_mode: Submission mode to run the qualification tool.
                 Supported modes are "local" and "distributed".
-        :param target_cluster_info: Path to a JSON file that contains the target cluster information.
+        :param target_cluster_info: Path to a YAML file that contains the target cluster information.
+                For sample target cluster info files, please visit
+                https://github.com/NVIDIA/spark-rapids-tools/tree/main/core/src/main/resources/targetClusterInfo
         :param rapids_options: A list of valid Qualification tool options.
                 Note that the wrapper ignores ["output-directory", "platform"] flags, and it does not support
                 multiple "spark-property" arguments.
@@ -175,9 +177,11 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                 Default is calculated as a function of the total number of cores and the heap size on the host.
         :param verbose: True or False to enable verbosity of the script.
         :param tools_config_file: Path to a configuration file that contains the tools' options.
-               For sample configuration files, please visit
-               https://github.com/NVIDIA/spark-rapids-tools/tree/main/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid
-        :param target_cluster_info: Path to a JSON file that contains the target cluster information.
+                For sample configuration files, please visit
+                https://github.com/NVIDIA/spark-rapids-tools/tree/main/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid
+        :param target_cluster_info: Path to a YAML file that contains the target cluster information.
+                For sample target cluster info files, please visit
+                https://github.com/NVIDIA/spark-rapids-tools/tree/main/core/src/main/resources/targetClusterInfo
         :param rapids_options: A list of valid Profiling tool options.
                 Note that the wrapper ignores ["output-directory", "worker-info"] flags, and it does not support
                 multiple "spark-property" arguments.

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -48,6 +48,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                       verbose: bool = None,
                       tools_config_file: str = None,
                       submission_mode: str = None,
+                      target_cluster_info: str = None,
                       **rapids_options) -> None:
         """The Qualification cmd provides estimated speedups by migrating Apache Spark applications
         to GPU accelerated clusters.
@@ -87,6 +88,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                https://github.com/NVIDIA/spark-rapids-tools/tree/main/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid
         :param submission_mode: Submission mode to run the qualification tool.
                 Supported modes are "local" and "distributed".
+        :param target_cluster_info: Path to a JSON file that contains the target cluster information.
         :param rapids_options: A list of valid Qualification tool options.
                 Note that the wrapper ignores ["output-directory", "platform"] flags, and it does not support
                 multiple "spark-property" arguments.
@@ -95,7 +97,6 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         """
         eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
         platform = Utils.get_value_or_pop(platform, rapids_options, 'p')
-        tools_jar = Utils.get_value_or_pop(tools_jar, rapids_options, 't')
         output_folder = Utils.get_value_or_pop(output_folder, rapids_options, 'o')
         filter_apps = Utils.get_value_or_pop(filter_apps, rapids_options, 'f')
         verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
@@ -123,8 +124,10 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                                          filter_apps=filter_apps,
                                                          estimation_model_args=estimation_model_args,
                                                          tools_config_path=tools_config_file,
-                                                         submission_mode=submission_mode)
+                                                         submission_mode=submission_mode,
+                                                         target_cluster_info=target_cluster_info)
         if qual_args:
+            rapids_options.update(qual_args['rapidOptions'])
             tool_obj = QualificationAsLocal(platform_type=qual_args['runtimePlatform'],
                                             output_folder=qual_args['outputFolder'],
                                             wrapper_options=qual_args,
@@ -143,6 +146,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                   jvm_threads: int = None,
                   verbose: bool = None,
                   tools_config_file: str = None,
+                  target_cluster_info: str = None,
                   **rapids_options):
         """The Profiling cmd provides information which can be used for debugging and profiling
         Apache Spark applications running on GPU accelerated clusters.
@@ -173,6 +177,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         :param tools_config_file: Path to a configuration file that contains the tools' options.
                For sample configuration files, please visit
                https://github.com/NVIDIA/spark-rapids-tools/tree/main/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid
+        :param target_cluster_info: Path to a JSON file that contains the target cluster information.
         :param rapids_options: A list of valid Profiling tool options.
                 Note that the wrapper ignores ["output-directory", "worker-info"] flags, and it does not support
                 multiple "spark-property" arguments.
@@ -184,7 +189,6 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         platform = Utils.get_value_or_pop(platform, rapids_options, 'p')
         driverlog = Utils.get_value_or_pop(driverlog, rapids_options, 'd')
         output_folder = Utils.get_value_or_pop(output_folder, rapids_options, 'o')
-        tools_jar = Utils.get_value_or_pop(tools_jar, rapids_options, 't')
         verbose = Utils.get_value_or_pop(verbose, rapids_options, 'v', False)
         if verbose:
             ToolLogging.enable_debug_mode()
@@ -198,7 +202,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                                          jvm_threads=jvm_threads,
                                                          output_folder=output_folder,
                                                          tools_jar=tools_jar,
-                                                         tools_config_path=tools_config_file)
+                                                         tools_config_path=tools_config_file,
+                                                         target_cluster_info=target_cluster_info)
         if prof_args:
             rapids_options.update(prof_args['rapidOptions'])
             tool_obj = ProfilingAsLocal(platform_type=prof_args['runtimePlatform'],

--- a/user_tools/tests/spark_rapids_tools_e2e/features/event_log_processing.feature
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/event_log_processing.feature
@@ -64,12 +64,13 @@ Feature: Event Log Processing
   Scenario Outline: Check stdout contains speed up warning when target_cluster_info is provided
     Given platform is "<platform>"
     And target_cluster_info "<target_cluster_info>" is provided
-    When spark-rapids tool is executed with "<eventlog>" eventlogs
+    When spark-rapids "<tool_name>" tool is executed with "<eventlog>" eventlogs
     Then stdout does "<contain>" the following
       """
       <expected_stdout>
       """
     Examples:
-      | platform | target_cluster_info                              | eventlog                                                    | contain     | expected_stdout                                                                        |
-      | onprem   | target-cluster-worker-info-and-spark-props.yaml  | onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | contain     | Speed up estimations may be inaccurate because custom worker information was provided. |
-      | onprem   | target-cluster-only-spark-props.yaml             | onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | not contain | Speed up estimations may be inaccurate because custom worker information was provided. |
+      | platform | target_cluster_info                             | tool_name      | eventlog                                                    | contain     | expected_stdout                                                                               |
+      | onprem   | target-cluster-worker-info-and-spark-props.yaml | qualification  | onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | contain     | Speed up estimations may be inaccurate because custom target worker information was provided. |
+      | onprem   | target-cluster-only-spark-props.yaml            | qualification  | onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | not contain | Speed up estimations may be inaccurate because custom target worker information was provided. |
+      | onprem   | target-cluster-worker-info-and-spark-props.yaml | profiling      | onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | not contain | Speed up estimations may be inaccurate because custom target worker information was provided. |

--- a/user_tools/tests/spark_rapids_tools_e2e/features/event_log_processing.feature
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/event_log_processing.feature
@@ -59,3 +59,17 @@ Feature: Event Log Processing
       | onprem  	| RAPIDS_USER_TOOLS_SPILL_BYTES_THRESHOLD                   |   -1            |onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | qualification_summary.csv     | app-20231122005806-0064 | Skipping due to total data spill in stages exceeding -1.00 B.|
       | onprem  	| RAPIDS_USER_TOOLS_GPU_SPEEDUP_SPARK_LOWER_BOUND           |   20.0          |onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | qualification_summary.csv     | app-20231122005806-0064 | Skipping due to total data spill in stages exceeding -1.00 B.; GPU SpeedUp < Qualifying Threshold (More is qualified) |
       | onprem  	| RAPIDS_USER_TOOLS_UNSUPPORTED_OPERATORS_SPARK_UPPER_BOUND |   -1            |onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | qualification_summary.csv     | app-20231122005806-0064 | Skipping due to total data spill in stages exceeding -1.00 B.; GPU SpeedUp < Qualifying Threshold (More is qualified); Unsupported Operators Stage Duration Percent > Qualifying Threshold (Less is qualified) |
+
+  @test_id_ELP_0004
+  Scenario Outline: Check stdout contains speed up warning when target_cluster_info is provided
+    Given platform is "<platform>"
+    And target_cluster_info "<target_cluster_info>" is provided
+    When spark-rapids tool is executed with "<eventlog>" eventlogs
+    Then stdout does "<contain>" the following
+      """
+      <expected_stdout>
+      """
+    Examples:
+      | platform | target_cluster_info                              | eventlog                                                    | contain     | expected_stdout                                                                        |
+      | onprem   | target-cluster-worker-info-and-spark-props.yaml  | onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | contain     | Speed up estimations may be inaccurate because custom worker information was provided. |
+      | onprem   | target-cluster-only-spark-props.yaml             | onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | not contain | Speed up estimations may be inaccurate because custom worker information was provided. |

--- a/user_tools/tests/spark_rapids_tools_e2e/features/installation_checks.feature
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/installation_checks.feature
@@ -19,7 +19,7 @@ Feature: Tool Installation Checks
     Given platform is "<platform>"
     And "<cli>" is not installed
     When spark-rapids tool is executed with "join_agg_on_yarn_eventlog.zstd" eventlogs
-    Then stdout contains the following
+    Then stdout does "contain" the following
       """
       <expected_stdout>
       """

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/e2e_utils.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/e2e_utils.py
@@ -68,13 +68,13 @@ class E2ETestUtils:
             f"{error_msg}\n{cls.get_cmd_output_str(cmd_result)}"
 
     @classmethod
-    def create_spark_rapids_cmd(cls,
-                                *,
-                                event_logs: List[str],
-                                output_dir: str,
-                                platform: str = 'onprem',
-                                filter_apps: str = 'all',
-                                target_cluster_info: Optional[str] = None) -> List[str]:
+    def create_spark_rapids_qual_cmd(cls,
+                                     *,
+                                     event_logs: List[str],
+                                     output_dir: str,
+                                     platform: str = 'onprem',
+                                     filter_apps: str = 'all',
+                                     target_cluster_info: Optional[str] = None) -> List[str]:
         """
         Create the command to run the Spark Rapids qualification tool.
         TODO: We can add more options to the command as needed.
@@ -87,6 +87,29 @@ class E2ETestUtils:
             '-o', output_dir,
             '--verbose',
             '--filter_apps', filter_apps
+        ]
+        if target_cluster_info:
+            base_cmd.extend(['--target_cluster_info', target_cluster_info])
+        return base_cmd
+
+    @classmethod
+    def create_spark_rapids_profiling_cmd(cls,
+                                          *,
+                                          event_logs: List[str],
+                                          output_dir: str,
+                                          platform: str = 'onprem',
+                                          target_cluster_info: Optional[str] = None) -> List[str]:
+        """
+        Create the command to run the Spark Rapids profiling tool.
+        TODO: We can add more options to the command as needed.
+        """
+        base_cmd = [
+            cls.get_spark_rapids_cli(),
+            'profiling',
+            '--platform', platform,
+            '--eventlogs', ','.join(event_logs),
+            '-o', output_dir,
+            '--verbose'
         ]
         if target_cluster_info:
             base_cmd.extend(['--target_cluster_info', target_cluster_info])

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/e2e_utils.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/e2e_utils.py
@@ -24,7 +24,7 @@ import subprocess
 from attr import dataclass
 from enum import auto
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 from urllib.parse import urlparse
 
 from spark_rapids_tools import EnumeratedType
@@ -69,15 +69,17 @@ class E2ETestUtils:
 
     @classmethod
     def create_spark_rapids_cmd(cls,
+                                *,
                                 event_logs: List[str],
                                 output_dir: str,
                                 platform: str = 'onprem',
-                                filter_apps: str = 'all') -> List[str]:
+                                filter_apps: str = 'all',
+                                target_cluster_info: Optional[str] = None) -> List[str]:
         """
         Create the command to run the Spark Rapids qualification tool.
         TODO: We can add more options to the command as needed.
         """
-        return [
+        base_cmd = [
             cls.get_spark_rapids_cli(),
             'qualification',
             '--platform', platform,
@@ -86,6 +88,9 @@ class E2ETestUtils:
             '--verbose',
             '--filter_apps', filter_apps
         ]
+        if target_cluster_info:
+            base_cmd.extend(['--target_cluster_info', target_cluster_info])
+        return base_cmd
 
     # Utility getter functions
     @staticmethod

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/test_steps.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/test_steps.py
@@ -151,13 +151,29 @@ def step_file_is_generated(context, file) -> None:
     context.generated_file_paths.update(file_paths)
 
 
-@when('spark-rapids tool is executed with "{event_logs}" eventlogs')
-def step_execute_spark_rapids_tool(context, event_logs) -> None:
+@when('spark-rapids "qualification" tool is executed with "{event_logs}" eventlogs')
+@when('spark-rapids tool is executed with "{event_logs}" eventlogs')  # For backward compatibility
+def step_execute_spark_rapids_qual_tool(context, event_logs) -> None:
     event_logs_list = E2ETestUtils.resolve_event_logs(event_logs.split(","))
     platform = getattr(context, 'platform', 'onprem')
     target_cluster_info = getattr(context, 'target_cluster_info', None)
 
-    cmd = E2ETestUtils.create_spark_rapids_cmd(
+    cmd = E2ETestUtils.create_spark_rapids_qual_cmd(
+        event_logs=event_logs_list,
+        output_dir=context.temp_dir,
+        platform=platform,
+        target_cluster_info=target_cluster_info
+    )
+    context.result = E2ETestUtils.run_sys_cmd(cmd)
+
+
+@when('spark-rapids "profiling" tool is executed with "{event_logs}" eventlogs')
+def step_execute_spark_rapids_profiling_tool(context, event_logs) -> None:
+    event_logs_list = E2ETestUtils.resolve_event_logs(event_logs.split(","))
+    platform = getattr(context, 'platform', 'onprem')
+    target_cluster_info = getattr(context, 'target_cluster_info', None)
+
+    cmd = E2ETestUtils.create_spark_rapids_profiling_cmd(
         event_logs=event_logs_list,
         output_dir=context.temp_dir,
         platform=platform,

--- a/user_tools/tests/spark_rapids_tools_e2e/resources/target_cluster_files/target-cluster-only-spark-props.yaml
+++ b/user_tools/tests/spark_rapids_tools_e2e/resources/target_cluster_files/target-cluster-only-spark-props.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Defines the example target cluster information to be used by the Profiling Tool.
+# Usage: `<JAVA CMD> --platform onprem --target-cluster-info <path to this file>`
+sparkProperties:
+  enforced:
+    spark.memory.offHeap.size: 18g
+    spark.memory.offHeap.enabled: true
+    spark.sql.shuffle.partitions: 400
+    spark.sql.files.maxPartitionBytes: 101m
+    spark.rapids.sql.concurrentGpuTasks: 2

--- a/user_tools/tests/spark_rapids_tools_e2e/resources/target_cluster_files/target-cluster-only-spark-props.yaml
+++ b/user_tools/tests/spark_rapids_tools_e2e/resources/target_cluster_files/target-cluster-only-spark-props.yaml
@@ -12,8 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Defines the example target cluster information to be used by the Profiling Tool.
-# Usage: `<JAVA CMD> --platform onprem --target-cluster-info <path to this file>`
+# Defines the example target cluster information file containing spark properties
+# that should be enforced on the target cluster. This will be used by the AutoTuner
+# to generate the recommended spark properties for the target cluster.
+#
+# Usage: `spark_rapids qualification/profiling --platform <platform> \
+#           --eventlogs <path to eventlogs> \
+#           --target_cluster_info <path to this file>`
 sparkProperties:
   enforced:
     spark.memory.offHeap.size: 18g

--- a/user_tools/tests/spark_rapids_tools_e2e/resources/target_cluster_files/target-cluster-worker-info-and-spark-props.yaml
+++ b/user_tools/tests/spark_rapids_tools_e2e/resources/target_cluster_files/target-cluster-worker-info-and-spark-props.yaml
@@ -12,8 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Defines the example target cluster information to be used by the Profiling Tool.
-# Usage: `<JAVA CMD> --platform onprem --target-cluster-info <path to this file>`
+# Defines the example target cluster information file containing spark properties
+# that should be enforced on the target cluster. This will be used by the AutoTuner
+# to generate the recommended spark properties for the target cluster.
+# Note: The format of the workerInfo is for OnPrem platform.
+#
+# Usage: `spark_rapids qualification/profiling --platform <platform> \
+#           --eventlogs <path to eventlogs> \
+#           --target_cluster_info <path to this file>`
 workerInfo:
   cpuCores: 8
   memoryGB: 40

--- a/user_tools/tests/spark_rapids_tools_e2e/resources/target_cluster_files/target-cluster-worker-info-and-spark-props.yaml
+++ b/user_tools/tests/spark_rapids_tools_e2e/resources/target_cluster_files/target-cluster-worker-info-and-spark-props.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Defines the example target cluster information to be used by the Profiling Tool.
+# Usage: `<JAVA CMD> --platform onprem --target-cluster-info <path to this file>`
+workerInfo:
+  cpuCores: 8
+  memoryGB: 40
+  gpu:
+    count: 1
+    name: l4
+sparkProperties:
+  enforced:
+    spark.memory.offHeap.size: 18g
+    spark.memory.offHeap.enabled: true
+    spark.sql.shuffle.partitions: 400
+    spark.sql.files.maxPartitionBytes: 101m
+    spark.rapids.sql.concurrentGpuTasks: 2


### PR DESCRIPTION
Fixes #1690 

## Issues:
1. The `--target-cluster-info` argument was passed through directly to the Tools JAR. However, this format was inconsistent with the preferred argument naming style in the Tools CLI (preferred style: `--target_cluster_info`).
2. There was no early validation to check whether the target cluster info file exists or is a valid YAML file.
3. Following #1765, we need to inform users that providing custom target cluster information may cause inaccurate speed up estimations in Qualification Tool CLI.


## Changes:
This PR fixes the above issues by:
1. Introduce a CLI argument for both Qualification and Profiling tools (thus replacing `-` with `_`):
```
spark_rapids qualification/profiling --platform $PLATFORM \
  --eventlogs $EVENTLOGS \ 
  --target_cluster_info $PATH_TO_YAML_FILE
```
2. Early validation of the file to ensure it exists and is a valid YAML file.
   - Note: It does not verify the structure as the structure is defined in the JAR.
```
ERROR spark_rapids_tools.argparser: Validation err: Target cluster info file path /invalid/target-cluster-worker.yaml is not valid. It is expected to be a valid YAML file.
```
3. In the Qualification Tool CLI, added a comment in STDOUT to state that speed up estimations may be inaccurate because custom target worker information was provided

```
    - To learn more about the output details, visit https://docs.nvidia.com/spark-rapids/user-guide/latest/qualification/quickstart.html#qualification-output
    - Speed up estimations may be inaccurate because custom target worker information was provided.
    - Summarized speedups CSV report: /Users/psarthi/Work/spark-rapids-tools/user_tools/src/spark_rapids_tools/cmdli/qual_20250708155756_99971BB7/qualification_summary.csv
    - Statistics CSV report: /Users/psarthi/Work/spark-rapids-tools/user_tools/src/spark_rapids_tools/cmdli/qual_20250708155756_99971BB7/qualification_statistics.csv
    - Intermediate output generated by tools: /Users/psarthi/Work/spark-rapids-tools/user_tools/src/spark_rapids_tools/cmdli/qual_20250708155756_99971BB7/intermediate_output
    - Metadata file with cluster recommendation and tuning details: /Users/psarthi/Work/spark-rapids-tools/user_tools/src/spark_rapids_tools/cmdli/qual_20250708155756_99971BB7/app_metadata.json
    - Application status report: /Users/psarthi/Work/spark-rapids-tools/user_tools/src/spark_rapids_tools/cmdli/qual_20250708155756_99971BB7/qual_core_output/status.csv
``` 
### Note:
- Currently this comment is not persisted in any of the CSVs, as there is no appropriate column for it.  
- Column `Not Recommended Reason` is somewhat related, but using it to store this comment seemed to overload its purpose.

## Tests

Added E2E tests in `behave` to verify that:
- In Qualification Tool CLI:
   - When the target cluster info file includes both worker info and user-enforced Spark properties, the stdout does contain the expected comment.
   - When the target cluster info file includes only user-enforced Spark properties, the stdout does not contain the comment.
- In Profiling Tool CLI:
   - When the target cluster info file includes both worker info and user-enforced Spark properties, the stdout does not contain the comment (since speed up estimations are not provided in Profiling Tool)
