### PR TITLE
Use enforced offheapLimit.size for pinned memory 

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -678,7 +678,10 @@ abstract class AutoTuner(
         isOffHeapLimitUserEnabled) {
         if (platform.getUserEnforcedSparkProperty("spark.rapids.memory.host.offHeapLimit.size").isDefined) {
           StringUtils.convertToMB(
-            platform.getUserEnforcedSparkProperty("spark.rapids.memory.host.offHeapLimit.size").get,
+        val userOffHeapLimitOpt = platform.getUserEnforcedSparkProperty("spark.rapids.memory.host.offHeapLimit.size")
+        if (userOffHeapLimitOpt.isDefined) {
+          StringUtils.convertToMB(
+            userOffHeapLimitOpt.get,
             Some(ByteUnit.BYTE))
         } else {
           executorMemOverhead + sparkOffHeapMemMB

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -677,7 +677,9 @@ abstract class AutoTuner(
       val hostOffHeapLimitSizeMB = if (!platform.isPlatformCSP &&
         isOffHeapLimitUserEnabled) {
         if (platform.getUserEnforcedSparkProperty("spark.rapids.memory.host.offHeapLimit.size").isDefined) {
-          platform.getUserEnforcedSparkProperty("spark.rapids.memory.host.offHeapLimit.size").get.toLong
+          StringUtils.convertToMB(
+            platform.getUserEnforcedSparkProperty("spark.rapids.memory.host.offHeapLimit.size").get,
+            Some(ByteUnit.BYTE))
         } else {
           executorMemOverhead + sparkOffHeapMemMB
         }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -676,7 +676,11 @@ abstract class AutoTuner(
       // (only for onPrem when offHeapLimit is enabled)
       val hostOffHeapLimitSizeMB = if (!platform.isPlatformCSP &&
         isOffHeapLimitUserEnabled) {
-        executorMemOverhead + sparkOffHeapMemMB
+        if (platform.getUserEnforcedSparkProperty("spark.rapids.memory.host.offHeapLimit.size").isDefined) {
+          platform.getUserEnforcedSparkProperty("spark.rapids.memory.host.offHeapLimit.size").get.toLong
+        } else {
+          executorMemOverhead + sparkOffHeapMemMB
+        }
       } else {
         0L // Not used for CSP platforms or when offHeapLimit is disabled
       }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -676,8 +676,6 @@ abstract class AutoTuner(
       // (only for onPrem when offHeapLimit is enabled)
       val hostOffHeapLimitSizeMB = if (!platform.isPlatformCSP &&
         isOffHeapLimitUserEnabled) {
-        if (platform.getUserEnforcedSparkProperty("spark.rapids.memory.host.offHeapLimit.size").isDefined) {
-          StringUtils.convertToMB(
         val userOffHeapLimitOpt = platform.getUserEnforcedSparkProperty("spark.rapids.memory.host.offHeapLimit.size")
         if (userOffHeapLimitOpt.isDefined) {
           StringUtils.convertToMB(

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -676,7 +676,8 @@ abstract class AutoTuner(
       // (only for onPrem when offHeapLimit is enabled)
       val hostOffHeapLimitSizeMB = if (!platform.isPlatformCSP &&
         isOffHeapLimitUserEnabled) {
-        val userOffHeapLimitOpt = platform.getUserEnforcedSparkProperty("spark.rapids.memory.host.offHeapLimit.size")
+        val userOffHeapLimitOpt = platform
+          .getUserEnforcedSparkProperty("spark.rapids.memory.host.offHeapLimit.size")
         if (userOffHeapLimitOpt.isDefined) {
           StringUtils.convertToMB(
             userOffHeapLimitOpt.get,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -1576,7 +1576,7 @@ abstract class AutoTuner(
 
   /**
    * Calculate recommended pinned memory size using the new formula:
-   * min (2 * spark executor cores * GPU batch size, 1/4 * host.offHeapLimit.Size)
+   * pinned pool-offHeap ratio * host.offHeapLimit.Size for onPrem platform.
    *
    * Note: This new formula is only used for onPrem platform.
    * For CSP platforms, the original calculation is used.

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -719,7 +719,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.plugins=com.nvidia.spark.SQLPlugin
           |--conf spark.rapids.memory.host.offHeapLimit.enabled=true
           |--conf spark.rapids.memory.host.offHeapLimit.size=80g
-          |--conf spark.rapids.memory.pinnedPool.size=48640m
+          |--conf spark.rapids.memory.pinnedPool.size=40g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=30
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=30
           |--conf spark.rapids.sql.batchSizeBytes=1g


### PR DESCRIPTION
This is a fixing to PR https://github.com/NVIDIA/spark-rapids-tools/pull/1842.
When setting enforced offHeapLimit.size, the original code used memoryOverhead+offHeap as the offHeadLimit size. It recommended a wrong pinnedMemory.
Check the enforced offHeapLimit.size, if it exists, use the value directly, otherwise using the original memoryOverhead+offHeap.
