### PR TITLE
Add support for L20 GPU in Tools 

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/GpuDevice.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/GpuDevice.scala
@@ -27,6 +27,7 @@ object GpuTypes {
   val P100 = "p100"
   val P4 = "p4"
   val L4 = "l4"
+  val L20 = "l20"
   val A10 = "a10"
   val A10G = "a10G"
 }
@@ -63,6 +64,12 @@ case object T4Gpu extends GpuDevice {
 case object L4Gpu extends GpuDevice {
   override def getMemory: String = "24576m"
   override def toString: String = GpuTypes.L4
+}
+
+case object L20Gpu extends GpuDevice {
+  // TODO: Add recommended values for advisory partition size
+  override def getMemory: String = "49152m"
+  override def toString: String = GpuTypes.L20
 }
 
 case object V100Gpu extends GpuDevice {
@@ -107,6 +114,7 @@ object GpuDevice extends Logging {
     GpuTypes.A100-> A100Gpu,
     GpuTypes.T4 -> T4Gpu,
     GpuTypes.L4 -> L4Gpu,
+    GpuTypes.L20 -> L20Gpu,
     GpuTypes.V100 -> V100Gpu,
     GpuTypes.K80 -> K80Gpu,
     GpuTypes.P100 -> P100Gpu,

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -790,4 +790,85 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
       }
     }
   }
+
+  // This test uses target cluster properties with a worker node having 16 cores, 64g memory,
+  // and 1 L20 GPU. The platform is mocked as Kubernetes on OnPrem
+  // to enable memory overhead calculation.
+  // AutoTuner is expected to:
+  // - Recommend `spark.rapids.sql.concurrentGpuTasks` to a value of 4 since L20
+  //   has high memory.
+  test("Target cluster properties for OnPrem with worker having L20 GPU") {
+    // 1. Mock source cluster info for OnPrem
+    val sourceWorkerInfo = buildGpuWorkerInfoAsString(None, Some(8), Some("14000MiB"))
+    val sourceClusterInfoOpt =
+      PropertiesLoader[ClusterProperties].loadFromContent(sourceWorkerInfo)
+    // 2. Mock the properties loaded from eventLog
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "8",
+        "spark.executor.instances" -> "2",
+        "spark.rapids.memory.pinnedPool.size" -> "5g",
+        "spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
+        "spark.executor.resource.gpu.amount" -> "1"
+      )
+    // workerInfo:
+    //   cpuCores: 16
+    //   memoryGB: 64
+    //   gpu:
+    //     count: 1
+    //     name: l20
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      cpuCores = Some(16), memoryGB = Some(64),
+      gpuCount = Some(1), gpuDevice = Some(GpuTypes.L20)
+    )
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0), logEventsProps,
+      Some(testSparkVersion))
+    val platform = PlatformFactory.createInstance(PlatformNames.ONPREM,
+      sourceClusterInfoOpt, Some(targetClusterInfo))
+    val autoTuner = buildAutoTunerForTests(sourceWorkerInfo, infoProvider, platform,
+      sparkMaster = Some(Kubernetes))
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.executor.cores=16
+          |--conf spark.executor.memory=32g
+          |--conf spark.executor.memoryOverhead=11468m
+          |--conf spark.locality.wait=0
+          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=24
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
+          |--conf spark.rapids.sql.concurrentGpuTasks=4
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=32
+          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
+          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
+          |--conf spark.sql.files.maxPartitionBytes=512m
+          |--conf spark.task.resource.gpu.amount=0.001
+          |
+          |Comments:
+          |- 'spark.executor.memory' was not set.
+          |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- 'spark.rapids.sql.concurrentGpuTasks' was not set.
+          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
+          |- 'spark.shuffle.manager' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+          |- 'spark.sql.files.maxPartitionBytes' was not set.
+          |- 'spark.task.resource.gpu.amount' was not set.
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.jars.missing")}
+          |- ${ProfilingAutoTunerConfigsProvider.classPathComments("rapids.shuffle.jars")}
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    compareOutput(expectedResults, autoTunerOutput)
+  }
 }


### PR DESCRIPTION
Fixes #1761 


This PR adds support for L20 GPUs in the RAPIDS Tools. OnPrem users can now specify L20 GPU in the target cluster configuration YAML. 

### Usage
1.  Create a target cluster info for OnPrem as:

```yaml
workerInfo:
  cpuCores: 20
  memoryGB: 120
  gpu:
    count: 1
    name: l20
sparkProperties:
  enforced:
    spark.executor.memory: 20g
    spark.executor.memoryOverhead: 55g
    spark.memory.offHeap.enabled: true
    spark.memory.offHeap.size: 45g
``` 

2. Run the Tools CLI as:
```
spark_rapids profiling \
  --platform onprem \
  --eventlogs $EVENT_LOG \
  --target_cluster_info $PATH_TO_TARGET_YAML \
``` 

### Testing
- Add unit test for recommending `spark.rapids.sql.concurrentGpuTasks` to a value of 4 since L20 has high memory.

### TODO:
- Due to lack of access to L20, could not benchmark the optimal value for `spark.sql.adaptive.advisoryPartitionSizeInBytes`.
- @wjxiz1992 — could you help run tests on L20 to get the optimal values for this config?
    - For advisoryPartitionSizeInBytes, we could test in the range: 32m, 64m, 128m.