### PR TITLE
Add option to report SQL-graphs in profiler

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
@@ -62,8 +62,14 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
       descr = "Generate query visualizations in DOT format. Default is false.")
   val printPlans: ScallopOption[Boolean] =
     opt[Boolean](required = false,
-      descr = "Print the SQL plans to a file named 'planDescriptions.log'." +
+      descr = "Print the SQL physical plan descriptions to a file named 'planDescriptions.log'." +
         " Default is false.")
+  val printPlanGraph: ScallopOption[Boolean] =
+    opt[Boolean](
+      required = false,
+      descr = "Print the SQL Spark-Graph of the SQL plans to a file." +
+        " Default is false.",
+      default = Some(false))
   val platform: ScallopOption[String] =
     opt[String](required = false,
       descr = "Cluster platform where Spark GPU workloads were executed. Options include " +

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -131,6 +131,44 @@ case class SQLPlanInfoProfileResult(sqlID: Long, sparkPlanInfo: SparkPlanInfoTru
   }
 }
 
+/**
+ * This result class is used in the SQL graph report that displays
+ * the full list of operators executed within a plan.
+ * @param sqlID the SQL ID
+ * @param planVersion the plan version (commonly the final plan)
+ * @param nodeID the node ID
+ * @param nodeName the node name
+ * @param nodeDesc the node description. The caller should cleanup the description and escape the
+ *                 special characters.
+ * @param sinkNodes A comma separated list of adjacent node Ids. Those nodes are the destination of
+ *                  the edge going out of the current node.
+ * @param stageIds The stage IDs that the node belongs to.
+ *                 This typically a raw representation using the accumulable IDs.
+ */
+case class SQLPlanGraphProfileResult(
+    sqlID: Long,
+    planVersion: Int,
+    nodeID: Long,
+    nodeName: String,
+    nodeDesc: String, // node desc should be processed to escape characters
+    sinkNodes: Iterable[Long],
+    stageIds: Iterable[Int]) extends ProfileResult {
+  override def outputHeaders: Array[String] = {
+    OutHeaderRegistry.outputHeaders("SQLPlanGraph")
+  }
+  override def convertToSeq(): Array[String] = {
+    Array(sqlID.toString, planVersion.toString, nodeID.toString,
+      nodeName, nodeDesc, sinkNodes.mkString(","), stageIds.mkString(","))
+  }
+  override def convertToCSVSeq(): Array[String] = {
+    Array(sqlID.toString, planVersion.toString, nodeID.toString,
+      StringUtils.reformatCSVString(nodeName),
+      StringUtils.reformatCSVString(nodeDesc),
+      StringUtils.quoteCSVString(sinkNodes.mkString(",")),
+      StringUtils.quoteCSVString(stageIds.mkString(",")))
+  }
+}
+
 case class SQLStageInfoProfileResult(
     sqlID: Long,
     jobID: Int,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
@@ -412,6 +412,12 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
       profileOutputWriter.writeCSVTable(ProfIODiagnosticMetricsView.getLabel,
         profilerResult.diagnostics.IODiagnostics)
     }
