### PR TITLE
Unify the status CSV label across the tools

### DIFF
--- a/core/docs/qual_core_output.md
+++ b/core/docs/qual_core_output.md
@@ -71,7 +71,7 @@ The output files are defined in the following format:
   * description: column description.
 
 
-### qualCoreCSVStatus
+### coreCSVStatus
 
 * _Scope_: global
 * _File name_: status.csv

--- a/core/src/main/resources/configs/reports/profCoreReport.yaml
+++ b/core/src/main/resources/configs/reports/profCoreReport.yaml
@@ -25,7 +25,7 @@ reportDefinitions:
       - reportId: coreRawMetrics
     tableDefinitions:
       # AppStatusResult
-      - label: profCoreCSVStatus
+      - label: coreCSVStatus
         description: >-
           Status of each eventlog passed to the profiling tool.
           The status is either success, failure, skipped, or unknown (failure).

--- a/core/src/main/resources/configs/reports/qualCoreReport.yaml
+++ b/core/src/main/resources/configs/reports/qualCoreReport.yaml
@@ -71,7 +71,7 @@ reportDefinitions:
             dataType: String
             description: >-
               The value of the property
-      - label: qualCoreCSVStatus
+      - label: coreCSVStatus
         description: >-
           Status of each eventlog passed to the qualification tool.
           The status is either success, failure, skipped, or unknown (failure).

--- a/core/src/main/resources/configs/reports/qualOutputTable.yaml
+++ b/core/src/main/resources/configs/reports/qualOutputTable.yaml
@@ -44,7 +44,7 @@
 #        ├── unsupported_operators.csv
 
 qualTableDefinitions:
