### PR TITLE
Add Invoke to the supportedExprs in core-tools

### DIFF
--- a/core/src/main/resources/operatorsScore-databricks-aws-a10G.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws-a10G.csv
@@ -321,3 +321,4 @@ BitOrAgg,1.5
 BitXorAgg,1.5
 MapZipWith,1.5
 Uuid,1.5
+Invoke,1.5

--- a/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-aws-t4.csv
@@ -321,3 +321,4 @@ BitOrAgg,1.5
 BitXorAgg,1.5
 MapZipWith,1.5
 Uuid,1.5
+Invoke,1.5

--- a/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
+++ b/core/src/main/resources/operatorsScore-databricks-azure-t4.csv
@@ -309,3 +309,4 @@ BitOrAgg,1.5
 BitXorAgg,1.5
 MapZipWith,1.5
 Uuid,1.5
+Invoke,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-l4.csv
@@ -303,3 +303,4 @@ BitOrAgg,1.5
 BitXorAgg,1.5
 MapZipWith,1.5
 Uuid,1.5
+Invoke,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-gke-t4.csv
@@ -303,3 +303,4 @@ BitOrAgg,1.5
 BitXorAgg,1.5
 MapZipWith,1.5
 Uuid,1.5
+Invoke,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-l4.csv
@@ -309,3 +309,4 @@ BitOrAgg,1.5
 BitXorAgg,1.5
 MapZipWith,1.5
 Uuid,1.5
+Invoke,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-serverless-l4.csv
@@ -303,3 +303,4 @@ BitOrAgg,1.5
 BitXorAgg,1.5
 MapZipWith,1.5
 Uuid,1.5
+Invoke,1.5

--- a/core/src/main/resources/operatorsScore-dataproc-t4.csv
+++ b/core/src/main/resources/operatorsScore-dataproc-t4.csv
@@ -309,3 +309,4 @@ BitOrAgg,1.5
 BitXorAgg,1.5
 MapZipWith,1.5
 Uuid,1.5
+Invoke,1.5

--- a/core/src/main/resources/operatorsScore-emr-a10.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10.csv
@@ -309,3 +309,4 @@ BitOrAgg,1.5
 BitXorAgg,1.5
 MapZipWith,1.5
 Uuid,1.5
+Invoke,1.5

--- a/core/src/main/resources/operatorsScore-emr-a10G.csv
+++ b/core/src/main/resources/operatorsScore-emr-a10G.csv
@@ -309,3 +309,4 @@ BitOrAgg,1.5
 BitXorAgg,1.5
 MapZipWith,1.5
 Uuid,1.5
+Invoke,1.5

--- a/core/src/main/resources/operatorsScore-emr-t4.csv
+++ b/core/src/main/resources/operatorsScore-emr-t4.csv
@@ -309,3 +309,4 @@ BitOrAgg,1.5
 BitXorAgg,1.5
 MapZipWith,1.5
 Uuid,1.5
+Invoke,1.5

--- a/core/src/main/resources/operatorsScore-onprem-a100.csv
+++ b/core/src/main/resources/operatorsScore-onprem-a100.csv
@@ -321,3 +321,4 @@ BitOrAgg,1.5
 BitXorAgg,1.5
 MapZipWith,1.5
 Uuid,1.5
+Invoke,1.5

--- a/core/src/main/resources/supportedExprs.csv
+++ b/core/src/main/resources/supportedExprs.csv
@@ -305,6 +305,7 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
+Invoke,S, ,The supported types are not deterministic since it's a dynamic expression,project,result,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1876

- Adds `Invoke` to the list of supported-exprs in the core module.
- there is no way to test the behavior on databricks since tools cannot run on spark-4.0 yet. Filed separate issue to keep track of that.
