### PR TITLE
Fix: Change spark.executor.resource.gpu.amount Datatype from Double to Long

### DIFF
--- a/core/src/main/resources/bootstrap/tuningConfigs.yaml
+++ b/core/src/main/resources/bootstrap/tuningConfigs.yaml
@@ -48,7 +48,7 @@ default:
   - name: EXECUTOR_GPU_RESOURCE_AMT
     description: >-
       Amount of GPU resource each executor requires (fraction of GPU)
-    default: 1.0
+    default: 1
     usedBy: spark.executor.resource.gpu.amount
 
   - name: TASK_GPU_RESOURCE_AMT

--- a/core/src/main/resources/bootstrap/tuningConfigs.yaml
+++ b/core/src/main/resources/bootstrap/tuningConfigs.yaml
@@ -48,6 +48,9 @@ default:
   - name: EXECUTOR_GPU_RESOURCE_AMT
     description: >-
       Amount of GPU resource each executor requires (fraction of GPU)
+      Note:
+      - This value should be an integer (e.g. 1, 2, etc.).
+      - https://github.com/apache/spark/blob/6a7a3debda0748d7e72445de27ecc6ebfe01078b/core/src/main/scala/org/apache/spark/resource/ExecutorResourceRequest.scala#L56
     default: 1
     usedBy: spark.executor.resource.gpu.amount
 

--- a/core/src/main/resources/bootstrap/tuningTable.yaml
+++ b/core/src/main/resources/bootstrap/tuningTable.yaml
@@ -341,8 +341,8 @@ tuningDefinitions:
       The GPU resource amount per task when Apache Spark schedules GPU resources.
       For example, setting the value to 1 means that only one task will run concurrently per executor.
       Note:
-      - It supports fractional values (e.g., 0.25)
-      - https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/resource/TaskResourceRequest.scala
+      - This value should be a fraction (e.g. 0.25, 1.0, etc.).
+      - https://github.com/apache/spark/blob/6a7a3debda0748d7e72445de27ecc6ebfe01078b/core/src/main/scala/org/apache/spark/resource/TaskResourceRequest.scala#L37
     enabled: true
     level: cluster
     category: tuning
@@ -353,8 +353,8 @@ tuningDefinitions:
       The GPU resource amount per executor when Spark schedules GPU resources.
       This should typically be set to 1 to allocate one GPU per executor.
       Note:
-      - It only support numeric values (unlike task resource amount which can be a fraction).
-      - https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/resource/ExecutorResourceRequest.scala
+      - This value should be an integer (e.g. 1, 2, etc.).
+      - https://github.com/apache/spark/blob/6a7a3debda0748d7e72445de27ecc6ebfe01078b/core/src/main/scala/org/apache/spark/resource/ExecutorResourceRequest.scala#L56
     enabled: true
     level: cluster
     category: functionality

--- a/core/src/main/resources/bootstrap/tuningTable.yaml
+++ b/core/src/main/resources/bootstrap/tuningTable.yaml
@@ -340,6 +340,9 @@ tuningDefinitions:
     description: >-
       The GPU resource amount per task when Apache Spark schedules GPU resources.
       For example, setting the value to 1 means that only one task will run concurrently per executor.
+      Note:
+      - It supports fractional values (e.g., 0.25)
+      - https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/resource/TaskResourceRequest.scala
     enabled: true
     level: cluster
     category: tuning
@@ -349,11 +352,14 @@ tuningDefinitions:
     description: >-
       The GPU resource amount per executor when Spark schedules GPU resources.
       This should typically be set to 1 to allocate one GPU per executor.
+      Note:
+      - It only support numeric values (unlike task resource amount which can be a fraction).
+      - https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/resource/ExecutorResourceRequest.scala
     enabled: true
     level: cluster
     category: functionality
     confType:
