### PR TITLE
Add a new rule to recommend AQE post shuffle partition num

### DIFF
--- a/core/src/main/resources/bootstrap/tuningConfigs.yaml
+++ b/core/src/main/resources/bootstrap/tuningConfigs.yaml
@@ -190,6 +190,12 @@ default:
     default: 50000b
     usedBy: spark.sql.adaptive.advisoryPartitionSizeInBytes
 
+  - name: AQE_MIN_INITIAL_PARTITION_NUM
+    description: >-
+      Minimum initial partition number for AQE coalescing
+    default: 200
+    usedBy: spark.sql.adaptive.coalescePartitions.initialPartitionNum, spark.sql.adaptive.shuffle.minNumPostShufflePartitions
+
   - name: AQE_MAX_INITIAL_PARTITION_NUM
     description: >-
       Maximum initial partition number for AQE coalescing

--- a/core/src/main/resources/bootstrap/tuningConfigs.yaml
+++ b/core/src/main/resources/bootstrap/tuningConfigs.yaml
@@ -190,11 +190,11 @@ default:
     default: 50000b
     usedBy: spark.sql.adaptive.advisoryPartitionSizeInBytes
 
-  - name: AQE_MIN_INITIAL_PARTITION_NUM
+  - name: AQE_MAX_INITIAL_PARTITION_NUM
     description: >-
       Minimum initial partition number for AQE coalescing
     default: 200
-    usedBy: spark.sql.adaptive.coalescePartitions.minPartitionNum, spark.sql.adaptive.shuffle.minNumPostShufflePartitions
+    usedBy: spark.sql.adaptive.coalescePartitions.initialPartitionNum, spark.sql.adaptive.shuffle.maxNumPostShufflePartitions
 
   - name: AQE_AUTO_BROADCAST_JOIN_THRESHOLD
     description: >-

--- a/core/src/main/resources/bootstrap/tuningConfigs.yaml
+++ b/core/src/main/resources/bootstrap/tuningConfigs.yaml
@@ -192,7 +192,7 @@ default:
 
   - name: AQE_MAX_INITIAL_PARTITION_NUM
     description: >-
-      Minimum initial partition number for AQE coalescing
+      Maximum initial partition number for AQE coalescing
     default: 200
     usedBy: spark.sql.adaptive.coalescePartitions.initialPartitionNum, spark.sql.adaptive.shuffle.maxNumPostShufflePartitions
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/AppSummaryInfoBaseProvider.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/AppSummaryInfoBaseProvider.scala
@@ -17,7 +17,7 @@
 package com.nvidia.spark.rapids.tool
 
 import com.nvidia.spark.rapids.tool.analysis.AggRawMetricsResult
-import com.nvidia.spark.rapids.tool.profiling.{AppInfoJobStageAggMetricsVisitor, AppInfoPropertyGetter, AppInfoReadMetrics, AppInfoSqlTaskAggMetricsVisitor, AppInfoSQLTaskInputSizes, BaseProfilingAppSummaryInfoProvider, DataSourceProfileResult, ProfilerResult, SingleAppSummaryInfoProvider}
+import com.nvidia.spark.rapids.tool.profiling.{AppInfoColumnarExchangeMetrics, AppInfoJobStageAggMetricsVisitor, AppInfoPropertyGetter, AppInfoReadMetrics, AppInfoSqlTaskAggMetricsVisitor, AppInfoSQLTaskInputSizes, BaseProfilingAppSummaryInfoProvider, DataSourceProfileResult, ProfilerResult, SingleAppSummaryInfoProvider}
 import com.nvidia.spark.rapids.tool.tuning.QualAppSummaryInfoProvider
 
 import org.apache.spark.sql.rapids.tool.ToolUtils
@@ -31,7 +31,8 @@ class AppSummaryInfoBaseProvider extends AppInfoPropertyGetter
   with AppInfoJobStageAggMetricsVisitor
   with AppInfoSqlTaskAggMetricsVisitor
   with AppInfoSQLTaskInputSizes
