### PR TITLE
Train/Evaluate to use list of eventlogs feature + Tools JVM Resource logic update

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -939,7 +939,7 @@ class RapidsJarTool(RapidsTool):
         if job_resources is None:
             # default values
             platform_args = submission_args.get('platformArgs')
-            job_resources = Utilities.adjust_tools_resources(platform_args.get('jvmMaxHeapSize'), jvm_processes=1)
+            job_resources = Utilities.adjust_tools_resources(platform_args.get('jvmMaxHeapSize'))
         return job_resources.get(tool_name)
 
     def _get_rapids_threads_count(self, tool_name) -> List[str]:
@@ -1038,7 +1038,7 @@ class RapidsJarTool(RapidsTool):
         rapids_job_containers = self.ctxt.get_ctxt('rapidsJobContainers')
         futures_list = []
         results = []
-        executors_cnt = len(rapids_job_containers) if Utilities.conc_mode_enabled else 1
+        executors_cnt = len(rapids_job_containers)
         with ThreadPoolExecutor(max_workers=executors_cnt) as executor:
             for rapids_job in rapids_job_containers:
                 if self.ctxt.is_distributed_mode():


### PR DESCRIPTION
### Issue

- **Previous Approach:**
  - Used Python's `ThreadPoolExecutor` to run multiple Qual/Prof tool instances.
  - JVM tuning in each instance led to high resource contention, as tuning assumed a single tool per process.
  - Internal Java ThreadPool was underutilized, even though it more efficiently supported multi-eventlog processing (Python’s GIL limits true parallelism).
  - Redundant JVM startups added overhead.

### Changes

- QualX now passes a list of eventlogs directly to Qual/Prof for batch processing.
- JVM parameter logic updated for recent performance improvements.

### JVM Parameter Logic Updates

- **Concurrent Mode:** Removed, as multithreading now handled within a single JVM process.
- **JVM Process Count:** Fixed at 1.
- **Thread Limit:** Increased maximum tools threads to 16.
- **Per-Thread Memory Logic:** Removed. The previous method limited threads based on assumed minimum memory per thread, which is no longer relevant due to a 90% reduction in tools' memory footprint.
    - When processing a single eventlog, only one thread is used, regardless of the configured thread count.
    - Over-allocation of threads is now safe and preferred.
- **Heap Limit:** Now uses 60% of available heap, lessening conservatism.

### Benchmark Results

#### Profiler Run (~200 local eventlogs)

| Threads | Time        | Peak Heap Used | Peak CPU Utilization |
| ------- | ----------- | -------------- | -------------------- |
| 3       | 2m 30s      | 3G             | 33%                  |
| 8       | 1m 20s      | 4G             | 70%                  |
| 16      | 1m          | 5G             | 92%                  |

#### Qualification Run (~200 eventlogs)

| Threads | Time        | Peak Heap Used | Peak CPU Utilization |
| ------- | ----------- | -------------- | -------------------- |
| 3       | 2m          | 4G             | 40%                  |
| 8       | 1m 15s      | 5G             | 72%                  |
| 16      | 1m          | 5.4G           | 93%                  |

- Thread wait/contention at 16 threads remained low (~1%).

### Pre- and Post-Process Comparison

| Stage       | Old Total Time | New Total Time |
| ----------- | -------------- | -------------- |
| QualX Pre-Process   | 19m            | 8m 30s         |

### Summary

- Resource contention dramatically reduced.
- Processing performance significantly improved.
- Over-allocation of threads is now both safe and beneficial.
- Per-thread heap estimation and concurrent mode logic were removed, simplifying configuration.