### PR TITLE
Updates to setup_env and build script to remove redundant installations

### DIFF
--- a/user_tools/build.sh
+++ b/user_tools/build.sh
@@ -190,7 +190,7 @@ pre_build() {
   echo "rm previous build and dist directories"
   rm -rf build/ dist/
   echo "install build dependencies using pip"
-  pip install build .[qualx,test]
+  pip install build
   # Note: Removed -e .[qualx,test] to avoid overriding existing package installations
 }
 

--- a/user_tools/tests/spark_rapids_tools_e2e/features/preprocess.feature
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/preprocess.feature
@@ -18,8 +18,7 @@ Feature: Testing preprocessing functionality
   So that I can reliably process Spark event logs
 
   Background:
-    Given SPARK_RAPIDS_TOOLS_JAR environment variable is set
-    And SPARK_HOME environment variable is set
+    Given SPARK_HOME environment variable is set
     And QUALX_DATA_DIR environment variable is set
     And QUALX_CACHE_DIR environment variable is set
     And sample event logs in the QUALX_DATA_DIR

--- a/user_tools/tests/spark_rapids_tools_e2e/resources/scripts/setup_env.sh
+++ b/user_tools/tests/spark_rapids_tools_e2e/resources/scripts/setup_env.sh
@@ -93,7 +93,6 @@ install_python_package() {
 
   echo "Installing wheel: $wheel_file"
   pip install "$wheel_file"
-  pip install .
   popd
 }
 
@@ -104,8 +103,8 @@ if [ -d "$python_tools_dir/dist" ] && [ -n "$(find "$python_tools_dir/dist" -nam
   wheel_exists=true
 fi
 
-# Build the wheel file using build.sh in non-fat mode if needed
-if [ "$E2E_TEST_BUILD_WHEEL" = "true" ] || [ "$wheel_exists" = false ]; then
+# Build wheel if: wheel doesn't exist AND E2E_BUILD_WHEEL is explicitly true
+if [ "$wheel_exists" = false ] && [ "$E2E_TEST_BUILD_WHEEL" = "true" ]; then
   build_wheel
 fi
 


### PR DESCRIPTION
Fixes #1774 

This PR patches the process for building wheel file and fixes the `setup_env.sh` to take care of flaky internal tests.
There were a few redundant installations from source which messed up the Utils.resource_path logic from path to check and find the appropriate files. Conflicting installations