-      name: double
+      name: long
     comments:
       missing: should be set to allow Spark to schedule GPU resources.
   - label: spark.executor.resource.gpu.discoveryScript

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -520,8 +520,8 @@ abstract class AutoTuner(
    * Safely appends the recommendation to the given key.
    * It skips if the value is 0.
    */
-  def appendRecommendation(key: String, value: Int): Unit = {
-    if (value > 0) {
+  def appendRecommendation(key: String, value: Long): Unit = {
+    if (value > 0L) {
       appendRecommendation(key: String, s"$value")
     }
   }
@@ -854,11 +854,11 @@ abstract class AutoTuner(
     if (platform.recommendedClusterInfo.isDefined) {
       // Since executor. executor level property, we only recommend it if it is not set.
       val isUnsetOrZero = getPropertyValue("spark.executor.resource.gpu.amount").forall { v =>
-        v.trim.isEmpty || scala.util.Try(v.toDouble).toOption.contains(0.0)
+        v.trim.isEmpty || scala.util.Try(v.toLong).toOption.contains(0L)
       }
       if (isUnsetOrZero) {
         appendRecommendation("spark.executor.resource.gpu.amount",
-          tuningConfigs.getEntry("EXECUTOR_GPU_RESOURCE_AMT").getDefault.toDouble)
+          tuningConfigs.getEntry("EXECUTOR_GPU_RESOURCE_AMT").getDefault.toLong)
       }
       // However, for task GPU resources, always recommend.
       // Set to low value for Spark RAPIDS usage as task parallelism will be honoured

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -1180,7 +1180,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
         "spark.rapids.memory.pinnedPool.size" -> "5g",
         "spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
-        "spark.executor.resource.gpu.amount" -> "0.8"
+        "spark.executor.resource.gpu.amount" -> "2"
       )
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0), logEventsProps,
       Some(testSparkVersion))

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -262,7 +262,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
             |--conf spark.executor.instances=4
             |--conf spark.executor.memory=16g
             |--conf spark.executor.memoryOverhead=9830m
-            |--conf spark.executor.resource.gpu.amount=1.0
+            |--conf spark.executor.resource.gpu.amount=1
             |--conf spark.executor.resource.gpu.discoveryScript=$${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh
             |--conf spark.locality.wait=0
             |--conf spark.plugins=com.nvidia.spark.SQLPlugin
@@ -359,7 +359,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.executor.instances=2
           |--conf spark.executor.memory=19648m
           |--conf spark.executor.memoryOverhead=10156m
-          |--conf spark.executor.resource.gpu.amount=1.0
+          |--conf spark.executor.resource.gpu.amount=1
           |--conf spark.executor.resource.gpu.discoveryScript=$${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.nvidia.spark.SQLPlugin
@@ -412,13 +412,13 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
     ("Standalone",
       Standalone,
       Seq(
-        "--conf spark.executor.resource.gpu.amount=1.0",
+        "--conf spark.executor.resource.gpu.amount=1",
         "- 'spark.executor.resource.gpu.amount' should be set to allow Spark to schedule GPU resources."
       )),
     ("Yarn",
       Yarn,
       Seq(
-        "--conf spark.executor.resource.gpu.amount=1.0",
+        "--conf spark.executor.resource.gpu.amount=1",
         "--conf spark.executor.resource.gpu.discoveryScript=${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh",
         "- 'spark.executor.resource.gpu.amount' should be set to allow Spark to schedule GPU resources.",
         "- 'spark.executor.resource.gpu.discoveryScript' should be set to allow Spark to discover GPU resources."
@@ -426,7 +426,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
     ("Kubernetes",
       Kubernetes,
       Seq(
-        "--conf spark.executor.resource.gpu.amount=1.0",
+        "--conf spark.executor.resource.gpu.amount=1",
         "--conf spark.executor.resource.gpu.discoveryScript=${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh",
         "--conf spark.executor.resource.gpu.vendor=nvidia.com",
         "- 'spark.executor.resource.gpu.amount' should be set to allow Spark to schedule GPU resources.",


### PR DESCRIPTION
In #1818, AutoTuner added recommendation for `spark.executor.resource.gpu.amount`. However on further investigation, I found that the this configuration only support numeric values (unlike task resource which supports fractional values).

This PR adds a minor fix to change the datatype for executor resource gpu amount from double to long.

References:
- Executor Resource GPU - https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/resource/ExecutorResourceRequest.scala
- Task Resource GPU - https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/resource/TaskResourceRequest.scala