### PR TITLE
Add tuning summary to the profiler handler API

### DIFF
--- a/user_tools/docs/user-tools-aws-emr.md
+++ b/user_tools/docs/user-tools-aws-emr.md
@@ -209,12 +209,12 @@ A typical workflow to successfully run the `profiling` command in local mode is 
 4. Depending on the accessibility of the cluster properties, the user chooses one of the 2 cases below (_"Case-A"_, and _"Case-B"_) to trigger the CLI.
 
 For each successful execution, the wrapper generates a new directory in the format of
-`prof_<YYYYmmddHHmmss>_<0x%08X>`. The directory contains `profiling_summary.log` in addition to
+`prof_<YYYYmmddHHmmss>_<0x%08X>`. The directory contains `tuning_summary.log` in addition to
 the actual folder of the RAPIDS Profiling tool. The directory will be mirrored to S3 folder if the
 argument `--remote_folder` was a valid S3 path.
 
    ```
-    ./prof_<YYYYmmddHHmmss>_<0x%08X>/profiling_summary.log
+    ./prof_<YYYYmmddHHmmss>_<0x%08X>/tuning_summary.log
     ./prof_<YYYYmmddHHmmss>_<0x%08X>/rapids_4_spark_profile/
    ```
 

--- a/user_tools/docs/user-tools-databricks-aws.md
+++ b/user_tools/docs/user-tools-databricks-aws.md
@@ -214,12 +214,12 @@ A typical workflow to successfully run the `profiling` command in local mode is 
 4. Depending on the accessibility of the cluster properties, the user chooses one of the 2 cases below (_"Case-A"_, and _"Case-B"_) to trigger the CLI.
 
 For each successful execution, the wrapper generates a new directory in the format of
-`prof_<YYYYmmddHHmmss>_<0x%08X>`. The directory contains `profiling_summary.log` in addition to
+`prof_<YYYYmmddHHmmss>_<0x%08X>`. The directory contains `tuning_summary.log` in addition to
 the actual folder of the RAPIDS Profiling tool. The directory will be mirrored to S3 folder if the
 argument `--remote_folder` was a valid S3 path.
 
    ```
-    ./prof_<YYYYmmddHHmmss>_<0x%08X>/profiling_summary.log
+    ./prof_<YYYYmmddHHmmss>_<0x%08X>/tuning_summary.log
     ./prof_<YYYYmmddHHmmss>_<0x%08X>/rapids_4_spark_profile/
    ```
 

--- a/user_tools/docs/user-tools-databricks-azure.md
+++ b/user_tools/docs/user-tools-databricks-azure.md
@@ -216,12 +216,12 @@ A typical workflow to successfully run the `profiling` command in local mode is 
 4. Depending on the accessibility of the cluster properties, the user chooses one of the 2 cases below (_"Case-A"_, and _"Case-B"_) to trigger the CLI.
 
 For each successful execution, the wrapper generates a new directory in the format of
-`prof_<YYYYmmddHHmmss>_<0x%08X>`. The directory contains `profiling_summary.log` in addition to
+`prof_<YYYYmmddHHmmss>_<0x%08X>`. The directory contains `tuning_summary.log` in addition to
 the actual folder of the RAPIDS Profiling tool. The directory will be mirrored to ABFS folder if the
 argument `--remote_folder` was a valid ABFS path.
 
    ```
-    ./prof_<YYYYmmddHHmmss>_<0x%08X>/profiling_summary.log
+    ./prof_<YYYYmmddHHmmss>_<0x%08X>/tuning_summary.log
     ./prof_<YYYYmmddHHmmss>_<0x%08X>/rapids_4_spark_profile/
    ```
 

--- a/user_tools/docs/user-tools-dataproc.md
+++ b/user_tools/docs/user-tools-dataproc.md
@@ -217,12 +217,12 @@ A typical workflow to successfully run the `profiling` command in local mode is 
    cases below (_"Case-A"_, and _"Case-B"_) to trigger the CLI.
 
 For each successful execution, the wrapper generates a new directory in the format of
