### PR TITLE
Eventlog processing happens post cluster information processing

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/profiling.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/profiling.py
@@ -53,14 +53,13 @@ class Profiling(ProfilingCore):
         1. the worker_info argument
         2. the clusters
         """
-        super()._process_custom_args()
-
         self._process_worker_info_arg()
         # if the workerInfo is not set, then we need to use the gpu_cluster
         if not self.ctxt.get_ctxt('autoTunerFilePath'):
             self._process_offline_cluster_args()
         else:
             self.logger.info('Skipping building of GPU_CLUSTER because WorkerInfo is defined')
+        super()._process_custom_args()
 
     def _process_offline_cluster_args(self):
         offline_cluster_opts = self.wrapper_options.get('migrationClustersProps', {})

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -172,8 +172,6 @@ class Qualification(QualificationCore):
         3. gpu_per_machine: number of gpu installed on a worker node.
         4. cuda version
         """
-        super()._process_custom_args()
-
         gpu_device = self.ctxt.get_value('sparkRapids', 'gpu', 'device')
         gpu_device_arg = self.wrapper_options.get('gpuDevice')
         if gpu_device_arg is not None:
@@ -196,6 +194,7 @@ class Qualification(QualificationCore):
         self._process_submission_mode_arg()
         # This is noise to dump everything
         # self.logger.debug('%s custom arguments = %s', self.pretty_name(), self.ctxt.props['wrapperCtx'])
+        super()._process_custom_args()
 
     def __remap_columns_and_prune(self, all_rows) -> pd.DataFrame:
         cols_subset = self.ctxt.get_value('toolOutput', 'csv', 'summaryReport', 'columns')


### PR DESCRIPTION
Fixes #1828 

This PR fixes the bug introduced where the code tries to process eventlogs args before it has processed the cluster args, which is relevant in case of eventlogs being processsed for offline_clusters.

### Changes
Moves the super.process_custom_args() to the post cluster processing phase

### Testing
Tested locally for remote EMR cluster for both profiling and qualification