### PR TITLE
AutoTuner: Add spark.executor.resource.gpu.amount and spark.plugins support

### DIFF
--- a/core/src/main/resources/bootstrap/tuningConfigs.yaml
+++ b/core/src/main/resources/bootstrap/tuningConfigs.yaml
@@ -45,6 +45,12 @@ default:
     default: 16
     usedBy: spark.executor.cores
 
+  - name: EXECUTOR_GPU_RESOURCE_AMT
+    description: >-
+      Amount of GPU resource each executor requires (fraction of GPU)
+    default: 1.0
+    usedBy: spark.executor.resource.gpu.amount
+
   - name: TASK_GPU_RESOURCE_AMT
     description: >-
       Amount of GPU resource each task requires (fraction of GPU)

--- a/core/src/main/resources/bootstrap/tuningTable.yaml
+++ b/core/src/main/resources/bootstrap/tuningTable.yaml
@@ -69,7 +69,7 @@ tuningDefinitions:
     description: >-
       Amount of additional memory to be allocated per executor process, in MiB unless otherwise specified.
       This is memory that accounts for things like VM overheads, interned strings, other native overheads, etc.
-      This tends to grow with the executor size. 
+      This tends to grow with the executor size.
       Note: memoryOverheadFactor is not recommended as specifying the overhead explicitly is sufficient.
     enabled: true
     level: cluster
@@ -341,3 +341,37 @@ tuningDefinitions:
     category: tuning
     confType:
       name: double
+  - label: spark.executor.resource.gpu.amount
+    description: >-
+      The GPU resource amount per executor when Spark schedules GPU resources.
+      This should typically be set to 1 to allocate one GPU per executor.
+    enabled: true
+    level: cluster
+    category: functionality
+    confType:
+      name: double
+    comments:
+      missing: should be set to allow Spark to schedule GPU resources.
+  - label: spark.executor.resource.gpu.discoveryScript
+    description: >-
+      The absolute path to a discovery script that Spark will run on each executor to determine available GPU resources.
+      This is needed for YARN and K8s clusters.
+      Reference: https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html
+    enabled: true
+    level: cluster
+    category: functionality
+    confType:
+      name: string
+    comments:
+      missing: should be set to allow Spark to discover GPU resources.
+  - label: spark.plugins
+    description: >-
+      A comma-separated list of plugin class names to be loaded by Spark.
+      Setting this to com.nvidia.spark.SQLPlugin enables the RAPIDS Accelerator SQL plugin for GPU acceleration.
+    enabled: true
+    level: cluster
+    category: functionality
+    confType:
+      name: string
+    comments:
+      missing: should include "com.nvidia.spark.SQLPlugin" to enable the RAPIDS Accelerator SQL plugin.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntry.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntry.scala
@@ -90,6 +90,30 @@ class TuningEntry(
     definition: Option[TuningEntryDefinition] = None)
   extends TuningEntryBase(name, originalValueRaw, tunedValueRaw, definition) {
 
+  /**
+   * Normalize the value based on the configuration data type defined in the tuning definition.
+   * This ensures consistent formatting for comparison, as users may provide values in different
+   * units or formats. For example, if a property is defined as a double, a user provided value
+   * of "1" will be normalized to "1.0".
+   */
+  override def normalizeValue(propValue: String): String = {
+    definition.map { defn =>
+      defn.getConfTypeAsEnum match {
+        case ConfTypeEnum.Int => propValue.toInt.toString
+        case ConfTypeEnum.Long => propValue.toLong.toString
+        case ConfTypeEnum.Double => propValue.toDouble.toString
+        case ConfTypeEnum.Boolean => propValue.toBoolean.toString
+        case ConfTypeEnum.Time =>
+          // TODO: Implement time normalization if needed (Ref: JavaUtils.timeStringAs())
+          propValue
+        case ConfTypeEnum.String => propValue
+        case _ => throw new IllegalArgumentException(
+          s"Unsupported configuration type: ${defn.getConfTypeAsEnum}. " +
+            s"Valid types are: ${ConfTypeEnum.values.mkString(", ")}")
+      }
+    }.getOrElse(propValue)
+  }
+
   init()
 }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntryDefinition.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntryDefinition.scala