-`prof_<YYYYmmddHHmmss>_<0x%08X>`. The directory contains `profiling_summary.log` in addition to
+`prof_<YYYYmmddHHmmss>_<0x%08X>`. The directory contains `tuning_summary.log` in addition to
 the actual folder of the RAPIDS Profiling tool. The directory will be mirrored to gs folder if the
 argument `--remote_folder` was a valid gs path.
 
    ```
-    ./prof_<YYYYmmddHHmmss>_<0x%08X>/profiling_summary.log
+    ./prof_<YYYYmmddHHmmss>_<0x%08X>/tuning_summary.log
     ./prof_<YYYYmmddHHmmss>_<0x%08X>/rapids_4_spark_profile/
    ```
 

--- a/user_tools/docs/user-tools-onprem.md
+++ b/user_tools/docs/user-tools-onprem.md
@@ -262,11 +262,11 @@ A typical workflow to successfully run the `profiling` command in local mode is 
 4. User runs profiling tool CLI command.
 
 For each successful execution, the wrapper generates a new directory in the format of
-`prof_<YYYYmmddHHmmss>_<0x%08X>`. The directory contains `profiling_summary.log` in addition to
+`prof_<YYYYmmddHHmmss>_<0x%08X>`. The directory contains `tuning_summary.log` in addition to
 the actual folder of the RAPIDS Profiling tool.
 
    ```
-    ./prof_<YYYYmmddHHmmss>_<0x%08X>/profiling_summary.log
+    ./prof_<YYYYmmddHHmmss>_<0x%08X>/tuning_summary.log
     ./prof_<YYYYmmddHHmmss>_<0x%08X>/rapids_4_spark_profile/
    ```
 

--- a/user_tools/src/spark_rapids_pytools/rapids/profiling.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/profiling.py
@@ -136,7 +136,7 @@ class Profiling(ProfilingCore):
                    app_name,
                    Utils.gen_multiline_str(recommendations),
                    Utils.gen_multiline_str(comments)]
