### PR TITLE
Add modular categories to changelog release action

### DIFF
--- a/.github/workflows/configuration.json
+++ b/.github/workflows/configuration.json
@@ -8,52 +8,61 @@
     {
       "title": "### QualX",
       "labels": ["qualx"],
+      "exclude_labels": ["autotuner"],
       "exhaustive": true
     },
     {
       "title": "### API Change",
       "labels": ["api_change"],
+      "exclude_labels": ["autotuner", "qualx"],
       "exhaustive": true
     },
     {
       "title": "### Feature Request",
       "labels": ["feature request"],
+      "exclude_labels": ["autotuner", "qualx", "api_change"],
       "exhaustive": true
     },
     {
       "title": "### Performance",
       "labels": ["performance"],
-      "exhaustive": true
-    },
-    {
-      "title": "### Build and CI/CD",
-      "labels": ["dependencies", "cicd", "build"],
+      "exclude_labels": ["autotuner", "qualx", "api_change", "feature request"],
       "exhaustive": true
     },
     {
       "title": "### Bug Fixes",
       "labels": ["bug"],
+      "exclude_labels": ["autotuner", "qualx", "api_change", "feature request", "performance"],
+      "exhaustive": true
+    },
+    {
+      "title": "### Build and CI/CD",
+      "labels": ["dependencies", "cicd", "build"],
+      "exclude_labels": ["autotuner", "qualx", "api_change", "feature request", "performance", "bug"],
       "exhaustive": true
     },
     {
       "title": "### User Tools",
       "labels": ["user_tools"],
+      "exclude_labels": ["autotuner", "qualx", "api_change", "feature request", "performance", "bug", "dependencies", "cicd", "build"],
       "exhaustive": true
     },
     {
       "title": "### Core",
       "labels": ["core_tools"],
+      "exclude_labels": ["autotuner", "qualx", "api_change", "feature request", "performance", "bug", "dependencies", "cicd", "build", "user_tools"],
       "exhaustive": true
     },
     {
       "title": "### Documentation",
       "labels": ["documentation"],
+      "exclude_labels": ["autotuner", "qualx", "api_change", "feature request", "performance", "bug", "dependencies", "cicd", "build", "user_tools", "core_tools"],
       "exhaustive": true
     },
     {
       "title": "## Miscellaneous",
-      "labels": [],
-      "exhaustive": false
+      "exclude_labels": ["autotuner", "qualx", "api_change", "feature request", "performance", "bug", "dependencies", "cicd", "build", "user_tools", "core_tools", "documentation"],
+      "exhaustive": true
     }
   ],
   "sort": {

--- a/.github/workflows/configuration.json
+++ b/.github/workflows/configuration.json
@@ -3,56 +3,57 @@
     {
       "title": "### Autotuner",
       "labels": ["autotuner"],
-      "exhaustive": false,
-      "exhaustive_rules": false
+      "exhaustive": true
     },
     {
       "title": "### QualX",
       "labels": ["qualx"],
-      "exhaustive": false,
-      "exhaustive_rules": false
+      "exhaustive": true
     },
     {
       "title": "### API Change",
       "labels": ["api_change"],
-      "exhaustive": false,
-      "exhaustive_rules": false
+      "exhaustive": true
     },
     {
       "title": "### Feature Request",
       "labels": ["feature request"],
-      "exhaustive": false,
-      "exhaustive_rules": false
+      "exhaustive": true
     },
     {
       "title": "### Performance",
       "labels": ["performance"],
-      "exhaustive": false,
-      "exhaustive_rules": false
+      "exhaustive": true
     },
     {
       "title": "### Build and CI/CD",
       "labels": ["dependencies", "cicd", "build"],
-      "exhaustive": false,
-      "exhaustive_rules": false
+      "exhaustive": true
     },
     {
       "title": "### Bug Fixes",
       "labels": ["bug"],
-      "exhaustive": false,
-      "exhaustive_rules": false
+      "exhaustive": true
     },
     {
       "title": "### User Tools",
       "labels": ["user_tools"],
-      "exhaustive": false,
-      "exhaustive_rules": false
+      "exhaustive": true
     },
     {
       "title": "### Core",
       "labels": ["core_tools"],
-      "exhaustive": false,
-      "exhaustive_rules": false
+      "exhaustive": true
+    },
+    {
+      "title": "### Documentation",
+      "labels": ["documentation"],
+      "exhaustive": true
+    },
+    {
+      "title": "## Miscellaneous",
+      "labels": [],
+      "exhaustive": false
     }
   ],
   "sort": {

--- a/.github/workflows/configuration.json
+++ b/.github/workflows/configuration.json
@@ -1,16 +1,58 @@
 {
   "categories": [
     {
+      "title": "### Autotuner",
+      "labels": ["autotuner"],
+      "exhaustive": false,
+      "exhaustive_rules": false
+    },
+    {
+      "title": "### QualX",
+      "labels": ["qualx"],
+      "exhaustive": false,
+      "exhaustive_rules": false
+    },
+    {
+      "title": "### API Change",
+      "labels": ["api_change"],
+      "exhaustive": false,
+      "exhaustive_rules": false
+    },
+    {
+      "title": "### Feature Request",
+      "labels": ["feature request"],
+      "exhaustive": false,
+      "exhaustive_rules": false
+    },
+    {
+      "title": "### Performance",
+      "labels": ["performance"],
+      "exhaustive": false,
+      "exhaustive_rules": false
+    },
+    {
+      "title": "### Build and CI/CD",
+      "labels": ["dependencies", "cicd", "build"],
+      "exhaustive": false,
+      "exhaustive_rules": false
+    },
+    {
+      "title": "### Bug Fixes",
+      "labels": ["bug"],
+      "exhaustive": false,
+      "exhaustive_rules": false
+    },
+    {
       "title": "### User Tools",
-      "labels": ["user_tools"]
+      "labels": ["user_tools"],
+      "exhaustive": false,
+      "exhaustive_rules": false
     },
     {
       "title": "### Core",
-      "labels": ["core_tools"]
-    },
-    {
-      "title": "### Miscellaneous",
-      "labels": []
+      "labels": ["core_tools"],
+      "exhaustive": false,
+      "exhaustive_rules": false
     }
   ],
   "sort": {

--- a/.github/workflows/configuration.json
+++ b/.github/workflows/configuration.json
@@ -60,7 +60,7 @@
       "exhaustive": true
     },
     {
-      "title": "## Miscellaneous",
+      "title": "### Miscellaneous",
       "exclude_labels": ["autotuner", "qualx", "api_change", "feature request", "performance", "bug", "dependencies", "cicd", "build", "user_tools", "core_tools", "documentation"],
       "exhaustive": true
     }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build Changelog
         id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v4
+        uses: mikepenz/release-changelog-builder-action@v5
         with:
           configuration: ".github/workflows/configuration.json" # Configuration file for the changelog builder (optional)z
           outputFile: "CHANGELOG_BODY.md"
@@ -81,10 +81,10 @@ jobs:
           release_name: ${{ github.ref }} # Use the version number as the release name
           body: |
             ## Packages
-            
+
             - Maven Release: ${{ env.MAVEN_URL }}/${{ env.VERSION }}/
             - PyPI Package: ${{ env.PYPI_URL }}/${{ env.VERSION }}/
-            
+
             ## Changes
             ${{ steps.build_changelog.outputs.changelog }}
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v5
         with:
-          configuration: ".github/workflows/configuration.json" # Configuration file for the changelog builder (optional)z
+          configuration: ".github/workflows/configuration.json" # Configuration file for the changelog builder (optional)
           outputFile: "CHANGELOG_BODY.md"
         env:
           GITHUB_TOKEN: ${{ secrets.NVAUTO_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1827

This change updates the changelog workflow and reorganizes changelog category configuration to improve release note automation and categorization.
We need to have better categorization of the PRs based on the priority of the change. Previously, we had 2 main categories `user_tools/core_tools` which does not capture the main changes in a release.

**Changelog workflow improvements:**

* Upgraded the changelog builder action in `.github/workflows/release.yml` from version 4 to version 5 for improved features and compatibility.

**Changelog category configuration updates:**

* Overhauled the categories in `.github/workflows/configuration.json`:
  - Added new categories: `Autotuner`, `QualX`, `API Change`, `Feature Request`, `Performance`, `Build and CI/CD`, and `Bug Fixes` with appropriate labels.
  - Reordered and expanded existing categories for better organization.
  - Added `exhaustive` and `exhaustive_rules` flags to all categories for more precise changelog generation.

**Logic:**

This is basically a mutually exclusive “first match wins” classification.

Each PR will be classified into the first category it qualifies for based on labels and `exclude_labels`.
If no match is found, it goes into `Miscellaneous`.
The order here matters — the changelog is processed _top to bottom_:

1. PRs labeled autotuner → go under `### Autotuner.`
2. PRs labeled qualx (but not autotuner) → go under `### QualX`.
3. PRs labeled api_change (but not in above categories) → go under `### API Change`.
4. And so on…
5. If a PR doesn’t fit any of the specific label rules, it falls into `### Miscellaneous` (the last category).

