### PR TITLE
Use Tools-API to get output-paths in QualX

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -542,8 +542,8 @@ class Qualification(QualificationCore):
                 model=estimation_model_args['customModelFile'],
                 config=estimation_model_args['qualxConfig'],
                 qual_handlers=[
-                    APIHelpers.build_qual_core_handler(
-                        qual_output_dir,
+                    APIHelpers.QualCore.build_handler(
+                        dir_path=qual_output_dir,
                         raise_on_empty=True
                     )
                 ]

--- a/user_tools/src/spark_rapids_pytools/rapids/qualx/prediction.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualx/prediction.py
@@ -38,7 +38,7 @@ class Prediction(QualXTool):
 
     @property
     def qual_handler(self) -> QualCoreResultHandler:
-        return APIHelpers.build_qual_core_handler(dir_path=self.qual_output)
+        return APIHelpers.QualCore.build_handler(dir_path=self.qual_output)
 
     def __prepare_prediction_output_info(self) -> dict:
         """

--- a/user_tools/src/spark_rapids_tools/api_v1/__init__.py
+++ b/user_tools/src/spark_rapids_tools/api_v1/__init__.py
@@ -22,6 +22,9 @@ from .common import (
 from .app_handler import (
     AppHandler
 )
+from .report_reader import (
+    ToolReportReaderT
+)
 from .result_handler import (
     register_result_class,
     result_registry,
@@ -46,6 +49,7 @@ __all__ = [
     'APIUtils',
     'LoadCombinedRepResult',
     'AppHandler',
+    'ToolReportReaderT',
     'register_result_class',
     'result_registry',
     'ResultHandler',

--- a/user_tools/src/spark_rapids_tools/api_v1/builder.py
+++ b/user_tools/src/spark_rapids_tools/api_v1/builder.py
@@ -22,10 +22,18 @@ from typing import Union, Optional, TypeVar, Generic, List, Dict, Callable, Any,
 import pandas as pd
 
 from spark_rapids_tools import override
-from spark_rapids_tools.api_v1 import ToolResultHandlerT, LoadCombinedRepResult, APIUtils
 from spark_rapids_tools.api_v1 import AppHandler
+from spark_rapids_tools.api_v1 import (
+    ToolReportReaderT,
+    ToolResultHandlerT,
+    LoadCombinedRepResult,
+    APIUtils,
+    ProfWrapperResultHandler,
+    QualCoreResultHandler,
+    QualWrapperResultHandler,
+    result_registry
+)
 from spark_rapids_tools.api_v1.report_loader import ReportLoader
-from spark_rapids_tools.api_v1.report_reader import ToolReportReaderT
 from spark_rapids_tools.storagelib.cspfs import BoundedCspPath
 from spark_rapids_tools.utils.data_utils import LoadDFResult, JPropsResult, TXTResult
 
@@ -699,14 +707,37 @@ class CSVReportCombiner(object):
             load_error=load_error)
 
 
-@dataclass
-class APIHelpers(object):
+# ResHGenT = TypeVar('ResHGenT', bound=ResultHandler)
+class GenericRH(Generic[ToolResultHandlerT]):
     """
-    A helper class for API v1 components.
-    This class provides static methods to process results from CSVReportCombiner and handle exceptions.
+    A generic internal class for building API result handlers.
     """
-    @staticmethod
-    def build_qual_core_handler(
+    class Meta:  # pylint: disable=too-few-public-methods
+        report_id: str
+
+    @classmethod
+    def _init_builder(cls, dir_path: Union[str, BoundedCspPath]) -> 'APIResultHandler':
+        return APIResultHandler().with_path(dir_path)
+
+    @classmethod
+    def _set_handler_report(cls, builder: APIResultHandler, report_id: str) -> 'APIResultHandler':
+        return builder.report(report_id)
+
+    @classmethod
+    def find_report_paths(
+            cls,
+            root_path: Union[str, BoundedCspPath],
+            filter_cb: Optional[Callable[[BoundedCspPath], bool]] = None
+    ) -> Union[List[str], List[BoundedCspPath]]:
+        impl_class = result_registry.get(cls.Meta.report_id)
+        return impl_class.Meta.find_report_paths(
+            root_path=root_path,
+            filter_cb=filter_cb
+        )
+
+    @classmethod
+    def build_handler(
+            cls,
             dir_path: Union[str, BoundedCspPath],
             raise_on_empty: bool = False
     ) -> ToolResultHandlerT:
@@ -718,38 +749,51 @@ class APIHelpers(object):
         :return: An instance of ToolResultHandlerT for the Qual Core report.
         :raises ValueError: If raise_on_empty is True and the report is empty or missing.
         """
-        q_core_h = (
-            APIResultHandler()
-            .qual_core()
-            .with_path(dir_path)
-            .build()
-        )
-        if raise_on_empty and q_core_h.is_empty():
-            raise ValueError(f'Qual Core report at {dir_path} is empty or does not exist.')
-        return q_core_h
+        builder_obj = cls._init_builder(dir_path)
+        builder_obj = cls._set_handler_report(builder_obj, cls.Meta.report_id)
+        res_h = builder_obj.build()
+        if raise_on_empty and res_h.is_empty():
+            if res_h.out_path.exists():
+                empty_reason = 'Directory does not exist'
+            else:
+                empty_reason = 'No apps found in the reports'
+            raise ValueError(f'Report at [{dir_path}] is empty. {empty_reason}.')
+        return res_h
 
-    @staticmethod
-    def build_qual_wrapper_handler(
-            dir_path: Union[str, BoundedCspPath],
-            raise_on_empty: bool = False
-    ) -> ToolResultHandlerT:
-        """
-        Builds and returns a ToolResultHandlerT for the Qual Wrapper report.
 
-        :param dir_path: The directory path or BoundedCspPath where the Qual Wrapper report is located.
-        :param raise_on_empty: If True, raises a ValueError if the report is empty or does not exist.
-        :return: An instance of ToolResultHandlerT for the Qual Wrapper report.
-        :raises ValueError: If raise_on_empty is True and the report is empty or missing.
+@dataclass
+class APIHelpers(object):
+    """
+    A collection of helper classes and methods for building API reports and combining them.
+    """
+
+    ###################################
+    # Public API for API Helpers
+    ###################################
+
+    class QualCore(GenericRH[QualCoreResultHandler]):
         """
-        q_wrapper_h = (
-            APIResultHandler()
-            .qual_wrapper()
-            .with_path(dir_path)
-            .build()
-        )
-        if raise_on_empty and q_wrapper_h.is_empty():
-            raise ValueError(f'Qual Wrapper report at {dir_path} is empty or does not exist.')
-        return q_wrapper_h
+        A helper class for building Qual Core reports.
+        It provides static methods to build ResultHandler for Qual Core reports.
+        """
+        class Meta(GenericRH[QualCoreResultHandler].Meta):    # pylint: disable=too-few-public-methods
+            report_id: str = 'qualCoreOutput'
+
+    class QualWrapper(GenericRH[QualWrapperResultHandler]):
+        """
+        A helper class for building Qual Wrapper reports.
+        It provides static methods to build Result Handler for Qual Wrapper reports.
+        """
+        class Meta(GenericRH[QualWrapperResultHandler].Meta):    # pylint: disable=too-few-public-methods
+            report_id: str = 'qualWrapperOutput'
+
+    class ProfWrapper(GenericRH[ProfWrapperResultHandler]):
+        """
+        A helper class for building Prof Wrapper reports.
+        It provides static methods to build Result Handler for Prof Wrapper reports.
+        """
+        class Meta(GenericRH[ProfWrapperResultHandler].Meta):    # pylint: disable=too-few-public-methods
+            report_id: str = 'profWrapperOutput'
 
     @staticmethod
     def combine_reports(

--- a/user_tools/src/spark_rapids_tools/api_v1/core/prof_handler.py
+++ b/user_tools/src/spark_rapids_tools/api_v1/core/prof_handler.py
@@ -14,6 +14,7 @@
 
 """Module that contains the definition of the profiling Result handler for the core module."""
 
+import re
 from dataclasses import dataclass
 
 from spark_rapids_tools import override
@@ -25,6 +26,12 @@ from spark_rapids_tools.api_v1.report_reader import ToolReportReader
 @dataclass
 class ProfCoreResultHandler(ResultHandler):
     """Result handler for the profiling core module."""
+    class Meta(ResultHandler.Meta):    # pylint: disable=too-few-public-methods
+        """
+        Meta class for ProfCoreResultHandler to define common attributes.
+        """
+        id_regex = re.compile(r'rapids_4_spark_profile')
+
     @override
     @property
     def alpha_reader(self) -> ToolReportReader:

--- a/user_tools/src/spark_rapids_tools/api_v1/core/qual_handler.py
+++ b/user_tools/src/spark_rapids_tools/api_v1/core/qual_handler.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Module that contains the definition of the qualification Result handler for the core module."""
-
+import re
 from dataclasses import dataclass
 from typing import Optional
 
@@ -27,6 +27,12 @@ from spark_rapids_tools.storagelib.cspfs import BoundedCspPath
 @dataclass
 class QualCoreResultHandler(ResultHandler):
     """Result handler for the qualification core module."""
+    class Meta(ResultHandler.Meta):    # pylint: disable=too-few-public-methods
+        """
+        Meta class for QualCoreResultHandler to define common attributes.
+        """
+        id_regex = re.compile(r'qual_core_output')
+
     @override
     @property
     def alpha_reader(self) -> ToolReportReader:

--- a/user_tools/src/spark_rapids_tools/api_v1/result_handler.py
+++ b/user_tools/src/spark_rapids_tools/api_v1/result_handler.py
@@ -14,18 +14,54 @@
 
 """Module that contains the definitions of result accessors and handlers"""
 
+import re
 from collections import defaultdict
 from dataclasses import dataclass, field
 from functools import cached_property
 from logging import Logger
-from typing import Dict, Optional, TypeVar, Type
+from typing import Dict, Optional, TypeVar, Type, Union, List, Callable
 
 import pandas as pd
+from pyarrow.fs import FileType
 
 from spark_rapids_pytools.common.utilities import ToolLogging
 from spark_rapids_tools.api_v1 import AppHandler
 from spark_rapids_tools.api_v1.report_reader import ToolReportReader
-from spark_rapids_tools.storagelib.cspfs import BoundedCspPath
+from spark_rapids_tools.storagelib.cspfs import BoundedCspPath, CspFs
+
+
+class ResultHandlerBaseMeta:    # pylint: disable=too-few-public-methods
+    """
+    Meta class for ResultHandler to define common attributes.
+    """
+    id_regex: re.Pattern[str] = None
+
+    @classmethod
+    def find_report_paths(
+            cls,
+            root_path: Union[str, BoundedCspPath],
+            filter_cb: Optional[Callable[[BoundedCspPath], bool]] = None
+    ) -> Union[List[str], List[BoundedCspPath]]:
+        """
+        Find all report directory paths under the given root that match the class-defined `id_regex` pattern.
+        :param root_path: The root directory or `BoundedCspPath` where reports are stored.
+        :param filter_cb: Optional callback to filter the found report paths.
+        :return: A list of matching report directory paths as strings or `BoundedCspPath` objects,
+                depending on the input type.
+        """
+        report_csps = CspFs.glob_path(
+            path=root_path,
+            pattern=cls.id_regex,
+            item_type=FileType.Directory,
+            recursive=False
+        )
+        if filter_cb is None:
+            filtered_csp_paths = report_csps
+        else:
+            filtered_csp_paths = [p for p in report_csps if filter_cb(p)]
+        if isinstance(root_path, str):
+            return [p.to_str_format() for p in filtered_csp_paths]
+        return report_csps
 
 
 @dataclass
@@ -43,6 +79,9 @@ class ResultHandler(object):
                         created. These handlers manage application-specific data and metadata. This
                         field is not initialized directly and is set up in the `__post_init__` method.
     """
+    class Meta(ResultHandlerBaseMeta):    # pylint: disable=too-few-public-methods
+        id_regex = re.compile(r'UNDEFINED')
+
     report_id: str
     out_path: BoundedCspPath
     readers: Dict[str, ToolReportReader]

--- a/user_tools/src/spark_rapids_tools/api_v1/wrapper/prof_handler.py
+++ b/user_tools/src/spark_rapids_tools/api_v1/wrapper/prof_handler.py
@@ -15,7 +15,7 @@
 """
 Module that contains the definition of the Profiling wrapper result handler.
 """
-
+import re
 from dataclasses import dataclass
 
 from spark_rapids_tools import override
@@ -26,6 +26,12 @@ from spark_rapids_tools.api_v1.result_handler import register_result_class, Resu
 @register_result_class('profWrapperOutput')
 @dataclass
 class ProfWrapperResultHandler(ResultHandler):
+    """
+    Result handler for the profiling wrapper module. This handler is used to manage
+    the final output of the profiling CLI cmd.
+    """
+    class Meta(ResultHandler.Meta):    # pylint: disable=too-few-public-methods
+        id_regex = re.compile(r'prof_[0-9]+_[0-9a-zA-Z]+')
 
     @property
     def core_reader(self) -> ToolReportReader:

--- a/user_tools/src/spark_rapids_tools/api_v1/wrapper/qual_handler.py
+++ b/user_tools/src/spark_rapids_tools/api_v1/wrapper/qual_handler.py
@@ -15,7 +15,7 @@
 """
 Module that contains the definition of the Qualification wrapper result handler.
 """
-
+import re
 from dataclasses import dataclass
 
 from spark_rapids_tools import override
@@ -26,6 +26,12 @@ from spark_rapids_tools.api_v1.result_handler import register_result_class, Resu
 @register_result_class('qualWrapperOutput')
 @dataclass
 class QualWrapperResultHandler(ResultHandler):
+    """
+    Result handler for the qualification wrapper module. This handler is used to manage
+    the final output of the qualification process (qualification + prediction)
+    """
+    class Meta(ResultHandler.Meta):    # pylint: disable=too-few-public-methods
+        id_regex = re.compile(r'qual_[0-9]+_[0-9a-zA-Z]+')
 
     @property
     def core_reader(self) -> ToolReportReader:

--- a/user_tools/src/spark_rapids_tools/cmdli/dev_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/dev_cli.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """CLI to run development related tools."""
-
+from typing import Optional
 
 import fire
 
@@ -39,7 +39,7 @@ class DevCLI(object):  # pylint: disable=too-few-public-methods
                            jvm_threads: int = None,
                            tools_config_file: str = None,
                            verbose: bool = None,
-                           **rapids_options) -> None:
+                           **rapids_options) -> Optional[str]:
         """The Core Qualification cmd.
 
         :param eventlogs: Event log filenames, CSP storage directories containing event logs
@@ -57,6 +57,7 @@ class DevCLI(object):  # pylint: disable=too-few-public-methods
                https://github.com/NVIDIA/spark-rapids-tools/tree/main/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid
         :param verbose: True or False to enable verbosity of the script.
         :param rapids_options: A list of valid Qualification tool options.
+        :return: The output folder where the qualification results are stored.
         """
         if verbose:
             ToolLogging.enable_debug_mode()
@@ -78,6 +79,8 @@ class DevCLI(object):  # pylint: disable=too-few-public-methods
                                                 wrapper_options=qual_args,
                                                 rapids_options=rapids_options)
             tool_obj.launch()
+            return tool_obj.output_folder
+        return None
 
     def profiling_core(self,
                        eventlogs: str = None,
@@ -88,7 +91,7 @@ class DevCLI(object):  # pylint: disable=too-few-public-methods
                        jvm_threads: int = None,
                        tools_config_file: str = None,
                        verbose: bool = None,
-                       **rapids_options):
+                       **rapids_options) -> Optional[str]:
         """The Core Profiling cmd runs the profiling tool JAR directly with minimal processing.
 
         This is a simplified version for development and testing purposes that directly executes
@@ -109,6 +112,7 @@ class DevCLI(object):  # pylint: disable=too-few-public-methods
                https://github.com/NVIDIA/spark-rapids-tools/tree/main/user_tools/tests/spark_rapids_tools_ut/resources/tools_config/valid
         :param verbose: True or False to enable verbosity of the script.
         :param rapids_options: A list of valid Profiling tool options.
+        :return: The output folder where the profiling results are stored.
         """
         if verbose:
             ToolLogging.enable_debug_mode()
@@ -130,6 +134,8 @@ class DevCLI(object):  # pylint: disable=too-few-public-methods
                                             wrapper_options=prof_args,
                                             rapids_options=rapids_options)
             tool_obj.launch()
+            return tool_obj.output_folder
+        return None
 
     def generate_instance_description(self,
                                       platform: str = None,

--- a/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
+++ b/user_tools/src/spark_rapids_tools/cmdli/tools_cli.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """CLI to run tools associated with RAPIDS Accelerator for Apache Spark plugin."""
-
+from typing import Optional
 
 import fire
 
@@ -51,7 +51,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                       target_cluster_info: str = None,
                       tuning_configs: str = None,
                       qualx_config: str = None,
-                      **rapids_options) -> None:
+                      **rapids_options) -> Optional[str]:
         """The Qualification cmd provides estimated speedups by migrating Apache Spark applications
         to GPU accelerated clusters.
 
@@ -104,6 +104,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         :param qualx_config: Path to a qualx-conf.yaml file to use for configuration.
                If not provided, the wrapper will use the default:
                https://github.com/NVIDIA/spark-rapids-tools/blob/main/user_tools/src/spark_rapids_pytools/resources/qualx-conf.yaml.
+        :return: The output folder where the qualification tool output is stored.
+        :rtype: Optional[str]
         """
         eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
         platform = Utils.get_value_or_pop(platform, rapids_options, 'p')
@@ -145,6 +147,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                             wrapper_options=qual_args,
                                             rapids_options=rapids_options)
             tool_obj.launch()
+            return tool_obj.output_folder
         return None
 
     def profiling(self,
@@ -160,7 +163,7 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                   tools_config_file: str = None,
                   target_cluster_info: str = None,
                   tuning_configs: str = None,
-                  **rapids_options):
+                  **rapids_options) -> Optional[str]:
         """The Profiling cmd provides information which can be used for debugging and profiling
         Apache Spark applications running on GPU accelerated clusters.
 
@@ -202,6 +205,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
         :param tuning_configs: Path to a YAML file that contains the tuning configurations.
                 For sample tuning configs files, please visit
                 https://github.com/NVIDIA/spark-rapids-tools/tree/main/core/src/main/resources/bootstrap/tuningConfigs.yaml
+        :return: The output folder where the profiling tool output is stored.
+        :rtype: Optional[str]
         """
         eventlogs = Utils.get_value_or_pop(eventlogs, rapids_options, 'e')
         cluster = Utils.get_value_or_pop(cluster, rapids_options, 'c')
@@ -231,6 +236,8 @@ class ToolsCLI(object):  # pylint: disable=too-few-public-methods
                                         wrapper_options=prof_args,
                                         rapids_options=rapids_options)
             tool_obj.launch()
+            return tool_obj.output_folder
+        return None
 
     def prediction(self,
                    qual_output: str = None,

--- a/user_tools/src/spark_rapids_tools/storagelib/csppath.py
+++ b/user_tools/src/spark_rapids_tools/storagelib/csppath.py
@@ -349,6 +349,17 @@ class CspPath(metaclass=CspPathMeta):
         new_path = f'{self._fpath}{postfix}{sub_path}'
         return CspPath(new_path)
 
+    def to_str_format(self) -> str:
+        """
+        Returns the string representation of the path in a way compatible with
+        the remaining functionalities in the code. For example, modules that do not
+        support remote files, then they shoould use this method to convert
+        LocalFS to normal paths..
+        This is useful for logging and debugging purposes.
+        :return: The string representation of the path.
+        """
+        return str(self)
+
     @property
     def size(self) -> int:
         return self.file_info.size

--- a/user_tools/src/spark_rapids_tools/storagelib/local/localpath.py
+++ b/user_tools/src/spark_rapids_tools/storagelib/local/localpath.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,10 +13,28 @@
 # limitations under the License.
 
 """Wrapper implementation for local path"""
+from typing import override
 
 from ..csppath import register_path_class, CspPath
 
 
 @register_path_class('local')
 class LocalPath(CspPath):
+    """
+    A path implementation for the local file system. This class is used to represent
+    file paths on the local machine. It is a subclass of CspPath and provides
+    a specific implementation for local file paths.
+    """
     protocol_prefix: str = 'file://'
+
+    @override
+    def to_str_format(self) -> str:
+        """
+        Returns the string representation of the path in a way compatible with
+        the remaining functionalities in the code. For example, modules that do not
+        support remote files, then they should use this method to convert
+        LocalFS to normal paths..
+        This is useful for logging and debugging purposes.
+        :return: The string representation of the path.
+        """
+        return self.no_scheme

--- a/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/preprocess.py
@@ -23,6 +23,8 @@ import os
 import re
 
 import pandas as pd
+
+from spark_rapids_tools.api_v1 import APIHelpers
 from spark_rapids_tools.tools.qualx.config import get_config
 from spark_rapids_tools.tools.qualx.util import (
     ensure_directory,
@@ -267,7 +269,7 @@ def load_profiles(
             app_meta = ds_meta['app_meta']
         elif profile_dir is not None:
             # during training/evaluation, we expect profile_dir to point to the qualx_cache
-            profile_paths = glob.glob(f'{profile_dir}/{ds_name}/*')
+            profile_paths = APIHelpers.ProfWrapper.find_report_paths(f'{profile_dir}/{ds_name}')
             # get app_meta, or infer from directory structure of eventlogs
             app_meta = ds_meta.get('app_meta', infer_app_meta(ds_meta['eventlogs']))
         else:

--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_main.py
@@ -935,7 +935,7 @@ def _predict_cli(
         qual = output_dir
     else:
         qual = qual_output
-        qual_handlers.append(APIHelpers.build_qual_core_handler(dir_path=qual_output))
+        qual_handlers.append(APIHelpers.QualCore.build_handler(dir_path=qual_output))
 
     output_info = {
         'perSql': {'path': os.path.join(output_dir, 'per_sql.csv')},


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1836

This pull request introduces a significant refactor and enhancement of the API helper and result handler infrastructure for report management in the RAPIDS tools codebase. The main goals are to provide a more extensible and generic approach to building result handlers, standardize how report directories are discovered, and improve type safety and maintainability. Additionally, the CLI now returns output folder paths for core qualification and profiling commands. The most important changes are grouped below:

### Refactoring and Generalization of API Helpers and Result Handlers

* Introduced a generic `GenericRH` class to standardize the construction of API result handlers, replacing static helper methods with class-based helpers for each report type (e.g., `APIHelpers.QualCore`, `APIHelpers.QualWrapper`, `APIHelpers.ProfWrapper`). This makes handler creation more extensible and type-safe. [[1]](diffhunk://#diff-4740d6cd7e745bd38b4929a7007c33cf621de035d372567eade38353fc0c3ad6L702-R740) [[2]](diffhunk://#diff-4740d6cd7e745bd38b4929a7007c33cf621de035d372567eade38353fc0c3ad6L721-R796)
* Updated usages throughout the codebase to use the new class-based helper methods (e.g., `APIHelpers.QualCore.build_handler`) instead of the old static methods. [[1]](diffhunk://#diff-b0a32bd51bc60911ea7a9d91a6794a312db06d32a1df38c5aeac8243a4f4816fL545-R546) [[2]](diffhunk://#diff-aa62a0cd8e5fad6838d392344bb917b03b499597cf97b69569b0b7e6f3820fd5L41-R41)

### Meta Classes and Report Discovery

* Added `Meta` classes to all result handler classes (`QualCoreResultHandler`, `ProfCoreResultHandler`, `QualWrapperResultHandler`, `ProfWrapperResultHandler`) to hold report identification regexes and provide a unified `find_report_paths` method for locating report directories. [[1]](diffhunk://#diff-dbb2c1a162cfc02df540e84bfba786cc45a6746ddb58881816b82d8fb66e9c7cR30-R35) [[2]](diffhunk://#diff-9ce91b6fe1ca7403c67dacfabf97c179688cebf5465065278bde901882304b80R29-R34) [[3]](diffhunk://#diff-05efb66c3d55254baf629e945c66e7ac16e3b163b0f6b4612731ccd2f50e120dR29-R34) [[4]](diffhunk://#diff-cbd04e961d60a9af6ea2d5d7a3bc7c87e3dc605b122e09725958f3fb7be4062fR29-R34) [[5]](diffhunk://#diff-07eaed260e81f070b4daf5bd6e9fdba7a799f81d3315e96820bd3a79386e6ef8R17-R64) [[6]](diffhunk://#diff-07eaed260e81f070b4daf5bd6e9fdba7a799f81d3315e96820bd3a79386e6ef8R82-R84)
* Centralized the logic for finding report directories by regex pattern in the new `ResultHandlerBaseMeta` class, which is inherited by all result handler `Meta` classes.

### CLI Improvements

* Modified the core qualification and profiling CLI commands (`qualification_core`, `profiling_core`) to return the output folder path where results are stored, improving usability for downstream scripting and automation. [[1]](diffhunk://#diff-23ada65bff3cf99f5c0b8ac6b6c0f1a98b27bf49f8b4675743d3d95e55cd45cdL42-R42) [[2]](diffhunk://#diff-23ada65bff3cf99f5c0b8ac6b6c0f1a98b27bf49f8b4675743d3d95e55cd45cdR60) [[3]](diffhunk://#diff-23ada65bff3cf99f5c0b8ac6b6c0f1a98b27bf49f8b4675743d3d95e55cd45cdR82-R83) [[4]](diffhunk://#diff-23ada65bff3cf99f5c0b8ac6b6c0f1a98b27bf49f8b4675743d3d95e55cd45cdL91-R94) [[5]](diffhunk://#diff-23ada65bff3cf99f5c0b8ac6b6c0f1a98b27bf49f8b4675743d3d95e55cd45cdR115) [[6]](diffhunk://#diff-23ada65bff3cf99f5c0b8ac6b6c0f1a98b27bf49f8b4675743d3d95e55cd45cdR137-R138) [[7]](diffhunk://#diff-b93aac4011b6df99eb1e4ce667e23103255d5b09ee5459438acb8bf4535b7eb5L54-R54)

### API and Import Cleanups

* Updated imports and `__init__.py` exports to expose new types and ensure all relevant handler classes and types are available for API consumers. [[1]](diffhunk://#diff-685c459b50b2a4df268c80d864590f3077716981785b8e145ca0344199ecd9fbR25-R27) [[2]](diffhunk://#diff-685c459b50b2a4df268c80d864590f3077716981785b8e145ca0344199ecd9fbR52) [[3]](diffhunk://#diff-4740d6cd7e745bd38b4929a7007c33cf621de035d372567eade38353fc0c3ad6L25-L28)
* Minor code hygiene improvements, such as adding missing imports and docstrings. [[1]](diffhunk://#diff-9ce91b6fe1ca7403c67dacfabf97c179688cebf5465065278bde901882304b80R17) [[2]](diffhunk://#diff-dbb2c1a162cfc02df540e84bfba786cc45a6746ddb58881816b82d8fb66e9c7cL16-R16) [[3]](diffhunk://#diff-cbd04e961d60a9af6ea2d5d7a3bc7c87e3dc605b122e09725958f3fb7be4062fL18-R18) [[4]](diffhunk://#diff-05efb66c3d55254baf629e945c66e7ac16e3b163b0f6b4612731ccd2f50e120dL18-R18) [[5]](diffhunk://#diff-23ada65bff3cf99f5c0b8ac6b6c0f1a98b27bf49f8b4675743d3d95e55cd45cdL16-R16) [[6]](diffhunk://#diff-b93aac4011b6df99eb1e4ce667e23103255d5b09ee5459438acb8bf4535b7eb5L16-R16)

These changes modernize and streamline the report handler infrastructure, making it easier to extend and maintain as new report types are added.
