### PR TITLE
Add AppendData parser for Iceberg

### DIFF
--- a/core/src/main/resources/supportedExecs.csv
+++ b/core/src/main/resources/supportedExecs.csv
@@ -22,6 +22,7 @@ InMemoryTableScanExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,PS,PS,
 DataWritingCommandExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,PS,NS,S,NS,PS,PS,PS,NS,S,S
 ExecutedCommandExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
 WriteFilesExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
+AppendDataExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,NS,S,NS,PS,PS,PS,NS,S,S
 AppendDataExecV1,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,NS,S,NS,PS,PS,PS,NS,S,S
 AtomicCreateTableAsSelectExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,NS,S,NS,PS,PS,PS,NS,S,S
 AtomicReplaceTableAsSelectExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,NS,S,NS,PS,PS,PS,NS,S,S

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/GenericExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/GenericExecParser.scala
@@ -34,9 +34,11 @@ class GenericExecParser(
     val app: Option[AppBase] = None
 ) extends ExecParser {
 
+  var unsupportedReason = ""
+
   lazy val trimmedNodeName: String = GenericExecParser.cleanupNodeName(node)
 
-  val fullExecName: String = execName.getOrElse(trimmedNodeName + "Exec")
+  lazy val fullExecName: String = execName.getOrElse(trimmedNodeName + "Exec")
 
   def pullSupportedFlag(registeredName: Option[String] = None): Boolean = {
     checker.isExecSupported(registeredName.getOrElse(fullExecName))
@@ -44,6 +46,10 @@ class GenericExecParser(
 
   def pullSpeedupFactor(registeredName: Option[String] = None): Double = {
     checker.getSpeedupFactor(registeredName.getOrElse(fullExecName))
+  }
+
+  def setUnsupportedReason(r: String): Unit = {
+    unsupportedReason = r
   }
 
   override def parse: ExecInfo = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/GroupParserTrait.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/GroupParserTrait.scala
@@ -20,6 +20,7 @@ import com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker
 
 import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
 import org.apache.spark.sql.rapids.tool.AppBase
+import org.apache.spark.sql.rapids.tool.util.CacheablePropsHandler
 
 trait GroupParserTrait {
   /**
@@ -28,6 +29,31 @@ trait GroupParserTrait {
    * @return true if this parserGroup can handle the node, false otherwise
    */
   def accepts(nodeName: String): Boolean = false
+
+  /**
+   * Checks whether this parserGroup should handle the given node name.
+   * This is used when the node name alone is not sufficient to determine
+   * if the node should be handled by this parserGroup.
+   * @param nodeName name of the node to check
+   * @param confProvider optional configuration provider.
+   * @return true if this parserGroup can handle the node, false otherwise
+   */
+  def accepts(
+      nodeName: String,
+      confProvider: Option[CacheablePropsHandler]): Boolean = false
+
+  /**
+   * Checks whether this parserGroup should handle the given node.
+   * @param node spark plan graph node
+   * @param confProvider optional configuration provider.
+   *                     This is used to access the spark configurations to decide whether
+   *                     the node is handled by the parserGroup. For example, check if the
+   *                     providerImpl is Iceberg/DeltaLake
+   * @return true if this parserGroup can handle the node, false otherwise
+   */
+  def accepts(
+      node: SparkPlanGraphNode,
+      confProvider: Option[CacheablePropsHandler]): Boolean = false
 
   /**
    * Create an ExecParser for the given node.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SupportedBlankExec.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SupportedBlankExec.scala
@@ -58,7 +58,7 @@ class SupportedBlankExec(
   }
 
   // If execName is provided, use it. Otherwise, derive from node name.
-  override val fullExecName: String = {
+  override lazy val fullExecName: String = {
     execName match {
       case Some(v) => v
       case _ =>

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SupportedOpStub.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SupportedOpStub.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.planparser
+
+/**
+ * A stub class to hold the static information about a Delta Lake operator.
+ *
+ * @param nodeName       the exact name of the SparkPlanGraphNode
+ * @param isSupported    whether this operator is supported in the plugin
+ * @param opType         the type of the operator, default to OpTypes.Exec
+ * @param sqlMetricNames the set of SQL metric names to be used to compute the duration
+ */
+case class SupportedOpStub(
+  nodeName: String,
+  isSupported: Boolean = true,
+  opType: Option[OpTypes.Value] = Option(OpTypes.Exec),
+  sqlMetricNames: Set[String] = Set.empty) {
+
+  // The name without the "Execute " prefix if any.
+  val execNoPrefix: String = if (nodeName.startsWith("Execute ")) {
+    nodeName.stripPrefix("Execute ")
+  } else {
+    nodeName
+  }
+
+  // The ID used by the plugin. This is useful to match with the PluginTypeChecker.
+  val execID: String = {
+    execNoPrefix + "Exec"
+  }
+
+  // Get the OpType, default to OpTypes.Exec
+  def pullOpType: OpTypes.Value = {
+    opType match {
+      case Some(v) => v
+      case None => OpTypes.Exec
+    }
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/WriteOpMetaExtractorTrait.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/WriteOpMetaExtractorTrait.scala
@@ -85,6 +85,7 @@ trait WriteOpMetaExtractorTrait {
     components.headOption.flatMap { p =>
       p.split("\\s+") match {
         case Array(pref, cmd, _*) if pref.startsWith("Execute") => Some(cmd)
+        case Array(cmd, _*) => Some(cmd) // No Execute prefix
         case _ => None
       }
     }.getOrElse(StringUtils.UNKNOWN_EXTRACT)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/delta/DeltaLakeBlankExec.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/delta/DeltaLakeBlankExec.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids.tool.planparser.delta
 
-import com.nvidia.spark.rapids.tool.planparser.{OpTypes, SupportedBlankExec}
+import com.nvidia.spark.rapids.tool.planparser.{OpTypes, SupportedBlankExec, SupportedOpStub}
 import com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker
 
 import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
@@ -49,7 +49,7 @@ class DeltaLakeBlankExec(
     opStub.sqlMetricNames
   }
 
-  override val fullExecName: String = opStub.execID
+  override lazy val fullExecName: String = opStub.execID
 
   override def reportedExecName: String = opStub.nodeName
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/delta/DeltaLakeOps.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/delta/DeltaLakeOps.scala
@@ -16,44 +16,12 @@
 
 package com.nvidia.spark.rapids.tool.planparser.delta
 
-import com.nvidia.spark.rapids.tool.planparser.{ExecParser, GroupParserTrait, OpTypes}
+import com.nvidia.spark.rapids.tool.planparser.{ExecParser, GroupParserTrait, OpTypes, SupportedOpStub}
 import com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker
 
 import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
 import org.apache.spark.sql.rapids.tool.AppBase
 
-/**
- * A stub class to hold the static information about a Delta Lake operator.
- * @param nodeName the exact name of the SparkPlanGraphNode
- * @param isSupported whether this operator is supported in the plugin
- * @param opType the type of the operator, default to OpTypes.Exec
- * @param sqlMetricNames the set of SQL metric names to be used to compute the duration
- * @param deltaSpecific whether this operator is specific to Delta Lake. Default to true.
- */
-case class SupportedOpStub(
-    nodeName: String,
-    isSupported: Boolean = true,
-    opType: Option[OpTypes.Value] = Option(OpTypes.Exec),
-    sqlMetricNames: Set[String] = Set.empty,
-    deltaSpecific: Boolean = true) {
-  // The name without the "Execute " prefix if any.
-  val execNoPrefix: String = if (nodeName.startsWith("Execute ")) {
-      nodeName.stripPrefix("Execute ")
-    } else {
-      nodeName
-    }
-  // The ID used by the plugin. This is useful to match with the PluginTypeChecker.
-  val execID: String = {
-    execNoPrefix + "Exec"
-  }
-  // Get the OpType, default to OpTypes.Exec
-  def pullOpType: OpTypes.Value = {
-    opType match {
-      case Some(v) => v
-      case None => OpTypes.Exec
-    }
-  }
-}
 
 /**
  * Delta Lake operators.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/iceberg/AppendDataIcebergExtract.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/iceberg/AppendDataIcebergExtract.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids.tool.planparser.iceberg
+
+import com.nvidia.spark.rapids.tool.planparser.{InsertCmdExtractorTrait, InsertIntoHadoopExtract}
+
+import org.apache.spark.sql.rapids.tool.store.WriteOperationMetadataTrait
+import org.apache.spark.sql.rapids.tool.util.StringUtils
+
+/**
+ * Extracts metadata from an Iceberg AppendData operation.
+ * This is subject to change depending on collecting more samples that show that sample text is
+ * different.
+ * A sample planInfo extracted from Spark-3.5.6 looks like:
+ * ```json
+ * {
+ * "sparkPlanInfo": {
+ *   "nodeName": "AppendData",
+ *   "simpleString":
+ *     "AppendData org.apache.spark.sql.execution.datasources.v2.DataSourceV2Strategy$$Lambda$$2293/
+ *     1470843699@46290193, IcebergWrite(table=local.db.my_iceberg_table, format=PARQUET)",
+ *   "children": [..],
+ *   "metadata": {},
+ *   "metrics": [] }
+ * }
+ *
+ * @param nodeDescr description of the node to parse.
+ */
+class AppendDataIcebergExtract(
+    override val nodeDescr: String) extends InsertIntoHadoopExtract(nodeDescr) {
+
+  // Determines if a component string contains catalog information.
+  // It returns true if the string starts with "IcebergWrite(".
+  override def catalogPredicate(compStr: String): Boolean = {
+    compStr.startsWith("IcebergWrite(")
+  }
+
+  // Retrieves a property value from the catalog information.
+  // If found, it returns the trimmed value from that match.
+  private def getPropertyFromCatalog(key: String): Option[String] = {
+    // The (?m) flag enables multiline mode so that ^ matches the beginning of a line.
+    val regex = s"""$key=\\s*([^,)]*)""".r
+    regex.findFirstMatchIn(catalogStr).map(_.group(1).trim)
+  }
+
+  override def extractFormat(components: Seq[String]): String = {
+    // Try to extract the format from the catalog string first.
+    getPropertyFromCatalog("format") match {
+      case Some(format) =>
+        val formatLower = format.toLowerCase
+        if (!formatLower.startsWith("iceberg")) {
+          s"Iceberg${formatLower.capitalize}"
+        } else {
+          formatLower.capitalize
+        }
+      case None =>
+        // If not found, fall back to the parent class method.
+        StringUtils.UNKNOWN_EXTRACT
+    }
+  }
+
+  // the format index is not relevant here  since it is extracted from the catalog string.
+  override var formatIndex: Int = 3
+
+  override def extractCatalog(components: Seq[String]): (String, String) = {
+    // Attempt to extract the database and table from the catalog property "table"
+    if (hasCatalog) {
+      getPropertyFromCatalog("table") match {
+        case Some(databaseTable) =>
+          // Split by dot and extract the last two elements as database and table
+          val parts = databaseTable.split("\\.")
+          if (parts.length >= 2) {
+            val db = parts(parts.length - 2)
+            val table = parts.last
+            (db, table)
+          } else {
+            (StringUtils.UNKNOWN_EXTRACT, StringUtils.UNKNOWN_EXTRACT)
+          }
+        case None =>
+          (StringUtils.UNKNOWN_EXTRACT, StringUtils.UNKNOWN_EXTRACT)
+      }
+    } else {
+      (StringUtils.UNKNOWN_EXTRACT, StringUtils.UNKNOWN_EXTRACT)
+    }
+  }
+}
+
+/**
+ * Companion object for AppendDataIcebergExtract.
+ * It provides methods to build write operation metadata and
+ * to check if a given operation name corresponds to an Iceberg append operation.
+ */
+object AppendDataIcebergExtract extends InsertCmdExtractorTrait {
+  // Constructs the write operation metadata by instantiating AppendDataExtract
+  // and invoking its build method.
+  def buildWriteOp(nodeDescr: String): WriteOperationMetadataTrait = {
+    new AppendDataIcebergExtract(nodeDescr).build()
+  }
+
+  // Determines if the given operation name corresponds to an Iceberg append operation.
+  def accepts(opName: String): Boolean = {
+    opName.equals(IcebergHelper.EXEC_APPEND_DATA)
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/iceberg/AppendDataIcebergParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/iceberg/AppendDataIcebergParser.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.planparser.iceberg
+
+import com.nvidia.spark.rapids.tool.planparser.{ExecInfo, GenericExecParser, OpTypes, SupportedOpStub}
+import com.nvidia.spark.rapids.tool.planparser.ops.UnsupportedExprOpRef
+import com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker
+
+import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
+import org.apache.spark.sql.rapids.tool.AppBase
+import org.apache.spark.sql.rapids.tool.store.{CompressionCodec, WriteOperationMetadataTrait}
+import org.apache.spark.sql.rapids.tool.util.StringUtils
+
+/**
+ * A parser for Iceberg AppendData operations.
+ * @param node the Spark plan graph node
+ * @param checker the plugin type checker
+ * @param sqlID SQL ID associated with the node
+ * @param opStub the SupportedOpStub for this operation
+ * @param app optional application context
+ */
+class AppendDataIcebergParser(
+    override val node: SparkPlanGraphNode,
+    override val checker: PluginTypeChecker,
+    override val sqlID: Long,
+    opStub: SupportedOpStub,
+    override val app: Option[AppBase] = None
+) extends GenericExecParser(
+    node = node,
+    checker = checker,
+    sqlID = sqlID,
+    app = app) {
+
+  override val execName: Option[String] = Some(opStub.nodeName)
+  override lazy val fullExecName: String = opStub.execID
+  // Extract the write operation metadata from the node description
+  // This will parse the node description to extract format, compression, etc.
+  lazy val writeOpMeta: WriteOperationMetadataTrait = {
+    AppendDataIcebergExtract.buildWriteOp(nodeDescr = node.desc)
+  }
+  private lazy val compressionSupported: Boolean = {
+    writeOpMeta.compressOption() match {
+      case StringUtils.UNKNOWN_EXTRACT | CompressionCodec.UNCOMPRESSED =>
+        true
+      case codec => // the output depends on the format
+        writeOpMeta.dataFormat() match {
+          case StringUtils.UNKNOWN_EXTRACT =>
+            true // unknown format, so return true when it comes to compression.
+          case f if f.toLowerCase.contains("parquet") =>
+            // Parquet, IcebergParquet
+            // Parquet supports compression, so we need to check if the compression is supported.
+            checkCompressionParquet(codec)
+          case f if f.toLowerCase.contains("orc") =>
+            // ORC, HiveORC, IcebergORC
+            checkCompressionORC(codec)
+          case _ =>
+            // Other formats do not support compression, so return false.
+            false
+        }
+    }
+  }
+
+  override def pullSpeedupFactor(registeredName: Option[String] = None): Double = 1.5
+
+  override def pullSupportedFlag(registeredName: Option[String] = None): Boolean = {
+    // Check if the operation is supported in the stub,
+    // and if the format and compression are supported.
+    // Also check if the catalog is supported.
+    // Finally, check if the write operation is supported.
+    opStub.isSupported && super.pullSupportedFlag() && isWriteSupported
+  }
+
+  protected def checkCompressionORC(codec: String): Boolean = {
+    // IcebergORC compression is not supported
+    false
+  }
+
+  protected def checkCompressionParquet(codec: String): Boolean = {
+    // IcebergParquet compression is supported for zstd, snappy, gzip
+    codec match {
+      case "zstd" | "snappy" | "gzip" =>
+        true
+      case _ => false // something does not match, so return false.
+    }
+  }
+
+  protected def checkCatalogSupport(): Boolean = {
+    // For Iceberg, RAPIDS only supports running against the Hadoop filesystem catalog.
+    val res = app match {
+      case Some(a) =>
+        IcebergHelper.isSparkCatalogSupported(a.sparkProperties)
+      case _ => true  // we could not extract the catalog, default to True.
+    }
+    if (!res) {
+      setUnsupportedReason("Unsupported Iceberg catalog")
+    }
+    res
+  }
+
+  protected def checkCompression: Boolean = {
+    if (!compressionSupported) {
+      setUnsupportedReason("Unsupported compression")
+    }
+    compressionSupported
+  }
+
+  protected def isWriteSupported: Boolean = {
+    if (checker.isWriteFormatSupported(writeOpMeta.dataFormat())) {
+      // check if the compression is supported
+      checkCatalogSupport() && checkCompression
+    } else {
+      false
+    }
+  }
+
+  override def createExecInfo(
+      speedupFactor: Double,
+      isSupported: Boolean,
+      duration: Option[Long],
+      notSupportedExprs: Seq[UnsupportedExprOpRef],
+      expressions: Array[String]): ExecInfo = {
+    // We do not want to parse the node description to avoid mistakenly marking the node as RDD/UDF.
+    ExecInfo.createExecNoNode(sqlID, s"$trimmedNodeName ${writeOpMeta.dataFormat()}",
+      s"Format: ${writeOpMeta.dataFormat()}",
+      speedupFactor, duration, node.id,
+      opType = OpTypes.WriteExec,
+      isSupported = isSupported,
+      children = None,
+      unsupportedExecReason = unsupportedReason,
+      expressions = Seq.empty
+    )
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/iceberg/IcebergHelper.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/iceberg/IcebergHelper.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.planparser.iceberg
+
+import com.nvidia.spark.rapids.tool.planparser.{OpTypes, SupportedOpStub}
+
+import org.apache.spark.sql.rapids.tool.util.EventUtils.SPARK_CATALOG_REGEX
+
+/**
+ * Helper object for Iceberg related utilities.
+ * This includes methods to check if Iceberg is enabled in the Spark properties,
+ * and to extract the catalog type among other static functionalities.
+ */
+object IcebergHelper {
+  // An Iceberg app is identified using the following properties from spark properties.
+  private val SPARK_PROPS_ENABLING_ICEBERG = Map(
+    "spark.sql.extensions" -> ".*IcebergSparkSessionExtensions.*"
+  )
+
+  // For Iceberg, RAPIDS only supports running against the Hadoop filesystem catalog.
+  private val SUPPORTED_CATALOGS = Set("hadoop")
+
+  val EXEC_APPEND_DATA: String = "AppendData"
+  // A Map between the spark node name and the SupportedOpStub.
+  // Note that AppendDataExec is not supported for Iceberg.
+  val DEFINED_EXECS: Map[String, SupportedOpStub] = Map(
+    EXEC_APPEND_DATA ->
+      SupportedOpStub(
+        EXEC_APPEND_DATA,
+        // The writeOp is not supported in Iceberg
+        isSupported = false,
+        opType = Option(OpTypes.WriteExec)
+      )
+  )
+
+  /**
+   * Checks if the properties indicate that the application is using Iceberg.
+   * This can be checked by looking for keywords in one of the keys defined in
+   * SPARK_PROPS_ENABLING_ICEBERG or if any spark catalog is set.
+   *
+   * @param properties spark properties captured from the eventlog environment details
+   * @return true if the properties indicate that it is an Iceberg app.
+   */
+  def isIcebergEnabled(properties: collection.Map[String, String]): Boolean = {
+    SPARK_PROPS_ENABLING_ICEBERG.exists { case (key, value) =>
+      properties.get(key).exists(_.matches(value))
+    } || properties.keys.exists(key => SPARK_CATALOG_REGEX.pattern.matcher(key).matches())
+  }
+
+  /**
+   * Extracts the catalog type from the spark properties.
+   * This is needed as some ops may not be supported depending on the catalog type.
+   * @param properties spark properties captured from the eventlog environment details
+   * @return the catalog type if found, None otherwise
+   */
+  def getCatalogType(properties: collection.Map[String, String]): Option[String] = {
+    // find the spark catalog property and then get the property that has "catalog.type"
+    properties.keys
+      .find(key => SPARK_CATALOG_REGEX.pattern.matcher(key).matches())
+      .flatMap { catalog =>
+        properties.get(s"$catalog.type")
+      }
+  }
+
+  /**
+   * Checks if the catalog type is supported by RAPIDS.
+   * If the catalog type is not found, it defaults to true.
+   * @param properties spark properties captured from the eventlog environment details
+   * @return true if the catalog type is supported or not found, false otherwise
+   */
+  def isSparkCatalogSupported(properties: collection.Map[String, String]): Boolean = {
+    getCatalogType(properties) match {
+      case Some(catalog) =>
+        SUPPORTED_CATALOGS.contains(catalog.toLowerCase)
+      case _ =>
+        // we could not extract the catalog, default to True.
+        true
+    }
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/iceberg/IcebergWriteOps.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/iceberg/IcebergWriteOps.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.planparser.iceberg
+
+import com.nvidia.spark.rapids.tool.planparser.{ExecParser, GroupParserTrait, OpTypes, SupportedOpStub}
+import com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker
+
+import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
+import org.apache.spark.sql.rapids.tool.AppBase
+import org.apache.spark.sql.rapids.tool.store.WriteOperationMetadataTrait
+import org.apache.spark.sql.rapids.tool.util.CacheablePropsHandler
+
+/**
+ * A GroupParserTrait implementation for Iceberg write operations.
+ * This class identifies and creates ExecParsers for Iceberg write operations
+ * based on the node name and configuration.
+ */
+object IcebergWriteOps extends GroupParserTrait {
+  // A Map between the spark node name and the SupportedOpStub
+  private val DEFINED_EXECS: Map[String, SupportedOpStub] =
+    IcebergHelper.DEFINED_EXECS.filter {
+      case (_, stub) => stub.opType.contains(OpTypes.WriteExec)
+    }
+
+  /**
+   * Checks whether this parserGroup should handle the given node name.
+   *
+   * @param nodeName name of the node to check
+   * @return true if this parserGroup can handle the node, false otherwise
+   */
+  override def accepts(nodeName: String): Boolean = {
+    DEFINED_EXECS.contains(nodeName)
+  }
+
+  /**
+   * Checks whether this parserGroup should handle the given node name.
+   * If conf-provider is defined, it checks if the providerImpl is Iceberg.
+   *
+   * @param nodeName     name of the node to check
+   * @param confProvider optional configuration provider.
+   *                     This is used to access the spark configurations to decide whether
+   *                     the node is handled by the parserGroup. For example, check if the
+   *                     providerImpl is Iceberg/DeltaLake
+   * @return true if this parserGroup can handle the node, false otherwise
+   */
+  override def accepts(
+      nodeName: String,
+      confProvider: Option[CacheablePropsHandler]): Boolean = {
+    confProvider match {
+      case Some(a) if a.icebergEnabled =>
+        a.icebergEnabled && accepts(nodeName)
+      case _ => accepts(nodeName)
+    }
+  }
+
+  /**
+   * Checks whether this parserGroup should handle the given node.
+   *
+   * @param node         spark plan graph node
+   * @param confProvider optional configuration provider.
+   *                     This is used to access the spark configurations to decide whether
+   *                     the node is handled by the parserGroup. For example, check if the
+   *                     providerImpl is Iceberg/DeltaLake
+   * @return true if this parserGroup can handle the node, false otherwise
+   */
+  override def accepts(
+      node: SparkPlanGraphNode,
+      confProvider: Option[CacheablePropsHandler]): Boolean = {
+    accepts(node.name, confProvider)
+  }
+
+  /**
+   * Create an ExecParser for the given node.
+   *
+   * @param node     spark plan graph node
+   * @param checker  plugin type checker
+   * @param sqlID    SQL ID
+   * @param execName optional exec name override
+   * @param opType   optional op type override
+   * @param app      optional AppBase instance
+   * @return an ExecParser for the given node
+   */
+  override def createExecParser(
+      node: SparkPlanGraphNode,
+      checker: PluginTypeChecker,
+      sqlID: Long,
+      execName: Option[String],
+      opType: Option[OpTypes.Value],
+      app: Option[AppBase]): ExecParser = {
+    DEFINED_EXECS.get(node.name) match {
+      case Some(stub) if stub.execID.equals("AppendDataExec") =>
+        new AppendDataIcebergParser(
+          node = node,
+          checker = checker,
+          sqlID = sqlID,
+          opStub = stub,
+          app = app
+        )
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Unsupported Iceberg write op: ${node.name}"
+        )
+    }
+  }
+
+  /**
+   * Extracts the WriteOperationMetadataTrait from the given SparkPlanGraphNode if it is an
+   * accepted Iceberg write operation.
+   * If the node is not accepted, it returns None.
+   * @param node the SparkPlanGraphNode to extract metadata from
+   * @param confProvider optional configuration provider to determine if Iceberg is enabled
+   * @return Some(WriteOperationMetadataTrait) if extraction is successful, None otherwise
+   */
+  def extractOpMeta(
+      node: SparkPlanGraphNode,
+      confProvider: Option[CacheablePropsHandler]
+  ): Option[WriteOperationMetadataTrait] = {
+    if (!accepts(node, confProvider)) {
+      return None
+    }
+    node match {
+      case n if AppendDataIcebergExtract.accepts(n.name) =>
+        Some(AppendDataIcebergExtract.buildWriteOp(n.desc))
+      case _ =>
+        None
+    }
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
@@ -345,7 +345,7 @@ class RunningQualificationApp(
   def buildPlanGraphsInternal(): Unit = {
     this.synchronized {
       if (!_graphBuilt) {
-        sqlManager.buildPlanGraph(this)
+        sqlManager.buildPlanGraph(this, this)
         _graphBuilt = true
       }
     }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -545,7 +545,7 @@ abstract class AppBase(
    * @note This should only be called once.
    */
   protected def buildPlanGraphs(): Unit = {
-    sqlManager.buildPlanGraph(this)
+    sqlManager.buildPlanGraph(this, this)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManager.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManager.scala
@@ -20,6 +20,7 @@ import scala.collection.{breakOut, immutable, mutable}
 
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.rapids.tool.AccumToStageRetriever
+import org.apache.spark.sql.rapids.tool.util.CacheablePropsHandler
 
 // This SparkPlanInfoTruncated is used to trim and serialize
 // SparkPlanInfo by removing the unnecessary fields. Only three fields are kept:
@@ -226,10 +227,14 @@ class SQLPlanModelManager {
    * in the plan and it will only process the most recent version of the given plan.
    * @note This should be called only once to avoid recreating the SparkPlanGraph.
    * @param accumStageMapper The AccumToStageRetriever used to find the stage for each accumulator
+   * @param sparkConfigProvider An object that provides access to the Spark configuration of the
+   *                            analyzed app.
    */
-  def buildPlanGraph(accumStageMapper: AccumToStageRetriever): Unit = {
+  def buildPlanGraph(
+      accumStageMapper: AccumToStageRetriever,
+      sparkConfigProvider: CacheablePropsHandler): Unit = {
     sqlPlans.values.foreach { planModel =>
-      planModel.plan.buildSparkGraph(accumStageMapper)
+      planModel.plan.buildSparkGraph(accumStageMapper, sparkConfigProvider)
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/CacheablePropsHandler.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/CacheablePropsHandler.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.rapids.tool.util
 import scala.collection.JavaConverters._
 
 import com.nvidia.spark.rapids.tool.planparser.HiveParseHelper
+import com.nvidia.spark.rapids.tool.planparser.iceberg.IcebergHelper
 import com.nvidia.spark.rapids.tool.profiling.ProfileUtils
 
 import org.apache.spark.scheduler.{SparkListenerEnvironmentUpdate, SparkListenerJobStart, SparkListenerLogStart}
@@ -116,6 +117,9 @@ trait CacheablePropsHandler {
   // property is global to the entire application once it is set. a.k.a, it cannot be disabled
   // once it was set to true.
   var hiveEnabled = false
+  // A flag to indicate whether the spark App is configured to use Iceberg.
+  // Note that this is only a best-effort flag based on the spark properties.
+  var icebergEnabled = false
   // Indicates the ML eventlogType (i.e., Scala or pyspark). It is set only when MLOps are detected.
   // By default, it is empty.
   var mlEventLogType = ""
@@ -145,6 +149,7 @@ trait CacheablePropsHandler {
 
   def updatePredicatesFromSparkProperties(): Unit = {
     gpuMode ||= ProfileUtils.isPluginEnabled(sparkProperties)
+    icebergEnabled ||= IcebergHelper.isIcebergEnabled(sparkProperties)
     hiveEnabled ||= HiveParseHelper.isHiveEnabled(sparkProperties)
   }
 
@@ -165,6 +170,7 @@ trait CacheablePropsHandler {
 
   def handleJobStartForCachedProps(event: SparkListenerJobStart): Unit = {
     // TODO: we need to improve this in order to support per-job-level
+    icebergEnabled ||= IcebergHelper.isIcebergEnabled(event.properties.asScala)
     hiveEnabled ||= HiveParseHelper.isHiveEnabled(event.properties.asScala)
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
@@ -21,6 +21,7 @@ import java.lang.reflect.InvocationTargetException
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
+import scala.util.matching.Regex
 
 import org.json4s.jackson.JsonMethods.parse
 
@@ -31,6 +32,10 @@ import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart
  * Utility containing the implementation of helpers used for parsing data from event.
  */
 object EventUtils extends Logging {
+  // A valid Spark catalog name must start with a letter, can contain letters, digits,
+  // underscores, or dashes, and must not end with a dot.
+  val SPARK_CATALOG_REGEX: Regex = """spark\\.sql\\.catalog\\.([A-Za-z][A-Za-z0-9_-]*)$""".r
+
   // Set to keep track of missing classes
   private val missingEventClasses = mutable.HashSet[String]()
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/WriteOperationParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/WriteOperationParserSuite.scala
@@ -16,6 +16,7 @@
 
 package com.nvidia.spark.rapids.tool.planparser
 
+import com.nvidia.spark.rapids.tool.planparser.iceberg.IcebergWriteOps
 import org.scalatest.FunSuite
 
 import org.apache.spark.sql.execution.ui
@@ -51,7 +52,8 @@ class WriteOperationParserSuite extends FunSuite {
     expectedCompressionOpt: String = CompressionCodec.UNCOMPRESSED): Unit = {
 
     val metadata: WriteOperationMetadataTrait =
-      DataWritingCommandExecParser.getWriteOpMetaFromNode(node)
+      IcebergWriteOps.extractOpMeta(node, confProvider = None)
+        .getOrElse(DataWritingCommandExecParser.getWriteOpMetaFromNode(node))
 
     assert(metadata.execName() == expectedExecName, "execName")
     assert(metadata.dataFormat() == expectedDataFormat, "dataFormat")
@@ -625,6 +627,29 @@ class WriteOperationParserSuite extends FunSuite {
       expectedDatabaseName = "database1",
       expectedPartitionCols = "date=Some(20240621)",
       expectedCompressionOpt = StringUtils.UNKNOWN_EXTRACT
+    )
+  }
+
+  test("AppendData — Iceberg table Parquet format") {
+    // Test that AppendData is parsed correctly for Iceberg tables.
+    val node = new ui.SparkPlanGraphNode(
+      id = 5,
+      name = "AppendData",
+      desc = "AppendData org.apache.spark.sql.execution.datasources.v2.DataSourceV2Strategy$$Lambda$2293/1470843699@46290193, " +
+        "IcebergWrite(table=local.db.my_iceberg_table, format=PARQUET)",
+      Seq.empty
+    )
+
+    testGetWriteOpMetaFromNode(
+      node,
+      expectedExecName = "AppendData",
+      expectedDataFormat = "IcebergParquet",
+      expectedOutputPath = StringUtils.UNKNOWN_EXTRACT,
+      expectedOutputColumns = StringUtils.UNKNOWN_EXTRACT,
+      expectedWriteMode = StringUtils.UNKNOWN_EXTRACT,
+      expectedTableName = "my_iceberg_table",
+      expectedDatabaseName = "db",
+      expectedPartitionCols = StringUtils.UNKNOWN_EXTRACT
     )
   }
   // scalastyle:on line.size.limit


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1919

- add object helper for Iceberg operators.
- add parser and writeMeta extractor for AppendData
- Currently, AppendData Iceberg is handled as unsupported and it only shows up with Iceberg.
- Added some refactoring to pass the spark configurations to the Parser. this will help improve the accuracy taking decisions based on the spark configs.

This pull request introduces support for parsing and extracting metadata from Iceberg write operations, specifically `AppendDataExec`, in the Spark RAPIDS tool. It generalizes operator stubs for reuse, extends the plan parser infrastructure to better handle catalog-specific logic, and improves the flexibility and maintainability of the codebase.

**Iceberg Write Operations Support:**

- Added a new parser (`IcebergWriteOps`) and extractor (`AppendDataIcebergExtract`) to recognize and extract metadata from Iceberg `AppendDataExec` nodes, including catalog and format information. [[1]](diffhunk://#diff-f3af3132cbefbed7e6fb91b6313a137c8d09d65944f77893453bc7ff1bbf5b22R1-R117) [[2]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeR553-R558) [[3]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeR27) [[4]](diffhunk://#diff-f9bf3fcb53f8ff711f2a5a29c69336cfe63bd0c0fb19a2f62c1f6302cb0dbd35R25)

**Operator Stub Refactoring:**

- Generalized the `SupportedOpStub` class (previously Delta Lake-specific) for use with other catalog implementations, like Iceberg, and updated Delta Lake code to use the new shared version. [[1]](diffhunk://#diff-c945ef0306006d7ea2d1c56e4fe12f132763afaba9a845986e9607fb8493207dR1-R52) [[2]](diffhunk://#diff-d9f9e31d60e11ef2beb825984766db6b6baf7072e6c2d1fabfd72084c352fccaL19-L56) [[3]](diffhunk://#diff-2c7917b676700e8e9a3b4c68d146849b252ef0e219d089d37ddd686fb47b53baL19-R19)

**Plan Parser Infrastructure Enhancements:**

- Extended the `GroupParserTrait` with new `accepts` overloads to allow more flexible matching based on node names, nodes, and configuration providers, enabling better handling of catalog-specific logic. [[1]](diffhunk://#diff-97583edc37a96dc5b6d11fc31a355f0fa1b458b2ac7f49871040cd3ce0e06ebcR23) [[2]](diffhunk://#diff-97583edc37a96dc5b6d11fc31a355f0fa1b458b2ac7f49871040cd3ce0e06ebcR33-R57)
- Improved handling of operator names without the "Execute" prefix in write operation metadata extraction.

**General Improvements and Bug Fixes:**

- Changed `fullExecName` in several classes to be `lazy val` for consistency and performance. [[1]](diffhunk://#diff-171692b6f14db0908428557745327f788da85301dba7c16296a43ed493c7a2d9R37-R41) [[2]](diffhunk://#diff-7ebec57e59e181632a8f8dfc46e417cffd510f45d1cfc7d535853a42cb09c10cL61-R61) [[3]](diffhunk://#diff-2c7917b676700e8e9a3b4c68d146849b252ef0e219d089d37ddd686fb47b53baL52-R52)
- Added an `unsupportedReason` field and setter to `GenericExecParser` for better reporting of unsupported cases. [[1]](diffhunk://#diff-171692b6f14db0908428557745327f788da85301dba7c16296a43ed493c7a2d9R37-R41) [[2]](diffhunk://#diff-171692b6f14db0908428557745327f788da85301dba7c16296a43ed493c7a2d9R51-R54)
- Added a new unsupported reason, `UNSUPPORTED_CATALOG`, to the `UnsupportedReasons` enumeration for clearer diagnostics. [[1]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL55-R57) [[2]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeR79)

**Iceberg Write Operation Recognition:**

- Updated the main plan parser (`SQLPlanParser`) to recognize and delegate Iceberg write operations to the new parser, ensuring correct handling and extensibility for future catalog types. [[1]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeR553-R558) [[2]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL520-L521)

These changes collectively improve the tool's ability to parse, analyze, and report on Spark plans involving different data catalogs, with a particular focus on extending support for Iceberg.
