### PR TITLE
Fix compute_sample_weights when LOG_LABEL=True

### DIFF
--- a/user_tools/src/spark_rapids_tools/tools/qualx/model.py
+++ b/user_tools/src/spark_rapids_tools/tools/qualx/model.py
@@ -133,6 +133,9 @@ def train(
     positive_weight = sample_weight.get('positive', 1.0)
     negative_weight = sample_weight.get('negative', 1.0)
 
+    if LOG_LABEL:
+        threshold = np.log(threshold)
+
     # automatically compute weights (if 'auto' is specified) to balance positive/negative samples
     positive_weight, negative_weight = compute_sample_weights(y_tune, threshold, positive_weight, negative_weight)
 


### PR DESCRIPTION
This PR fixes #1891 by converting the threshold to log domain before invoking compute_sample_weights if LOG_LABEL=True.

Tests:
- qualx train
- spark_rapids train_and_evaluate
