### PR TITLE
Allow users to specify driver instance type in target cluster file

### DIFF
--- a/core/src/main/resources/targetClusterInfo/target-cluster-05.yaml
+++ b/core/src/main/resources/targetClusterInfo/target-cluster-05.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Defines the example target cluster information to be used by the Profiling Tool.
+# Usage: `<JAVA CMD> --platform dataproc --target-cluster-info <path to this file>`
+driverInfo:
+  instanceType: n1-standard-8
+workerInfo:
+  instanceType: g2-standard-24

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -165,6 +165,9 @@ class Qualification(outputPath: String, hadoopConf: Configuration,
           if (qualSumInfo.isDefined) {
             // add the recommend cluster info into the summary
             val newQualSummary = qualSumInfo.get
+            // If the recommended cluster info does not have a driver node type,
+            // set it to the platform default.
+            platform.setDefaultDriverNodeToRecommendedClusterIfMissing()
             val newClusterSummary = newQualSummary.clusterSummary.copy(
               recommendedClusterInfo = platform.recommendedClusterInfo)
             AppSubscriber.withSafeValidAttempt(app.appId, app.attemptId) { () =>

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -794,7 +794,7 @@ class AutoTuner(
       appendRecommendation("spark.rapids.sql.concurrentGpuTasks",
         calcGpuConcTasks().toInt)
       val availableMemPerExec =
-        platform.recommendedNodeInstanceInfo.map(_.getMemoryPerExec).getOrElse(0.0)
+        platform.recommendedWorkerNode.map(_.getMemoryPerExec).getOrElse(0.0)
       val shouldSetMaxBytesInFlight = if (availableMemPerExec > 0.0) {
         val availableMemPerExecExpr = () => availableMemPerExec
         val executorHeap = calcInitialExecutorHeap(availableMemPerExecExpr, execCores)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TargetClusterProps.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TargetClusterProps.scala
@@ -84,6 +84,18 @@ class WorkerInfo (
 }
 
 /**
+ * Class to hold the driver instance information for the target cluster.
+ */
+class DriverInfo (
+  @BeanProperty var instanceType: String) {
+  def this() = this("")
+
+  def isEmpty: Boolean = {
+    instanceType == null || instanceType.isEmpty
+  }
+}
+
+/**
  * Class to hold the Spark properties specified for the target cluster.
  * This will be extended in future to include preserved and removed categories.
  */
@@ -109,14 +121,19 @@ class SparkProperties(
  * @see [[org.apache.spark.sql.rapids.tool.util.PropertiesLoader]]
  */
 class TargetClusterProps (
+  @BeanProperty var driverInfo: DriverInfo,
   @BeanProperty var workerInfo: WorkerInfo,
   @BeanProperty var sparkProperties: SparkProperties) extends ValidatableProperties {
 
-  def this() = this(new WorkerInfo(), new SparkProperties())
+  def this() = this(new DriverInfo(), new WorkerInfo(), new SparkProperties())
 
-  // Validating only the worker info for now.
   override def validate(): Unit = {
     workerInfo.validate()
+    if (workerInfo.isOnpremInfo && !driverInfo.isEmpty) {
+      throw new IllegalArgumentException(
+        "OnPrem target cluster info does not support specifying driver instance type. " +
+          "Please remove the driver instance type from the target cluster info.")
+    }
   }
 
   override def toString: String = {

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ClusterRecommendationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ClusterRecommendationSuite.scala
@@ -42,7 +42,7 @@ class ClusterRecommendationSuite extends ProfilingAutoTunerSuiteBase
   val validClusterRecommendationScenarios: TableFor4[
       String, String, Option[Int], RecommendedClusterInfo] = Table(
     // Define the column headers
-    ("platform", "instanceType", "gpuCount", "expectedClusterInfo"),
+    ("platform", "workerNodeInstanceType", "gpuCount", "expectedClusterInfo"),
     // Test scenarios
     (
       PlatformNames.DATAPROC,
@@ -132,16 +132,16 @@ class ClusterRecommendationSuite extends ProfilingAutoTunerSuiteBase
   )
   // scalastyle:on line.size.limit
   forAll(validClusterRecommendationScenarios) {
-    (platform, instanceType, gpuCount, expectedClusterInfo) =>
+    (platform, workerNodeInstanceType, gpuCount, expectedClusterInfo) =>
       val scenarioName = gpuCount match {
-        case Some(count) => s"$instanceType with $count GPUs"
-        case None => instanceType
+        case Some(count) => s"$workerNodeInstanceType with $count GPUs"
+        case None => workerNodeInstanceType
       }
       test(s"test valid cluster shape recommendation on $platform - $scenarioName") {
         TrampolineUtil.withTempDir { tempDir =>
           val targetClusterInfoFile = ToolTestUtils.createTargetClusterInfoFile(
             tempDir.getAbsolutePath,
-            instanceType = Some(instanceType),
+            workerNodeInstanceType = Some(workerNodeInstanceType),
             gpuCount = gpuCount)
 
           val appArgs = new ProfileArgs(Array(
@@ -220,7 +220,7 @@ class ClusterRecommendationSuite extends ProfilingAutoTunerSuiteBase
         TrampolineUtil.withTempDir { tempDir =>
           val targetClusterInfoFile = ToolTestUtils.createTargetClusterInfoFile(
             tempDir.getAbsolutePath,
-            instanceType = Some(instanceType),
+            workerNodeInstanceType = Some(instanceType),
             gpuCount = gpuCount)
 
           val appArgs = new ProfileArgs(Array(
@@ -250,6 +250,8 @@ class ClusterRecommendationSuite extends ProfilingAutoTunerSuiteBase
    *
    * Target Cluster YAML file:
    * {{{
+   * driverInfo:
+   *  instanceType: n1-standard-8
    * workerInfo:
    *  instanceType: g2-standard-8
    * sparkProperties:
@@ -273,6 +275,7 @@ class ClusterRecommendationSuite extends ProfilingAutoTunerSuiteBase
       dynamicAllocationMaxExecutors = "N/A",
       dynamicAllocationMinExecutors = "N/A",
       dynamicAllocationInitialExecutors = "N/A",
+      driverNodeType = Some("n1-standard-8"),
       workerNodeType = Some("g2-standard-8")
     )
     val expectedEnforcedSparkProperties = Map(
@@ -285,7 +288,8 @@ class ClusterRecommendationSuite extends ProfilingAutoTunerSuiteBase
     TrampolineUtil.withTempDir { tempDir =>
       val targetClusterInfoFile = ToolTestUtils.createTargetClusterInfoFile(
         tempDir.getAbsolutePath,
-        instanceType = expectedClusterInfo.workerNodeType,
+        driverNodeInstanceType = expectedClusterInfo.driverNodeType,
+        workerNodeInstanceType = expectedClusterInfo.workerNodeType,
         enforcedSparkProperties = expectedEnforcedSparkProperties)
 
       val appArgs = new ProfileArgs(Array(
@@ -396,6 +400,7 @@ class ClusterRecommendationSuite extends ProfilingAutoTunerSuiteBase
       dynamicAllocationMaxExecutors = "N/A",
       dynamicAllocationMinExecutors = "N/A",
       dynamicAllocationInitialExecutors = "N/A",
+      driverNodeType = None,
       workerNodeType = Some("g2-standard-8")
     )
     val expectedEnforcedSparkProperties = Map(
@@ -406,7 +411,8 @@ class ClusterRecommendationSuite extends ProfilingAutoTunerSuiteBase
     TrampolineUtil.withTempDir { tempDir =>
       val targetClusterInfoFile = ToolTestUtils.createTargetClusterInfoFile(
         tempDir.getAbsolutePath,
-        instanceType = expectedClusterInfo.workerNodeType,
+        driverNodeInstanceType = expectedClusterInfo.driverNodeType,
+        workerNodeInstanceType = expectedClusterInfo.workerNodeType,
         enforcedSparkProperties = expectedEnforcedSparkProperties)
 
       val appArgs = new ProfileArgs(Array(

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -766,10 +766,10 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
       //   gpu:
       //     count: 1
       //     name: l4
-      intercept[IllegalArgumentException] {
+      assertThrows[IllegalArgumentException] {
         ToolTestUtils.createTargetClusterInfoFile(
           tempDir.getAbsolutePath,
-          instanceType = Some("g2-standard-8"),
+          workerNodeInstanceType = Some("g2-standard-8"),
           cpuCores = Some(16), memoryGB = Some(64),
           gpuCount = Some(1), gpuDevice = Some(GpuTypes.L4))
       }
@@ -783,10 +783,32 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
       // workerInfo:
       //   cpuCores: 16
       //   memoryGB: 64
-      intercept[IllegalArgumentException] {
+      assertThrows[IllegalArgumentException] {
         ToolTestUtils.createTargetClusterInfoFile(
           tempDir.getAbsolutePath,
           cpuCores = Some(16), memoryGB = Some(64))
+      }
+    }
+  }
+
+  // This test verifies that an error is thrown when the target cluster YAML file
+  // contains both worker info and driver info for OnPrem
+  test("Should fail when target cluster contains both worker info and driver info for OnPrem") {
+    TrampolineUtil.withTempDir { tempDir =>
+      // driverInfo:
+      //   instanceType: foobar
+      // workerInfo:
+      //   cpuCores: 16
+      //   memoryGB: 64
+      //   gpu:
+      //     count: 1
+      //     name: l4
+      assertThrows[IllegalArgumentException] {
+        ToolTestUtils.createTargetClusterInfoFile(
+          tempDir.getAbsolutePath,
+          driverNodeInstanceType = Some("foobar"),
+          cpuCores = Some(16), memoryGB = Some(64),
+          gpuCount = Some(1), gpuDevice = Some(GpuTypes.L4))
       }
     }
   }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -179,6 +179,8 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
    *
    * Target Cluster YAML file:
    * {{{
+   * driverInfo:
+   *  instanceType: n1-standard-8
    * workerInfo:
    *  instanceType: g2-standard-8
    * sparkProperties:
@@ -191,7 +193,6 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
   test(s"test valid cluster shape recommendation with enforced spark properties on dataproc " +
     s"affecting the cluster shape") {
     val testEventLog = s"$qualLogDir/nds_q72_dataproc_2_2.zstd"
-    val testWorkerNodeType = Some("g2-standard-8")
     val testEnforcedSparkProperties = Map(
       "spark.executor.cores" -> "8",
       "spark.executor.instances" -> "4",
@@ -208,12 +209,14 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
       dynamicAllocationMaxExecutors = "N/A",
       dynamicAllocationMinExecutors = "N/A",
       dynamicAllocationInitialExecutors = "N/A",
-      workerNodeType = testWorkerNodeType
+      driverNodeType = Some("n1-standard-8"),
+      workerNodeType = Some("g2-standard-8")
     )
     TrampolineUtil.withTempDir { tempDir =>
       val targetClusterInfoFile = ToolTestUtils.createTargetClusterInfoFile(
         tempDir.getAbsolutePath,
-        instanceType = testWorkerNodeType,
+        driverNodeInstanceType = expectedClusterInfo.driverNodeType,
+        workerNodeInstanceType = expectedClusterInfo.workerNodeType,
         enforcedSparkProperties = testEnforcedSparkProperties)
 
       val appArgs = new QualificationArgs(Array(

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -370,10 +370,12 @@ local:
     clusterInference:
       cpuClusterColumns:
         - 'Num Worker Nodes'
+        - 'Driver Node Type'
         - 'Worker Node Type'
         - 'Cores Per Executor'
       gpuClusterColumns:
         - 'Recommended Num Worker Nodes'
+        - 'Recommended Driver Node Type'
         - 'Recommended Worker Node Type'
         - 'Recommended Cores Per Executor'
 

--- a/user_tools/src/spark_rapids_tools/tools/core/qual_output_reader.py
+++ b/user_tools/src/spark_rapids_tools/tools/core/qual_output_reader.py
@@ -193,6 +193,7 @@ class QualOutputFileReader:
             'sourceClusterInfo.dynamicAllocationMinExecutors': 'Dynamic Allocation Min Executors',
             'sourceClusterInfo.dynamicAllocationInitialExecutors': 'Dynamic Allocation Initial Executors',
             'sourceClusterInfo.coresPerExecutor': 'Cores Per Executor',
+            'recommendedClusterInfo.driverNodeType': 'Recommended Driver Node Type',
             'recommendedClusterInfo.workerNodeType': 'Recommended Worker Node Type',
             'recommendedClusterInfo.numExecutors': 'Recommended Num Executors',
             'recommendedClusterInfo.numWorkerNodes': 'Recommended Num Worker Nodes',


### PR DESCRIPTION
Fixes #1779 

This PR allows users to specify a custom driver instance type in Qualification and Profiling Tool. It also includes CSP-specific default driver instance types which will be added in the recommended cluster shape only in the Qualification Tool.


### Usage

### Usage via Python CLI
1. Build and install the Python CLI in non-fat mode

```shell
$ cd spark-rapids-tools/user_tools
$ ./build.sh non-fat
$ pip install dist/spark_rapids_user_tools-25.4.5-py3-none-any.whl
```

#### Case 1: Qualification: Driver Info is provided in the YAML file
- Create a target cluster YAML file
```yaml
driverInfo:
  instanceType: n1-standard-8
workerInfo:
  instanceType: g2-standard-24
```

- Run the Qualification CLI as:
```shell
spark_rapids qualification \
  --platform $PLATFORM \
  --eventlogs $EVENT_LOG \
  --target_cluster_info $PATH_TO_TARGET_YAML \
```

- Custom driver information will be used:
`qual_2025xxx/qual_core_output/qual_metrics/appxx/cluster_information.json`:
```json
{ 
  "dynamicAllocationInitialExecutors" : "1",
   "driverNodeType" : "n1-standard-8",
   "workerNodeType" : "g2-standard-24"
}
```

#### Case 2: Qualification: Driver Info is not provided in the YAML file
- Create a target cluster YAML file
```yaml
workerInfo:
  instanceType: g2-standard-24
```

- Run the Qualification CLI as:
```shell
spark_rapids qualification \
  --platform $PLATFORM \
  --eventlogs $EVENT_LOG \
  --target_cluster_info $PATH_TO_TARGET_YAML \
```

- Default driver information will be used:
`qual_2025xxx/qual_core_output/qual_metrics/appxx/cluster_information.json`:
```json
{ 
  "dynamicAllocationInitialExecutors" : "1",
   "driverNodeType" : "n1-standard-16",
   "workerNodeType" : "g2-standard-24"
}
```


#### Case 3: Profiling: Driver Info is not provided in the YAML file
- Create a target cluster YAML file
```yaml
workerInfo:
  instanceType: g2-standard-24
```

- Run the Profiling CLI as:
```shell
spark_rapids qualification \
  --platform $PLATFORM \
  --eventlogs $EVENT_LOG \
  --target_cluster_info $PATH_TO_TARGET_YAML \
```

- Default driver information will not be used:
`prof_2025xxx/rapids_4_spark_profile/appxxx/cluster_information.json`:
```json
{ 
  "dynamicAllocationInitialExecutors" : "1",
   "workerNodeType" : "g2-standard-24"
}
```