### PR TITLE
Add unit test for new memory tune logic

### DIFF
--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -520,10 +520,10 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
   }
 
   /**
-   * Test to validate onPrem platform with offHeapLimit enabled and hybrid scan configuration.
+   * Test to validate onPrem platform with offHeapLimit enabled.
    * This tests the new memory calculation logic with OS_RESERVED_MEM and offHeapLimit features.
    */
-  test("test onPrem platform with offHeapLimit enabled and hybrid scan configuration") {
+  test("test onPrem platform with offHeapLimit enabled") {
     // Log events properties
     val logEventsProps: mutable.Map[String, String] = mutable.LinkedHashMap[String, String](
       "spark.executor.cores" -> "4",

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -521,7 +521,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
 
   /**
    * Test to validate onPrem platform with offHeapLimit enabled and hybrid scan configuration.
-   * This tests the new memory calculation logic with OFFHEAP_PER_CORE and offHeapLimit features.
+   * This tests the new memory calculation logic with OS_RESERVED_MEM and offHeapLimit features.
    */
   test("test onPrem platform with offHeapLimit enabled and hybrid scan configuration") {
     // Log events properties

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -528,7 +528,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
     val logEventsProps: mutable.Map[String, String] = mutable.LinkedHashMap[String, String](
       "spark.executor.cores" -> "4",
       "spark.executor.memory" -> "6144M",
-      "spark.executor.instances" -> "20",
+      "spark.executor.instances" -> "20"
     )
 
     // Enforced Spark properties
@@ -561,7 +561,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
         customProps = None,
         numCores = Some(20),
         systemMemory = Some("8g"),
-        numWorkers = Some(1),
+        numWorkers = Some(1)
       )
 
       // Create cluster properties
@@ -583,7 +583,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
     val defaultTuningConfigsEntries = List(
       TuningConfigEntry(name = "HEAP_PER_CORE", default = "1g"),
       TuningConfigEntry(name = "CONC_GPU_TASKS", max = "2"),
-      TuningConfigEntry(name = "OS_RESERVED_MEM", default = "5g"),
+      TuningConfigEntry(name = "OS_RESERVED_MEM", default = "5g")
     )
     val userProvidedTuningConfigs = ToolTestUtils.buildTuningConfigs(
       default = defaultTuningConfigsEntries)


### PR DESCRIPTION
When offHeapLimit.enabled is set to true, the memory tune logic will go into the new routine for those memory configs. 
This PR adds in a unit test to cover them, close #1835 

The enforced values are from a real use case to make it work like in production.