### PR TITLE
Add attempt-id to core app status report

### DIFF
--- a/core/docs/qual_core_output.md
+++ b/core/docs/qual_core_output.md
@@ -83,6 +83,8 @@ The output files are defined in the following format:
 | Event Log | Path to the eventlog file |
 | Status | Results of the processing of the eventlog. It can be: success the tool successfully processed the entire events failure an exception was thrown by the tool skipped the eventlog is not supported by the tool (i.e., streaming and GPU eventlogs) unknown an unexpected kind of failure happened |
 | App ID | ID of the app associated with the eventlog. If the eventlog failed to be processed, this value is empty. |
+| Attempt ID | Attempt ID of the app associated with the eventlog. For Yarn, the Unique ID of the app is the concatenation of the application ID and the attempt ID. |
+| App Name | Name of application associated with the eventlog. |
 | Description | Contains the details of the failure reason for a given eventlog. If the eventlog succeeded, this value contains the total processing time of that file. |
 
 ### qualCoreCSVSummary

--- a/core/src/main/resources/configs/reports/qualCoreReport.yaml
+++ b/core/src/main/resources/configs/reports/qualCoreReport.yaml
@@ -96,6 +96,15 @@ reportDefinitions:
             description: >-
               ID of the app associated with the eventlog.
               If the eventlog failed to be processed, this value is empty.
+          - name: Attempt ID
+            dataType: Int
+            description: >-
+              Attempt ID of the app associated with the eventlog.
+              For Yarn, the Unique ID of the app is the concatenation of the application ID and the attempt ID.
+          - name: App Name
+            dataType: String
+            description: >-
+              Name of application associated with the eventlog.
           - name: Description
             dataType: String
             description: >-

--- a/core/src/main/resources/configs/reports/qualOutputTable.yaml
+++ b/core/src/main/resources/configs/reports/qualOutputTable.yaml
@@ -69,6 +69,15 @@ qualTableDefinitions:
         description: >-
           ID of the app associated with the eventlog.
           If the eventlog failed to be processed, this value is empty.
+      - name: Attempt ID
+        dataType: Int
+        description: >-
+          Attempt ID of the app associated with the eventlog.
+          For Yarn, the Unique ID of the app is the concatenation of the application ID and the attempt ID.
+      - name: App Name
+        dataType: String
+        description: >-
+          Name of application associated with the eventlog.
       - name: Description
         dataType: String
         description: >-

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualToolResult.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualToolResult.scala
@@ -56,9 +56,9 @@ class QualToolResultBuilder {
   /**
    * This method is used to generate a QualToolResult from the builder.
    * It will return a QualToolResult which contains the main summary information
-   * of the apps and the cluster status.
+   * of the app analysis status.
    *
-   * @param appStatuses the cluster status
+   * @param appStatuses app analysis status.
    * @return a QualToolResult which contains the main summary information
    *         of the apps and the cluster status
    */
@@ -67,7 +67,11 @@ class QualToolResultBuilder {
     val appSummaryList = appSummaries.values().asScala.toSeq.sortBy { rec =>
       (rec.estimatedInfo.gpuOpportunity, rec.startTime + rec.estimatedInfo.appDur)
     }.reverse
-    QualToolResult(0, appSummaryList, appStatuses, None)
+    // sort statuses by eventlogpath and appMeta if possible
+    val sortedAppStatus = appStatuses.sortBy { status =>
+      (status.path, status.appId, status.attemptId)
+    }
+    QualToolResult(0, appSummaryList, sortedAppStatus, None)
   }
 }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -26,7 +26,7 @@ import com.nvidia.spark.rapids.tool.views.QualRawReportGenerator
 import com.nvidia.spark.rapids.tool.views.qualification.{QualPerAppReportGenerator, QualReportGenConfProvider, QualToolReportGenerator}
 import org.apache.hadoop.conf.Configuration
 
-import org.apache.spark.sql.rapids.tool.FailureApp
+import org.apache.spark.sql.rapids.tool.{AppBase, FailureApp}
 import org.apache.spark.sql.rapids.tool.qualification._
 import org.apache.spark.sql.rapids.tool.ui.ConsoleProgressBar
 import org.apache.spark.sql.rapids.tool.util._
@@ -119,7 +119,6 @@ class Qualification(outputPath: String, hadoopConf: Configuration,
           return
         case _ => // No action needed for other cases
       }
