### PR TITLE
QualX model calibration functionality

### DIFF
--- a/user_tools/src/spark_rapids_pytools/resources/qualx-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualx-conf.yaml
@@ -32,3 +32,4 @@ xgboost:
   model_name: xgb_model.json
   n_trials: 200
   qual_tool_filter: stage
+#calib: false

--- a/user_tools/src/spark_rapids_tools/tools/qualx/model.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/model.py
@@ -14,14 +14,18 @@
 
 """ Model training and prediction functions for QualX """
 
-from typing import Callable, Mapping, Optional, List, Tuple, Union
+from typing import Callable, Mapping, Optional, List, Tuple, Union, Dict
 import json
+import math
 import shap
 import numpy as np
 import pandas as pd
 
 import xgboost as xgb
 from xgboost import Booster
+
+from sklearn.model_selection import train_test_split
+from scipy.optimize import least_squares
 
 from spark_rapids_tools.tools.qualx.config import get_config, get_label
 from spark_rapids_tools.tools.qualx.preprocess import expected_raw_features
@@ -81,6 +85,7 @@ def train(
     label_col: str,
     n_trials: int = 200,
     base_model: Optional[Booster] = None,
+    hyperparams: Optional[Dict[str, any]] = None,
 ) -> Booster:
     """Train model on preprocessed data."""
     if 'split' not in cpu_aug_tbl.columns:
