### PR TITLE
set buildver-356 to be active by default

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -328,7 +328,6 @@
         <profile>
             <id>spark350</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
                 <property>
                     <name>buildver</name>
                     <value>350</value>
@@ -425,6 +424,7 @@
         <profile>
             <id>spark356</id>
             <activation>
+                <activeByDefault>true</activeByDefault>
                 <property>
                     <name>buildver</name>
                     <value>356</value>


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

This is a followup on #1903
The active buildver should be set to 356

