### PR TITLE
Dedupe qualx alignments in more deterministic manner

### DIFF
--- a/user_tools/src/spark_rapids_tools/tools/qualx/qualx_pipeline.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/qualx_pipeline.py
@@ -254,11 +254,12 @@ def train_and_evaluate(
         raise ValueError(f'Alignment CSV missing required columns: {missing_cols}')
 
     # get previous alignment files, if exist
-    prev_alignments = glob.glob(os.path.join(alignment_dir, f'{dataset_basename}_*.csv'))
+    prev_alignments = sorted(glob.glob(os.path.join(alignment_dir, f'{dataset_basename}_*.csv')))
     if len(prev_alignments) > 0:
         # load all previous alignment files, remove duplicates, and mark as processed
         prev_df = pd.concat([pd.read_csv(f) for f in prev_alignments])
-        prev_df = prev_df.drop_duplicates()
+        subset = [col for col in ['appId_cpu', 'sqlID_cpu'] if col in prev_df.columns]
+        prev_df = prev_df.drop_duplicates(subset=subset, keep='last')
         prev_df['processed'] = 1
 
         # merge with current alignment file

--- a/user_tools/src/spark_rapids_tools/tools/qualx/util.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/util.py
@@ -90,7 +90,7 @@ def find_paths(directory: str, filter_fn: Callable = None, return_directories: b
             else:
                 filtered_files = filter(filter_fn, files)
                 paths.extend([os.path.join(root, file) for file in filtered_files])
-    return paths
+    return sorted(paths)
 
 
 def find_eventlogs(path: str) -> List[str]:


### PR DESCRIPTION
This PR fixes #1886 by making reading of datasets more deterministic.

Changes:
- Sort alignment files before reading, keeping current/latest file (without timestamp suffix) at the end of the list.
- Use `drop_duplicates` with `subset` arg to consider `appId_cpu` (and optionally `sqlID_cpu`) vs. entire row, keeping the last of the dupes (by sorted/time order).
- Sort list of dataset JSON files to ensure datasets are read in lexicographic order.

Tests:
- `qualx preprocess`
- `spark_rapids train_and_evaluate`