### PR TITLE
AutoTuner: Support Custom Core Multiplier Property for Multithread Read

### DIFF
--- a/core/src/main/resources/bootstrap/tuningConfigs.yaml
+++ b/core/src/main/resources/bootstrap/tuningConfigs.yaml
@@ -271,7 +271,7 @@ default:
 
   - name: MULTITHREAD_READ_NUM_THREADS
     description: >-
-      The maximum number of threads on each executor to use for reading small files in parallel.
+      The minimum and maximum number of threads on each executor to use for reading small files in parallel.
     min: 20
     max: 1000
     usedBy: spark.rapids.sql.multiThreadedRead.numThreads

--- a/core/src/main/resources/bootstrap/tuningConfigs.yaml
+++ b/core/src/main/resources/bootstrap/tuningConfigs.yaml
@@ -272,7 +272,8 @@ default:
   - name: MULTITHREAD_READ_NUM_THREADS
     description: >-
       The maximum number of threads on each executor to use for reading small files in parallel.
-    max: 20
+    min: 20
+    max: 1000 # Users can override this value to limit the max number of threads.
     usedBy: spark.rapids.sql.multiThreadedRead.numThreads
 
   - name: MULTITHREAD_READ_CORE_MULTIPLIER

--- a/core/src/main/resources/bootstrap/tuningConfigs.yaml
+++ b/core/src/main/resources/bootstrap/tuningConfigs.yaml
@@ -273,7 +273,7 @@ default:
     description: >-
       The maximum number of threads on each executor to use for reading small files in parallel.
     min: 20
-    max: 1000 # Users can override this value to limit the max number of threads.
+    max: 1000
     usedBy: spark.rapids.sql.multiThreadedRead.numThreads
 
   - name: MULTITHREAD_READ_CORE_MULTIPLIER

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -664,7 +664,6 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
 
             // Calculate cores per executor by dividing the total cores in the instance
             // by the number of GPUs in the instance
-            val recommendedCoresPerExecutor = _recommendedWorkerNode.cores /
             val recommendedCoresPerExecutor = math.ceil(
               _recommendedWorkerNode.cores.toDouble / _recommendedWorkerNode.numGpus
             ).toInt

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -665,7 +665,9 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
             // Calculate cores per executor by dividing the total cores in the instance
             // by the number of GPUs in the instance
             val recommendedCoresPerExecutor = _recommendedWorkerNode.cores /
-              _recommendedWorkerNode.numGpus
+            val recommendedCoresPerExecutor = math.ceil(
+              _recommendedWorkerNode.cores.toDouble / _recommendedWorkerNode.numGpus
+            ).toInt
 
             // Calculate the recommended number of executors by dividing the total number of
             // executors by the recommended cores per executor

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -662,14 +662,25 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
                 _recommendedWorkerNode.numGpus).toInt
             }
 