-      val startTime = System.currentTimeMillis()
       // we need a platform per application because it's storing cluster information which could
       // vary between applications, especially when using dynamic allocation
       val platform = {
@@ -180,9 +179,7 @@ class Qualification(outputPath: String, hadoopConf: Configuration,
               // generate report for the current QualApp.
               QualPerAppReportGenerator.build(
                 newQualSummary, outputDir, Option(hadoopConf), qualAppReportOptions)
-              val endTime = System.currentTimeMillis()
-              SuccessAppResult(pathStr, app.appId, app.attemptId,
-                s"Took ${endTime - startTime}ms to process")
+              AppBase.toSuccessAppResult(app)
             } match {
               case Some(successfulResult) => successfulResult
               case _ =>

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/OutHeaderRegistry.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/OutHeaderRegistry.scala
@@ -55,7 +55,7 @@ object OutHeaderRegistry {
     "DriverLogUnsupportedOperators" ->
       Array("operatorName", "count", "reason"),
     "AppStatusResult" ->
-      Array("Event Log", "Status", "AppID", "Description"),
+      Array("Event Log", "Status", "App ID", "Attempt ID", "App Name", "Description"),
     "SQLAccumProfileResults" ->
       Array("sqlID", "nodeID", "nodeName", "accumulatorId", "name", "min", "median", "max",
         "total", "metricType", "stageIds"),

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/qualification/QualToolReportGenerator.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/qualification/QualToolReportGenerator.scala
@@ -127,6 +127,8 @@ class QualToolStatusTable(
         Seq(formatStr(r.path),
           formatStr(r.status),
           formatStr(r.appId),
+          r.attemptId,
+          formatStr(r.appName),
           formatStr(r.message)
         ).mkString(delim))
     }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -38,7 +38,7 @@ import org.apache.spark.scheduler.{SparkListenerEvent, StageInfo}
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
 import org.apache.spark.sql.rapids.tool.store.{AccumManager, DataSourceRecord, SparkPlanInfoTruncated, SQLPlanModel, SQLPlanModelManager, StageModel, StageModelManager, TaskModelManager, WriteOperationRecord}
-import org.apache.spark.sql.rapids.tool.util.{EventUtils, RapidsToolsConfUtil, StringUtils, ToolsPlanGraph, UTF8Source}
+import org.apache.spark.sql.rapids.tool.util.{EventUtils, RapidsToolsConfUtil, StringUtils, SuccessAppResult, ToolsPlanGraph, UTF8Source}
 import org.apache.spark.util.Utils
 
 abstract class AppBase(
@@ -737,5 +737,14 @@ object AppBase {
     }
 
     FailureApp(status, s"${e.getClass.getSimpleName}: $message")
+  }
+
+  def toSuccessAppResult(app: AppBase): SuccessAppResult = {
+    SuccessAppResult(
+      path = app.getEventLogPath,
+      appId = app.appId,
+      attemptId = app.attemptId,
+      appName = app.getAppName,
+      message = s"appDuration(ms): ${app.calculateAppDuration().getOrElse(0)}")
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppMetaData.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppMetaData.scala
@@ -117,9 +117,11 @@ object AppMetaData {
   def apply(
       evtLogPath: String,
       appStartEv: SparkListenerApplicationStart): AppMetaData = {
-    new AppMetaData(Some(evtLogPath),
+    new AppMetaData(
+      Some(evtLogPath),
       appStartEv.appName,
-      appStartEv.appId, appStartEv.sparkUser,
+      appStartEv.appId,
+      appStartEv.sparkUser,
       appStartEv.time)
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/OperationResult.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/OperationResult.scala
@@ -22,7 +22,7 @@ import org.apache.spark.internal.Logging
  *  Represents a result specific to `AppBase` class. This is a base class for
  *  Success, Failure and Unknown types.
  */
-class AppResult(path: String, message: String) extends Logging {
+abstract class AppResult(path: String, message: String) extends Logging {
   /**
    * Logs the message along with an optional exception, if provided.
    */
@@ -33,26 +33,37 @@ class AppResult(path: String, message: String) extends Logging {
       case None => logWarning(messageToLog)
     }
   }
+
+  val status: String
 }
 
 case class SuccessAppResult(
     path: String,
     appId: String,
     attemptId: Int,
+    appName: String,
     message: String = "") extends AppResult(path, message) {
   override def logMessage(exp: Option[Exception] = None): Unit = {
-    logInfo(s"File: $path, Message: $message")
+    logInfo(s"[SUCCESS] File: $path, appName: $appName, appId: $appId, attemptId: $attemptId")
   }
+
+  override val status: String = "SUCCESS"
 }
 
 case class FailureAppResult(path: String, message: String)
-  extends AppResult(path, message) {}
+  extends AppResult(path, message) {
+  override val status: String = "FAILURE"
+}
 
 case class UnknownAppResult(path: String, appId: String, message: String)
-  extends AppResult(path, message) {}
+  extends AppResult(path, message) {
+  override val status: String = "UNKNOWN"
+}
 
 case class SkippedAppResult(path: String, message: String)
-  extends AppResult(path, message) {}
+  extends AppResult(path, message) {
+  override val status: String = "SKIPPED"
+}
 
 object SkippedAppResult {
   def fromAppAttempt(path: String, appId: String, attemptId: Int): SkippedAppResult = {


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1626

The change is convenient for the tools-API implementation since it provides a common place to load the list of applications.

- Add fields to status CSV files to include the iapp main information (App ID, Attempt ID, App Name)
- Those fields are needed to make it convenient to build a list of analyzed apps without the need to access subfolders. For large eventlog pools, this is very important since list subdirectories is expensive.
- renamed `AppID` in profiler output to match the `App ID`
- sort the status CSV file by path, appID, and attemptId. This will make the generated report consistent across the runs. Therefore, easy to use in testing the output.
- The new csv file status will be:
  - "Event Log": String
  - "Status": String,
  - "App ID": String. "N/A" if missing
  - "Attempt ID": Int, "N/A" if missing,
  - "App Name": String, N/A if missing,
  - "Description": String. For successful apps it will have the appDuration `appDuration(ms): <value>`
 
### Enhancements to metadata and reporting:

* Added `Attempt ID` and `App Name` fields to the report definitions (`qualCoreReport.yaml`) and table definitions (`qualOutputTable.yaml`) for better identification of applications. [[1]](diffhunk://#diff-52c631ca835e0629758d7a832c74427324364b4104ceb2d044ddcc5b3f899057R99-R107) [[2]](diffhunk://#diff-590c12afd63feb7a9fdc91244a728b120d282003d2ed18f72051fc615a8440f5R72-R80)
* Updated `AppStatusResult` to include `Attempt ID` and `App Name` fields, and adjusted its methods to handle these new fields.
* Modified output headers in `OutHeaderRegistry` to include the new fields for `AppStatusResult`.

### Improvements to sorting and processing logic:

* Enhanced sorting logic in `Profiler` and `QualToolResultBuilder` to sort application statuses by `eventlog path`, `appId`, and `attemptId`. [[1]](diffhunk://#diff-d730a6c3d48ef0ddc22e721372d31caf6adc2240cc408f751fdda409c346ac56L89-R94) [[2]](diffhunk://#diff-c2bcf33d97267327c6af6f488ee415b37ad0d413208b7c87b4591437566b9477L70-R74)
* Refactored the generation of `SuccessAppResult` to use a new utility method `toSuccessAppResult` in `AppBase`, simplifying the code. [[1]](diffhunk://#diff-d730a6c3d48ef0ddc22e721372d31caf6adc2240cc408f751fdda409c346ac56L150-R154) [[2]](diffhunk://#diff-f00396d69ba02ca86319afc1095fcf0a2d7a9f25f3d7799fe58f6e61ca65889eL183-R182) [[3]](diffhunk://#diff-86930ce0c9a1fa003be4b6c67827f5ea8ad2c631485286d36217d9dc2bfc30e2R741-R749)

### Refactoring and code cleanup:

* Refactored `AppResult` to be an abstract class and added a `status` field to its subclasses (`SuccessAppResult`, `FailureAppResult`, `UnknownAppResult`, `SkippedAppResult`) for consistent handling of statuses. [[1]](diffhunk://#diff-fa58c77da2b33769bab4523b48dad28b667abc136a5f81ae588f21b6908a7349L25-R25) [[2]](diffhunk://#diff-fa58c77da2b33769bab4523b48dad28b667abc136a5f81ae588f21b6908a7349R36-R66)
* Updated `AppStatusResult` construction in `RuntimeReporter` to use a new `build` method, improving code readability and reducing duplication.
