### PR TITLE
Correct qual_summary formatting

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -337,7 +337,7 @@ class Qualification(QualificationCore):
         csv_out = output_files_info.get_value('summary', 'path')
         if not df_final_result.empty:
             self.logger.info('Generating GPU Estimated Speedup: as %s', csv_out)
-            df_final_result.to_csv(csv_out, float_format='%.2f')
+            df_final_result.to_csv(csv_out, float_format='%.2f', sep=',')
 
         # Add columns for cluster configuration recommendations and tuning configurations to the processed_apps.
         recommender = ClusterConfigRecommender(self.ctxt)

--- a/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
+++ b/user_tools/src/spark_rapids_tools/tools/additional_heuristics.py
@@ -127,7 +127,7 @@ class AdditionalHeuristics:
         # If there are any stages with spills caused by non-allowed Execs, skip the application
         if not relevant_stages_with_spills.empty:
             spill_threshold_human_readable = Utilities.bytes_to_human_readable(spill_threshold_bytes)
-            reason = f'Skipping due to total data spill in stages exceeding {spill_threshold_human_readable}.'
+            reason = f'Skipping due to total data spill in stages exceeding {spill_threshold_human_readable}'
             return True, reason
         return False, ''
 

--- a/user_tools/src/spark_rapids_tools/tools/speedup_category.py
+++ b/user_tools/src/spark_rapids_tools/tools/speedup_category.py
@@ -122,7 +122,7 @@ class SpeedupCategory:
                     existing_reason = single_row.get('Not Recommended Reason', '')
                     heuristic_skipping_reason = entry.get('skippingReason')
                     if existing_reason and heuristic_skipping_reason:
-                        single_row['Not Recommended Reason'] = existing_reason + f'; {heuristic_skipping_reason}'
+                        single_row['Not Recommended Reason'] = existing_reason + f', {heuristic_skipping_reason}'
                     elif heuristic_skipping_reason:
                         single_row['Not Recommended Reason'] = heuristic_skipping_reason
                     single_row[category_col_name] = self.props.get('defaultCategory')

--- a/user_tools/tests/spark_rapids_tools_e2e/features/event_log_processing.feature
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/event_log_processing.feature
@@ -56,9 +56,9 @@ Feature: Event Log Processing
 
     Examples:
       | platform 	| variable                                                  | value           |eventlog                                                    | file                          | app_id                  | expected_reason                                              |
-      | onprem  	| RAPIDS_USER_TOOLS_SPILL_BYTES_THRESHOLD                   |   -1            |onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | qualification_summary.csv     | app-20231122005806-0064 | Skipping due to total data spill in stages exceeding -1.00 B.|
-      | onprem  	| RAPIDS_USER_TOOLS_GPU_SPEEDUP_SPARK_LOWER_BOUND           |   20.0          |onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | qualification_summary.csv     | app-20231122005806-0064 | Skipping due to total data spill in stages exceeding -1.00 B.; GPU SpeedUp < Qualifying Threshold (More is qualified) |
-      | onprem  	| RAPIDS_USER_TOOLS_UNSUPPORTED_OPERATORS_SPARK_UPPER_BOUND |   -1            |onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | qualification_summary.csv     | app-20231122005806-0064 | Skipping due to total data spill in stages exceeding -1.00 B.; GPU SpeedUp < Qualifying Threshold (More is qualified); Unsupported Operators Stage Duration Percent > Qualifying Threshold (Less is qualified) |
+      | onprem  	| RAPIDS_USER_TOOLS_SPILL_BYTES_THRESHOLD                   |   -1            |onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | qualification_summary.csv     | app-20231122005806-0064 | Skipping due to total data spill in stages exceeding -1.00 B|
+      | onprem  	| RAPIDS_USER_TOOLS_GPU_SPEEDUP_SPARK_LOWER_BOUND           |   20.0          |onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | qualification_summary.csv     | app-20231122005806-0064 | Skipping due to total data spill in stages exceeding -1.00 B, GPU SpeedUp < Qualifying Threshold (More is qualified) |
+      | onprem  	| RAPIDS_USER_TOOLS_UNSUPPORTED_OPERATORS_SPARK_UPPER_BOUND |   -1            |onprem/nds/power/eventlogs/cpu/app-20231122005806-0064.zstd | qualification_summary.csv     | app-20231122005806-0064 | Skipping due to total data spill in stages exceeding -1.00 B, GPU SpeedUp < Qualifying Threshold (More is qualified), Unsupported Operators Stage Duration Percent > Qualifying Threshold (Less is qualified) |
 
   @test_id_ELP_0004
   Scenario Outline: Check stdout contains speed up warning when target_cluster_info is provided


### PR DESCRIPTION
Fixes #1850 

This PR changes the output formatting for the `qualification_summary.csv`.
With the previous change for the adding `Not Recommended Reason`, the format of the reason looked something like -
```
,Vendor,Driver Host,App Name,App ID,Estimated GPU Speedup,Estimated GPU Duration,App Duration,SQL Stage Durations Sum,Unsupported Operators Stage Duration,Unsupported Operators Stage Duration Percent,Total Core Seconds,Skip by Heuristics,Not Recommended Reason,Spark Runtime,Estimated GPU Speedup Category
0,onprem,Test_App_Name,application_123,1.44,7394624,10640109,10447427,7858222.00,75.22,91394440,True,Skipping due to total data spill in stages exceeding 1.00 TB; Unsupported Operators Stage Duration Percent > Qualifying Threshold (Less is qualified),SPARK,Not Recommended
```

The problem with this - since the Reason Column is not quote protected, the semi colon can be interpreted as a delimiter by some CSV openers.

With the latest changes, the output has been updated to be comma separated with quotation safe-guarding
```
Vendor,Driver Host,App Name,App ID,Estimated GPU Speedup,Estimated GPU Duration,App Duration,SQL Stage Durations Sum,Unsupported Operators Stage Duration,Unsupported Operators Stage Duration Percent,Total Core Seconds,Skip by Heuristics,Not Recommended Reason,Spark Runtime,Estimated GPU Speedup Category
0,onprem,Test_App_Name,application_123,1.44,7394624,10640109,10447427,7858222.00,75.22,91394440,True,"Skipping due to total data spill in stages exceeding 1.00 TB, Unsupported Operators Stage Duration Percent > Qualifying Threshold (Less is qualified)",SPARK,Not Recommended
```

Caveats -
- Since the reason can sometimes be just a single one having no comma in it, only when it has the comma, does it pop up in quotes