+            // Calculate cores per executor by dividing the total cores in the instance
+            // by the number of GPUs in the instance
+            val recommendedCoresPerExecutor = _recommendedWorkerNode.cores /
+              _recommendedWorkerNode.numGpus
+
+            // Calculate the recommended number of executors by dividing the total number of
+            // executors by the recommended cores per executor
+            val recommendedNumExecutors =
+              (clusterConfig.coresPerExec * clusterConfig.numExecutors) /
+                recommendedCoresPerExecutor
+
             val dynamicAllocSettings = Platform.getDynamicAllocationSettings(sourceSparkProperties)
             recommendedWorkerNode = Some(_recommendedWorkerNode)
             recommendedClusterInfo = Some(RecommendedClusterInfo(
               vendor = vendor,
-              coresPerExecutor = clusterConfig.coresPerExec,
+              coresPerExecutor = recommendedCoresPerExecutor,
               numWorkerNodes = numWorkerNodes,
               numGpusPerNode = _recommendedWorkerNode.numGpus,
-              numExecutors = clusterConfig.numExecutors,
+              numExecutors = recommendedNumExecutors,
               gpuDevice = _recommendedWorkerNode.gpuDevice.toString,
               dynamicAllocationEnabled = dynamicAllocSettings.enabled,
               dynamicAllocationMaxExecutors = dynamicAllocSettings.max,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -470,7 +470,7 @@ abstract class AutoTuner(
 
   private def getMultithreadReadCoreMultiplierProperty: Option[String] = {
     val coreMultiplierDefs = finalTuningTable.values
-      .filter(_.category == "multithreadReadCoreMultiplier")
+      .filter(_.getCategoryAsEnum == CategoryEnum.MultiThreadReadCoreMultiplier)
     assert(coreMultiplierDefs.size <= 1,
       s"Only one multithread read core multiplier property is allowed. " +
         s"Found: ${coreMultiplierDefs.map(_.label).mkString(", ")}")

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -468,9 +468,14 @@ abstract class AutoTuner(
     }
   }
 
-  def calcNumExecutorCores: Int = {
-    val executorCores = platform.recommendedClusterInfo.map(_.coresPerExecutor).getOrElse(1)
-    Math.max(1, executorCores)
+  private def getMultithreadReadCoreMultiplierProperty: Option[String] = {
+    val coreMultiplierDefs = finalTuningTable.values
+      .filter(_.category == "multithreadReadCoreMultiplier")
+    assert(coreMultiplierDefs.size <= 1,
+      s"Only one multithread read core multiplier property is allowed. " +
+        s"Found: ${coreMultiplierDefs.map(_.label).mkString(", ")}")
+
+    coreMultiplierDefs.headOption.map(_.label)
   }
 
   /**
@@ -757,6 +762,24 @@ abstract class AutoTuner(
   // configuration is like. On prem we don't know so don't set these for now.
   private def configureMultiThreadedReaders(numExecutorCores: Int,
       setMaxBytesInFlight: Boolean): Unit = {
+
+    // Helper function to get the bounded number of threads
+    def getBoundedNumThreads(coreMultiplier: Double): Int = {
+      val numThreads = (numExecutorCores * coreMultiplier).toInt
+      val numThreadsTuningEntry = tuningConfigs.getEntry("MULTITHREAD_READ_NUM_THREADS")
+      Math.max(numThreadsTuningEntry.getMin.toInt,
+        Math.min(numThreadsTuningEntry.getMax.toInt, numThreads))
+    }
+
+    val coreMultiplierProp =
+      getMultithreadReadCoreMultiplierProperty.flatMap(getPropertyValue).map(_.toDouble)
+    // If a core multiplier is defined in the property, use it to calculate
+    // the number of threads for multithreaded reads.
+    if (coreMultiplierProp.isDefined && !platform.isPlatformCSP) {
+      appendRecommendation("spark.rapids.sql.multiThreadedRead.numThreads",
+        getBoundedNumThreads(coreMultiplierProp.get))
+      return
+    }
     if (numExecutorCores < 4) {
       appendRecommendation("spark.rapids.sql.multiThreadedRead.numThreads",
         Math.max(20, numExecutorCores))
@@ -778,10 +801,12 @@ abstract class AutoTuner(
       appendRecommendation("spark.rapids.sql.format.parquet.multithreaded.combine.waitTime",
         tuningConfigs.getEntry("READER_MULTITHREADED_COMBINE_WAIT_TIME").getDefault)
     } else {
-      val numThreads = numExecutorCores * tuningConfigs
-        .getEntry("MULTITHREAD_READ_CORE_MULTIPLIER").getDefault.toInt
+      // For 20+ cores, use the core multiplier defined in tuning configs
+      // to calculate the number of threads for multithreaded reads.
+      val coreMultiplier =
+        tuningConfigs.getEntry("MULTITHREAD_READ_CORE_MULTIPLIER").getDefault.toDouble
       appendRecommendation("spark.rapids.sql.multiThreadedRead.numThreads",
-        Math.max(tuningConfigs.getEntry("MULTITHREAD_READ_NUM_THREADS").getMax.toInt, numThreads))
+        getBoundedNumThreads(coreMultiplier))
       if (platform.isPlatformCSP) {
         if (setMaxBytesInFlight) {
           appendRecommendationForMemoryMB("spark.rapids.shuffle.multiThreaded.maxBytesInFlight",

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -1155,13 +1155,12 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
     assertExpectedLinesExist(expectedResults, autoTunerOutput)
   }
 
-  test("test multithread read core multiplier is specified in the tuning configs") {
-    // Mock properties from event log including the core multiplier property
+  test("test multithread read core multiplier config is specified in the tuning configs") {
+    // Mock properties from event log
     val logEventsProps: mutable.Map[String, String] = mutable.LinkedHashMap[String, String](
       "spark.executor.cores" -> "6",
       "spark.executor.instances" -> "4",
-      "spark.executor.memory" -> "12g",
-      "com.custom.spark.coreMultiplier" -> "2.5"
+      "spark.executor.memory" -> "12g"
     )
 
     // Create target cluster info WITHOUT tuning definitions for the multiplier property

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -984,4 +984,228 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
     // scalastyle:on line.size.limit
     compareOutput(expectedResults, autoTunerOutput)
   }
+
+  test("test multithread read core multiplier category config is specified" +
+    " in the target cluster and defined in tuning definitions") {
+    // Mock properties from event log
+    val logEventsProps: mutable.Map[String, String] = mutable.LinkedHashMap[String, String](
+      "spark.executor.cores" -> "8",
+      "spark.executor.instances" -> "4",
+      "spark.executor.memory" -> "16g"
+    )
+
+    // Define core multiplier property in enforced section
+    val enforcedSparkProperties = Map(
+      "com.custom.spark.coreMultiplier" -> "2.0"
+    )
+
+    // Create tuning definitions for the core multiplier property in the target cluster
+    import scala.collection.JavaConverters._
+    val coreMultiplierTuningDef = TuningEntryDefinition(
+      label = "com.custom.spark.coreMultiplier",
+      description = "Core multiplier property",
+      confType = ConfTypeEnum.Double,
+      level = "cluster",
+      category = "multithreadReadCoreMultiplier"
+    )
+
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      cpuCores = Some(32),
+      memoryGB = Some(128L),
+      gpuCount = Some(1),
+      gpuMemory = Some("24g"),
+      gpuDevice = Some("a100"),
+      enforcedSparkProperties = enforcedSparkProperties,
+      tuningDefinitions = List(coreMultiplierTuningDef).asJava
+    )
+
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
+      logEventsProps, Some(testSparkVersion))
+
+    val platform = PlatformFactory.createInstance(PlatformNames.ONPREM, Some(targetClusterInfo))
+    platform.configureClusterInfoFromEventLog(
+      coresPerExecutor = 8,
+      execsPerNode = 1,
+      numExecs = 4,
+      numExecutorNodes = 4,
+      sparkProperties = logEventsProps.toMap,
+      systemProperties = Map.empty
+    )
+
+    val autoTuner = buildAutoTunerForTests(infoProvider, platform)
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+
+    // With multiplier of 2.0 -> From target cluster
+    // Expected results should reflect this multiplier in calculations:
+    // - multiThreadedRead.numThreads = 32 * 2.0 = 64
+    val expectedResults = Seq(
+      "--conf com.custom.spark.coreMultiplier=2.0",
+      "--conf spark.rapids.sql.multiThreadedRead.numThreads=64",
+      "- 'com.custom.spark.coreMultiplier' was user-enforced in the target cluster properties."
+    )
+
+    assertExpectedLinesExist(expectedResults, autoTunerOutput)
+  }
+
+  test("test multithread read core multiplier category config is specified" +
+    " in the event log and defined in tuning definitions") {
+    // Mock properties from event log including the core multiplier property
+    val logEventsProps: mutable.Map[String, String] = mutable.LinkedHashMap[String, String](
+      "spark.executor.cores" -> "4",
+      "spark.executor.instances" -> "8",
+      "spark.executor.memory" -> "8g",
+      "com.custom.spark.coreMultiplier" -> "3.0"
+    )
+
+    // Create tuning definitions for the core multiplier property
+    import scala.collection.JavaConverters._
+    val coreMultiplierTuningDef = TuningEntryDefinition(
+      label = "com.custom.spark.coreMultiplier",
+      description = "Core multiplier property",
+      confType = ConfTypeEnum.Double,
+      level = "cluster",
+      category = "multithreadReadCoreMultiplier"
+    )
+
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      cpuCores = Some(32),
+      memoryGB = Some(128L),
+      gpuCount = Some(1),
+      gpuMemory = Some("24g"),
+      gpuDevice = Some("a100"),
+      tuningDefinitions = List(coreMultiplierTuningDef).asJava
+    )
+
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
+      logEventsProps, Some(testSparkVersion))
+
+    val platform = PlatformFactory.createInstance(PlatformNames.ONPREM, Some(targetClusterInfo))
+    platform.configureClusterInfoFromEventLog(
+      coresPerExecutor = 4,
+      execsPerNode = 1,
+      numExecs = 8,
+      numExecutorNodes = 8,
+      sparkProperties = logEventsProps.toMap,
+      systemProperties = Map.empty
+    )
+
+    val autoTuner = buildAutoTunerForTests(infoProvider, platform)
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+
+    // With multiplier of 3.0 -> From event log
+    // Expected results should reflect this multiplier in calculations:
+    // - multiThreadedRead.numThreads = 32 * 3.0 = 96
+    val expectedResults = Seq(
+      "--conf spark.rapids.sql.multiThreadedRead.numThreads=96"
+    )
+
+    assertExpectedLinesExist(expectedResults, autoTunerOutput)
+
+    // Verify the multiplier property is not in recommendations since it's unchanged
+    assert(!autoTunerOutput.contains("--conf com.custom.spark.coreMultiplier=3.0"),
+      "Core multiplier property should not appear in recommendations when unchanged from event log")
+  }
+
+  test("test multithread read core multiplier category config is specified" +
+    " in the event log and but not defined in tuning definitions") {
+    // Mock properties from event log including the core multiplier property
+    val logEventsProps: mutable.Map[String, String] = mutable.LinkedHashMap[String, String](
+      "spark.executor.cores" -> "6",
+      "spark.executor.instances" -> "4",
+      "spark.executor.memory" -> "12g",
+      "com.custom.spark.coreMultiplier" -> "2.5"
+    )
+
+    // Create target cluster info WITHOUT tuning definitions for the multiplier property
+    // This means the multiplier should be ignored
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      cpuCores = Some(32),
+      memoryGB = Some(128L),
+      gpuCount = Some(1),
+      gpuMemory = Some("24g"),
+      gpuDevice = Some("a100")
+    )
+
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
+      logEventsProps, Some(testSparkVersion))
+
+    val platform = PlatformFactory.createInstance(PlatformNames.ONPREM, Some(targetClusterInfo))
+    platform.configureClusterInfoFromEventLog(
+      coresPerExecutor = 6,
+      execsPerNode = 1,
+      numExecs = 4,
+      numExecutorNodes = 4,
+      sparkProperties = logEventsProps.toMap,
+      systemProperties = Map.empty
+    )
+
+    val autoTuner = buildAutoTunerForTests(infoProvider, platform)
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+
+    // With NO multiplier specified as property -> Use default multiplier from tuning configs
+    // Expected results should reflect normal core calculations
+    // - multiThreadedRead.numThreads = 32 * 2 = 64
+    val expectedResults = Seq(
+      "--conf spark.rapids.sql.multiThreadedRead.numThreads=64"
+    )
+
+    assertExpectedLinesExist(expectedResults, autoTunerOutput)
+  }
+
+  test("test multithread read core multiplier is specified in the tuning configs") {
+    // Mock properties from event log including the core multiplier property
+    val logEventsProps: mutable.Map[String, String] = mutable.LinkedHashMap[String, String](
+      "spark.executor.cores" -> "6",
+      "spark.executor.instances" -> "4",
+      "spark.executor.memory" -> "12g",
+      "com.custom.spark.coreMultiplier" -> "2.5"
+    )
+
+    // Create target cluster info WITHOUT tuning definitions for the multiplier property
+    // This means the multiplier should be ignored
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      cpuCores = Some(32),
+      memoryGB = Some(128L),
+      gpuCount = Some(1),
+      gpuMemory = Some("24g"),
+      gpuDevice = Some("a100")
+    )
+
+    val defaultTuningConfigsEntries = List(
+      TuningConfigEntry(name = "MULTITHREAD_READ_CORE_MULTIPLIER", default = "5"),
+      TuningConfigEntry(name = "MULTITHREAD_READ_NUM_THREADS", max = "100")
+    )
+    val userProvidedTuningConfigs = ToolTestUtils.buildTuningConfigs(
+      default = defaultTuningConfigsEntries)
+
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
+      logEventsProps, Some(testSparkVersion))
+
+    val platform = PlatformFactory.createInstance(PlatformNames.ONPREM, Some(targetClusterInfo))
+    platform.configureClusterInfoFromEventLog(
+      coresPerExecutor = 6,
+      execsPerNode = 1,
+      numExecs = 4,
+      numExecutorNodes = 4,
+      sparkProperties = logEventsProps.toMap,
+      systemProperties = Map.empty
+    )
+
+    val autoTuner = buildAutoTunerForTests(infoProvider, platform,
+      userProvidedTuningConfigs = Some(userProvidedTuningConfigs))
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+
+    // Use the multiplier from the user-provided tuning configs
+    // Expected results should reflect normal core calculations
+    // - multiThreadedRead.numThreads = min(100, 32 * 5) = 100
+    val expectedResults = Seq(
+      "--conf spark.rapids.sql.multiThreadedRead.numThreads=100"
+    )
+
+    assertExpectedLinesExist(expectedResults, autoTunerOutput)
+  }
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -1005,8 +1005,8 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
       label = "com.custom.spark.coreMultiplier",
       description = "Core multiplier property",
       confType = ConfTypeEnum.Double,
-      level = "cluster",
-      category = "multithreadReadCoreMultiplier"
+      level = LevelEnum.Cluster,
+      category = CategoryEnum.MultiThreadReadCoreMultiplier
     )
 
     val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
@@ -1064,8 +1064,8 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
       label = "com.custom.spark.coreMultiplier",
       description = "Core multiplier property",
       confType = ConfTypeEnum.Double,
-      level = "cluster",
-      category = "multithreadReadCoreMultiplier"
+      level = LevelEnum.Cluster,
+      category = CategoryEnum.MultiThreadReadCoreMultiplier
     )
 
     val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(


### PR DESCRIPTION
Fixes #1869 

## Problem

Currently, AutoTuner uses an internal `MULTITHREAD_READ_CORE_MULTIPLIER` config to determine the effective cores, which is then used to set `spark.rapids.sql.multiThreadedRead.numThreads`. However, in some cases, customers have a custom spark properties that can be used as core multipliers.

**Example:**
```bash
--conf com.mycompany.spark.coreMultiplier=2.5
```

### Solution

This PR allow AutoTuner to use customer-defined core multiplier property instead of `MULTITHREAD_READ_CORE_MULTIPLIER` for calculating num threads.

## Usage:
1. Define Target Cluster with the custom spark property in category `multiThreadReadCoreMultiplier`
```yaml
# Example Target Cluster
workerInfo:
    cpuCores: 20
    memoryGB: 120
    gpu:
      memoryGB: 48
      count: 1
      name: l20
sparkProperties:
  enforced:
    spark.rapids.memory.host.offHeapLimit.enabled: true
    spark.rapids.memory.host.offHeapLimit.size: 80g
  tuningDefinitions:
    - label: com.mycompany.spark.coreMultiplier
      level: job
      category: multiThreadReadCoreMultiplier
      confType:
        name: int
```

2. Run Tools CLI
   - If the event log contains `com.mycompany.spark.coreMultiplier`, it will be used to calculate numThreads else value from `MULTITHREAD_READ_CORE_MULTIPLIER` will be used.
   - Else, specify `com.mycompany.spark.coreMultiplier` in target cluster to use that property.
   - Also, see unit tests which cover these cases.

## Features

-  Introduced `CategoryEnum.MultiThreadReadCoreMultiplier` to identify properties that can be used as custom core multipliers
- Core multipliers can now be specified in:
  - Target cluster enforced properties
  - Event log properties
  - User-provided tuning configurations
- New `getBoundedNumThreads()` helper function ensures thread counts respect min/max limits from tuning configurations
- New Enums: 
  - `CategoryEnum`: `Functionality`, `Tuning`, `MultiThreadReadCoreMultiplier`
  - `LevelEnum`: `Job`, `Cluster`

## Test Coverage

1. Core multiplier config is specified in the target cluster and defined in tuning definitions
2. Core multiplier config is specified in the event log and defined in tuning definitions
4. Fallback when multiplier property exists but is not defined in tuning definitions
5. Core multiplier config is specified in the tuning configs
