### PR TITLE
Prefetching dependency jars for python unit tests

### DIFF
--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -20,8 +20,33 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  build:
+  prepare-deps:
     runs-on: ubuntu-latest
+    env:
+      RAPIDS_USER_TOOLS_CACHE_FOLDER: ${{ github.workspace }}/.cache/spark_rapids_user_tools_cache
+    steps:
+      - name: Checkout code
+        uses: NVIDIA/spark-rapids-common/checkout@main
+
+      - name: Prefetch heavy on-prem dependency artifacts
+        shell: bash
+        run: |
+          chmod +x scripts/prefetch_deps.sh
+          scripts/prefetch_deps.sh "$RAPIDS_USER_TOOLS_CACHE_FOLDER" "onprem,dataproc,emr,databricks_aws,databricks_azure" "user_tools/src/spark_rapids_pytools/resources"
+
+      - name: Upload RAPIDS cache artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rapids-cache
+          path: ${{ env.RAPIDS_USER_TOOLS_CACHE_FOLDER }}
+
+  build:
+    needs: prepare-deps
+    runs-on: ubuntu-latest
+    env:
+      # Ensure all runtime downloads (Spark archives, jars, temp build artifacts) land in a
+      # repo-local cache folder so they can be restored across matrix jobs via actions/cache
+      RAPIDS_USER_TOOLS_CACHE_FOLDER: ${{ github.workspace }}/.cache/spark_rapids_user_tools_cache
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
@@ -34,6 +59,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Restore RAPIDS cache artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: rapids-cache
+          path: ${{ env.RAPIDS_USER_TOOLS_CACHE_FOLDER }}
 
       - name: Install tox
         run: |

--- a/scripts/prefetch_deps.sh
+++ b/scripts/prefetch_deps.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Prefetch heavy dependency artifacts (Spark archives, Hadoop/GCS/Azure jars) used by unit tests
+# Usage: scripts/prefetch_deps.sh [CACHE_DIR] [PLATFORMS] [CONFIG_DIR]
+#
+# Arguments:
+#   CACHE_DIR  -> Target folder for cached artifacts
+#   PLATFORMS  -> Comma-separated list of platform keys matching <platform>-configs.json
+#                  e.g. "onprem,dataproc,databricks_aws,databricks_azure"
+#   CONFIG_DIR -> Directory containing the *-configs.json files
+#
+# Defaults:
+#   CACHE_DIR  -> $RAPIDS_USER_TOOLS_CACHE_FOLDER or ./.cache/spark_rapids_user_tools_cache
+#   PLATFORMS  -> onprem
+#   CONFIG_DIR -> user_tools/src/spark_rapids_pytools/resources
+
+set -euo pipefail
+
+CACHE_DIR="${1:-${RAPIDS_USER_TOOLS_CACHE_FOLDER:-}}"
+PLATFORMS_CSV="${2:-onprem}"
+CONFIG_DIR="${3:-user_tools/src/spark_rapids_pytools/resources}"
+
+if [[ -z "${CACHE_DIR}" ]]; then
+  CACHE_DIR="$(pwd)/.cache/spark_rapids_user_tools_cache"
+fi
+
+mkdir -p "${CACHE_DIR}"
+
+if [[ ! -d "${CONFIG_DIR}" ]]; then
+  echo "Config directory not found: ${CONFIG_DIR}" >&2
+  exit 1
+fi
+
+echo "Prefetching dependencies into: ${CACHE_DIR}"
+echo "Platforms: ${PLATFORMS_CSV}"
+echo "Config directory: ${CONFIG_DIR}"
+
+# Use Python to parse per-platform JSON config(s) and collect URIs from the
+# defined structure: dependencies -> deployMode -> LOCAL -> <activeBuildVer>: [ { uri } ]
+# If activeBuildVer is not set, the highest available numeric version key is used.
+readarray -t URIS < <(python - "$PLATFORMS_CSV" "$CONFIG_DIR" <<'PY'
+import json, os, sys
+
+platforms_csv = sys.argv[1]
+config_dir = sys.argv[2]
+platforms = [p.strip() for p in platforms_csv.split(',') if p.strip()]
+
+uris = []
+seen = set()
+
+for platform in platforms:
+    cfg = os.path.join(config_dir, f"{platform}-configs.json")
+    if not os.path.isfile(cfg):
+        # Silently skip unknown platform files to keep CI robust
+        continue
+    try:
+        with open(cfg, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except Exception:
+        continue
+    deps_local = data.get('dependencies', {}).get('deployMode', {}).get('LOCAL', {})
+    if not isinstance(deps_local, dict):
+        continue
+    active_ver = deps_local.get('activeBuildVer')
+    numeric_versions = [k for k, v in deps_local.items() if isinstance(k, str) and k.isdigit() and isinstance(v, list)]
+    if not active_ver or active_ver not in deps_local:
+        try:
+            active_ver = max(numeric_versions, key=lambda x: int(x)) if numeric_versions else None
+        except ValueError:
+            active_ver = None
+    if active_ver and isinstance(deps_local.get(active_ver), list):
+        for it in deps_local[active_ver]:
+            if isinstance(it, dict):
+                uri = it.get('uri')
+                if isinstance(uri, str) and uri and uri not in seen:
+                    seen.add(uri)
+                    uris.append(uri)
+
+for u in uris:
+    print(u)
+PY
+)
+
+echo "Found ${#URIS[@]} URIs to prefetch"
+
+for url in "${URIS[@]}"; do
+  fname="$(basename "${url}")"
+  dest="${CACHE_DIR}/${fname}"
+  if [[ -f "${dest}" ]]; then
+    echo "Already cached: ${fname}"
+    continue
+  fi
+  echo "Downloading: ${url} -> ${dest}"
+  curl -L --retry 3 --retry-delay 5 -o "${dest}" "${url}"
+done
+
+echo "Prefetch complete. Files in ${CACHE_DIR}:"
+ls -lh "${CACHE_DIR}" || true

--- a/user_tools/tox.ini
+++ b/user_tools/tox.ini
@@ -42,6 +42,9 @@ deps =
 extras = test
 setenv =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
+passenv =
+    # propagate RAPIDS_USER_TOOLS_* environment variables configured in GitHub Actions
+    RAPIDS_USER_TOOLS_*
 commands =
     pytest -vv \
     --cov "{envsitepackagesdir}/spark_rapids_pytools" \
@@ -97,7 +100,9 @@ per-file-ignores = src/spark_rapids_tools/utils/compat.py:F401
 
 [testenv:behave]
 deps = behave
-passenv	= JAVA_HOME
+passenv	=
+    JAVA_HOME
+    RAPIDS_USER_TOOLS_*
 extras = dev-env
 depends =
     prepare


### PR DESCRIPTION
Fixes #1798 

### Issue
- Tools behave tests use the spark and hadoop jars as part of their run
- These jars are used as a dependency by the core module
- As part of tox runs, each individual behave trigger, downloads the spark and hadoop jar which becomes a huge bottleneck for the test

### Solution
- This PR adds a prefetch step to the python workflow.
- The prefetch goes through the platform config files ( where the jar URIs are defined )
- And downloads the jars once and upload them as a temp artifact
- This temp artifact is then downloaded in the underlying python tests and used as a cache folder
- This skips the download since the target download location already has the files
- Also makes the individual runs consistent throughout