### PR TITLE
Upgrade default spark-version to 3.5.6

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         java-version: [8, 11]
-        spark-version: ['324', '334', '350']
+        spark-version: ['324', '356']
     steps:
     - name: Checkout code
       uses: NVIDIA/spark-rapids-common/checkout@main

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -423,6 +423,22 @@
             </properties>
         </profile>
         <profile>
+            <id>spark356</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>356</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>356</buildver>
+                <spark.version>${spark356.version}</spark.version>
+                <delta.core.artifactory>${delta.core.artifactory.post35}</delta.core.artifactory>
+                <delta.core.version>${delta31x.version}</delta.core.version>
+                <hadoop.version>3.3.6</hadoop.version>
+            </properties>
+        </profile>
+        <profile>
             <id>spark400</id>
             <activation>
                 <property>
@@ -448,8 +464,8 @@
             -->
             <id>release</id>
             <properties>
-                <buildver>350</buildver>
-                <spark.version>${spark350.version}</spark.version>
+                <buildver>356</buildver>
+                <spark.version>${spark356.version}</spark.version>
                 <delta.core.artifactory>${delta.core.artifactory.post35}</delta.core.artifactory>
                 <delta.core.version>${delta31x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
@@ -485,6 +501,7 @@
         <spark353.version>3.5.3</spark353.version>
         <spark354.version>3.5.4</spark354.version>
         <spark355.version>3.5.5</spark355.version>
+        <spark356.version>3.5.6</spark356.version>
         <spark400.version>4.0.0-SNAPSHOT</spark400.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.plugin.version>4.3.0</scala.plugin.version>

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -367,6 +367,7 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
     "3.5.3" -> "353",
     "3.5.4" -> "354",
     "3.5.5" -> "355",
+    "3.5.6" -> "356",
     "4.0.0" -> "400"
   )
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -49,7 +49,8 @@ object ToolUtils extends Logging {
     "330" -> new ComparableVersion("3.3.0"), // used to check for memoryOverheadFactor
     "331" -> new ComparableVersion("3.3.1"),
     "340" -> new ComparableVersion("3.4.0"), // introduces jsonProtocolChanges
-    "350" -> new ComparableVersion("3.5.0")  // default build version, introduces windowGroupLimit
+    "350" -> new ComparableVersion("3.5.0"), // introduces windowGroupLimit
+    "356" -> new ComparableVersion("3.5.6")  // default build version
   )
 
   // Property to check the spark runtime version. We need this outside of test module as we

--- a/user_tools/src/spark_rapids_pytools/__init__.py
+++ b/user_tools/src/spark_rapids_pytools/__init__.py
@@ -18,6 +18,6 @@ from spark_rapids_pytools.build import get_version, get_spark_dep_version
 
 VERSION = '25.08.2'
 # defines the default runtime build version for the user tools environment
