### PR TITLE
Remove noise from core tools log messages

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/EventLogPathProcessor.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/EventLogPathProcessor.scala
@@ -449,7 +449,7 @@ object EventLogPathProcessor extends Logging {
   }
 
   def logApplicationInfo(app: ApplicationInfo) = {
-    logInfo(s"==============  ${app.appId} ==============")
+    logDebug(s"==============  ${app.appId} ==============")
   }
 
   def getDBEventLogFileDate(eventLogFileName: String): LocalDateTime = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -943,7 +943,7 @@ class OnPremPlatform(gpuDevice: Option[GpuDevice],
           gpuDevice = gpuDevice)
       }
     }.orElse {
-      logInfo("Worker info or Gpu info is not provided in the target cluster. " +
+      logDebug("Worker info or Gpu info is not provided in the target cluster. " +
         "Skipping recommended instance info creation.")
       None
     }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
@@ -218,7 +218,7 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
       if (!app.isAppMetaDefined) {
         throw IncorrectAppStatusException()
       }
-      logInfo(s"Took ${endTime - startTime}ms to create App for ${path.eventLog.toString}")
+      logDebug(s"Took ${endTime - startTime}ms to create App for ${path.eventLog.toString}")
       Right(app)
     } catch {
       case e: Exception =>
@@ -277,7 +277,7 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
     val endTime = System.currentTimeMillis()
     val appInfo = collect.getAppInfo
     val sqlMetrics = collect.getSQLPlanMetrics
-    logInfo(s"Time to collect Profiling Info [${appInfo.head.appId}]: ${endTime - startTime}.")
+    logDebug(s"Time to collect Profiling Info [${appInfo.head.appId}]: ${endTime - startTime}.")
     val appInfoSummary = ApplicationSummaryInfo(
       appInfo = appInfo,
       dsInfo = collect.getDataSourceInfo(sqlMetrics),

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
@@ -39,10 +39,46 @@ object EventUtils extends Logging {
   // Set to keep track of missing classes
   private val missingEventClasses = mutable.HashSet[String]()
 
+  // This is the prefix of the assertion error message we want to track when IPV6 is not valid.
+  private val IPV6_ASSERTION_ERR_PREFIX =
+    "assertion failed: Expected hostname or IPv6 IP enclosed in [] but got"
+  // A cache to avoid reporting the same unknown exception more than once
+  // The key is the exception message, and the value is the count of occurences
+  private val cachedUnknownExceptions = new java.util.concurrent.ConcurrentHashMap[String, Int]()
+
   private def reportMissingEventClass(className: String): Unit = {
     if (!missingEventClasses.contains(className)) {
       missingEventClasses.add(className)
       logWarning(s"ClassNotFoundException while parsing an event: $className")
+    }
+  }
+
+  /**
+   * Handles AssertionError exceptions, specifically to catch and log the
+   * "assertion failed: expected hostname or IPv6" error only once. If the error keeps occuring we
+   * only report it once.
+   * @param t the Throwable to handle
+   */
+  private def handleAssertionError(t: Throwable): Unit = {
+    // report assertion failed: expected hostname or IPv6 only once
+    val (keyErrMsg, dumpStack) = if (t.getMessage.startsWith(IPV6_ASSERTION_ERR_PREFIX)) {
+      // use a constant key to track this specific error and suppress the entire stack.
+      (IPV6_ASSERTION_ERR_PREFIX, false)
+    } else {
+      (t.getMessage, true)
+    }
+    val errCount =
+      cachedUnknownExceptions.compute(keyErrMsg, (_, v) => Option(v).map(_ + 1).getOrElse(1))
+    if (errCount == 1) {
+      // only report the first occurrence
+      val errMessage = "Assertion Error encountered while parsing an event. " +
+        "Only the first occurrence will be logged; subsequent similar errors will be suppressed " +
+        "for clarity.\n\t\t"
+      if (dumpStack) {
+        logError(errMessage, t)
+      } else {
+        logError(errMessage + s"${t.getMessage}")
+      }
     }
   }
 
@@ -237,6 +273,10 @@ object EventUtils extends Logging {
                 case z: ClassNotFoundException if z.getMessage != null =>
                   // Avoid reporting missing classes more than once to reduce noise in the logs
                   reportMissingEventClass(z.getMessage)
+                case a: AssertionError =>
+                  // This is to catch "assertion failed: expected hostname or IPv6"
+                  // which may be caused by malformed eventlog.
+                  handleAssertionError(a)
                 case t: Throwable =>
                   // We do not want to swallow unknown exceptions so that we can handle later
                   logError(s"Unknown exception while parsing an event", t)


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1938

This change is reduce the noise from log messages converting some messages to debug level.
Most important change is to suppress the frequent Aseertion error messages caused by IPV6 compatibility. Instead, it will only be reported once.