@@ -126,6 +126,10 @@ class TuningEntryDefinition(
     confTypeInfo.defaultUnit
   }
 
+  def getConfTypeAsEnum: ConfTypeEnum.Value = {
+    confTypeInfo.name
+  }
+
   /**
    * Indicates if the property has a default value in Spark. This implies that the default value
    * can be used to set the original value of the property.

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -334,7 +334,10 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
         "spark.executor.resource.gpu.amount" -> "1",
         "spark.serializer" -> "org.apache.spark.serializer.KryoSerializer",
         "spark.kryo.registrator" ->
-          "org.apache.SomeRegistrator,com.nvidia.spark.rapids.GpuKryoRegistrator"
+          "org.apache.SomeRegistrator,com.nvidia.spark.rapids.GpuKryoRegistrator",
+        "spark.executor.resource.gpu.discoveryScript" ->
+          "${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin"
       )
     val autoTuner = buildDefaultDataprocAutoTuner(logEventsProps)
     val (properties, comments) = autoTuner.getRecommendedProperties()
@@ -389,7 +392,6 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
           |- 'spark.sql.files.maxPartitionBytes' was not set.
           |- 'spark.task.resource.gpu.amount' was not set.
-          |- RAPIDS Accelerator for Apache Spark jar is missing in "spark.plugins". Please refer to https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html
           |- ${classPathComments("rapids.jars.missing")}
           |- ${classPathComments("rapids.shuffle.jars")}
           |""".stripMargin
@@ -409,7 +411,10 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
         "spark.executor.resource.gpu.amount" -> "1",
         "spark.serializer" -> "org.apache.spark.serializer.KryoSerializer",
         "spark.kryo.registrator" ->
-          "org.apache.SomeRegistrator,, org.apache.OtherRegistrator,org.apache.SomeRegistrator"
+          "org.apache.SomeRegistrator,, org.apache.OtherRegistrator,org.apache.SomeRegistrator",
+        "spark.executor.resource.gpu.discoveryScript" ->
+          "${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin"
       )
     val autoTuner = buildDefaultDataprocAutoTuner(logEventsProps)
     val (properties, comments) = autoTuner.getRecommendedProperties()
@@ -466,7 +471,6 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
           |- 'spark.sql.files.maxPartitionBytes' was not set.
           |- 'spark.task.resource.gpu.amount' was not set.
-          |- RAPIDS Accelerator for Apache Spark jar is missing in "spark.plugins". Please refer to https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html
           |- ${classPathComments("rapids.jars.missing")}
           |- ${classPathComments("rapids.shuffle.jars")}
           |""".stripMargin


### PR DESCRIPTION
Fixes #1661

This PR improves the Bootstrap/AutoTuner tool to include 3 new configuration entries to `tuningTable.yaml`. This is needed for completeness specially working on OnPrem clusters where these values might not be configured.

| Configuration | Description |
|---------------|-------------|
| `spark.executor.resource.gpu.amount` | GPU resource amount per executor for scheduling |
| `spark.executor.resource.gpu.discoveryScript` | Discovery script path for GPU resources (YARN/K8s) |
| `spark.plugins` | Plugin class names for RAPIDS Accelerator SQL |

## Details

1.  `spark.executor.resource.gpu.amount`
    - Added `EXECUTOR_GPU_RESOURCE_AMT` tuning parameter with default value `1.0` for   `spark.executor.resource.gpu.amount`
2. `spark.plugins`
   - New `recommendClassNameProperty` method for handling comma-separated class properties
   - Prevents duplicate plugin entries while preserving existing configurations
3. `spark.executor.resource.gpu.discoveryScript`
   - YARN/Kubernetes: Recommend setting GPU discovery script path
   - Standalone: Only recommends GPU resource amount (no discovery script needed)
3. Configuration Value Normalization
    - Added type-aware normalization in `TuningEntry` for consistent formatting across data types
    - Values like `"1"` vs `"1.0"` are now normalized for correct comparison.

## Testing
- Updated existing test cases to account for new GPU resource configurations
- Added new test scenarios for YARN/Kubernetes GPU discovery and Standalone configurations
- Enhanced mock providers to include GPU resource properties