-SPARK_DEP_VERSION = '350'
+SPARK_DEP_VERSION = '356'
 __version__ = get_version(VERSION)
 __spark_dep_version__ = get_spark_dep_version()

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
@@ -3,6 +3,45 @@
       "deployMode": {
         "LOCAL": {
           "//activeBuildVer": "Define this key in order to set the default buildVer for that platform",
+          "356": [
+            {
+              "name": "Apache Spark",
+              "uri": "https://archive.apache.org/dist/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz",
+              "verification": {
+                "fileHash": {
+                  "algorithm": "sha512",
+                  "value": "1b9ce1cd6e1b78d08f5f36a0b2b9b6802c1e22a20c6b0c6f53ef56bb352ad1b5812e0de7927cb0d2eadcca17cfaa701d6ee0b8ebf8f0689e80a36679e15cd3a3"
+                },
+                "size": 400923510
+              },
+              "dependencyType": {
+                "depType": "archive",
+                "relativePath": "jars/*"
+              }
+            },
+            {
+              "name": "Hadoop AWS",
+              "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.4.1/hadoop-aws-3.4.1.jar",
+              "verification": {
+                "fileHash": {
+                  "algorithm": "sha1",
+                  "value": "641d8fe1d7683cdcc05cc3a794c0374553f6bd6a"
+                },
+                "size": 865554
+              }
+            },
+            {
+              "name": "AWS Java SDK Bundled",
+              "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
+              "verification": {
+                "fileHash": {
+                  "algorithm": "sha1",
+                  "value": "02deec3a0ad83d13d032b1812421b23d7a961eea"
+                },
+                "size": 280645251
+              }
+            }
+          ],
           "350": [
             {
               "name": "Apache Spark",

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_azure-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_azure-configs.json
@@ -3,6 +3,34 @@
       "deployMode": {
         "LOCAL": {
           "//activeBuildVer": "Define this key in order to set the default buildVer for that platform",
+          "356": [
+            {
+              "name": "Apache Spark",
+              "uri": "https://archive.apache.org/dist/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz",
+              "verification": {
+                "fileHash": {
+                  "algorithm": "sha512",
+                  "value": "1b9ce1cd6e1b78d08f5f36a0b2b9b6802c1e22a20c6b0c6f53ef56bb352ad1b5812e0de7927cb0d2eadcca17cfaa701d6ee0b8ebf8f0689e80a36679e15cd3a3"
+                },
+                "size": 400923510
+              },
+              "dependencyType": {
+                "depType": "archive",
+                "relativePath": "jars/*"
+              }
+            },
+            {
+              "name": "Hadoop Azure",
+              "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/3.3.4/hadoop-azure-3.3.4.jar",
+              "verification": {
+                "fileHash": {
+                  "algorithm": "sha1",
+                  "value": "a23f621bca9b2100554150f6b0b521f94b8b419e"
+                },
+                "size": 574116
+              }
+            }
+          ],
           "350": [
             {
               "name": "Apache Spark",

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc-configs.json
@@ -3,6 +3,34 @@
     "deployMode": {
       "LOCAL": {
         "//activeBuildVer": "Define this key in order to set the default buildVer for that platform",
+        "356": [
+          {
+            "name": "Apache Spark",
+            "uri": "https://archive.apache.org/dist/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz",
+            "verification": {
+              "fileHash": {
+                "algorithm": "sha512",
+                "value": "1b9ce1cd6e1b78d08f5f36a0b2b9b6802c1e22a20c6b0c6f53ef56bb352ad1b5812e0de7927cb0d2eadcca17cfaa701d6ee0b8ebf8f0689e80a36679e15cd3a3"
+              },
+              "size": 400923510
+            },
+            "dependencyType": {
+              "depType": "archive",
+              "relativePath": "jars/*"
+            }
+          },
+          {
+            "name": "GCS Connector Hadoop3",
+            "uri": "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.14/gcs-connector-hadoop3-2.2.14.jar",
+            "verification": {
+              "fileHash": {
+                "algorithm": "sha1",
+                "value": "0cba424d7e107f92431ab7b7acf08c371d4aed52"
+              },
+              "size": 38298738
+            }
+          }
+        ],
         "350": [
           {
             "name": "Apache Spark",

--- a/user_tools/src/spark_rapids_pytools/resources/dataproc_gke-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/dataproc_gke-configs.json
@@ -3,6 +3,34 @@
     "deployMode": {
       "LOCAL": {
         "//activeBuildVer": "Define this key in order to set the default buildVer for that platform",
+        "356": [
+          {
+            "name": "Apache Spark",
+            "uri": "https://archive.apache.org/dist/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz",
+            "verification": {
+              "fileHash": {
+                "algorithm": "sha512",
+                "value": "1b9ce1cd6e1b78d08f5f36a0b2b9b6802c1e22a20c6b0c6f53ef56bb352ad1b5812e0de7927cb0d2eadcca17cfaa701d6ee0b8ebf8f0689e80a36679e15cd3a3"
+              },
+              "size": 400923510
+            },
+            "dependencyType": {
+              "depType": "archive",
+              "relativePath": "jars/*"
+            }
+          },
+          {
+            "name": "GCS Connector Hadoop3",
+            "uri": "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.14/gcs-connector-hadoop3-2.2.14.jar",
+            "verification": {
+              "fileHash": {
+                "algorithm": "sha1",
+                "value": "0cba424d7e107f92431ab7b7acf08c371d4aed52"
+              },
+              "size": 38298738
+            }
+          }
+        ],
         "350": [
           {
             "name": "Apache Spark",

--- a/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
@@ -3,6 +3,45 @@
     "deployMode": {
       "LOCAL": {
         "//activeBuildVer": "Define this key in order to set the default buildVer for that platform",
+        "356": [
+          {
+            "name": "Apache Spark",
+            "uri": "https://archive.apache.org/dist/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz",
+            "verification": {
+              "fileHash": {
+                "algorithm": "sha512",
+                "value": "1b9ce1cd6e1b78d08f5f36a0b2b9b6802c1e22a20c6b0c6f53ef56bb352ad1b5812e0de7927cb0d2eadcca17cfaa701d6ee0b8ebf8f0689e80a36679e15cd3a3"
+              },
+              "size": 400923510
+            },
+            "dependencyType": {
+              "depType": "archive",
+              "relativePath": "jars/*"
+            }
+          },
+          {
+            "name": "Hadoop AWS",
+            "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.4.1/hadoop-aws-3.4.1.jar",
+            "verification": {
+              "fileHash": {
+                "algorithm": "sha1",
+                "value": "641d8fe1d7683cdcc05cc3a794c0374553f6bd6a"
+              },
+              "size": 865554
+            }
+          },
+          {
+            "name": "AWS Java SDK Bundled",
+            "uri": "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
+            "verification": {
+              "fileHash": {
+                "algorithm": "sha1",
+                "value": "02deec3a0ad83d13d032b1812421b23d7a961eea"
+              },
+              "size": 280645251
+            }
+          }
+        ],
         "350": [
           {
             "name": "Apache Spark",

--- a/user_tools/src/spark_rapids_pytools/resources/onprem-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/onprem-configs.json
@@ -2,7 +2,24 @@
   "dependencies": {
     "deployMode": {
       "LOCAL": {
-        "activeBuildVer": "342",
+        "//activeBuildVer": "Define this key in order to set the default buildVer for that platform",
+        "356": [
+          {
+            "name": "Apache Spark",
+            "uri": "https://archive.apache.org/dist/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz",
+            "verification": {
+              "fileHash": {
+                "algorithm": "sha512",
+                "value": "1b9ce1cd6e1b78d08f5f36a0b2b9b6802c1e22a20c6b0c6f53ef56bb352ad1b5812e0de7927cb0d2eadcca17cfaa701d6ee0b8ebf8f0689e80a36679e15cd3a3"
+              },
+              "size": 400923510
+            },
+            "dependencyType": {
+              "depType": "archive",
+              "relativePath": "jars/*"
+            }
+          }
+        ],
         "350": [
           {
             "name": "Apache Spark",

--- a/user_tools/tox.ini
+++ b/user_tools/tox.ini
@@ -115,7 +115,7 @@ commands = behave {posargs}
 description = Generate Tools JAR and copy reports into generated_files prior to isolated builds
 passenv = JAVA_HOME
 setenv =
-    TOOLS_SPARK_BUILDVER = {env:TOOLS_SPARK_BUILDVER:350}
+    TOOLS_SPARK_BUILDVER = {env:TOOLS_SPARK_BUILDVER:356}
     TOOLS_HADOOP_VERSION = {env:TOOLS_HADOOP_VERSION:3.3.6}
     TOOLS_MAVEN_ARGS = {env:TOOLS_MAVEN_ARGS:-Dbuildver={env:TOOLS_SPARK_BUILDVER} -Dhadoop.version={env:TOOLS_HADOOP_VERSION}}
 allowlist_externals = bash


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1601

- Upgrade default spark to 3.5.6
- remove mvn test on spark 3.4.x

We need this change because:
- 3.5.6 has bug fixes. Especially, the json string limitation of https://issues.apache.org/jira/browse/SPARK-49872
- reduce the fat-wheel since we will need only 1 version of spark (3.5.6)
- reduce build and testing between on-prem/csps as they have same spark release by default.