+    if (appArgs.printPlanGraph()) {
+      // print the Spark-Plan graph.
+      // this won't be part of the text formatted report.
+      profileOutputWriter.writeCSVTable(
+        ProfSQLPlanGraphView.getLabel, ProfSQLPlanGraphView.getRawView(profilerResult.app))
+    }
     // Construct the cluster summary information
     // Note:
     // - This is available only after AutoTuner is run

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/OutHeaderRegistry.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/OutHeaderRegistry.scala
@@ -39,6 +39,11 @@ object OutHeaderRegistry {
       Array("sqlID"),
     "SQLPlanInfoProfileResult" ->
       Array("sqlID", "SparkPlanInfoTruncated"),
+    "SQLPlanGraph" ->
+      // This is the table that shows the SQL plan graph. It dumps basic information
+      // about the nodes in each SQL. See "SQLPlanGraphProfileResult" for more details.
+      Array("sqlID", "sqlPlanVersion", "nodeID", "nodeName", "description", "sinkNodes",
+        "stageIds"),
     "SQLStageInfoProfileResult" ->
       Array("sqlID", "jobID", "stageId", "stageAttemptId", "Stage Duration", "SQL Nodes(IDs)"),
     "RapidsJarProfileResult" ->

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/ViewableTrait.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/ViewableTrait.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,10 @@ trait ViewableTrait[R <: ProfileResult] extends AppIndexMapperTrait with Logging
   def getDescription: String = ""
 
   def getRawView(app: AppBase, index: Int): Seq[R]
+
+  def getRawView(app: AppBase): Seq[R] = {
+    getRawView(app, 1)
+  }
 
   def getRawView(apps: Seq[AppBase]): Seq[R] = {
     val allRows = zipAppsWithIndex(apps).flatMap { case (app, index) =>

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManager.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManager.scala
@@ -149,6 +149,16 @@ class SQLPlanModelManager {
   }
 
   /**
+   * Apply a function to all the SqlPlanModels.
+   * @param f function to be applied
+   * @tparam A Type of the result of the function
+   * @return Iterable of type A
+   */
+  def applyToAllPlanModels[A](f: SQLPlanModel => A): Iterable[A] = {
+    sqlPlans.values.map(f)
+  }
+
+  /**
    * Shortcuts to make the new implementation compatible with previous code that was expecting a
    * Map[Long, String]
    * @return map between executionId and the physical description of the last version.

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/StringUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/StringUtils.scala
@@ -94,8 +94,18 @@ object StringUtils extends Logging {
     }
   }
 
+  /**
+   * A utility function to guard a string with double quotes. This is handy to use when we know that
+   * the argument string has no double_quotes. Therefore, it is faster to execute.
+   * @param str the string to be processed.
+   * @return return the str surrounded with double quotes.
+   */
+  def quoteCSVString(str: String): String = {
+    "\"" + str + "\""
+  }
+
   def reformatCSVString(str: String): String = {
-    "\"" + str.replace("\"", "\"\"") + "\""
+    quoteCSVString(str.replace("\"", "\"\""))
   }
 
   def escapeMetaCharacters(str: String): String = {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/ToolsPlanGraph.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/ToolsPlanGraph.scala
@@ -484,6 +484,15 @@ class ToolsPlanGraph(val sparkGraph: SparkPlanGraph,
   def getStageNodesByRawAssignment(stageId: Int): collection.Set[Long] = {
     nodeStageMapper.getRawSTN(stageId)
   }
+
+  /**
+   * retrieve all the sinkNodes adajacent to a given node.
+   * @param nodeId the id of the current node
+   * @return a set of nodeIds, or empty if none.
+   */
+  def getSinkNodes(nodeId: Long): collection.Set[Long] = {
+    edges.filter(_.fromId == nodeId).map(_.toId).toSet
+  }
 } // end of class ToolsPlanGraph
 
 /**

--- a/user_tools/src/spark_rapids_pytools/resources/profiling-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/profiling-conf.yaml
@@ -50,6 +50,7 @@ sparkRapids:
       - order
       - p
       - print-plans
+      - print-plan-graph
       - s
       - start-app-time
       - t


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1784

This change adds support to generate a new report that contains the SQL graphs of an application.
- the option is deiabled by default to reduce overhead.
- `--print-plan-graph` enables the report.
- the new report will be generated in new file `sql_plan_graph.csv`
- the table won't be added to the `profiler.log`.
- the CSV schema is:
  - sqlID: long
  - sqlPlanVersion: Int (version of the plan)
  - nodeID: long
  - nodeName: String
  - description: string (node description)
  - sinkNodes: string (comma separate of adjacentNodeIds starting from the current node). empty if none
  - stageIds: string (comma separated int of stageIds). this is raw representation that rely on accumulableIds. a.ka., no heuristics applied. Empty string if None.

### New SQL Plan Graph Functionality:

* **Added a new command-line option for SQL plan graph generation**: The `printPlanGraph` option was introduced in `ProfileArgs.scala` to allow users to generate SQL plan graphs and save them to a file. This option is disabled by default.
* **Created `SQLPlanGraphProfileResult` class**: A new result class was added to represent nodes in the SQL plan graph, including attributes like `sqlID`, `nodeID`, `nodeName`, and `sinkNodes`. Methods for converting the data to CSV and headers were also implemented.

### Enhancements to Views and Profiling:

* **Implemented `AppSQLPlanGraphViewTrait`**: This new trait provides a comprehensive view of SQL plan graph nodes, including methods for retrieving and sorting graph data. It integrates with the profiling workflow via `ProfSQLPlanGraphView`. [[1]](diffhunk://#diff-4b3181a5d300d4bc6851c762d61691f449a0fb59632dc7798fb55f8b14ecc03aR38-R70) [[2]](diffhunk://#diff-4b3181a5d300d4bc6851c762d61691f449a0fb59632dc7798fb55f8b14ecc03aR213-R216)
* **Integrated graph generation into profiling workflow**: The `Profiler` class was updated to write SQL plan graph data to a CSV file when the `printPlanGraph` option is enabled.
* **Updated `OutHeaderRegistry`**: Added headers for the SQL plan graph table to ensure proper formatting and output.

### Utility Improvements:

* **Enhanced `StringUtils`**: Added a `quoteCSVString` utility method for efficiently wrapping strings in double quotes, which is now used in the `reformatCSVString` method.
* **Added `getSinkNodes` method to `ToolsPlanGraph`**: This method retrieves all adjacent sink nodes for a given node in the graph, enabling edge traversal.

These changes collectively enhance the profiling tool's ability to visualize and analyze SQL execution plans in graph format, providing deeper insights into query execution.
