### PR TITLE
Use hadoop-aws 3.3.4 with spark-356 and 357

### DIFF
--- a/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
@@ -21,13 +21,13 @@
             },
             {
               "name": "Hadoop AWS",
-              "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.4.1/hadoop-aws-3.4.1.jar",
+              "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
               "verification": {
                 "fileHash": {
                   "algorithm": "sha1",
-                  "value": "641d8fe1d7683cdcc05cc3a794c0374553f6bd6a"
+                  "value": "a65839fbf1869f81a1632e09f415e586922e4f80"
                 },
-                "size": 865554
+                "size": 962685
               }
             },
             {
@@ -60,13 +60,13 @@
             },
             {
               "name": "Hadoop AWS",
-              "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.4.1/hadoop-aws-3.4.1.jar",
+              "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
               "verification": {
                 "fileHash": {
                   "algorithm": "sha1",
-                  "value": "641d8fe1d7683cdcc05cc3a794c0374553f6bd6a"
+                  "value": "a65839fbf1869f81a1632e09f415e586922e4f80"
                 },
-                "size": 865554
+                "size": 962685
               }
             },
             {

--- a/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
@@ -21,13 +21,13 @@
           },
           {
             "name": "Hadoop AWS",
-            "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.4.1/hadoop-aws-3.4.1.jar",
+            "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
             "verification": {
               "fileHash": {
                 "algorithm": "sha1",
-                "value": "641d8fe1d7683cdcc05cc3a794c0374553f6bd6a"
+                "value": "a65839fbf1869f81a1632e09f415e586922e4f80"
               },
-              "size": 865554
+              "size": 962685
             }
           },
           {
@@ -60,13 +60,13 @@
           },
           {
             "name": "Hadoop AWS",
-            "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.4.1/hadoop-aws-3.4.1.jar",
+            "uri": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar",
             "verification": {
               "fileHash": {
                 "algorithm": "sha1",
-                "value": "641d8fe1d7683cdcc05cc3a794c0374553f6bd6a"
+                "value": "a65839fbf1869f81a1632e09f415e586922e4f80"
               },
-              "size": 865554
+              "size": 962685
             }
           },
           {


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

contributes to #1962

Hadoop-aws 3.4 is not compatible with aws-sdk 1.x
This code forces aws back to 3.3.4

Hadoop-aws 3.4 causes an exception. this exception disappears when switching to 3.3.4
```
        | Exception in thread "main" java.lang.NoClassDefFoundError: software/amazon/awssdk/core/exception/SdkException
        |       at java.base/java.lang.Class.forName0(Native Method)
        |       at java.base/java.lang.Class.forName(Class.java:467)
        |       at org.apache.hadoop.conf.Configuration.getClassByNameOrNull(Configuration.java:2625)
```

The original issue is planned to change baws-sdk jar. However, this is a big change because the entire file would require changes in the enviornment variables and how the default behavior works.