### PR TITLE
Add Qual's support to expressions uuid and mapZipWith

### DIFF
--- a/core/src/main/resources/operatorsScore-databricks-aws-a10G.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws-a10G.csv
@@ -319,3 +319,5 @@ BitwiseCount,1.5
 BitAndAgg,1.5
 BitOrAgg,1.5
 BitXorAgg,1.5
+MapZipWith,1.5
+Uuid,1.5

--- a/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
@@ -319,3 +319,5 @@ BitwiseCount,1.5
 BitAndAgg,1.5
 BitOrAgg,1.5
 BitXorAgg,1.5
+MapZipWith,1.5
+Uuid,1.5

--- a/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
@@ -307,3 +307,5 @@ BitwiseCount,1.5
 BitAndAgg,1.5
 BitOrAgg,1.5
 BitXorAgg,1.5
+MapZipWith,1.5
+Uuid,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
@@ -301,3 +301,5 @@ BitwiseCount,1.5
 BitAndAgg,1.5
 BitOrAgg,1.5
 BitXorAgg,1.5
+MapZipWith,1.5
+Uuid,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
@@ -301,3 +301,5 @@ BitwiseCount,1.5
 BitAndAgg,1.5
 BitOrAgg,1.5
 BitXorAgg,1.5
+MapZipWith,1.5
+Uuid,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-l4.csv
@@ -307,3 +307,5 @@ BitwiseCount,1.5
 BitAndAgg,1.5
 BitOrAgg,1.5
 BitXorAgg,1.5
+MapZipWith,1.5
+Uuid,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
@@ -301,3 +301,5 @@ BitwiseCount,1.5
 BitAndAgg,1.5
 BitOrAgg,1.5
 BitXorAgg,1.5
+MapZipWith,1.5
+Uuid,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-t4.csv
@@ -307,3 +307,5 @@ BitwiseCount,1.5
 BitAndAgg,1.5
 BitOrAgg,1.5
 BitXorAgg,1.5
+MapZipWith,1.5
+Uuid,1.5

--- a/core/src/main/resources/operatorsScore-emr-a10.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10.csv
@@ -307,3 +307,5 @@ BitwiseCount,1.5
 BitAndAgg,1.5
 BitOrAgg,1.5
 BitXorAgg,1.5
+MapZipWith,1.5
+Uuid,1.5

--- a/core/src/main/resources/operatorsScore-emr-a10G.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10G.csv
@@ -307,3 +307,5 @@ BitwiseCount,1.5
 BitAndAgg,1.5
 BitOrAgg,1.5
 BitXorAgg,1.5
+MapZipWith,1.5
+Uuid,1.5

--- a/core/src/main/resources/operatorsScore-emr-t4.csv
+++ b/core/src/main/resources/operatorsScore-emr-t4.csv
@@ -307,3 +307,5 @@ BitwiseCount,1.5
 BitAndAgg,1.5
 BitOrAgg,1.5
 BitXorAgg,1.5
+MapZipWith,1.5
+Uuid,1.5

--- a/core/src/main/resources/operatorsScore-onprem-a100.csv
+++ b/core/src/main/resources/operatorsScore-onprem-a100.csv
@@ -319,3 +319,5 @@ BitwiseCount,1.5
 BitAndAgg,1.5
 BitOrAgg,1.5
 BitXorAgg,1.5
+MapZipWith,1.5
+Uuid,1.5

--- a/core/src/main/resources/supportedExprs.csv
+++ b/core/src/main/resources/supportedExprs.csv
@@ -271,6 +271,10 @@ GetJsonObject,S,`get_json_object`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA
 GetMapValue,S, ,None,project,map,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA
 GetMapValue,S, ,None,project,key,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NS,NS,NS,NS,NS
 GetMapValue,S, ,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,NS,NS
+MapZipWith,S,`map_zip_with`,None,project,argument1,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA
+MapZipWith,S,`map_zip_with`,None,project,argument2,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA
+MapZipWith,S,`map_zip_with`,None,project,function,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,PS,PS,PS,NS,NS,NS
+MapZipWith,S,`map_zip_with`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA
 GetStructField,S, ,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA
 GetStructField,S, ,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,NS,NS
 GetTimestamp,S, ,None,project,timeExp,NA,NA,NA,NA,NA,NA,NA,S,PS,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
@@ -686,6 +690,7 @@ UnscaledValue,S, ,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,N
 UnscaledValue,S, ,None,project,result,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Upper,S,`ucase`; `upper`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Upper,S,`ucase`; `upper`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+Uuid,S,`uuid`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 WeekDay,S,`weekday`,None,project,input,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 WeekDay,S,`weekday`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 WindowExpression,S, ,None,window,windowFunction,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1896

- Adds support to `MapZipWith`
- Adds support to `Uuid`
- Adds unit test to verify that `MapZipWith` is supported

The Qual tool cannot detect some information about the types of the expressions. Therefore, it may mistakenly mark `MapZipWith` as supported eventhough it has unsupported timezone.