@@ -150,6 +155,15 @@ def train(
         xgb_params['subsample'] = float(train_params['subsample'])
         n_estimators = cfg['learner']['gradient_booster']['gbtree_model_param']['num_trees']
         n_estimators = int(float(n_estimators) * 1.1)              # increase n_estimators
+    elif hyperparams:
+        base_params = {
+            'random_state': 0,
+            'objective': 'reg:squarederror',
+            'eval_metric': ['mae', 'mape'],  # applied to eval_set/test_data if provided
+            'booster': 'gbtree',
+        }
+        xgb_params = {**base_params, **hyperparams}
+        n_estimators = xgb_params.pop('n_estimators', 100)
     else:
         # use optuna hyper-parameter tuning
         best_params = tune_hyperparameters(x_tune, y_tune, n_trials, sample_weights)
@@ -179,11 +193,117 @@ def train(
     return xgb_model
 
 
+def calibrate(
+    cpu_aug_tbl: pd.DataFrame,
+    feature_cols: List[str],
+    label_col: str,
+    xgb_model: Booster,
+) -> Dict[str, float]:
+    """
+    Calibration involves first training a pre-calib xgb model on a smaller random split of full
+    training data (train+val) that was used for training the main model that we want to calibrate.
+    This pre-calibrated model serves as an independent near-identical version of the main model.
+    This surrogate model is needed instead of main model since the calibration bias is only observed
+    on out-of-sample data (not seen previously in training). We refer to this split of the full
+    training data as pre-calib holdout data.
+
+    The calibration parameters are fit using the pre-calib model predictions
+    on the remaining training data, that is referred to as calib holdout data.
+    """
+
+    # Create (stratified) random split of train data into precalib and calib data
+    cpu_aug_tbl = cpu_aug_tbl[cpu_aug_tbl['split'].isin(['train', 'val'])
+                              & cpu_aug_tbl[label_col].notna()].copy()
+    cpu_aug_tbl['label_quantile'] = pd.qcut(cpu_aug_tbl[label_col], q=10, duplicates='drop')
+    cpu_aug_tbl_precalib, cpu_aug_tbl_calib = train_test_split(
+        cpu_aug_tbl,
+        test_size=0.2,
+        random_state=0,
+        stratify=cpu_aug_tbl[['label_quantile']]
+    )
+
+    # Extract and use same hyperparams as main model we want to calibrate
+    hyperparams = {}
+    cfg = json.loads(xgb_model.save_config())
+    train_params = cfg['learner']['gradient_booster']['tree_train_param']
+    hyperparams['eta'] = float(train_params['eta'])
+    hyperparams['gamma'] = float(train_params['gamma'])
+    hyperparams['lambda'] = float(train_params['lambda'])
+    hyperparams['max_depth'] = int(train_params['max_depth'])
+    hyperparams['min_child_weight'] = int(train_params['min_child_weight'])
+    hyperparams['subsample'] = float(train_params['subsample'])
+    hyperparams['n_estimators'] = int(cfg['learner']['gradient_booster']['gbtree_model_param']['num_trees'])
+
+    # Train precalib model as an independent near-identical version of main model
+    xgb_model_precalib = train(cpu_aug_tbl_precalib, feature_cols, label_col, hyperparams=hyperparams)
+
+    # Get predictions from precalib model on calib holdout samples
+    x = cpu_aug_tbl_calib[xgb_model_precalib.feature_names]
+    y_pred = xgb_model_precalib.predict(xgb.DMatrix(x))
+    if LOG_LABEL:
+        y_pred = np.exp(y_pred)
+
+    # Sample importance weighting to address label imbalance across the range.
+    # Divide the entire range of label into bins of roughly equal length
+    # such that each bin has a minimum number of samples.
+    # Samples in each bin get importance weight as the ratio of
+    # the largest count of samples in any bin to the count of samples in its bin.
+    max_num_bins = 10
+    min_samples_per_bin = 5
+    y = cpu_aug_tbl_calib[label_col]
+    y_min, y_max, y_avg = np.min(y), np.max(y), np.average(y)
+    calib_df = pd.DataFrame({'y': y, 'y_pred': y_pred})
+    for num_bins in range(max_num_bins, 1, -1):
+        bins = np.append(
+            np.linspace(y_min*0.99, y_avg, (num_bins+1)//2 + 1)[:-1],
+            np.exp(np.linspace(math.log(y_avg), math.log(y_max*1.01), math.ceil((num_bins+1)/2)))
+        )
+        bin_labels = np.arange(0, num_bins)
+        calib_df['y_qz'] = pd.cut(calib_df['y'], bins, labels=bin_labels)
+        y_qz_hist_df = calib_df \
+            .groupby(['y_qz'], as_index=False) \
+            .agg(count=pd.NamedAgg('y_qz', 'size')) \
+            .sort_values('y_qz')
+        smallest_count_per_bin = np.min(y_qz_hist_df['count'])
+        print(y_qz_hist_df)
+        if smallest_count_per_bin >= min_samples_per_bin:
+            break
+
+    largest_count_per_bin = np.max(y_qz_hist_df['count'])
+    calib_df = calib_df.merge(y_qz_hist_df, on=['y_qz'])
+    calib_df['weight'] = largest_count_per_bin / calib_df['count']
+
+    # Fit calibration params y ~ c1*y_pred^c2 + c3
+    y_pred = calib_df['y_pred'].to_numpy()
+    y = calib_df['y'].to_numpy()
+    w = calib_df['weight'].to_numpy()
+    if LOG_LABEL:
+        c_argmin = least_squares(
+                        fun=lambda c: (np.log(y) - np.log(c[0]*np.pow(y_pred, c[1])+c[2])) * np.sqrt(w),
+                        x0=np.array([1.0, 1.0, 0.0]),
+                        bounds=([0.25, 1.0, 0.0], [4.0, 2.5, 0.001])
+                    ).x
+    else:
+        c_argmin = least_squares(
+                fun=lambda c: (y - (c[0]*np.pow(y_pred, c[1])+c[2])) * np.sqrt(w),
+                x0=np.array([1.0, 1.0, 0.0]),
+                bounds=([1.0, 1.0, -0.1], [3.0, 2.5, 0.1])
+            ).x
+
+    calib_params = {
+        'c1': round(float(c_argmin[0]), 4),
+        'c2': round(float(c_argmin[1]), 4),
+        'c3': round(float(c_argmin[2]), 4)
+    }
+    return calib_params
+
+
 def predict(
     xgb_model: xgb.Booster,
     cpu_aug_tbl: pd.DataFrame,
     feature_cols: List[str],
     label_col: str,
+    calib_params: Dict[str, float] = None,
 ) -> pd.DataFrame:
     """Use model to predict on feature data."""
     model_features = xgb_model.feature_names
@@ -203,6 +323,14 @@ def predict(
 
     if LOG_LABEL:
         y_pred = np.exp(y_pred)
+
+    cfg = get_config()
+    calib = cfg.calib
+    if calib and calib_params:
+        c1 = calib_params['c1']
+        c2 = calib_params['c2']
+        c3 = calib_params['c3']
+        y_pred = np.maximum(c1 * np.pow(y_pred, c2) + c3, 0.01)
 
     preds = {'y_pred': y_pred}
     if y is not None:

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_config.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_config.py
@@ -90,6 +90,11 @@ class QualxConfig(BaseConfig):
             'negative': 1.0
         }])
 
+    calib: Optional[bool] = Field(
+        default=False,
+        description='Flag to perform model calibration',
+        examples=[True, False])
+
     alignment_dir: Optional[str] = Field(
         default=None,
         description='OPTIONAL: Path to alignment directory.',


### PR DESCRIPTION
This PR adds functionality for optionally calibrating the QualX model after the training.
Regression models like QualX often have a calibration bias wherein the predictions are shrunk
towards the mean (underprediction at higher ranges and overprediction at lower range of labels)
when using L2 regularization. For background see https://arxiv.org/pdf/2405.15950 and references therein.

There are no changes to training process for the existing main model. 
We use a simple calibration formula `y_pred_calib = c1*y_pred**c2+c3` to calibrate
the existing model prediction `y_pred` where the calibration parameters `c1`, `c2`, `c3`
are learned based on the same training data. E.g., if `y_pred = 4.5` and `c1, c2, c3 = 1.2, 1.36, 0.1`,
then the calibrated prediction is `y_pred_calib = 1.2*4.5**1.36+0.1 = 9.38`.

Calibration functionality can be enabled in yaml config using `calib: true`, e.g., see default config [qualx-conf.yaml](https://github.com/NVIDIA/spark-rapids-tools/blob/dev/user_tools/src/spark_rapids_pytools/resources/qualx-conf.yaml). Currently it is not enabled by default `#calib: false`.
When enabled, the `qualx train` command will perform the model calibration immediately after the main model is trained. The calibration params are saved to a config file `{model_name}_calib_params.cfg` where `{model_name}.json` is the main model file name. For prediction using `qualx predict` or `qualx evaluate` etc, the calibration params are loaded from this file if present and functionality is enabled in the yaml config.

## Changes
  * Added `calib` flag and section to [qualx-conf.yaml](https://github.com/NVIDIA/spark-rapids-tools/blob/dev/user_tools/src/spark_rapids_pytools/resources/qualx-conf.yaml) and support in `QualxConfig` ([qualx_config.py](https://github.com/NVIDIA/spark-rapids-tools/blob/dev/user_tools/src/spark_rapids_tools/tools/qualx/qualx_config.py)).
  * If enabled by setting to `calib: true`, calibration parameters are trained for the model using the same training data. Since calibration bias only shows on out-of-sample data (samples not seen in training), we do not use the main model directly (since it uses the entire training data). Instead we split the train data into precalib and calib splits in 80:20 ratio and train a "surrogate" of the main model on the precalib split with the same hyperparameters. We then learn calibration parameters on the calib split using predictions from the surrogate model. This is implemented in `calibrate()` method in [model.py](https://github.com/NVIDIA/spark-rapids-tools/blob/dev/user_tools/src/spark_rapids_tools/tools/qualx/model.py) and used inside the `train()` wrapper method in [qualx_main.py](https://github.com/NVIDIA/spark-rapids-tools/blob/dev/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py).
  * The calibration params are saved to a config file `{model_name}_calib_params.cfg` where `{model_name}.json` is the main model file name. The `predict()` method in [model.py](https://github.com/NVIDIA/spark-rapids-tools/blob/dev/user_tools/src/spark_rapids_tools/tools/qualx/model.py) and corresponding wrapper methods in [qualx_main.py](https://github.com/NVIDIA/spark-rapids-tools/blob/dev/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py) load and use the calibration parameters if present and enabled.
  * Added simple unit test.

## Tests
Following CMDs have been tested:
```
spark_rapids train_and_evaluate
spark_rapids prediction
```

Internal Usage:
```
python qualx_main.py preprocess
python qualx_main.py train
python qualx_main.py predict
python qualx_main.py evaluate
```