-            log_lines.append(app_id)
+            log_lines.append(f'App ID: {app_id}')
             sec_props = Utils.gen_joined_str(join_elem='\n\t',
                                              items=list(chain(sec_props_head, recommendations)))
             sec_comments = Utils.gen_joined_str(join_elem='\n\t',

--- a/user_tools/src/spark_rapids_pytools/resources/profiling-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/profiling-conf.yaml
@@ -15,7 +15,7 @@
 toolOutput:
   subFolder: rapids_4_spark_profile
   textFormat:
-    log4jFileName: rapids_4_spark_profile_stderr.log
+    log4jFileName: prof_core_stderr.log
   recommendations:
     fileName: profile.log
     headers:
@@ -60,7 +60,7 @@ sparkRapids:
 local:
   output:
     cleanUp: true
-    fileName: profiling_summary.log
+    fileName: tuning_summary.log
     summaryColumns:
       - 'App ID'
       - 'App Name'

--- a/user_tools/src/spark_rapids_pytools/resources/reports/profWrapperReport.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/reports/profWrapperReport.yaml
@@ -22,3 +22,12 @@ reportDefinitions:
     nestedReports:
       - reportId: profCoreOutput
         relativePath: rapids_4_spark_profile
+    tableDefinitions:
+      - label: tuningSummary
+        description: >-
+          Summary of the auto-tuning analysis preformed on the eventlogs. It lists all the applications
+          along with a list of recommended-configurations and comments to help the user understand the
+          recommendations.
+        fileName: tuning_summary.log
+        fileFormat: TXT
+        scope: global


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Contributes to #1882

- Add `tuningSummary` report to the profileWrapper handler.
- Changes the name of the summary file from `profiling_summary.log` to `tuning_summary.log`
- Change the format of the report to include prefix `App ID:` in order to make it easier to break the file down by app IDs

**How to load the tuning recommendations using the ToolsAPI**

```python
prof_handler = APIHelpers.ProfWrapper.build_handler('/path/to/prof_20250827130250_8CdbDa3c')
with TXTReport(prof_handler).table('tuningSummary') as tuner_rep:
    # by default the string is binary format.
    # decode it to get the string (default encoding is utf-8)
    tuning_content = tuner_rep.decode_txt()
    print(tuning_content)
```

<details><summary>Example of the new output file after change:</summary>
<p>

```
### Recommended configurations ###
App ID: application_XYZ_0001
	Spark Properties:
	--conf spark.executor.cores=16
	--conf spark.executor.memory=32g
	--conf spark.executor.memoryOverhead=11468m
	--conf spark.locality.wait=0
	--conf spark.rapids.memory.pinnedPool.size=4g
	--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
	--conf spark.rapids.shuffle.multiThreaded.writer.threads=24
	--conf spark.rapids.sql.batchSizeBytes=2147483647b
	--conf spark.rapids.sql.concurrentGpuTasks=3
	--conf spark.rapids.sql.enabled=true
	--conf spark.rapids.sql.multiThreadedRead.numThreads=32
	--conf spark.shuffle.manager=[FILL_IN_VALUE]
	--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
	--conf spark.sql.adaptive.coalescePartitions.minPartitionNum=16
	--conf spark.sql.adaptive.coalescePartitions.parallelismFirst=false
	--conf spark.sql.files.maxPartitionBytes=529m
	--conf spark.task.resource.gpu.amount=0.001
	Comments:
	- 'spark.executor.memoryOverhead' was not set.
	- 'spark.rapids.memory.pinnedPool.size' was not set.
	- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
	- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
	- 'spark.rapids.sql.batchSizeBytes' was not set.
	- 'spark.rapids.sql.concurrentGpuTasks' was not set.
	- 'spark.rapids.sql.enabled' was not set.
	- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
	- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
	- 'spark.sql.adaptive.coalescePartitions.minPartitionNum' was not set.
	- 'spark.sql.files.maxPartitionBytes' was not set.
	- 'spark.task.resource.gpu.amount' was not set.
	- A newer RAPIDS Accelerator for Apache Spark plugin is available:
	https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/25.08.0/rapids-4-spark_2.12-25.08.0.jar
	Version used in application is 22.12.0.
	- Cannot recommend RAPIDS Shuffle Manager for unsupported Spark version: '3.1.3'.
	To enable RAPIDS Shuffle Manager, use a supported Spark version (e.g., '4.0.0')
	and set: '--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark400.RapidsShuffleManager'.
	See supported versions: https://docs.nvidia.com/spark-rapids/user-guide/latest/additional-functionality/rapids-shuffle.html#rapids-shuffle-manager.
	- The RAPIDS Shuffle Manager requires spark.driver.extraClassPath
	and spark.executor.extraClassPath settings to include the
	path to the Spark RAPIDS plugin jar.
	If the Spark RAPIDS jar is being bundled with your Spark
	distribution, this step is not needed.
```

</p>
</details> 


<details><summary>Example of the new output file before change:</summary>
<p>

```
### Recommended configurations ###
application_XYZ_0001
	Spark Properties:
	--conf spark.executor.cores=16
	--conf spark.executor.memory=32g
	--conf spark.executor.memoryOverhead=11468m
	--conf spark.locality.wait=0
	--conf spark.rapids.memory.pinnedPool.size=4g
	--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
	--conf spark.rapids.shuffle.multiThreaded.writer.threads=24
	--conf spark.rapids.sql.batchSizeBytes=2147483647b
	--conf spark.rapids.sql.concurrentGpuTasks=3
	--conf spark.rapids.sql.enabled=true
	--conf spark.rapids.sql.multiThreadedRead.numThreads=32
	--conf spark.shuffle.manager=[FILL_IN_VALUE]
	--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
	--conf spark.sql.adaptive.coalescePartitions.minPartitionNum=16
	--conf spark.sql.adaptive.coalescePartitions.parallelismFirst=false
	--conf spark.sql.files.maxPartitionBytes=529m
	--conf spark.task.resource.gpu.amount=0.001
	Comments:
	- 'spark.executor.memoryOverhead' was not set.
	- 'spark.rapids.memory.pinnedPool.size' was not set.
	- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
	- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
	- 'spark.rapids.sql.batchSizeBytes' was not set.
	- 'spark.rapids.sql.concurrentGpuTasks' was not set.
	- 'spark.rapids.sql.enabled' was not set.
	- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
	- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
	- 'spark.sql.adaptive.coalescePartitions.minPartitionNum' was not set.
	- 'spark.sql.files.maxPartitionBytes' was not set.
	- 'spark.task.resource.gpu.amount' was not set.
	- A newer RAPIDS Accelerator for Apache Spark plugin is available:
	https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/25.08.0/rapids-4-spark_2.12-25.08.0.jar
	Version used in application is 22.12.0.
	- Cannot recommend RAPIDS Shuffle Manager for unsupported Spark version: '3.1.3'.
	To enable RAPIDS Shuffle Manager, use a supported Spark version (e.g., '4.0.0')
	and set: '--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark400.RapidsShuffleManager'.
	See supported versions: https://docs.nvidia.com/spark-rapids/user-guide/latest/additional-functionality/rapids-shuffle.html#rapids-shuffle-manager.
	- The RAPIDS Shuffle Manager requires spark.driver.extraClassPath
	and spark.executor.extraClassPath settings to include the
	path to the Spark RAPIDS plugin jar.
	If the Spark RAPIDS jar is being bundled with your Spark
	distribution, this step is not needed.
```
</p>
</details>

### Changes in details

This pull request updates the documentation and configuration for the profiling tool to standardize the output summary file name from `profiling_summary.log` to `tuning_summary.log` across all supported environments. It also improves the clarity and usability of the API report builder by enhancing docstrings, context management, and internal attribute handling.

**Documentation and Output File Naming Standardization:**

* Updated all user documentation files (`user-tools-aws-emr.md`, `user-tools-databricks-aws.md`, `user-tools-databricks-azure.md`, `user-tools-dataproc.md`, `user-tools-onprem.md`) to refer to `tuning_summary.log` instead of `profiling_summary.log` as the main summary output file. [[1]](diffhunk://#diff-33c5619ce322ba8ceb6bc4b296a8773c7355630d975fc80e687da154d42ef399L212-R217) [[2]](diffhunk://#diff-50a672d70b6e4c1a157037ea54ac50a2b8a34fb05fdd171795c540c8de16641bL217-R222) [[3]](diffhunk://#diff-d94309212de31480e1e4e882f2761080c9364b041d58ce5272da9c82baf2c506L219-R224) [[4]](diffhunk://#diff-32ac95dc94660643d585d00b6dbf79ac4e061290a503129398daefbaabba51c3L220-R225) [[5]](diffhunk://#diff-c8b3889946e0acc44061a791409c1bfe35b7d98753a50ffe0003721267e1d4c2L265-R269)
* Changed the output file name in the configuration (`profiling-conf.yaml`) from `profiling_summary.log` to `tuning_summary.log` and updated the log4j file name for clarity. [[1]](diffhunk://#diff-288f76442581c0ca5777006664feb82af59a84cb092a2a833bbea5c8e0e626e5L18-R18) [[2]](diffhunk://#diff-288f76442581c0ca5777006664feb82af59a84cb092a2a833bbea5c8e0e626e5L63-R63)
* Added a new table definition for `tuning_summary.log` in `profWrapperReport.yaml` to describe its purpose and usage.

**Profiling Tool Output and Logging Improvements:**

* Modified the profiling tool to log the application ID in a clearer format within the generated summary.

**API Report Builder Enhancements:**

* Enhanced the `APIReport` class with comprehensive docstrings, improved context manager support (`__enter__`, `__exit__`), and more robust load result handling. [[1]](diffhunk://#diff-4740d6cd7e745bd38b4929a7007c33cf621de035d372567eade38353fc0c3ad6L89-R113) [[2]](diffhunk://#diff-4740d6cd7e745bd38b4929a7007c33cf621de035d372567eade38353fc0c3ad6R148-R178)
* Refactored `CSVReport` to remove redundant `load_res` property and context manager methods, relying on the improved base class implementation. [[1]](diffhunk://#diff-4740d6cd7e745bd38b4929a7007c33cf621de035d372567eade38353fc0c3ad6L275-L284) [[2]](diffhunk://#diff-4740d6cd7e745bd38b4929a7007c33cf621de035d372567eade38353fc0c3ad6L362-L383)

