### PR TITLE
New memory tuning logic

### DIFF
--- a/core/src/main/resources/bootstrap/tuningConfigs.yaml
+++ b/core/src/main/resources/bootstrap/tuningConfigs.yaml
@@ -70,6 +70,13 @@ default:
     min: 750m
     usedBy: spark.executor.memory
 
+  - name: OFFHEAP_PER_CORE
+    description: >-
+      Amount of off-heap memory allocated per CPU core for hybrid scan operations
+    default: 2g
+    min: 750m
+    usedBy: spark.memory.offHeap.size
+
   - name: PINNED_MEMORY
     description: >-
       Amount of pinned memory for GPU operations

--- a/core/src/main/resources/bootstrap/tuningConfigs.yaml
+++ b/core/src/main/resources/bootstrap/tuningConfigs.yaml
@@ -259,6 +259,14 @@ default:
     default: 2
     usedBy: spark.rapids.sql.multiThreadedRead.numThreads
 
+  - name: OS_RESERVED_MEM
+    description: >-
+      Amount of memory reserved for the operating system and other system processes.
+      This is subtracted from the total available memory when calculating executor memory overhead.
+    default: 0g
+    usedBy: spark.executor.memoryOverhead, spark.rapids.memory.host.offHeapLimit.size
+
+
 # Qualification tool specific tuning configs
 qualification:
   - name: BATCH_SIZE_BYTES

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -592,7 +592,10 @@ abstract class AutoTuner(
     sparkOffHeapMem: Option[Long]
   ) {
     def hasAnyMemorySettings: Boolean = {
-      executorMemOverhead.isDefined || pinnedMem.isDefined || spillMem.isDefined || sparkOffHeapMem.isDefined
+      executorMemOverhead.isDefined ||
+        pinnedMem.isDefined ||
+        spillMem.isDefined ||
+        sparkOffHeapMem.isDefined
     }
   }
 
@@ -746,7 +749,7 @@ abstract class AutoTuner(
       // (only for onPrem when offHeapLimit is enabled)
       val hostOffHeapLimitSizeMB = if (!platform.isPlatformCSP &&
         isOffHeapLimitEnabled) {
-        executorMemOverhead + sparkOffHeapMemMB - osReservedMemory
+        executorMemOverhead + sparkOffHeapMemMB
       } else {
         0L // Not used for CSP platforms or when offHeapLimit is disabled
       }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -3432,6 +3432,7 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=9420m
           |--conf spark.locality.wait=0
+          |--conf spark.memory.offHeap.size=10240m
           |--conf spark.rapids.memory.pinnedPool.size=3g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28


### PR DESCRIPTION
This PR adds in new tune logic for memory configs such as memoryOverhead, offHeapSize and pinnedMemory.

The description and discussion for the new logics can be found at [issue thread](https://github.com/NVIDIA/spark-rapids-tools/issues/1740). 

NOTE: though I added a condition check to make the new logic only apply for OnPrem type, but there're still several unit test failures and hope I can get early feedbacks to help me decide to change logic code or unit test expected code.