-  with AppInfoReadMetrics {
+  with AppInfoReadMetrics
+  with AppInfoColumnarExchangeMetrics {
   def isAppInfoAvailable = false
   override def getAllProperties: Map[String, String] = Map[String, String]()
   override def getSparkProperty(propKey: String): Option[String] = None
@@ -57,6 +58,7 @@ class AppSummaryInfoBaseProvider extends AppInfoPropertyGetter
   override def getRapidsJars: Seq[String] = Seq()
   override def getDistinctLocationPct: Double = 0.0
   override def getRedundantReadSize: Long = 0
+  override def getMaxColumnarExchangeDataSizeBytes: Option[Long] = None
 }
 
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -95,23 +95,6 @@ trait AppInfoGpuOomCheck {
 
 trait AppInfoColumnarExchangeMetrics {
   def getMaxColumnarExchangeDataSizeBytes: Option[Long] = None
-  /**
-   * Helper method to extract maximum ColumnarExchange data size from SQL plan metrics.
-   * This method can be used by implementations to avoid code duplication.
-   */
-  protected def extractMaxColumnarExchangeDataSizeFromMetrics(
-    metrics: Seq[SQLAccumProfileResults]): Option[Long] = {
-    val columnarExchangeDataSizesBytes = metrics.collect {
-      case metric if metric.nodeName.contains("ColumnarExchange") &&
-                      metric.name == "data size" =>
-        metric.total
-    }
-    if (columnarExchangeDataSizesBytes.nonEmpty) {
-      Some(columnarExchangeDataSizesBytes.max)
-    } else {
-      None
-    }
-  }
 }
 
 /**
@@ -333,6 +316,15 @@ class SingleAppSummaryInfoProvider(
    *         ColumnarExchange "data size" metrics are found
    */
   override def getMaxColumnarExchangeDataSizeBytes: Option[Long] = {
-    extractMaxColumnarExchangeDataSizeFromMetrics(app.sqlMetrics)
+    val columnarExchangeDataSizesBytes = app.sqlMetrics.collect {
+      case metric if metric.nodeName.contains("ColumnarExchange") &&
+                      metric.name == "data size" =>
+        metric.total
+    }
+    if (columnarExchangeDataSizesBytes.nonEmpty) {
+      Some(columnarExchangeDataSizesBytes.max)
+    } else {
+      None
+    }
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -94,19 +94,36 @@ trait AppInfoGpuOomCheck {
 }
 
 trait AppInfoColumnarExchangeMetrics {
-  def getMaxColumnarExchangeDataSize: Option[Long]
+  def getMaxColumnarExchangeDataSizeBytes: Option[Long] = None
+  /**
+   * Helper method to extract maximum ColumnarExchange data size from SQL plan metrics.
+   * This method can be used by implementations to avoid code duplication.
+   */
+  protected def extractMaxColumnarExchangeDataSizeFromMetrics(
+    metrics: Seq[SQLAccumProfileResults]): Option[Long] = {
+    val columnarExchangeDataSizesBytes = metrics.collect {
+      case metric if metric.nodeName.contains("ColumnarExchange") &&
+                      metric.name == "data size" =>
+        metric.total
+    }
+    if (columnarExchangeDataSizesBytes.nonEmpty) {
+      Some(columnarExchangeDataSizesBytes.max)
+    } else {
+      None
+    }
+  }
 }
 
 /**
  * Base class for Profiling App Summary Info Provider.
  */
 class BaseProfilingAppSummaryInfoProvider
-  extends AppSummaryInfoBaseProvider with AppInfoGpuOomCheck with AppInfoColumnarExchangeMetrics {
+  extends AppSummaryInfoBaseProvider with AppInfoGpuOomCheck {
   /**
    * Default implementation returns None. Subclasses should override this method
    * to provide actual ColumnarExchange data size metrics.
    */
-  override def getMaxColumnarExchangeDataSize: Option[Long] = None
+  override def getMaxColumnarExchangeDataSizeBytes: Option[Long] = None
 }
 
 /**
@@ -315,16 +332,7 @@ class SingleAppSummaryInfoProvider(
    * @return Option[Long] containing the maximum data size in bytes, or None if no
    *         ColumnarExchange "data size" metrics are found
    */
-  override def getMaxColumnarExchangeDataSize: Option[Long] = {
-    val columnarExchangeDataSizes = app.sqlMetrics.collect {
-      case metric if metric.nodeName == "ColumnarExchange" &&
-                      metric.name == "data size" =>
-        metric.total
-    }
-    if (columnarExchangeDataSizes.nonEmpty) {
-      Some(columnarExchangeDataSizes.max)
-    } else {
-      None
-    }
+  override def getMaxColumnarExchangeDataSizeBytes: Option[Long] = {
+    extractMaxColumnarExchangeDataSizeFromMetrics(app.sqlMetrics)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -1141,8 +1141,7 @@ abstract class AutoTuner(
             val gpuBatchSize: Long = getPropertyValue("spark.rapids.sql.batchSizeBytes") match {
               case Some(value) =>
                 // Parse the actual batch size value (could be with units like "2g", "1GB", etc.)
-                // Convert to MB first, then to bytes
-                StringUtils.convertToMB(value, Some(ByteUnit.BYTE)) * 1024 * 1024
+                StringUtils.convertMemorySizeToBytes(value, Some(ByteUnit.BYTE))
               case None =>
                 // Use default batch size from tuning configs
                 tuningConfigs.getEntry("BATCH_SIZE_BYTES").getDefaultAsMemory(ByteUnit.BYTE)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TargetClusterProps.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TargetClusterProps.scala
@@ -117,7 +117,7 @@ class DriverInfo (
  *     - spark.rapids.sql.incompatibleDateFormats.enabled
  *     - spark.rapids.sql.explain
  *   tuningDefinitions:
- *     - label: spark.sql.adaptive.shuffle.minNumPostShufflePartitions
+ *     - label: spark.sql.adaptive.shuffle.maxNumPostShufflePartitions
  *       description: alias for spark.sql.adaptive.coalescePartitions.initialPartitionNum
  *       enabled: true
  *       level: job
@@ -227,7 +227,7 @@ class SparkProperties(
  *     - spark.rapids.sql.incompatibleDateFormats.enabled
  *     - spark.rapids.sql.explain
  *   tuningDefinitions:
- *     - label: spark.sql.adaptive.shuffle.minNumPostShufflePartitions
+ *     - label: spark.sql.adaptive.shuffle.maxNumPostShufflePartitions
  *       description: Legacy property for initial shuffle partitions
  *       enabled: true
  *       level: job

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
@@ -48,7 +48,7 @@ class AppInfoProviderMockTest(val maxInput: Double,
     val shuffleSkewStages: Set[Long],
     val scanStagesWithGpuOom: Boolean,
     val shuffleStagesWithOom: Boolean,
-    val maxColumnarExchangeDataSize: Option[Long] = None)
+    val maxColumnarExchangeDataSizeBytes: Option[Long] = None)
     extends BaseProfilingAppSummaryInfoProvider {
   override def isAppInfoAvailable = true
   override def getMaxInput: Double = maxInput
@@ -68,7 +68,7 @@ class AppInfoProviderMockTest(val maxInput: Double,
   override def getShuffleSkewStages: Set[Long] = shuffleSkewStages
   override def hasScanStagesWithGpuOom: Boolean = scanStagesWithGpuOom
   override def hasShuffleStagesWithOom: Boolean = shuffleStagesWithOom
-  override def getMaxColumnarExchangeDataSize: Option[Long] = maxColumnarExchangeDataSize
+  override def getMaxColumnarExchangeDataSizeBytes: Option[Long] = maxColumnarExchangeDataSizeBytes
 
   /**
    * Sets the spark master property in the properties map.
@@ -134,11 +134,11 @@ abstract class BaseAutoTunerSuite extends FunSuite with BeforeAndAfterEach
       shuffleSkewStages: Set[Long] = Set(),
       scanStagesWithGpuOom: Boolean = false,
       shuffleStagesWithOom: Boolean = false,
-      maxColumnarExchangeDataSize: Option[Long] = None): AppInfoProviderMockTest = {
+      maxColumnarExchangeDataSizeBytes: Option[Long] = None): AppInfoProviderMockTest = {
     new AppInfoProviderMockTest(maxInput, spilledMetrics, jvmGCFractions, propsFromLog,
       sparkVersion, rapidsJars, distinctLocationPct, redundantReadSize, meanInput, meanShuffleRead,
       shuffleStagesWithPosSpilling, shuffleSkewStages, scanStagesWithGpuOom,
-      shuffleStagesWithOom, maxColumnarExchangeDataSize)
+      shuffleStagesWithOom, maxColumnarExchangeDataSizeBytes)
   }
 
   /**

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
@@ -47,7 +47,9 @@ class AppInfoProviderMockTest(val maxInput: Double,
     val shuffleStagesWithPosSpilling: Set[Long],
     val shuffleSkewStages: Set[Long],
     val scanStagesWithGpuOom: Boolean,
-    val shuffleStagesWithOom: Boolean) extends BaseProfilingAppSummaryInfoProvider {
+    val shuffleStagesWithOom: Boolean,
+    val maxColumnarExchangeDataSize: Option[Long] = None)
+    extends BaseProfilingAppSummaryInfoProvider {
   override def isAppInfoAvailable = true
   override def getMaxInput: Double = maxInput
   override def getMeanInput: Double = meanInput
@@ -66,6 +68,7 @@ class AppInfoProviderMockTest(val maxInput: Double,
   override def getShuffleSkewStages: Set[Long] = shuffleSkewStages
   override def hasScanStagesWithGpuOom: Boolean = scanStagesWithGpuOom
   override def hasShuffleStagesWithOom: Boolean = shuffleStagesWithOom
+  override def getMaxColumnarExchangeDataSize: Option[Long] = maxColumnarExchangeDataSize
 
   /**
    * Sets the spark master property in the properties map.
@@ -130,10 +133,12 @@ abstract class BaseAutoTunerSuite extends FunSuite with BeforeAndAfterEach
       shuffleStagesWithPosSpilling: Set[Long] = Set(),
       shuffleSkewStages: Set[Long] = Set(),
       scanStagesWithGpuOom: Boolean = false,
-      shuffleStagesWithOom: Boolean = false): AppInfoProviderMockTest = {
+      shuffleStagesWithOom: Boolean = false,
+      maxColumnarExchangeDataSize: Option[Long] = None): AppInfoProviderMockTest = {
     new AppInfoProviderMockTest(maxInput, spilledMetrics, jvmGCFractions, propsFromLog,
       sparkVersion, rapidsJars, distinctLocationPct, redundantReadSize, meanInput, meanShuffleRead,
-      shuffleStagesWithPosSpilling, shuffleSkewStages, scanStagesWithGpuOom, shuffleStagesWithOom)
+      shuffleStagesWithPosSpilling, shuffleSkewStages, scanStagesWithGpuOom,
+      shuffleStagesWithOom, maxColumnarExchangeDataSize)
   }
 
   /**

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -950,7 +950,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
 
   // Test that the alias feature works correctly for mapping non-standard Spark properties
   // to standard ones, using the specific example from the issue:
-  // spark.sql.adaptive.shuffle.minNumPostShufflePartitions ->
+  // spark.sql.adaptive.shuffle.maxNumPostShufflePartitions ->
   //   spark.sql.adaptive.coalescePartitions.initialPartitionNum
   test("AutoTuner should handle aliased properties from tuningDefinitions") {
     // 1. Mock source cluster info for dataproc
@@ -1640,4 +1640,137 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
     // scalastyle:on line.size.limit
     compareOutput(expectedResults, autoTunerOutput)
   }
+
+  // Test that the alias feature works correctly for initialPartitionNum properties
+  // using spark.sql.adaptive.maxNumPostShufflePartitions as alias
+  test("AutoTuner should handle aliased initialPartitionNum properties from tuningDefinitions") {
+    // 1. Mock source cluster info for dataproc
+    val instanceMapKey = NodeInstanceMapKey("n1-standard-16", Option(1))
+    val gpuInstance = PlatformInstanceTypes.DATAPROC_BY_INSTANCE_NAME(instanceMapKey)
+
+    // 2. Mock the properties loaded from eventLog with the aliased property
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "8",
+        "spark.executor.instances" -> "2",
+        "spark.rapids.memory.pinnedPool.size" -> "5g",
+        "spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
+        "spark.executor.resource.gpu.amount" -> "1",
+        // alias property for initialPartitionNum
+        "spark.sql.adaptive.maxNumPostShufflePartitions" -> "2000"
+      )
+
+    // 3. Create user-defined tuningDefinitions for the target cluster
+    val userTuningDefinitions = createMaxNumPostShufflePartitionsTuningDefinition()
+
+    // 4. Define enforced properties for the target cluster
+    val enforcedSparkProperties = Map(
+      "spark.task.resource.gpu.amount" -> "0.25",
+      "spark.rapids.sql.concurrentGpuTasks" -> "2"
+    )
+
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      workerNodeInstanceType = Some("n1-standard-16"),
+      gpuCount = Some(1),
+      enforcedSparkProperties = enforcedSparkProperties,
+      tuningDefinitions = userTuningDefinitions
+    )
+
+    val infoProvider = getMockInfoProvider(
+      maxInput = 100000.0,
+      spilledMetrics = Seq(100000),
+      jvmGCFractions = Seq(0.004),
+      propsFromLog = logEventsProps,
+      sparkVersion = Some(testSparkVersion),
+      meanInput = 60000.0,  // > 35000 (AQE_INPUT_SIZE_BYTES_THRESHOLD)
+      meanShuffleRead = 70000.0,  // > 50000 (AQE_SHUFFLE_READ_BYTES_THRESHOLD)
+      rapidsJars = Seq.empty,
+      distinctLocationPct = 0.0,
+      redundantReadSize = 0L,
+      shuffleStagesWithPosSpilling = Set.empty,
+      shuffleSkewStages = Set.empty,
+      scanStagesWithGpuOom = false,
+      shuffleStagesWithOom = false,
+      maxColumnarExchangeDataSize = Some(1000L * 1024 * 1024 * 1024) // 1000GB
+    )
+    val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, Some(targetClusterInfo))
+
+    val sparkPropsWithMemory =
+      logEventsProps + ("spark.executor.memory" -> (gpuInstance.memoryMB.toString + "MiB"))
+    configureEventLogClusterInfoForTest(
+      platform,
+      numCores = gpuInstance.cores,
+      numWorkers = 4,
+      gpuCount = 1,
+      sparkProperties = sparkPropsWithMemory.toMap
+    )
+    val autoTuner = buildAutoTunerForTests(infoProvider, platform)
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.dataproc.enhanced.execution.enabled=false
+          |--conf spark.dataproc.enhanced.optimizer.enabled=false
+          |--conf spark.executor.cores=16
+          |--conf spark.executor.memory=32g
+          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.locality.wait=0
+          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
+          |--conf spark.rapids.sql.concurrentGpuTasks=2
+          |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
+          |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
+          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=32m
+          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
+          |--conf spark.sql.adaptive.coalescePartitions.parallelismFirst=false
+          |--conf spark.sql.adaptive.maxNumPostShufflePartitions=501
+          |--conf spark.sql.files.maxPartitionBytes=4g
+          |--conf spark.sql.shuffle.partitions=2000
+          |--conf spark.task.resource.gpu.amount=0.25
+          |
+          |Comments:
+          |- 'spark.dataproc.enhanced.execution.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.execution.enabled' was not set.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' should be disabled. WARN: Turning this property on might case the GPU accelerated Dataproc cluster to hang.
+          |- 'spark.dataproc.enhanced.optimizer.enabled' was not set.
+          |- 'spark.executor.memory' was not set.
+          |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- 'spark.rapids.sql.concurrentGpuTasks' was user-enforced in the target cluster properties.
+          |- 'spark.rapids.sql.format.parquet.multithreaded.combine.waitTime' was not set.
+          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
+          |- 'spark.rapids.sql.reader.multithreaded.combine.sizeBytes' was not set.
+          |- 'spark.shuffle.manager' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.maxNumPostShufflePartitions' adjusted from 2000 to 501 based on ColumnarExchange data size (1073741824000 bytes) and GPU batch size (2147483647 bytes)
+          |- 'spark.sql.files.maxPartitionBytes' was not set.
+          |- 'spark.task.resource.gpu.amount' was user-enforced in the target cluster properties.
+          |- RAPIDS Accelerator for Apache Spark plugin jar is missing
+          |  from the classpath entries.
+          |  If the Spark RAPIDS jar is being bundled with your
+          |  Spark distribution, this step is not needed.
+          |- The RAPIDS Shuffle Manager requires spark.driver.extraClassPath
+          |  and spark.executor.extraClassPath settings to include the
+          |  path to the Spark RAPIDS plugin jar.
+          |  If the Spark RAPIDS jar is being bundled with your Spark
+          |  distribution, this step is not needed.
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    compareOutput(expectedResults, autoTunerOutput)
+  }
+
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -1333,8 +1333,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
         "spark.task.resource.gpu.amount" -> "0.25",
         "spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
-        "spark.rapids.sql.concurrentGpuTasks" -> "1",
-        "spark.shuffle.manager" -> "com.nvidia.spark.rapids.spark355.RapidsShuffleManager"
+        "spark.rapids.sql.concurrentGpuTasks" -> "1"
       )
 
     val infoProvider = getMockInfoProvider(
@@ -1381,7 +1380,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
           |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
-          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark334.RapidsShuffleManager
+          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.initialPartitionNum=501
           |--conf spark.sql.adaptive.coalescePartitions.parallelismFirst=false
@@ -1402,6 +1401,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |- 'spark.rapids.sql.format.parquet.multithreaded.combine.waitTime' was not set.
           |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
           |- 'spark.rapids.sql.reader.multithreaded.combine.sizeBytes' was not set.
+          |- 'spark.shuffle.manager' was not set.
           |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
           |- 'spark.sql.adaptive.coalescePartitions.initialPartitionNum' adjusted from 2560 to 501 based on ColumnarExchange data size (1073741824000 bytes) and GPU batch size (2147483647 bytes)
           |- 'spark.sql.files.maxPartitionBytes' was not set.
@@ -1443,8 +1443,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
         "spark.task.resource.gpu.amount" -> "0.25",
         "spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
-        "spark.rapids.sql.concurrentGpuTasks" -> "1",
-        "spark.shuffle.manager" -> "com.nvidia.spark.rapids.spark355.RapidsShuffleManager"
+        "spark.rapids.sql.concurrentGpuTasks" -> "1"
       )
 
     val infoProvider = getMockInfoProvider(
@@ -1490,7 +1489,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
           |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
-          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark334.RapidsShuffleManager
+          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.parallelismFirst=false
           |--conf spark.sql.files.maxPartitionBytes=137m
@@ -1510,6 +1509,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |- 'spark.rapids.sql.format.parquet.multithreaded.combine.waitTime' was not set.
           |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
           |- 'spark.rapids.sql.reader.multithreaded.combine.sizeBytes' was not set.
+          |- 'spark.shuffle.manager' was not set.
           |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
           |- 'spark.sql.files.maxPartitionBytes' was not set.
           |- RAPIDS Accelerator for Apache Spark plugin jar is missing
@@ -1545,8 +1545,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
         "spark.task.resource.gpu.amount" -> "0.25",
         "spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
-        "spark.rapids.sql.concurrentGpuTasks" -> "1",
-        "spark.shuffle.manager" -> "com.nvidia.spark.rapids.spark355.RapidsShuffleManager"
+        "spark.rapids.sql.concurrentGpuTasks" -> "1"
       )
 
     val infoProvider = getMockInfoProvider(
@@ -1592,7 +1591,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.rapids.sql.format.parquet.multithreaded.combine.waitTime=1000
           |--conf spark.rapids.sql.multiThreadedRead.numThreads=80
           |--conf spark.rapids.sql.reader.multithreaded.combine.sizeBytes=10m
-          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark334.RapidsShuffleManager
+          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
           |--conf spark.sql.adaptive.coalescePartitions.parallelismFirst=false
           |--conf spark.sql.files.maxPartitionBytes=137m
@@ -1612,6 +1611,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |- 'spark.rapids.sql.format.parquet.multithreaded.combine.waitTime' was not set.
           |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
           |- 'spark.rapids.sql.reader.multithreaded.combine.sizeBytes' was not set.
+          |- 'spark.shuffle.manager' was not set.
           |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
           |- 'spark.sql.files.maxPartitionBytes' was not set.
           |- RAPIDS Accelerator for Apache Spark plugin jar is missing

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -1322,11 +1322,11 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
   }
 
   test("AutoTuner adjusts initialPartitionNum based on ColumnarExchange data size") {
-    // Test case: max columnar exchange data size = 1000GB,
+    // Test case: max columnar exchange data size = 1000GB, batch size is default value 2gb
     // original initialPartitionNum = 2560
-    // Expected: recommended initialPartitionNum = min(2560, 1000) = 1000
+    // Expected: recommended initialPartitionNum = min(2560, 500) = 500
 
-    val maxColumnarExchangeDataSize = Some(1000L * 1024 * 1024 * 1024) // 1000GB in bytes
+    val maxColumnarExchangeDataSizeBytes = Some(1000L * 1024 * 1024 * 1024) // 1000GB in bytes
     val originalInitialPartitionNum = "2560"
 
     val logEventsProps: mutable.Map[String, String] =
@@ -1354,7 +1354,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
       sparkVersion = Some(testSparkVersion),
       meanInput = 1.0E9, // Large mean input
       meanShuffleRead = 1.0E9, // Large mean shuffle read
-      maxColumnarExchangeDataSize = maxColumnarExchangeDataSize
+      maxColumnarExchangeDataSizeBytes = maxColumnarExchangeDataSizeBytes
     )
 
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC)
@@ -1395,7 +1395,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.sql.adaptive.coalescePartitions.initialPartitionNum=501
           |--conf spark.sql.adaptive.coalescePartitions.parallelismFirst=false
           |--conf spark.sql.files.maxPartitionBytes=137m
-          |--conf spark.sql.shuffle.partitions=2560
+          |--conf spark.sql.shuffle.partitions=501
           |--conf spark.task.resource.gpu.amount=0.001
           |
           |Comments:
@@ -1437,7 +1437,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
     // Expected: ratio = ceil(6000GB / 2GB) = 3000, which is > 2560
     // So recommended initialPartitionNum = min(2560, 3000) = 2560 (no change)
 
-    val maxColumnarExchangeDataSize = Some(6000L * 1024 * 1024 * 1024) // 6000GB in bytes
+    val maxColumnarExchangeDataSizeBytes = Some(6000L * 1024 * 1024 * 1024) // 6000GB in bytes
     val originalInitialPartitionNum = "2560"
 
     val logEventsProps: mutable.Map[String, String] =
@@ -1465,7 +1465,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
       sparkVersion = Some(testSparkVersion),
       meanInput = 1.0E9,
       meanShuffleRead = 1.0E9,
-      maxColumnarExchangeDataSize = maxColumnarExchangeDataSize
+      maxColumnarExchangeDataSizeBytes = maxColumnarExchangeDataSizeBytes
     )
 
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC)
@@ -1568,7 +1568,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
       sparkVersion = Some(testSparkVersion),
       meanInput = 1.0E9,
       meanShuffleRead = 1.0E9,
-      maxColumnarExchangeDataSize = None // No ColumnarExchange data size
+      maxColumnarExchangeDataSizeBytes = None // No ColumnarExchange data size
     )
 
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC)
@@ -1692,7 +1692,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
       shuffleSkewStages = Set.empty,
       scanStagesWithGpuOom = false,
       shuffleStagesWithOom = false,
-      maxColumnarExchangeDataSize = Some(1000L * 1024 * 1024 * 1024) // 1000GB
+      maxColumnarExchangeDataSizeBytes = Some(1000L * 1024 * 1024 * 1024) // 1000GB
     )
     val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, Some(targetClusterInfo))
 
@@ -1735,7 +1735,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.sql.adaptive.coalescePartitions.parallelismFirst=false
           |--conf spark.sql.adaptive.maxNumPostShufflePartitions=501
           |--conf spark.sql.files.maxPartitionBytes=4g
-          |--conf spark.sql.shuffle.partitions=2000
+          |--conf spark.sql.shuffle.partitions=501
           |--conf spark.task.resource.gpu.amount=0.25
           |
           |Comments:


### PR DESCRIPTION
to close #1911.

Added a new rule to adjust the `spark.sql.adaptive.coalescePartitions.initialPartitionNum` when AQE is on. Also fixed an alias naming typo.

new rule logic:
   1. Gets the maximum data size from ColumnarExchange "data size" metrics
   2. Calculates ratio = ceil(maxDataSize / gpuDefaultBatchSize)
   3. Recommends min(originalInitialPartitionNum, ratio) as the new value