### PR TITLE
[FEA] Add config argument to Qualification tool

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -539,9 +539,11 @@ class Qualification(QualificationCore):
         output_info = self.__build_prediction_output_files_info()
         qual_handler = self.ctxt.get_ctxt('qualHandler')
         try:
-            predictions_df = predict(platform=model_name, qual=qual_output_dir,
+            predictions_df = predict(platform=model_name,
+                                     qual=qual_output_dir,
                                      output_info=output_info,
                                      model=estimation_model_args['customModelFile'],
+                                     config=estimation_model_args['config'],
                                      qual_handlers=[qual_handler])
         except Exception as e:  # pylint: disable=broad-except
             predictions_df = pd.DataFrame()

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -50,6 +50,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                       submission_mode: str = None,
                       target_cluster_info: str = None,
                       tuning_configs: str = None,
+                      config: str = None,
                       **rapids_options) -> None:
         """The Qualification cmd provides estimated speedups by migrating Apache Spark applications
         to GPU accelerated clusters.
@@ -100,6 +101,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         :param tuning_configs: Path to a YAML file that contains the tuning configurations.
                 For sample tuning configs files, please visit
                 https://github.com/NVIDIA/spark-rapids-tools/tree/main/core/src/main/resources/bootstrap/tuningConfigs.yaml
+        :param config: Path to a qualx-conf.yaml file to use for configuration.
         """
         eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
         platform = Utils.get_value_or_pop(platform, rapids_options, 'p')
@@ -116,7 +118,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         }
         estimation_model_args = AbsToolUserArgModel.create_tool_args(estimation_arg_valid,
                                                                      estimation_model=None,
-                                                                     custom_model_file=custom_model_file)
+                                                                     custom_model_file=custom_model_file,
+                                                                     config=config)
         if estimation_model_args is None:
             return None
         qual_args = AbsToolUserArgModel.create_tool_args('qualification',


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-tools/issues/1847.

### Changes

This PR adds a config argument to Qualification tool to support user-provided qualx-conf.yaml files

### Usage

`spark_rapids qualification [...] --config <qualx-conf.yaml>`