### PR TITLE
Add Iceberg to core pom dependency

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         java-version: [8, 11]
-        spark-version: ['324', '356']
+        spark-version: ['321', '356']
     steps:
     - name: Checkout code
       uses: NVIDIA/spark-rapids-common/checkout@main

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -83,6 +83,8 @@
                 <spark.version>${spark320.version}</spark.version>
                 <delta.core.version>${delta20x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark32x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark32x.runtime.version}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -98,6 +100,8 @@
                 <spark.version>${spark321.version}</spark.version>
                 <delta.core.version>${delta20x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark32x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark32x.runtime.version}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -113,6 +117,8 @@
                 <spark.version>${spark322.version}</spark.version>
                 <delta.core.version>${delta20x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark32x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark32x.runtime.version}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -128,6 +134,8 @@
                 <spark.version>${spark323.version}</spark.version>
                 <delta.core.version>${delta20x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark32x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark32x.runtime.version}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -143,6 +151,8 @@
                 <spark.version>${spark324.version}</spark.version>
                 <delta.core.version>${delta20x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark32x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark32x.runtime.version}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -158,6 +168,8 @@
                 <spark.version>${spark325.version}</spark.version>
                 <delta.core.version>${delta20x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark32x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark32x.runtime.version}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -173,6 +185,8 @@
                 <spark.version>${spark330.version}</spark.version>
                 <delta.core.version>${delta23x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark33x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -188,6 +202,8 @@
                 <spark.version>${spark331.version}</spark.version>
                 <delta.core.version>${delta23x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark33x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -203,6 +219,8 @@
                 <spark.version>${spark332.version}</spark.version>
                 <delta.core.version>${delta23x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark33x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -218,6 +236,8 @@
                 <spark.version>${spark333.version}</spark.version>
                 <delta.core.version>${delta23x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark33x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -233,6 +253,8 @@
                 <spark.version>${spark334.version}</spark.version>
                 <delta.core.version>${delta23x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark33x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -248,6 +270,8 @@
                 <spark.version>${spark335.version}</spark.version>
                 <delta.core.version>${delta23x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark33x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -263,6 +287,8 @@
                 <spark.version>${spark340.version}</spark.version>
                 <delta.core.version>${delta24x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark34x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -278,6 +304,8 @@
                 <spark.version>${spark341.version}</spark.version>
                 <delta.core.version>${delta24x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark34x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -293,6 +321,8 @@
                 <spark.version>${spark342.version}</spark.version>
                 <delta.core.version>${delta24x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark34x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -308,6 +338,8 @@
                 <spark.version>${spark343.version}</spark.version>
                 <delta.core.version>${delta24x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark34x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -323,6 +355,8 @@
                 <spark.version>${spark344.version}</spark.version>
                 <delta.core.version>${delta24x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark34x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -339,6 +373,8 @@
                 <delta.core.artifactory>${delta.core.artifactory.post35}</delta.core.artifactory>
                 <delta.core.version>${delta33x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark35x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -355,6 +391,8 @@
                 <delta.core.artifactory>${delta.core.artifactory.post35}</delta.core.artifactory>
                 <delta.core.version>${delta33x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark35x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -371,6 +409,8 @@
                 <delta.core.artifactory>${delta.core.artifactory.post35}</delta.core.artifactory>
                 <delta.core.version>${delta33x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark35x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -387,6 +427,8 @@
                 <delta.core.artifactory>${delta.core.artifactory.post35}</delta.core.artifactory>
                 <delta.core.version>${delta33x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark35x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -403,6 +445,8 @@
                 <delta.core.artifactory>${delta.core.artifactory.post35}</delta.core.artifactory>
                 <delta.core.version>${delta33x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark35x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -419,6 +463,8 @@
                 <delta.core.artifactory>${delta.core.artifactory.post35}</delta.core.artifactory>
                 <delta.core.version>${delta33x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark35x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -436,6 +482,8 @@
                 <delta.core.artifactory>${delta.core.artifactory.post35}</delta.core.artifactory>
                 <delta.core.version>${delta33x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
+                <iceberg.spark.artifact>${iceberg.spark35x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
         <profile>
@@ -454,10 +502,15 @@
                 <delta.core.version>${delta33x.version}</delta.core.version>
                 <hadoop.version>3.3.6</hadoop.version>
                 <elide.level>${elide.level.release}</elide.level>
+                <iceberg.spark.artifact>${iceberg.spark35x.artifact}</iceberg.spark.artifact>
+                <iceberg.spark.runtime.version>${iceberg.spark.runtime.java.8}</iceberg.spark.runtime.version>
             </properties>
         </profile>
     </profiles>
     <properties>
+        <java.version>1.8</java.version>
+        <platform-encoding>UTF-8</platform-encoding>
+        <!-- Define all spark versions we might want to build against -->
         <spark311.version>3.1.1</spark311.version>
         <spark312.version>3.1.2</spark312.version>
         <spark313.version>3.1.3</spark313.version>
@@ -486,17 +539,15 @@
         <spark354.version>3.5.4</spark354.version>
         <spark355.version>3.5.5</spark355.version>
         <spark356.version>3.5.6</spark356.version>
+        <!-- Define default versions for other dependencies -->
         <scala.binary.version>2.12</scala.binary.version>
         <scala.plugin.version>4.3.0</scala.plugin.version>
         <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>
         <maven.clean.plugin.version>3.2.0</maven.clean.plugin.version>
         <scala.version>2.12.15</scala.version>
-        <spark.test.version>${spark333.version}</spark.test.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <scallop.version>3.5.1</scallop.version>
         <scalatest.version>3.0.5</scalatest.version>
-        <spark.version.classifier>spark${buildver}</spark.version.classifier>
-        <target.classifier>${spark.version.classifier}</target.classifier>
         <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>
         <maven.source.plugin.version>3.0.0</maven.source.plugin.version>
         <maven.artifact.version>3.9.0</maven.artifact.version>
@@ -504,6 +555,23 @@
         <rapids.shade.package>com.nvidia.shaded.spark</rapids.shade.package>
         <benchmarks.checkpoints>noOp</benchmarks.checkpoints>
         <jsoup.version>1.16.1</jsoup.version>
+        <!-- properties used for IceBerg (mainly for testing) -->
+        <!--
+          Iceberg artifacts are suffixed by the spark major version they are built against and the
+          scala binaries.
+        -->
+        <iceberg.spark35x.artifact>iceberg-spark-runtime-3.5_${scala.binary.version}</iceberg.spark35x.artifact>
+        <iceberg.spark34x.artifact>iceberg-spark-runtime-3.4_${scala.binary.version}</iceberg.spark34x.artifact>
+        <iceberg.spark33x.artifact>iceberg-spark-runtime-3.3_${scala.binary.version}</iceberg.spark33x.artifact>
+        <iceberg.spark32x.artifact>iceberg-spark-runtime-3.2_${scala.binary.version}</iceberg.spark32x.artifact>
+        <!--
+             Iceberg 1.7.0+ requires Java 11+.
+             Since we use jdk 1.8 as default, we need to use an older version of Iceberg.
+             For Spark-3.2, the version is 1.4.3
+        -->
+        <iceberg.spark32x.runtime.version>1.4.3</iceberg.spark32x.runtime.version>
+        <iceberg.spark.runtime.java.8>1.6.1</iceberg.spark.runtime.java.8>
+        <iceberg.spark.runtime.java.11>1.10.0</iceberg.spark.runtime.java.11>
         <!-- properties used for DeltaLake -->
         <delta10x.version>1.0.1</delta10x.version>
         <delta11x.version>1.1.0</delta11x.version>
@@ -532,8 +600,6 @@
             that to disable non-production code (i.e., Scala asserts).
         -->
         <elide.level>${elide.level.dev}</elide.level>
-        <java.version>1.8</java.version>
-        <platform-encoding>UTF-8</platform-encoding>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -596,6 +662,12 @@
             <groupId>com.github.tototoshi</groupId>
             <artifactId>scala-csv_${scala.binary.version}</artifactId>
             <version>2.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>${iceberg.spark.artifact}</artifactId>
+            <version>${iceberg.spark.runtime.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -555,7 +555,7 @@
         <rapids.shade.package>com.nvidia.shaded.spark</rapids.shade.package>
         <benchmarks.checkpoints>noOp</benchmarks.checkpoints>
         <jsoup.version>1.16.1</jsoup.version>
-        <!-- properties used for IceBerg (mainly for testing) -->
+        <!-- properties used for Iceberg (mainly for testing) -->
         <!--
           Iceberg artifacts are suffixed by the spark major version they are built against and the
           scala binaries.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -1050,7 +1050,7 @@ object PlatformFactory extends Logging {
     }
     val platform = createPlatformInstance(platformName, gpuDevice,
       targetClusterProps)
-    logInfo(s"Using platform: $platform")
+    logDebug(s"Using platform: $platform")
     platform
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SupportedBlankExec.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SupportedBlankExec.scala
@@ -71,9 +71,6 @@ class SupportedBlankExec(
     }
   }
 
-  // The value that will be reported as ExecName in the ExecInfo object created by this parser.
-  override def reportedExecName: String = fullExecName
-
   // No expressions to parse for this exec.
   override def parseExpressions(): Array[String] = Array.empty[String]
 
@@ -112,7 +109,7 @@ class SupportedBlankExec(
 }
 
 object SupportedBlankExec extends GroupParserTrait {
-  val EXEC_TYPES: Map[String, OpTypes.Value] = Map(
+  private val EXEC_TYPES: Map[String, OpTypes.Value] = Map(
     EX_NAME_WRITE_FILES -> OpTypes.WriteExec
   )
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -124,7 +124,7 @@ class PluginTypeChecker(platform: Platform = PlatformFactory.createInstance(),
   private def readOperatorsScore: Map[String, Double] = {
     speedupFactorFile match {
       case None =>
-        logInfo(s"Trying to read operators scores with platform: $platform")
+        logDebug(s"Trying to read operators scores with platform: $platform")
         val file = platform.getOperatorScoreFile
         try {
           val source = UTF8Source.fromResource(file)
@@ -138,7 +138,7 @@ class PluginTypeChecker(platform: Platform = PlatformFactory.createInstance(),
             readOperators(source, "score", true).map(x => (x._1, x._2.toDouble))
         }
       case Some(file) =>
-        logInfo(s"Reading operators scores from custom speedup factor file: $file")
+        logDebug(s"Reading operators scores from custom speedup factor file: $file")
         try {
           val path = new Path(file)
           val fs = FileSystem.get(path.toUri, new Configuration())

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -1028,7 +1028,7 @@ object QualificationAppInfo extends Logging {
       if (!app.isAppMetaDefined) {
         throw IncorrectAppStatusException()
       }
-      logInfo(s"${path.eventLog.toString} has App: ${app.appId}")
+      logDebug(s"${path.eventLog.toString} has App: ${app.appId}")
       Right(app)
     } catch {
       case e: Exception =>

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/stubs/GraphReflectionAPIHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/stubs/GraphReflectionAPIHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ object GraphReflectionAPIHelper extends Logging {
     }
     // Log this information or show an error to be aware of incompatible runtimes.
     if (res.isDefined) {
-      logInfo(s"Using runtime API [${res.get._1}] to Construct SparkPlan Graph")
+      logDebug(s"Using runtime API [${res.get._1}] to Construct SparkPlan Graph")
     } else {
       logError("No runtime Graph API found. Falling to the spark runtime constructor")
     }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -905,7 +905,7 @@ class QualificationSuite extends BaseWithSparkSuite {
                   ArrayBuffer[String]("Execute InsertIntoHadoopFsRelationCommand parquet")
                 if (ToolUtils.isSpark340OrLater()) {
                   // writeFiles is added in Spark 3.4+
-                  execNames += "WriteFilesExec"
+                  execNames += "WriteFiles"
                 }
                 csvF.getColumn("Exec Name") should contain allElementsOf execNames
               }
@@ -1005,7 +1005,7 @@ class QualificationSuite extends BaseWithSparkSuite {
                         ArrayBuffer[String]("Execute InsertIntoHadoopFsRelationCommand orc")
                       if (ToolUtils.isSpark340OrLater()) {
                         // writeFiles is added in Spark 3.4+
-                        execNames += "WriteFilesExec"
+                        execNames += "WriteFiles"
                       }
                       csvF.getColumn("Exec Name") should contain allElementsOf execNames
                     }
@@ -1116,7 +1116,7 @@ class QualificationSuite extends BaseWithSparkSuite {
                         ArrayBuffer[String]("Execute InsertIntoHadoopFsRelationCommand parquet")
                       if (ToolUtils.isSpark340OrLater()) {
                         // writeFiles is added in Spark 3.4+
-                        execNames += "WriteFilesExec"
+                        execNames += "WriteFiles"
                       }
                       csvF.getColumn("Exec Name") should contain allElementsOf execNames
                     }
@@ -1226,7 +1226,7 @@ class QualificationSuite extends BaseWithSparkSuite {
                         ArrayBuffer[String]("Execute InsertIntoHiveTable hiveparquet")
                       if (ToolUtils.isSpark340OrLater()) {
                         // writeFiles is added in Spark 3.4+
-                        execNames += "WriteFilesExec"
+                        execNames += "WriteFiles"
                       }
                       csvF.getColumn("Exec Name") should contain allElementsOf execNames
                     }
@@ -1301,7 +1301,7 @@ class QualificationSuite extends BaseWithSparkSuite {
                 ArrayBuffer[String]("Execute InsertIntoHadoopFsRelationCommand parquet")
               if (ToolUtils.isSpark340OrLater()) {
                 // writeFiles is added in Spark 3.4+
-                execNames += "WriteFilesExec"
+                execNames += "WriteFiles"
               }
               csvF.getColumn("Exec Name") should contain allElementsOf execNames
             }
@@ -1313,7 +1313,7 @@ class QualificationSuite extends BaseWithSparkSuite {
             "Parquet write appears in the Unsupported Operator column",
             csvF => {
               csvF.getColumn("Unsupported Operator") should contain noneOf (
-                "writeFilesExec", "Execute InsertIntoHadoopFsRelationCommand parquet"
+                "writeFiles", "Execute InsertIntoHadoopFsRelationCommand parquet"
               )
             }))
       .build()
@@ -1385,7 +1385,7 @@ class QualificationSuite extends BaseWithSparkSuite {
   }
 
   test("AppendDataExec is not Supported with Iceberg") {
-    // This UT configures Spark to use IceBerg.
+    // This UT configures Spark to use Iceberg.
     // It must use the writeToAPI to generate the AppendDataExec operator. This is the V2 version.
     // Otherwise, it will use the V1 version which is AppendDataExecV1.
     TrampolineUtil.withTempDir { warehouseDir =>

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.tool.qualification
 import java.io.{File, PrintWriter}
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
-import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 
 import com.nvidia.spark.rapids.BaseWithSparkSuite
 import com.nvidia.spark.rapids.tool.{EventlogProviderImpl, StatusReportCounts, ToolTestUtils}
@@ -29,7 +29,7 @@ import org.scalatest.AppendedClues.convertToClueful
 import org.scalatest.Matchers._
 
 import org.apache.spark.scheduler.{SparkListener, SparkListenerStageCompleted, SparkListenerTaskEnd}
-import org.apache.spark.sql.{SparkSession, TrampolineUtil}
+import org.apache.spark.sql.{SaveMode, SparkSession, TrampolineUtil}
 import org.apache.spark.sql.rapids.tool.ToolUtils
 import org.apache.spark.sql.rapids.tool.util.UTF8Source
 
@@ -901,10 +901,11 @@ class QualificationSuite extends BaseWithSparkSuite {
             .withContentVisitor(
               "Execs should list the write ops",
               csvF => {
-                val execNames = Seq[String]("Execute InsertIntoHadoopFsRelationCommand parquet")
+                val execNames =
+                  ArrayBuffer[String]("Execute InsertIntoHadoopFsRelationCommand parquet")
                 if (ToolUtils.isSpark340OrLater()) {
                   // writeFiles is added in Spark 3.4+
-                  execNames :+ "WriteFiles"
+                  execNames += "WriteFilesExec"
                 }
                 csvF.getColumn("Exec Name") should contain allElementsOf execNames
               }
@@ -1000,10 +1001,11 @@ class QualificationSuite extends BaseWithSparkSuite {
                   .withContentVisitor(
                     "Execs should list the write ops",
                     csvF => {
-                      val execNames = Seq[String]("Execute InsertIntoHadoopFsRelationCommand orc")
+                      val execNames =
+                        ArrayBuffer[String]("Execute InsertIntoHadoopFsRelationCommand orc")
                       if (ToolUtils.isSpark340OrLater()) {
                         // writeFiles is added in Spark 3.4+
-                        execNames :+ "WriteFiles"
+                        execNames += "WriteFilesExec"
                       }
                       csvF.getColumn("Exec Name") should contain allElementsOf execNames
                     }
@@ -1111,10 +1113,10 @@ class QualificationSuite extends BaseWithSparkSuite {
                     "Execs should list the write ops",
                     csvF => {
                       val execNames =
-                        Seq[String]("Execute InsertIntoHadoopFsRelationCommand parquet")
+                        ArrayBuffer[String]("Execute InsertIntoHadoopFsRelationCommand parquet")
                       if (ToolUtils.isSpark340OrLater()) {
                         // writeFiles is added in Spark 3.4+
-                        execNames :+ "WriteFiles"
+                        execNames += "WriteFilesExec"
                       }
                       csvF.getColumn("Exec Name") should contain allElementsOf execNames
                     }
@@ -1220,10 +1222,11 @@ class QualificationSuite extends BaseWithSparkSuite {
                   .withContentVisitor(
                     "Execs should list the write ops",
                     csvF => {
-                      val execNames = Seq[String]("Execute InsertIntoHiveTable hiveparquet")
+                      val execNames =
+                        ArrayBuffer[String]("Execute InsertIntoHiveTable hiveparquet")
                       if (ToolUtils.isSpark340OrLater()) {
                         // writeFiles is added in Spark 3.4+
-                        execNames :+ "WriteFiles"
+                        execNames += "WriteFilesExec"
                       }
                       csvF.getColumn("Exec Name") should contain allElementsOf execNames
                     }
@@ -1254,6 +1257,183 @@ class QualificationSuite extends BaseWithSparkSuite {
           }
         }
       }
+    }
+  }
+
+  test("InsertIntoHadoopFsRelationCommand parquet is supported with legacy V1 operator") {
+    // Legacy V1 operator InsertIntoHadoopFsRelationCommand is used when the write API is used
+    // to write into a parquet file. Append/Overwrite won't generate the AppendDataExec operator.
+    // In that case, we test that we support the cmd.
+    QToolTestCtxtBuilder()
+      .withEvLogProvider(
+        EventlogProviderImpl(s"create an app with parquet file write with")
+          .withAppName(s"AppendDataExecParquet")
+          .withFunc { (provider, spark) =>
+            import spark.implicits._
+            val rootDir = provider.rootDir.get
+            val outParquetFile = s"$rootDir/outparquet.parquet"
+            // 1. Create an initial DataFrame and save it
+            val initialData = Seq(("Alice", 30), ("Bob", 25)).toDF("name", "age")
+            initialData.write
+              .mode("Overwrite") // Overwrite if file exists for initial save
+              .parquet(outParquetFile)
+            // 2. Create new data to append
+            val newData = Seq(("Charlie", 35), ("David", 40)).toDF("name", "age")
+            // 3. Append the new data to the existing data source
+            newData.write
+              .mode("Append") // Append mode
+              .parquet(outParquetFile)
+            // 4. Read the combined data to verify
+            spark.read.parquet(outParquetFile)
+          })
+      .withPerSQL()
+      .withChecker(
+        QToolResultCoreChecker("check app count")
+          .withExpectedSize(1)
+          .withSuccessCode())
+      .withChecker(
+        QToolOutFileCheckerImpl("Execs should contain Write operation")
+          .withTableLabel("execCSVReport")
+          .withContentVisitor(
+            "Execs should list the write ops",
+            csvF => {
+              val execNames =
+                ArrayBuffer[String]("Execute InsertIntoHadoopFsRelationCommand parquet")
+              if (ToolUtils.isSpark340OrLater()) {
+                // writeFiles is added in Spark 3.4+
+                execNames += "WriteFilesExec"
+              }
+              csvF.getColumn("Exec Name") should contain allElementsOf execNames
+            }
+          ))
+      .withChecker(
+        QToolOutFileCheckerImpl("Unsupported operators should contain AppendDataExec")
+          .withTableLabel("unsupportedOpsCSVReport")
+          .withContentVisitor(
+            "Parquet write appears in the Unsupported Operator column",
+            csvF => {
+              csvF.getColumn("Unsupported Operator") should contain noneOf (
+                "writeFilesExec", "Execute InsertIntoHadoopFsRelationCommand parquet"
+              )
+            }))
+      .build()
+  }
+
+  test("AppendDataExecV1 DeltaLake is supported") {
+    // This UT configures Spark to use DeltaLake and uses the write API to generate the
+    // AppendDataExecV1 operator.
+    // Till the day the test was written, there was no clear way on how generate the V2
+    // AppendDataExec operator when using DeltaLake.
+    QToolTestCtxtBuilder()
+      .withEvLogProvider(
+        EventlogProviderImpl(s"create an app with parquet file write with")
+          .withAppName(s"TestAppAppendDataExecDeltaLake")
+          .withSparkConfigs(
+            Map(
+              "spark.sql.extensions" -> "io.delta.sql.DeltaSparkSessionExtension",
+              "spark.sql.catalog.spark_catalog" ->
+                "org.apache.spark.sql.delta.catalog.DeltaCatalog"
+            )
+          )
+          .withFunc { (provider, spark) =>
+            import spark.implicits._
+            val rootDir = provider.rootDir.get
+            val outDeltaPath = s"$rootDir/out_delta"
+            // 1. Create an initial DataFrame and save it to Delta table
+            val initialData = Seq(("apples", 100)).toDF("fruit", "quantity")
+            initialData.write.format("delta").mode(SaveMode.Overwrite).save(outDeltaPath)
+            // 2. Create new data to append
+            val newData = Seq(("bananas", 200)).toDF("fruit", "quantity")
+            // 3. Append new data
+            // This shows an AppenDataExecV1 because the usage of writeTo API.
+            newData.writeTo(s"delta.`$outDeltaPath`").append()
+            spark.sql(s"SELECT * FROM delta.`$outDeltaPath`")
+          })
+      .withPerSQL()
+      .withChecker(
+        QToolResultCoreChecker("check app count")
+          .withExpectedSize(1)
+          .withSuccessCode())
+      .withChecker(
+        QToolOutFileCheckerImpl("Execs should contain Write operation")
+          .withTableLabel("execCSVReport")
+          .withContentVisitor(
+            "Execs should list the write ops",
+            csvF => {
+              val execNames = Seq[String](
+                "Execute SaveIntoDataSourceCommand",
+                "AppendDataExecV1")
+              csvF.getColumn("Exec Name") should contain allElementsOf execNames
+              csvF.csvRows.count { r =>
+                execNames.contains(r("Exec Name")) &&
+                  r("Expression Name").toLowerCase.contains("delta")
+              } shouldBe 2
+            }
+          ))
+      .withChecker(
+        QToolOutFileCheckerImpl("Unsupported operators should contain AppendDataExec")
+          .withTableLabel("unsupportedOpsCSVReport")
+          .withContentVisitor(
+            "Parquet write appears in the Unsupported Operator column",
+            csvF => {
+              csvF.getColumn("Unsupported Operator") should contain noneOf (
+                "Execute SaveIntoDataSourceCommand",
+                "AppendDataExecV1"
+              )
+            }))
+      .build()
+  }
+
+  test("AppendDataExec is not Supported with Iceberg") {
+    // This UT configures Spark to use IceBerg.
+    // It must use the writeToAPI to generate the AppendDataExec operator. This is the V2 version.
+    // Otherwise, it will use the V1 version which is AppendDataExecV1.
+    TrampolineUtil.withTempDir { warehouseDir =>
+      QToolTestCtxtBuilder()
+        .withEvLogProvider(
+          EventlogProviderImpl(s"create an app with parquet file write with")
+            .withAppName(s"TestAppAppendDataExecDeltaLake")
+            .withSparkConfigs(
+              Map(
+                "spark.sql.extensions" ->
+                  "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.catalog.local" -> "org.apache.iceberg.spark.SparkCatalog",
+                "spark.sql.catalog.local.type" ->  "hadoop",
+                "spark.sql.catalog.local.warehouse" -> warehouseDir.getAbsolutePath))
+            .withFunc { (_, spark) =>
+              import spark.implicits._
+              // 1. Create an initial DataFrame and save it to iceberg table
+              spark.sql(
+                "CREATE TABLE local.db.my_iceberg_table (id BIGINT, data STRING) USING iceberg")
+              val df = Seq((3, "iceberg"), (4, "rocks")).toDF("id", "data")
+              // Use writeTo to use the Datasource V2 and generate AppendDataExec
+              df.writeTo("local.db.my_iceberg_table").append()
+              spark.sql("SELECT * FROM local.db.my_iceberg_table")
+            })
+        .withPerSQL()
+        .withChecker(
+          QToolResultCoreChecker("check app count")
+            .withExpectedSize(1)
+            .withSuccessCode())
+        .withChecker(
+          QToolOutFileCheckerImpl("Execs should contain Write operations such as AppendData")
+            .withTableLabel("execCSVReport")
+            .withContentVisitor(
+              "Execs should list the write ops",
+              csvF => {
+                val execNames = Seq[String]("AppendData")
+                csvF.getColumn("Exec Name") should contain allElementsOf execNames
+              }
+            ))
+        .withChecker(
+          QToolOutFileCheckerImpl("Unsupported operators should contain AppendDataExec")
+            .withTableLabel("unsupportedOpsCSVReport")
+            .withContentVisitor(
+              "AppendData appears in the Unsupported Operator column",
+              csvF => {
+                csvF.getColumn("Unsupported Operator") should contain ("AppendData")
+              }))
+        .build()
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Contributes to #1919

This change is to add support to run/generate tests with IceBerg. Prior to that, core-tools did not handle IceBerg.
For this initial change, the `AppenData` is considered unsupported. In followups to the same issue, we need to write Parser for AppenData and be able to recongnize it as a write Op along with the approprate Format.
We might need to define a separate Helper for Iceberg (similar to DeltaLake/Databricks)

- Updated pom file to contain `IceBerg` in the test-scope
- Added unit-test for ICeberg
- Fixed a couple of bugs in previous unit-tests related to checking for `WriteFiles` instead of `WriteFilesExec`.

This pull request updates the build configuration to improve compatibility and support for Apache Iceberg across multiple Spark versions. The main focus is on adding Iceberg-specific properties for different Spark profiles in `core/pom.xml`, and updating the workflow matrix for Spark versions in the CI configuration.

### Build and Dependency Management

* Added `iceberg.spark.artifact` and `iceberg.spark.runtime.version` properties to each Spark profile in `core/pom.xml`, ensuring correct Iceberg runtime versions are used for Spark 3.2.x through 3.5.x. This improves compatibility and simplifies testing across Spark versions. [[1]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR86-R87) [[2]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR103-R104) [[3]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR120-R121) [[4]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR137-R138) [[5]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR154-R155) [[6]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR171-R172) [[7]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR188-R189) [[8]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR205-R206) [[9]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR222-R223) [[10]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR239-R240) [[11]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR256-R257) [[12]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR273-R274) [[13]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR290-R291) [[14]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR307-R308) [[15]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR324-R325) [[16]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR341-R342) [[17]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR358-R359) [[18]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR376-R377) [[19]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR394-R395) [[20]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR412-R413) [[21]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR430-R431) [[22]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR448-R449) [[23]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR466-R467) [[24]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR485-R486) [[25]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR505-R513)
* Defined new Iceberg artifact and runtime version properties for Spark 3.2.x to 3.5.x, including notes about Java compatibility and version requirements.

### CI Workflow Updates

* Updated the Spark version matrix in `.github/workflows/mvn-verify-check.yml` to test against Spark 3.21 and 3.56, replacing 3.24 with 3.21 for broader compatibility coverage.

### General Maven Properties

* Moved the definition of `java.version` and `platform-encoding` to the top-level properties section, and removed redundant declarations from the bottom of `core/pom.xml`. [[1]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR505-R513) [[2]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcL535-L536)
* Added comments to clarify the purpose of the new Iceberg properties and their versioning logic.

These changes ensure that the project can build and test against a wider range of Spark versions with the correct Iceberg dependencies, improving reliability and maintainability of the build process.