### PR TITLE
Fix 'spark.plugin' logic and GPU discovery script recommendations 

### DIFF
--- a/core/src/main/resources/bootstrap/tuningTable.yaml
+++ b/core/src/main/resources/bootstrap/tuningTable.yaml
@@ -375,8 +375,6 @@ tuningDefinitions:
     category: functionality
     confType:
       name: string
-    comments:
-      missing: should be set to allow Spark to discover GPU resources.
   - label: spark.executor.resource.gpu.vendor
     description: >-
       The vendor of the GPU resource. This is needed for k8s clusters.
@@ -389,8 +387,6 @@ tuningDefinitions:
     category: functionality
     confType:
       name: string
-    comments:
-      missing: should be set to "nvidia.com" for NVIDIA GPUs in k8s clusters.
   - label: spark.plugins
     description: >-
       A comma-separated list of plugin class names to be loaded by Spark.
@@ -401,4 +397,9 @@ tuningDefinitions:
     confType:
       name: string
     comments:
-      missing: should include "com.nvidia.spark.SQLPlugin" to enable the RAPIDS Accelerator plugin.
+      missing: |-
+        should be set to the class name required for the RAPIDS Accelerator for Apache Spark.
+          Refer to: https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html
+      updated: |-
+        should include the class name required for the RAPIDS Accelerator for Apache Spark.
+          Refer to: https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -1412,7 +1412,7 @@ abstract class AutoTuner(
     if (!isRapidsPluginConfigured) {
       recommendPluginPropsInternal()
     }
-    // Always recommend enabling the plugin, regardless of current setting.
+    // Always recommend setting 'spark.rapids.sql.enabled=true', regardless of current setting.
     appendRecommendation("spark.rapids.sql.enabled", "true")
   }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -1439,8 +1439,15 @@ abstract class AutoTuner(
     if (!platform.isPlatformCSP) {
       // If YARN,Kubernetes or Standalone, recommend GPU discovery script
       // See: https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html
-      if (sparkMaster.contains(Yarn) || sparkMaster.contains(Kubernetes) ||
-        sparkMaster.contains(Standalone)) {
+      val isYarnK8sOrStandalone = sparkMaster.exists {
+        case Yarn | Kubernetes | Standalone => true
+        case _ => false
+      }
+      // If the GPU discovery script is not set or is empty
+      val gpuDiscoveryScriptIsMissing =
+        getPropertyValue("spark.executor.resource.gpu.discoveryScript")
+        .forall(_.trim.isEmpty)
+      if (isYarnK8sOrStandalone && gpuDiscoveryScriptIsMissing) {
         appendComment(missingGpuDiscoveryScriptComment)
       }
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -251,8 +251,10 @@ object SparkMaster {
     master.flatMap {
       case url if url.contains("yarn") => Some(Yarn)
       case url if url.contains("k8s") => Some(Kubernetes)
-      case url if url.contains("local") => Some(Local)
+      // Check for standalone Spark master before local mode as it can also contain "local"
+      // E.g. spark://localhost:7077
       case url if url.contains("spark://") => Some(Standalone)
+      case url if url.contains("local") => Some(Local)
       case _ => None
     }
   }
@@ -903,17 +905,9 @@ abstract class AutoTuner(
     // only if we were able to figure out a node type to recommend do we make
     // specific recommendations
     if (platform.recommendedClusterInfo.isDefined) {
-      // Since executor. executor level property, we only recommend it if it is not set.
-      val isUnsetOrZero = getPropertyValue("spark.executor.resource.gpu.amount").forall { v =>
-        v.trim.isEmpty || scala.util.Try(v.toLong).toOption.contains(0L)
-      }
-      if (isUnsetOrZero) {
-        appendRecommendation("spark.executor.resource.gpu.amount",
-          tuningConfigs.getEntry("EXECUTOR_GPU_RESOURCE_AMT").getDefault.toLong)
-      }
-      // However, for task GPU resources, always recommend.
       // Set to low value for Spark RAPIDS usage as task parallelism will be honoured
       // by `spark.executor.cores`.
+      recommendExecutorResourceGpuProps()
       appendRecommendation("spark.task.resource.gpu.amount",
         tuningConfigs.getEntry("TASK_GPU_RESOURCE_AMT").getDefault.toDouble)
       appendRecommendation("spark.rapids.sql.concurrentGpuTasks",
@@ -1405,31 +1399,58 @@ abstract class AutoTuner(
     }
   }
 
-  private def recommendPluginProps(): Unit = {
-    // Set the plugin to True without need to check if it is already set.
-    appendRecommendation("spark.rapids.sql.enabled", "true")
+  /**
+   * Internal method to recommend plugin properties based on the Tool.
+   */
+  protected def recommendPluginPropsInternal(): Unit
 
-    // Recommend adding the RAPIDS SQLPlugin if not already present
-    val pluginAdded = recommendClassNameProperty("spark.plugins",
-      autoTunerHelper.rapidsPluginClassName)
-    if (pluginAdded) {
-      // Set GPU discovery script for YARN and Kubernetes
+  private def recommendPluginProps(): Unit = {
+    val isPluginLoaded = getPropertyValue("spark.plugins") match {
+      case Some(f) => f.contains(autoTunerHelper.rapidsPluginClassName)
+      case None => false
+    }
+    if (!isPluginLoaded) {
+      recommendPluginPropsInternal()
+    }
+    // Always recommend enabling the plugin, regardless of current setting.
+    appendRecommendation("spark.rapids.sql.enabled", "true")
+  }
+
+  /**
+   * Recommend additional executor resource GPU properties.
+   * - spark.executor.resource.gpu.amount: recommended if unset or set to 0
+   * - spark.executor.resource.gpu.discoveryScript: comment if YARN, k8s or Standalone (On-Prem)
+   * - spark.executor.resource.gpu.vendor: recommended if k8s (On-Prem)
+   */
+  private def recommendExecutorResourceGpuProps(): Unit = {
+    val gpuAmountKey = "spark.executor.resource.gpu.amount"
+    val gpuAmountValueOpt = getPropertyValue(gpuAmountKey)
+    val isUnsetOrZero = gpuAmountValueOpt.forall { v =>
+      v.trim.isEmpty || scala.util.Try(v.toLong).toOption.contains(0L)
+    }
+    if (isUnsetOrZero) {
+      val recommendedGpuAmount =
+        tuningConfigs.getEntry("EXECUTOR_GPU_RESOURCE_AMT").getDefault
+      appendRecommendation(gpuAmountKey, recommendedGpuAmount)
+    }
+
+    // Include additional executor resource GPU properties for On-Prem
+    // Avoid recommending these for CSPs as they are handled by the platform.
+    if (!platform.isPlatformCSP) {
+      // If YARN,Kubernetes or Standalone, recommend GPU discovery script
       // See: https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html
-      sparkMaster match {
-        case Some(Yarn) =>
-          appendRecommendation("spark.executor.resource.gpu.discoveryScript",
-            autoTunerHelper.defaultGpuDiscoveryScript)
-        case Some(Kubernetes) =>
-          appendRecommendation("spark.executor.resource.gpu.discoveryScript",
-            autoTunerHelper.defaultGpuDiscoveryScript)
-          appendRecommendation("spark.executor.resource.gpu.vendor",
-            autoTunerHelper.kubernetesGpuVendor)
-        case _ =>
-        // No discovery script needed for other cluster managers
+      if (sparkMaster.contains(Yarn) || sparkMaster.contains(Kubernetes) ||
+        sparkMaster.contains(Standalone)) {
+        appendComment(missingGpuDiscoveryScriptComment)
       }
-      appendComment("RAPIDS Accelerator for Apache Spark jar is missing in \"spark.plugins\". " +
-        "Please refer to " +
-        "https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html")
+
+      // For Kubernetes, recommend setting the GPU vendor property
+      if (sparkMaster.contains(Kubernetes)) {
+        appendRecommendation(
+          "spark.executor.resource.gpu.vendor",
+          autoTunerHelper.kubernetesGpuVendor
+        )
+      }
     }
   }
 
@@ -1451,7 +1472,7 @@ abstract class AutoTuner(
    * @param className The class name to add if missing
    * @return True if a recommendation was made, false if the class name was already present
    */
-  private def recommendClassNameProperty(propertyKey: String, className: String): Boolean = {
+  protected def recommendClassNameProperty(propertyKey: String, className: String): Boolean = {
     val existingClasses = getPropertyValue(propertyKey)
       .map(v => v.split(",").map(_.trim).filter(_.nonEmpty))
       .getOrElse(Array.empty)
@@ -1566,7 +1587,7 @@ abstract class AutoTuner(
       configureClusterPropDefaults
       // Makes recommendations based on information extracted from the AppInfoProvider
       filterByUpdatedPropertiesEnabled = showOnlyUpdatedProps
-      recommendPluginProps
+      recommendPluginProps()
       calculateJobLevelRecommendations()
       calculateClusterLevelRecommendations()
 
@@ -1817,6 +1838,14 @@ class ProfilingAutoTuner(
       calculatedValue
     }
   }
+
+  /**
+   * Profiling AutoTuner retains existing "spark.plugins" property and
+   * RAPIDS plugin is added to it.
+   */
+  override def recommendPluginPropsInternal(): Unit = {
+    recommendClassNameProperty("spark.plugins", autoTunerHelper.rapidsPluginClassName)
+  }
 }
 
 /**
@@ -1833,8 +1862,6 @@ trait AutoTunerHelper extends Logging {
   lazy val gpuKryoRegistratorClassName = "com.nvidia.spark.rapids.GpuKryoRegistrator"
   lazy val rapidsPluginClassName = "com.nvidia.spark.SQLPlugin"
   lazy val kubernetesGpuVendor = "nvidia.com"
-  lazy val defaultGpuDiscoveryScript =
-    "${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh"
 
   // Recommended values for specific unsupported configurations
   lazy val unsupportedOperatorRecommendations: Map[String, String] = Map(
@@ -1982,6 +2009,27 @@ trait AutoTunerStaticComments {
 
   def shuffleManagerCommentForMissingVersion: String = {
     "Could not recommend RapidsShuffleManager as Spark version cannot be determined."
+  }
+
+  /**
+   * Comment for missing GPU discovery script.
+   * Since this comment is conditional, it is not included in the
+   * tuningTable yaml.
+   */
+  def missingGpuDiscoveryScriptComment: String = {
+    s"""
+       |To enable Spark to discover and schedule GPU resources, set the
+       |'spark.executor.resource.gpu.discoveryScript' property according to cluster
+       |manager's documentation. Sample discovery script is available at
+       |'$${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh'.
+       |""".stripMargin.trim.replaceAll("\n", "\n  ")
+  }
+
+  def additionalSparkPluginsComment: String = {
+    """
+      |To include additional plugins for the GPU cluster, specify 'spark.plugins' in the
+      |'sparkProperties.enforced' section in '--target_cluster_info'.
+      |""".stripMargin.trim.replaceAll("\n", "\n  ")
   }
 
   def latestPluginJarComment(latestJarMvnUrl: String, currentJarVer: String): String = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -1405,11 +1405,11 @@ abstract class AutoTuner(
   protected def recommendPluginPropsInternal(): Unit
 
   private def recommendPluginProps(): Unit = {
-    val isPluginLoaded = getPropertyValue("spark.plugins") match {
+    val isRapidsPluginConfigured = getPropertyValue("spark.plugins") match {
       case Some(f) => f.contains(autoTunerHelper.rapidsPluginClassName)
       case None => false
     }
-    if (!isPluginLoaded) {
+    if (!isRapidsPluginConfigured) {
       recommendPluginPropsInternal()
     }
     // Always recommend enabling the plugin, regardless of current setting.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTuner.scala
@@ -51,6 +51,21 @@ class QualificationAutoTuner(
     super.shouldIncludeInFinalRecommendations(tuningEntry) &&
       tuningEntry.isBootstrap() && !tuningEntry.isRemoved()
   }
+
+  /**
+   * Qualification Bootstrap ignores existing "spark.plugins" property and
+   * RAPIDS plugin is added.
+   * Reference: https://github.com/NVIDIA/spark-rapids-tools/issues/1825#issuecomment-3138122418
+   */
+  override def recommendPluginPropsInternal(): Unit = {
+    appendRecommendation("spark.plugins", autoTunerHelper.rapidsPluginClassName)
+    // If the user has not explicitly enforced any 'spark.plugins',
+    // add a comment to inform them about how to specify additional plugins
+    // using the target cluster's 'sparkProperties.enforced' section.
+    if (!platform.userEnforcedRecommendations.contains("spark.plugins")) {
+      appendComment(additionalSparkPluginsComment)
+    }
+  }
 }
 
 /**

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -1083,9 +1083,92 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
     compareOutput(expectedResults, autoTunerOutput)
   }
 
-  // This test verifies that AutoTuner sets the correct value for
-  // "spark.plugins" property when the existing values are invalid.
-  test("plugin set to the wrong values") {
+  // This test verifies that AutoTuner recommends the correct value for
+  // "spark.plugins" property.
+  test("test 'spark.plugins' is recommended correctly") {
+    val customProps = mutable.LinkedHashMap(
+      "spark.executor.cores" -> "8",
+      "spark.executor.memory" -> "47222m",
+      "spark.task.resource.gpu.amount" -> "0.001")
+    // mock the properties loaded from eventLog
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "16",
+        "spark.executor.instances" -> "1",
+        "spark.executor.memory" -> "80g",
+        "spark.executor.resource.gpu.amount" -> "1",
+        "spark.executor.instances" -> "1",
+        "spark.sql.shuffle.partitions" -> "200",
+        "spark.sql.files.maxPartitionBytes" -> "1g",
+        "spark.task.resource.gpu.amount" -> "0.001",
+        "spark.rapids.memory.pinnedPool.size" -> "5g",
+        "spark.rapids.sql.concurrentGpuTasks" -> "4")
+    val dataprocWorkerInfo = buildGpuWorkerInfoAsString(Some(customProps), Some(32),
+      Some("212992MiB"), Some(5), Some(4), Some(T4Gpu.getMemory), Some(T4Gpu.toString))
+    val clusterPropsOpt = PropertiesLoader[ClusterProperties].loadFromContent(dataprocWorkerInfo)
+    val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, clusterPropsOpt)
+    val infoProvider = getMockInfoProvider(8126464.0, Seq(0), Seq(0.004), logEventsProps,
+      Some(testSparkVersion))
+    val autoTuner = buildAutoTunerForTests(dataprocWorkerInfo, infoProvider, platform)
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
+          |--conf spark.executor.cores=16
+          |--conf spark.executor.memory=32g
+          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.locality.wait=0
+          |--conf spark.plugins=com.nvidia.spark.SQLPlugin
+          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
+          |--conf spark.rapids.sql.concurrentGpuTasks=3
+          |--conf spark.rapids.sql.enabled=true
+          |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
+          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
+          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
+          |--conf spark.sql.files.maxPartitionBytes=4g
+          |
+          |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
+          |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.plugins' should be set to the class name required for the RAPIDS Accelerator for Apache Spark.
+          |  Refer to: https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html
+          |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- 'spark.rapids.sql.enabled' was not set.
+          |- 'spark.rapids.sql.format.parquet.multithreaded.combine.waitTime' was not set.
+          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
+          |- 'spark.rapids.sql.reader.multithreaded.combine.sizeBytes' was not set.
+          |- 'spark.shuffle.manager' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+          |- ${classPathComments("rapids.jars.missing")}
+          |- ${classPathComments("rapids.shuffle.jars")}
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    compareOutput(expectedResults, autoTunerOutput)
+  }
+
+  // This test verifies that Profiling AutoTuner retains existing
+  // "spark.plugins" property and RAPIDS plugin is added to it.
+  test("test existing 'spark.plugins' are retained and RAPIDS plugin is added") {
     val customProps = mutable.LinkedHashMap(
       "spark.executor.cores" -> "8",
       "spark.executor.memory" -> "47222m",
@@ -1103,9 +1186,7 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
         "spark.task.resource.gpu.amount" -> "0.001",
         "spark.plugins" -> "com.nvidia.spark.WrongPlugin0, com.nvidia.spark.WrongPlugin1",
         "spark.rapids.memory.pinnedPool.size" -> "5g",
-        "spark.rapids.sql.concurrentGpuTasks" -> "4",
-        "spark.executor.resource.gpu.discoveryScript" ->
-          "${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh")
+        "spark.rapids.sql.concurrentGpuTasks" -> "4")
     val dataprocWorkerInfo = buildGpuWorkerInfoAsString(Some(customProps), Some(32),
       Some("212992MiB"), Some(5), Some(4), Some(T4Gpu.getMemory), Some(T4Gpu.toString))
     val clusterPropsOpt = PropertiesLoader[ClusterProperties].loadFromContent(dataprocWorkerInfo)
@@ -1148,6 +1229,8 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
           |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.plugins' should include the class name required for the RAPIDS Accelerator for Apache Spark.
+          |  Refer to: https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html
           |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
@@ -1160,7 +1243,6 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
           |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
           |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
-          |- RAPIDS Accelerator for Apache Spark jar is missing in "spark.plugins". Please refer to https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html
           |- ${classPathComments("rapids.jars.missing")}
           |- ${classPathComments("rapids.shuffle.jars")}
           |""".stripMargin
@@ -2555,8 +2637,6 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
         "spark.executor.resource.gpu.amount" -> "1",
         "spark.executor.instances" -> "1",
         "spark.serializer" -> "org.apache.spark.serializer.KryoSerializer",
-        "spark.executor.resource.gpu.discoveryScript" ->
-          "${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh",
         "spark.plugins" -> "com.nvidia.spark.SQLPlugin"
       )
     val autoTuner = buildDefaultDataprocAutoTuner(logEventsProps)
@@ -2632,8 +2712,6 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
         "spark.executor.instances" -> "1",
         "spark.serializer" -> "org.apache.spark.serializer.KryoSerializer",
         "spark.kryo.registrator" -> "org.apache.SomeRegistrator,org.apache.SomeOtherRegistrator",
-        "spark.executor.resource.gpu.discoveryScript" ->
-          "${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh",
         "spark.plugins" -> "com.nvidia.spark.SQLPlugin"
       )
     val autoTuner = buildDefaultDataprocAutoTuner(logEventsProps)
@@ -2708,8 +2786,6 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
         "spark.executor.resource.gpu.amount" -> "1",
         "spark.serializer" -> "org.apache.spark.serializer.KryoSerializer",
         "spark.kryo.registrator" -> "",
-        "spark.executor.resource.gpu.discoveryScript" ->
-          "${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh",
         "spark.plugins" -> "com.nvidia.spark.SQLPlugin"
       )
     val autoTuner = buildDefaultDataprocAutoTuner(logEventsProps)
@@ -2782,8 +2858,6 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
         "spark.executor.instances" -> "1",
         "spark.executor.memory" -> "80g",
         "spark.executor.resource.gpu.amount" -> "1",
-        "spark.executor.resource.gpu.discoveryScript" ->
-          "${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh",
         "spark.plugins" -> "com.nvidia.spark.SQLPlugin"
       )
     val emrWorkerInfo = buildGpuWorkerInfoAsString(None, Some(32),
@@ -2852,8 +2926,6 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
         "spark.executor.instances" -> "1",
         "spark.executor.memory" -> "80g",
         "spark.executor.resource.gpu.amount" -> "1",
-        "spark.executor.resource.gpu.discoveryScript" ->
-          "${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh",
         "spark.plugins" -> "com.nvidia.spark.SQLPlugin"
       )
     val autoTuner = buildDefaultDataprocAutoTuner(logEventsProps)
@@ -2923,8 +2995,6 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
         "spark.executor.memory" -> "80g",
         "spark.executor.resource.gpu.amount" -> "1",
         "spark.dataproc.enhanced.execution.enabled" -> "false",
-        "spark.executor.resource.gpu.discoveryScript" ->
-          "${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh",
         "spark.plugins" -> "com.nvidia.spark.SQLPlugin"
       )
     val autoTuner = buildDefaultDataprocAutoTuner(logEventsProps)
@@ -3112,6 +3182,7 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
             |- ${notEnoughMemCommentForKey("spark.rapids.memory.pinnedPool.size")}
             |- ${classPathComments("rapids.shuffle.jars")}
             |- ${notEnoughMemComment(40140)}
+            |- $missingGpuDiscoveryScriptComment
             |""".stripMargin.trim
       // scalastyle:on line.size.limit
       compareOutput(expectedResults, actualResults)

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -525,6 +525,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |Spark Properties:
           |--conf spark.executor.memory=16g
           |--conf spark.executor.memoryOverhead=9g
+          |--conf spark.executor.resource.gpu.vendor=nvidia.com
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=3789m
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
@@ -543,6 +544,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |Comments:
           |- 'spark.executor.memory' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.executor.resource.gpu.vendor' was not set.
           |- 'spark.rapids.memory.pinnedPool.size' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
@@ -558,6 +560,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |- ${getEnforcedPropertyComment("spark.task.resource.gpu.amount")}
           |- ${classPathComments("rapids.jars.missing")}
           |- ${classPathComments("rapids.shuffle.jars")}
+          |- $missingGpuDiscoveryScriptComment
           |""".stripMargin
     // scalastyle:on line.size.limit
     compareOutput(expectedResults, autoTunerOutput)
@@ -624,6 +627,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.executor.cores=16
           |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=11468m
+          |--conf spark.executor.resource.gpu.vendor=nvidia.com
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
@@ -642,6 +646,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |Comments:
           |- 'spark.executor.memory' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.executor.resource.gpu.vendor' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
           |- 'spark.rapids.sql.batchSizeBytes' was not set.
@@ -656,6 +661,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |- ${getEnforcedPropertyComment("spark.task.resource.gpu.amount")}
           |- ${classPathComments("rapids.jars.missing")}
           |- ${classPathComments("rapids.shuffle.jars")}
+          |- $missingGpuDiscoveryScriptComment
           |""".stripMargin
     // scalastyle:on line.size.limit
     compareOutput(expectedResults, autoTunerOutput)
@@ -718,6 +724,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.executor.cores=8
           |--conf spark.executor.memory=[FILL_IN_VALUE]
           |--conf spark.executor.memoryOverhead=[FILL_IN_VALUE]
+          |--conf spark.executor.resource.gpu.vendor=nvidia.com
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=[FILL_IN_VALUE]
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
@@ -736,6 +743,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |Comments:
           |- ${getEnforcedPropertyComment("spark.executor.cores")}
           |- ${getEnforcedPropertyComment("spark.executor.memory")}
+          |- 'spark.executor.resource.gpu.vendor' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
           |- 'spark.rapids.sql.batchSizeBytes' was not set.
@@ -754,6 +762,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |- ${classPathComments("rapids.jars.missing")}
           |- ${classPathComments("rapids.shuffle.jars")}
           |- ${notEnoughMemComment(24371)}
+          |- $missingGpuDiscoveryScriptComment
           |""".stripMargin
     // scalastyle:on line.size.limit
     compareOutput(expectedResults, autoTunerOutput)
@@ -863,6 +872,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.executor.cores=16
           |--conf spark.executor.memory=32g
           |--conf spark.executor.memoryOverhead=11468m
+          |--conf spark.executor.resource.gpu.vendor=nvidia.com
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
@@ -880,6 +890,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |Comments:
           |- 'spark.executor.memory' was not set.
           |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.executor.resource.gpu.vendor' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
           |- 'spark.rapids.sql.batchSizeBytes' was not set.
@@ -893,6 +904,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |- 'spark.task.resource.gpu.amount' was not set.
           |- ${classPathComments("rapids.jars.missing")}
           |- ${classPathComments("rapids.shuffle.jars")}
+          |- $missingGpuDiscoveryScriptComment
           |""".stripMargin
     // scalastyle:on line.size.limit
     compareOutput(expectedResults, autoTunerOutput)

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -263,7 +263,6 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
             |--conf spark.executor.memory=16g
             |--conf spark.executor.memoryOverhead=9830m
             |--conf spark.executor.resource.gpu.amount=1
-            |--conf spark.executor.resource.gpu.discoveryScript=$${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh
             |--conf spark.locality.wait=0
             |--conf spark.plugins=com.nvidia.spark.SQLPlugin
             |--conf spark.rapids.memory.pinnedPool.size=4g
@@ -285,8 +284,8 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
             |- ${getEnforcedPropertyComment("spark.executor.cores")}
             |- ${getEnforcedPropertyComment("spark.executor.instances")}
             |- 'spark.executor.resource.gpu.amount' should be set to allow Spark to schedule GPU resources.
-            |- 'spark.executor.resource.gpu.discoveryScript' should be set to allow Spark to discover GPU resources.
-            |- 'spark.plugins' should include "com.nvidia.spark.SQLPlugin" to enable the RAPIDS Accelerator plugin.
+            |- 'spark.plugins' should be set to the class name required for the RAPIDS Accelerator for Apache Spark.
+            |  Refer to: https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html
             |- 'spark.rapids.memory.pinnedPool.size' was not set.
             |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
             |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
@@ -297,9 +296,9 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
             |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
             |- 'spark.sql.files.maxPartitionBytes' was not set.
             |- 'spark.task.resource.gpu.amount' was not set.
-            |- RAPIDS Accelerator for Apache Spark jar is missing in "spark.plugins". Please refer to https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html
             |- ${classPathComments("rapids.jars.missing")}
             |- ${classPathComments("rapids.shuffle.jars")}
+            |- $additionalSparkPluginsComment
             |""".stripMargin.trim
       // scalastyle:on line.size.limit
       compareOutput(expectedResults, actualTuningResults)
@@ -360,7 +359,6 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.executor.memory=19648m
           |--conf spark.executor.memoryOverhead=10156m
           |--conf spark.executor.resource.gpu.amount=1
-          |--conf spark.executor.resource.gpu.discoveryScript=$${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.nvidia.spark.SQLPlugin
           |--conf spark.rapids.memory.pinnedPool.size=4g
@@ -378,8 +376,8 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
           |
           |Comments:
           |- 'spark.executor.resource.gpu.amount' should be set to allow Spark to schedule GPU resources.
-          |- 'spark.executor.resource.gpu.discoveryScript' should be set to allow Spark to discover GPU resources.
-          |- 'spark.plugins' should include "com.nvidia.spark.SQLPlugin" to enable the RAPIDS Accelerator plugin.
+          |- 'spark.plugins' should be set to the class name required for the RAPIDS Accelerator for Apache Spark.
+          |  Refer to: https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html
           |- 'spark.rapids.memory.pinnedPool.size' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
           |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
@@ -396,16 +394,17 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
           |- GPU count is missing. Setting default to 1.
           |- GPU device is missing. Setting default to l4.
           |- GPU memory is missing. Setting default to 24576m.
-          |- RAPIDS Accelerator for Apache Spark jar is missing in "spark.plugins". Please refer to https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html
           |- ${classPathComments("rapids.jars.missing")}
           |- ${classPathComments("rapids.shuffle.jars")}
+          |- $missingGpuDiscoveryScriptComment
+          |- $additionalSparkPluginsComment
           |""".stripMargin
     // scalastyle:on line.size.limit
     compareOutput(expectedResults, autoTunerOutput)
   }
 
-  // Test to validate that Bootstrap sets the appropriate GPU resource properties for the different
-  // Spark cluster managers.
+  // Test to validate that Bootstrap sets the appropriate GPU resource properties (i.e. amount,
+  // discovery script and vendor) based on the Spark master type.
   // scalastyle:off line.size.limit
   val gpuResourcePropertiesTestData: TableFor3[String, SparkMaster, Seq[String]] = Table(
     ("testName", "sparkMaster", "expectedResults"),
@@ -413,25 +412,24 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
       Standalone,
       Seq(
         "--conf spark.executor.resource.gpu.amount=1",
-        "- 'spark.executor.resource.gpu.amount' should be set to allow Spark to schedule GPU resources."
+        "- 'spark.executor.resource.gpu.amount' should be set to allow Spark to schedule GPU resources.",
+        s"- $missingGpuDiscoveryScriptComment"
       )),
     ("Yarn",
       Yarn,
       Seq(
         "--conf spark.executor.resource.gpu.amount=1",
-        "--conf spark.executor.resource.gpu.discoveryScript=${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh",
         "- 'spark.executor.resource.gpu.amount' should be set to allow Spark to schedule GPU resources.",
-        "- 'spark.executor.resource.gpu.discoveryScript' should be set to allow Spark to discover GPU resources."
+        s"- $missingGpuDiscoveryScriptComment"
       )),
     ("Kubernetes",
       Kubernetes,
       Seq(
         "--conf spark.executor.resource.gpu.amount=1",
-        "--conf spark.executor.resource.gpu.discoveryScript=${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh",
         "--conf spark.executor.resource.gpu.vendor=nvidia.com",
         "- 'spark.executor.resource.gpu.amount' should be set to allow Spark to schedule GPU resources.",
-        "- 'spark.executor.resource.gpu.discoveryScript' should be set to allow Spark to discover GPU resources.",
-        "- 'spark.executor.resource.gpu.vendor' should be set to \"nvidia.com\" for NVIDIA GPUs in k8s clusters."
+        "- 'spark.executor.resource.gpu.vendor' was not set.",
+        s"- $missingGpuDiscoveryScriptComment"
       ))
   )
   // scalastyle:on line.size.limit
@@ -517,5 +515,214 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
           s"Enforced property $propertyName=$propertyValue should appear in bootstrap config")
       }
     }
+  }
+
+  // This test verifies that AutoTuner recommends the correct value for
+  // "spark.plugins" property.
+  test("test 'spark.plugins' is recommended correctly") {
+    // mock the properties loaded from eventLog
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "8",
+        "spark.executor.instances" -> "1",
+        "spark.executor.memory" -> "32g",
+        "spark.sql.shuffle.partitions" -> "200",
+        "spark.sql.files.maxPartitionBytes" -> "1g")
+    val sourceWorkerInfo = buildCpuWorkerInfoAsString(None, Some(8), Some("40g"), Some(2))
+    val sourceClusterInfoOpt = PropertiesLoader[ClusterProperties].loadFromContent(sourceWorkerInfo)
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
+      logEventsProps, Some(testSparkVersion))
+    val platform = PlatformFactory.createInstance(PlatformNames.ONPREM,
+      sourceClusterInfoOpt)
+    val autoTuner = buildAutoTunerForTests(sourceWorkerInfo, infoProvider, platform)
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.executor.memory=16g
+          |--conf spark.executor.resource.gpu.amount=1
+          |--conf spark.locality.wait=0
+          |--conf spark.plugins=com.nvidia.spark.SQLPlugin
+          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=20
+          |--conf spark.rapids.sql.batchSizeBytes=1g
+          |--conf spark.rapids.sql.concurrentGpuTasks=3
+          |--conf spark.rapids.sql.enabled=true
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=20
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
+          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
+          |--conf spark.task.resource.gpu.amount=0.001
+          |
+          |Comments:
+          |- 'spark.executor.resource.gpu.amount' should be set to allow Spark to schedule GPU resources.
+          |- 'spark.plugins' should be set to the class name required for the RAPIDS Accelerator for Apache Spark.
+          |  Refer to: https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html
+          |- 'spark.rapids.memory.pinnedPool.size' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- 'spark.rapids.sql.concurrentGpuTasks' was not set.
+          |- 'spark.rapids.sql.enabled' was not set.
+          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
+          |- 'spark.shuffle.manager' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+          |- 'spark.task.resource.gpu.amount' was not set.
+          |- GPU count is missing. Setting default to 1.
+          |- GPU device is missing. Setting default to l4.
+          |- GPU memory is missing. Setting default to 24576m.
+          |- ${classPathComments("rapids.jars.missing")}
+          |- ${classPathComments("rapids.shuffle.jars")}
+          |- $additionalSparkPluginsComment
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    compareOutput(expectedResults, autoTunerOutput)
+  }
+
+  // This test verifies that Qualification Bootstrap ignores existing
+  // "spark.plugins" property and RAPIDS plugin is added.
+  test("test existing 'spark.plugins' are ignored and RAPIDS plugin is added") {
+    // mock the properties loaded from eventLog
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "8",
+        "spark.executor.instances" -> "1",
+        "spark.executor.memory" -> "32g",
+        "spark.sql.shuffle.partitions" -> "200",
+        "spark.sql.files.maxPartitionBytes" -> "1g",
+        "spark.plugins" -> "com.existing.plugin1,com.existing.plugin2")
+    val sourceWorkerInfo = buildCpuWorkerInfoAsString(None, Some(8), Some("40g"), Some(2))
+    val sourceClusterInfoOpt = PropertiesLoader[ClusterProperties].loadFromContent(sourceWorkerInfo)
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
+      logEventsProps, Some(testSparkVersion))
+    val platform = PlatformFactory.createInstance(PlatformNames.ONPREM,
+      sourceClusterInfoOpt)
+    val autoTuner = buildAutoTunerForTests(sourceWorkerInfo, infoProvider, platform)
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.executor.memory=16g
+          |--conf spark.executor.resource.gpu.amount=1
+          |--conf spark.locality.wait=0
+          |--conf spark.plugins=com.nvidia.spark.SQLPlugin
+          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=20
+          |--conf spark.rapids.sql.batchSizeBytes=1g
+          |--conf spark.rapids.sql.concurrentGpuTasks=3
+          |--conf spark.rapids.sql.enabled=true
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=20
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
+          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
+          |--conf spark.task.resource.gpu.amount=0.001
+          |
+          |Comments:
+          |- 'spark.executor.resource.gpu.amount' should be set to allow Spark to schedule GPU resources.
+          |- 'spark.plugins' should include the class name required for the RAPIDS Accelerator for Apache Spark.
+          |  Refer to: https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html
+          |- 'spark.rapids.memory.pinnedPool.size' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- 'spark.rapids.sql.concurrentGpuTasks' was not set.
+          |- 'spark.rapids.sql.enabled' was not set.
+          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
+          |- 'spark.shuffle.manager' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+          |- 'spark.task.resource.gpu.amount' was not set.
+          |- GPU count is missing. Setting default to 1.
+          |- GPU device is missing. Setting default to l4.
+          |- GPU memory is missing. Setting default to 24576m.
+          |- ${classPathComments("rapids.jars.missing")}
+          |- ${classPathComments("rapids.shuffle.jars")}
+          |- $additionalSparkPluginsComment
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    compareOutput(expectedResults, autoTunerOutput)
+  }
+
+  // This test verifies that AutoTuner honours enforced values of spark.plugins
+  test("test enforced values of 'spark.plugins' are honoured by AutoTuner") {
+    // mock the properties loaded from eventLog
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "8",
+        "spark.executor.instances" -> "1",
+        "spark.executor.memory" -> "32g",
+        "spark.sql.shuffle.partitions" -> "200",
+        "spark.sql.files.maxPartitionBytes" -> "1g")
+    val sourceWorkerInfo = buildCpuWorkerInfoAsString(None, Some(8), Some("40g"), Some(2))
+    val sourceClusterInfoOpt = PropertiesLoader[ClusterProperties].loadFromContent(sourceWorkerInfo)
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
+      logEventsProps, Some(testSparkVersion))
+
+    // Define 'spark.plugins' as an enforced property
+    val enforcedSparkProperties = Map(
+      "spark.plugins" -> "com.existing.plugin1,com.existing.plugin2"
+    )
+
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      enforcedSparkProperties = enforcedSparkProperties
+    )
+
+    val platform = PlatformFactory.createInstance(PlatformNames.ONPREM,
+      sourceClusterInfoOpt, Some(targetClusterInfo))
+    val autoTuner = buildAutoTunerForTests(sourceWorkerInfo, infoProvider, platform)
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.executor.memory=16g
+          |--conf spark.executor.resource.gpu.amount=1
+          |--conf spark.locality.wait=0
+          |--conf spark.plugins=com.existing.plugin1,com.existing.plugin2
+          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=20
+          |--conf spark.rapids.sql.batchSizeBytes=1g
+          |--conf spark.rapids.sql.concurrentGpuTasks=3
+          |--conf spark.rapids.sql.enabled=true
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=20
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
+          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
+          |--conf spark.task.resource.gpu.amount=0.001
+          |
+          |Comments:
+          |- 'spark.executor.resource.gpu.amount' should be set to allow Spark to schedule GPU resources.
+          |- ${getEnforcedPropertyComment("spark.plugins")}
+          |- 'spark.rapids.memory.pinnedPool.size' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- 'spark.rapids.sql.concurrentGpuTasks' was not set.
+          |- 'spark.rapids.sql.enabled' was not set.
+          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
+          |- 'spark.shuffle.manager' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+          |- 'spark.task.resource.gpu.amount' was not set.
+          |- GPU count is missing. Setting default to 1.
+          |- GPU device is missing. Setting default to l4.
+          |- GPU memory is missing. Setting default to 24576m.
+          |- ${classPathComments("rapids.jars.missing")}
+          |- ${classPathComments("rapids.shuffle.jars")}
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    compareOutput(expectedResults, autoTunerOutput)
   }
 }


### PR DESCRIPTION
Fixes #1825 Fixes #1839 

This PR addresses two issues related to configuration recommendations:

### Issue 1825: 'spark.plugin' Logic Issues

Current logic does not handle `spark.plugins` across different scenarios - sometimes overriding existing accelerator plugins, sometimes preserving non-accelerator plugins, and not providing clear guidance for advanced users who need custom plugin configurations.

### Issue 1839: GPU Discovery Script Recommendations

Current implementation hard-codes `${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh` which fails when `SPARK_HOME` is unset (common in CSPs) and does not handle custom discovery scripts.

## Solution

### Issue 1825: Tool-Specific Logic for "spark.plugins"

#### Qualification Bootstrap/AutoTuner
- Ignores existing `spark.plugins` completely.
- <ins>Always sets</ins> `spark.plugins=com.nvidia.spark.SQLPlugin`
- Adds comment on using target cluster enforced properties for additional plugins
- **Assumption**: Advanced users requiring custom plugins can configure target cluster info appropriately

####  Profiling AutoTuner 
- Retains existing `spark.plugins` values (since the job is already run on a GPU cluster, other plugins are there).
- <ins>Appends RAPIDS plugin</ins> if not already present

### Issue 1839: Discovery Script as Comments

- Removed recommendation of `spark.executor.resource.gpu.discoveryScript`
- Based on the Spark Master, adds comments to guide users to configure discovery scripts according to their cluster manager's documentation
- **Provided sample script reference** without hard-coding paths


## Key Changes

### Core Logic Changes
- **`AutoTuner.scala`**:
  - Added abstract `recommendPluginPropsInternal()` method for tool-specific plugin logic
  - Refactored GPU resource property recommendations into `recommendExecutorResourceGpuProps()`
  - Replaced discovery script recommendations with conditional comments
  - Added new comment generation methods for user guidance

- **`QualificationAutoTuner.scala`**:
  - Implemented qualification-specific plugin logic that ignores existing configurations
  - Added conditional comments for additional plugin configuration guidance

- **`ProfilingAutoTuner.scala`**:
  - Implemented profiling-specific plugin logic that preserves existing configurations
  - Ensures RAPIDS plugin is added without removing other plugins

### Configuration Updates
- `tuningTable.yaml`: Updated plugin comments to be more generic and reference official documentation
- Removed hardcoded discovery script paths from configuration templates

## Testing
- Tool specific UTs for various scenarios (no plugins, existing plugins, enforced plugins)
- UTs to verify comment generation for discoveryScript for different Spark manager.
- UT to verify AutoTuner honours enforced 'spark.executor.resource.gpu.discoveryScript' and skips missing script comment when master is YARN.
