### PR TITLE
Support OnPrem Target Cluster File Format for CSPs

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
@@ -161,7 +161,8 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
       case NonFatal(e) =>
         progressBar.foreach(_.reportFailedProcess())
         val failureAppResult = FailureAppResult(pathStr,
-          s"Unexpected exception processing log, skipping!")
+          s"Unexpected exception processing log, skipping!. " +
+            s"${e.getClass.getSimpleName}: ${e.getMessage}")
         failureAppResult.logMessage(Some(new Exception(e.getMessage, e)))
         appStatusReporter.put(pathStr, failureAppResult)
       case oom: OutOfMemoryError =>

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -207,7 +207,8 @@ class Qualification(outputPath: String, hadoopConf: Configuration,
       case e: Exception =>
         progressBar.foreach(_.reportFailedProcess())
         val failureAppResult = FailureAppResult(pathStr,
-          s"Unexpected exception processing log, skipping!")
+          s"Unexpected exception processing log, skipping!. " +
+            s"${e.getClass.getSimpleName}: ${e.getMessage}")
         failureAppResult.logMessage(Some(e))
         appStatusReporter.put(pathStr, failureAppResult)
     }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ClusterRecommendationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ClusterRecommendationSuite.scala
@@ -494,10 +494,8 @@ class ClusterRecommendationSuite extends ProfilingAutoTunerSuiteBase
   }
 
   test("test CSP platform with OnPrem-style target cluster specs") {
-    // This test verifies that CSP platforms (like dataproc) can now accept OnPrem-style
-    // target cluster specifications (cpuCores/memoryGB/GPU) instead of just instanceType.
-    // Previously, this would fail with:
-    // "Target cluster worker info does not match platform expectations"
+    // Verify that CSP platforms can accept OnPrem-style target cluster specifications
+    // (cpuCores/memoryGB/GPU) as a fallback when instanceType is not provided.
     val expectedClusterInfo = RecommendedClusterInfo(
       vendor = PlatformNames.DATAPROC,
       coresPerExecutor = 16,


### PR DESCRIPTION
Fixes #1967

## Summary

Extends CSP platforms to accept OnPrem-style target cluster specifications (`cpuCores`, `memoryGB`, `GPU`) in addition to the `instanceType` lookup. This enables AutoTuner to generate tuning recommendations for any instance type, not just those predefined in the tools.

## Motivation

Previously, CSP platforms required a known `instanceType` from the tools' predefined instance map. This blocked users from:
- Getting recommendations for new/unsupported instance types
- Testing arbitrary hardware configurations

**Error before this change:**
```
Target cluster worker info does not match platform expectations.
```

## Changes

### `Platform.scala`
- **Modified** `getRecommendedInstanceInfoFromTargetWorker()` to support fallback logic:
  1. First: Try CSP-style `instanceType` lookup
  2. Fallback: If no `instanceType`, check for On-Prem-style specs (`cpuCores`/`memoryGB`/`GPU`)
  3. Default: Use platform's default recommended instance
  
- **Removed** strict validation that enforced platform-worker info matching

- When OnPrem format detected on CSP, creates `InstanceInfo` dynamically using `InstanceInfo.createDefaultInstance()` with provided hardware specs

### Testing

Added test coverage in both qualification and profiling flows:

**`ClusterRecommendationSuite.scala`**
- New test: `"test CSP platform with OnPrem-style target cluster specs"`
- Verifies Dataproc accepts `cpuCores`/`memoryGB`/`GPU` format
- Validates correct cluster recommendations generated

**`QualificationAutoTunerSuite.scala`**
- New test: `"test CSP platform with OnPrem-style target cluster specs"`
- Confirms qualification tool accepts OnPrem format on CSP platforms
- Ensures app summaries and recommendations generated successfully

## Example

Target cluster file now supports both formats on CSPs:

**Traditional (still works):**
```yaml
workerInfo:
  instanceType: n1-standard-16
  gpu:
   count: 1
```

**New OnPrem style for CSPs:**
```yaml
workerInfo:
  cpuCores: 8
  memoryGB: 40
  gpu:
    count: 1
    name: l4
```

Both formats generate full tuning recommendations including memory-related Spark properties.

