### PR TITLE
[WIP] QualX model calibration functionality

### DIFF
--- a/user_tools/src/spark_rapids_pytools/resources/qualx-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualx-conf.yaml
@@ -32,3 +32,4 @@ xgboost:
   model_name: xgb_model.json
   n_trials: 200
   qual_tool_filter: stage
+#calib: false

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_config.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_config.py
@@ -90,6 +90,11 @@ class QualxConfig(BaseConfig):
             'negative': 1.0
         }])
 
+    calib: Optional[bool] = Field(
+        default=False,
+        description='Flag to perform model calibration',
+        examples=[True, False])
+
     alignment_dir: Optional[str] = Field(
         default=None,
         description='OPTIONAL: Path to alignment directory.',

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -184,11 +184,13 @@ def _get_calib_params(platform: str,
     """
     model_path = _get_model_path(platform, model, variant)
     calib_path = model_path.parent / Path(model_path.stem + '_calib.cfg')
-    logger.debug('Loading calib params from: %s', calib_path)
     calib_params = {'c1': 1.0, 'c2': 1.0, 'c3': 0.0}
     if calib_path.exists():
+        logger.debug('Loading calib params from: %s', calib_path)
         with open(calib_path, 'r', encoding='utf-8') as f:
             calib_params = json.load(f)
+    else:
+        logger.debug('Calib params file not found: %s', calib_path)
     return calib_params
 
 

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -14,7 +14,7 @@
 
 """ Main module for QualX related commands """
 
-from typing import Callable, List, Optional, Set, Tuple, Union
+from typing import Callable, List, Optional, Set, Tuple, Union, Dict
 import glob
 import json
 import os
@@ -44,7 +44,7 @@ from spark_rapids_tools.tools.qualx.model import (
     extract_model_features,
     compute_shapley_values,
 )
-from spark_rapids_tools.tools.qualx.model import train as train_model, predict as predict_model
+from spark_rapids_tools.tools.qualx.model import train as train_model, calibrate as calibrate_model, predict as predict_model
 from spark_rapids_tools.tools.qualx.util import (
     compute_accuracy,
     ensure_directory,
@@ -151,6 +151,45 @@ def _get_model(platform: str,
     xgb_model = xgb.Booster()
     xgb_model.load_model(model_path)
     return xgb_model
+
+
+def _get_calib_params(platform: str,
+                      model: Optional[str] = None,
+                      variant: Optional[str] = None) -> Dict[str, float]:
+    """
+    Load calibration params for the model, to be used similar to `_get_model()`.
+    Corresponding to model path `/path/to/{model_name}.json`, load calib params
+    from `/path/to/{model_name}_calib.cfg`
+
+    The "model" argument has a precedence over the other input options. If it is defined, this function checks
+    if it is a valid path to an XGBoost model or a string literal matching a pre-trained model name.
+    If "model" is not defined, then the pre-trained model matching "platform" will be used.
+
+    Parameters
+    ----------
+    platform: str
+        Name of the platform used to define the path of the pre-trained model.
+        The platform should match a JSON file in the "resources" directory.
+    model: str
+        Either a path to a model file or the name of a pre-trained model.
+        If the input is a string literal that cannot be a file path, then it is assumed that the file
+        is located under the resources directory.
+    variant: str
+        Value of the `sparkRuntime` column from the `application_information.csv` file from the profiler tool.
+        If set, will be used to load a pre-trained model matching the platform and variant.
+
+    Returns
+    -------
+    Calibration parameters dict
+    """
+    model_path = _get_model_path(platform, model, variant)
+    calib_path = model_path.parent / Path(model_path.stem + '_calib.cfg')
+    logger.debug('Loading calib params from: %s', calib_path)
+    calib_params = {'c1': 1.0, 'c2': 1.0, 'c3': 0.0}
+    if calib_path.exists():
+        with open(calib_path, 'r', encoding='utf-8') as f:
+            calib_params = json.load(f)
+    return calib_params
 
 
 def _get_qual_data(qual_handler: QualCoreHandler) -> Tuple[
@@ -304,6 +343,7 @@ def _predict(
     *,
     split_fn: Callable[[pd.DataFrame], pd.DataFrame] = None,
     qual_tool_filter: Optional[str] = 'stage',
+    calib_params: Dict[str, float] = None,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
     label = get_label()
     results = pd.DataFrame(
@@ -339,7 +379,7 @@ def _predict(
         features, feature_cols, label_col = extract_model_features(input_df, {'default': split_fn})
         # note: dataset name is already stored in the 'appName' field
         try:
-            results = predict_model(xgb_model, features, feature_cols, label_col)
+            results = predict_model(xgb_model, features, feature_cols, label_col, calib_params)
 
             # compute per-app speedups
             summary = _compute_summary(results)
@@ -550,6 +590,7 @@ def train(
     model_type = cfg.model_type
     model_config = cfg.__dict__.get(model_type, {})
     trials = n_trials if n_trials else model_config.get('n_trials', 200)
+    calib = cfg.calib
 
     datasets, profile_df = load_datasets(dataset)
     dataset_list = sorted(list(datasets.keys()))
@@ -616,6 +657,13 @@ def train(
     base_model_cfg = Path(model).with_suffix('.cfg')
     with open(base_model_cfg, 'w', encoding='utf-8') as f:
         f.write(cfg)
+
+    # calibrate model
+    if calib:
+        calib_params = calibrate_model(features, feature_cols, label_col, xgb_model)
+        calib_path = Path(model).parent / Path(Path(model).stem + '_calib.cfg')
+        with open(calib_path, 'w', encoding='utf-8') as f:
+            json.dump(calib_params, f)
 
     ensure_directory(output_dir)
 
@@ -729,15 +777,17 @@ def predict(
         prediction_groups = {}
         for variant in variants:
             xgb_model = _get_model(platform, None, variant)  # variants only supported for pre-trained platform models
+            calib_params = _get_calib_params(platform, None, variant)
             variant_profile_df = profile_df.loc[
                 (profile_df['sparkRuntime'] == variant) | (profile_df['sparkRuntime'] == 'SPARK_RAPIDS')
             ]
-            prediction_groups[xgb_model] = variant_profile_df
+            prediction_groups[(xgb_model, calib_params)] = variant_profile_df
     else:
         # single platform
         xgb_model = _get_model(platform, model)
+        calib_params = _get_calib_params(platform, model)
         prediction_groups = {
-            xgb_model: profile_df
+            (xgb_model, calib_params): profile_df
         }
 
     filter_str = (
@@ -750,11 +800,11 @@ def predict(
     try:
         features_list = []
         predictions_list = []
-        for xgb_model, prof_df in prediction_groups.items():
+        for (xgb_model, calib_params), prof_df in prediction_groups.items():
             features, feature_cols, label_col = extract_model_features(prof_df)
             features_index = features.index
             features_list.append(features)
-            predictions = predict_model(xgb_model, features, feature_cols, label_col)
+            predictions = predict_model(xgb_model, features, feature_cols, label_col, calib_params)
             predictions.index = features_index
             predictions_list.append(predictions)
         features = pd.concat(features_list)
@@ -940,6 +990,7 @@ def evaluate(
     ensure_directory(output_dir)
 
     xgb_model = _get_model(platform, model)
+    calib_params = _get_calib_params(platform, model)
 
     cache_dir = get_cache_dir()
 
@@ -990,6 +1041,7 @@ def evaluate(
         profile_df,
         split_fn=split_fn,
         qual_tool_filter=qual_tool_filter,
+        calib_params=calib_params
     )
 
     # app level ground truth
@@ -1026,6 +1078,7 @@ def evaluate(
         filtered_profile_df,
         split_fn=split_fn,
         qual_tool_filter=qual_tool_filter,
+        calib_params=calib_params
     )
 
     # merge results and join w/ qual_preds


### PR DESCRIPTION
This PR adds functionality for optionally calibrating the QualX model after the training.
Regression models like QualX often have a calibration bias wherein the predictions are shrunk
towards the mean (underprediction at higher ranges and overprediction at lower range of labels)
when using L2 regularization. For background see https://arxiv.org/pdf/2405.15950 and references therein.

There are no changes to training process for the existing main model. 
We use a simple calibration formula `y_pred_calib = c1*y_pred**c2+c3` to calibrate
the existing model prediction `y_pred` where the calibration parameters `c1`, `c2`, `c3`
are learned based on the same training data. E.g., if `y_pred = 4.5` and `c1, c2, c3 = 1.2, 1.36, 0.1`,
then the calibrated prediction is `y_pred_calib = 1.2*4.5**1.36+0.1 = 9.38`.

Calibration functionality can be enabled in yaml config using `calib: true`, e.g., see default config [qualx-conf.yaml](https://github.com/NVIDIA/spark-rapids-tools/blob/dev/user_tools/src/spark_rapids_pytools/resources/qualx-conf.yaml). Currently it is not enabled by default `#calib: false`.
When enabled, the `qualx train` command will perform the model calibration immediately after the main model is trained. The calibration params are saved to a config file `{model_name}_calib_params.cfg` where `{model_name}.json` is the main model file name. For prediction using `qualx predict` or `qualx evaluate` etc, the calibration params are loaded from this file if present and functionality is enabled in the yaml config.

## Changes

## Tests