-  - label: qualCoreCSVStatus
+  - label: coreCSVStatus
     description: >-
       Status of each eventlog passed to the qualification tool.
       The status is either success, failure, skipped, or unknown (failure).

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/qualification/QualToolReportGenerator.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/qualification/QualToolReportGenerator.scala
@@ -196,7 +196,7 @@ object QualToolReportGenerator extends QualReportGeneratorTrait[QualToolResult] 
       reportConfigs: Map[String, String],
       qualToolResult: QualToolResult): Unit = {
     val table = tableMeta.label match {
-      case "qualCoreCSVStatus" => new QualToolStatusTable(tableMeta, rootDirectory, hadoopConf)
+      case "coreCSVStatus" => new QualToolStatusTable(tableMeta, rootDirectory, hadoopConf)
       case "qualCoreCSVSummary" => new QualToolSummaryTable(tableMeta, rootDirectory, hadoopConf)
       case _ =>
         throw new IllegalArgumentException(

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationNoSparkSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationNoSparkSuite.scala
@@ -111,7 +111,7 @@ class QualificationNoSparkSuite extends BaseNoSparkSuite {
           .withExpectedCounts(StatusReportCounts(0, 0, 1, 0)))
       .withChecker(
         QToolOutFileCheckerImpl("Content of status file")
-          .withTableLabel("qualCoreCSVStatus")
+          .withTableLabel("coreCSVStatus")
           .withExpectedRows("expect only 1 row", 1)
           .withContentVisitor("Columns are correct while AppID might not be set",
             csvContainer => {
@@ -620,7 +620,7 @@ class QualificationNoSparkSuite extends BaseNoSparkSuite {
       .withChecker(
         QToolOutFileCheckerImpl("check the content of status file")
           .withExpectedRows("4 rows in the status", 4)
-          .withTableLabel("qualCoreCSVStatus")
+          .withTableLabel("coreCSVStatus")
           .withContentVisitor(
             "AttemptId [1, 3] should have description stating that they are skipped",
             csvContainer => {

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -465,7 +465,7 @@ class Qualification(QualificationCore):
             c_builder.combiner.on_app_fields({'app_id': 'App ID'})
             unsupported_ops_df = c_builder.build()
 
-        with CSVReport(self.core_handler, _tbl='qualCoreCSVStatus') as status_res:
+        with CSVReport(self.core_handler, _tbl='coreCSVStatus') as status_res:
             apps_status_df = status_res.data
 
         # 4. Operations related to output

--- a/user_tools/src/spark_rapids_tools/api_v1/core/core_reader.py
+++ b/user_tools/src/spark_rapids_tools/api_v1/core/core_reader.py
@@ -33,18 +33,18 @@ class CoreReaderBase(ToolReportReader):
     Base class for core report readers. It provides common functionality
     for reading core reports and loading application descriptions.
     Typically, a core reader has some more specific functionalities and capabilities. For example,
-    1. the core-reader has the reponsibility to list all the AppHandlers that were analyzed by the run.
+    1. the core-reader has the responsibility to list all the AppHandlers analyzed by the run.
     The reason we use a core-reader instead of a wrapper reader is that the core-reader has the
-    actual list of eventlogs. So, it can be used to define all the eventlogPaths and and categorize
+    actual list of eventlogs. So, it can be used to define all the eventlogPaths and categorize
     them into their perspective results.
     2. The core reader can define the version of the core-tools that generated the output results
-    and whether it is compatible
+    and whether it is compatible.
     """
 
     @property
     def _status_tbl(self) -> str:
         """Label for the CSV table in the report."""
-        raise NotImplementedError('Subclasses should implement this method.')
+        return 'coreCSVStatus'
 
     @cached_property
     def apps_status_res(self) -> LoadDFResult:

--- a/user_tools/src/spark_rapids_tools/api_v1/core/prof_reader.py
+++ b/user_tools/src/spark_rapids_tools/api_v1/core/prof_reader.py
@@ -16,7 +16,6 @@
 
 from dataclasses import dataclass
 
-from spark_rapids_tools import override
 from spark_rapids_tools.api_v1.core.core_reader import CoreReaderBase
 from spark_rapids_tools.api_v1.report_reader import register_report_class
 
@@ -27,8 +26,3 @@ class ProfCoreOutput(CoreReaderBase):
     """
     A class that reads the output of the Prof Core tool.
     """
-    @override
-    @property
-    def _status_tbl(self) -> str:
-        """Label for the CSV table in the report."""
-        return 'profCoreCSVStatus'

--- a/user_tools/src/spark_rapids_tools/api_v1/core/qual_reader.py
+++ b/user_tools/src/spark_rapids_tools/api_v1/core/qual_reader.py
@@ -19,7 +19,6 @@ from functools import cached_property
 
 import pandas as pd
 
-from spark_rapids_tools import override
 from spark_rapids_tools.api_v1.core.core_reader import CoreReaderBase
 from spark_rapids_tools.api_v1.report_reader import register_report_class
 
@@ -30,11 +29,6 @@ class QualCoreOutput(CoreReaderBase):
     """
     A class that reads the output of the Qual Core tool.
     """
-    @override
-    @property
-    def _status_tbl(self) -> str:
-        """Label for the CSV table in the report."""
-        return 'qualCoreCSVStatus'
 
     @cached_property
     def apps_summary_df(self) -> pd.DataFrame:

--- a/user_tools/tests/spark_rapids_tools_e2e/features/steps/test_result_handler_steps.py
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/steps/test_result_handler_steps.py
@@ -54,9 +54,9 @@ def step_then_rep_res_is_empty_dict(context, tbl_name):
 
 @then('CSV report result of status-report should fail with exception "{exception_type}"')
 def step_then_rep_res_fails_with_exception(context, exception_type):
-    tbl_name = 'qualCoreCSVStatus'
+    tbl_name = 'coreCSVStatus'
     if context.tools_res_handler.report_id in ['profWrapperOutput', 'profCoreOutput']:
-        tbl_name = 'profCoreCSVStatus'
+        tbl_name = 'coreCSVStatus'
     if not hasattr(context, 'csv_rep_res'):
         context.csv_rep_res = {}
     csv_rep = CSVReport(context.tools_res_handler).table(tbl_name)


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1881

Use the same label `coreCSVStatus` for both prof/qual handlers
This makes it easier for the downstream to consume the dataframe. Otherwise, the downstream has to use different labels depending on the type of the tool
