### PR TITLE
Fix the core log file to qual_core_stderr.log

### DIFF
--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -19,7 +19,7 @@ toolOutput:
   textFormat:
     summaryLog:
       fileName: rapids_4_spark_qualification_output.log
-    log4jFileName: rapids_4_spark_qualification_stderr.log
+    log4jFileName: qual_core_stderr.log
   csv:
     unsupportedOperatorsReport:
       fileName: rapids_4_spark_qualification_output_unsupportedOperators.csv


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Contributes to #1800

- rename `rapids_4_spark_qualification_stderr.log` to `qual_core_stderr.log`


