### PR TITLE
Support URI-prefixed file paths for target cluster info and handle zero GPU resource amount in AutoTuner

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -853,8 +853,10 @@ abstract class AutoTuner(
     // specific recommendations
     if (platform.recommendedClusterInfo.isDefined) {
       // Since executor. executor level property, we only recommend it if it is not set.
-      val currentExecutorGpuResourceAmount = getPropertyValue("spark.executor.resource.gpu.amount")
-      if (currentExecutorGpuResourceAmount.isEmpty) {
+      val isUnsetOrZero = getPropertyValue("spark.executor.resource.gpu.amount").forall { v =>
+        v.trim.isEmpty || scala.util.Try(v.toDouble).toOption.contains(0.0)
+      }
+      if (isUnsetOrZero) {
         appendRecommendation("spark.executor.resource.gpu.amount",
           tuningConfigs.getEntry("EXECUTOR_GPU_RESOURCE_AMT").getDefault.toDouble)
       }

--- a/user_tools/src/spark_rapids_pytools/common/prop_manager.py
+++ b/user_tools/src/spark_rapids_pytools/common/prop_manager.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Union
 
 import yaml
 from pyaml_env import parse_config
+from typing_extensions import deprecated
 
 from spark_rapids_tools import get_elem_from_dict, get_elem_non_safe
 
@@ -56,6 +57,7 @@ def is_valid_gpu_device(val) -> bool:
     return val.upper() in get_gpu_device_list()
 
 
+@deprecated('Deprecated: use AbstractPropContainer instead. This class does not support CspPaths.')
 @dataclass
 class AbstractPropertiesContainer(object):
     """
@@ -153,6 +155,7 @@ class AbstractPropertiesContainer(object):
                 raise RuntimeError('Incorrect Type of JSON content') from e
 
 
+@deprecated('Deprecated: use AbstractPropContainer instead. This class does not support CspPaths.')
 @dataclass
 class YAMLPropertiesContainer(AbstractPropertiesContainer):
 
@@ -161,6 +164,7 @@ class YAMLPropertiesContainer(AbstractPropertiesContainer):
         self._init_fields()
 
 
+@deprecated('Deprecated: use AbstractPropContainer instead. This class does not support CspPaths.')
 @dataclass
 class JSONPropertiesContainer(AbstractPropertiesContainer):
 

--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -44,7 +44,7 @@ from spark_rapids_tools.configuration.tools_config import ToolsConfig
 from spark_rapids_tools.enums import DependencyType
 from spark_rapids_tools.storagelib import LocalPath, CspFs
 from spark_rapids_tools.storagelib.tools.fs_utils import untar_file
-from spark_rapids_tools.utils import Utilities
+from spark_rapids_tools.utils import Utilities, AbstractPropContainer
 from spark_rapids_tools.utils.net_utils import DownloadTask
 
 
@@ -530,7 +530,10 @@ class RapidsJarTool(RapidsTool):
         # This is used later to determine if the Speed up calculation should be skipped if
         # running the Qualification Tool.
         target_cluster_info_file = self.rapids_options.get('target_cluster_info')
-        target_cluster_info = YAMLPropertiesContainer(target_cluster_info_file) if target_cluster_info_file else None
+        target_cluster_info = (
+            AbstractPropContainer.load_from_file(target_cluster_info_file)
+            if target_cluster_info_file else None
+        )
         # workerInfo may or may not be present in the target cluster info.
         worker_info = target_cluster_info.get_value_silent('workerInfo') if target_cluster_info else None
         if worker_info:


### PR DESCRIPTION
Fixes #1821 Fixes #1823

## Issue - Support URI-prefixed file paths for target cluster info

### Problem  
- Tools CLI uses `YAMLPropertiesContainer` to read the `--target_cluster_info` file. However, this legacy class does not support file paths with URI schemes (e.g., `file:///`).
- In environments where the default filesystem is set to HDFS, users need to specify `file:///` for local files. This leads to a `FileNotFoundException`, since `YAMLPropertiesContainer` cannot handle such paths.

### Solution  
- This PR replaces `YAMLPropertiesContainer` with the newer `AbstractPropContainer.load_from_file()` API, which properly supports file paths that include URI schemes.


## Issue - Handle spark.executor.resource.gpu.amount=0 in config recommendation

### Problem
- The current logic skips recommending `spark.executor.resource.gpu.amount` if the property is set, even if it is `"0"`.
- This causes issues for CPU event logs where the value is explicitly set to `0`, and a recommendation should still be made.

### Solution
- Updated the check to treat `"0"` and `"0.0"` as equivalent to unset, so a recommendation is correctly applied in such cases.

