### PR TITLE
Set the plugin jars back to point to maven-central

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/WebCrawlerUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/WebCrawlerUtil.scala
@@ -34,7 +34,7 @@ import org.apache.spark.internal.Logging
  */
 object WebCrawlerUtil extends Logging {
   private val MAX_CRAWLER_DEPTH = 1
-  private val NV_MVN_BASE_URL = "https://edge.urm.nvidia.com/artifactory/sw-spark-maven/com/nvidia"
+  private val NV_MVN_BASE_URL = "https://repo1.maven.org/maven2/com/nvidia"
   // defines the artifacts of the RAPIDS libraries
   private val NV_ARTIFACTS_LOOKUP = Map(
     "rapids.plugin" -> "rapids-4-spark_2.12",

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/ToolTestUtils.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/ToolTestUtils.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.types._
 
 object ToolTestUtils extends Logging {
   val RAPIDS_MVN_BASE_URL =
-    "https://edge.urm.nvidia.com/artifactory/sw-spark-maven/com/nvidia/rapids-4-spark_2.12/"
+    "https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/"
 
   // Scheme fields for Status Report file
   private val csvStatusFields = Seq(

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/util/ToolUtilsSuite.scala
@@ -47,21 +47,41 @@ class ToolUtilsSuite extends AnyFunSuite with Logging {
     val allLinks = WebCrawlerUtil.getPageLinks(webURL, None)
 
     val expected = Set[String](
+      s"$mvnPrefix.pom.asc.sha1",
+      s"$mvnPrefix-javadoc.jar.asc.sha1",
       s"${ToolTestUtils.RAPIDS_MVN_BASE_URL}",
-      s"$mvnPrefix-cuda12-arm64.jar",
-      s"$mvnPrefix-cuda12-arm64.jar.asc",
-      s"$mvnPrefix-cuda12.jar",
-      s"$mvnPrefix-cuda12.jar.asc",
-      s"$mvnPrefix-javadoc.jar",
-      s"$mvnPrefix-javadoc.jar.asc",
-      s"$mvnPrefix-sources.jar",
-      s"$mvnPrefix-sources.jar.asc",
-      s"$mvnPrefix.jar",
-      s"$mvnPrefix.jar.asc",
+      s"$mvnPrefix-sources.jar.md5",
+      s"$mvnPrefix-cuda12.jar.md5",
       s"$mvnPrefix.pom.asc",
-      s"$mvnPrefix.pom")
+      s"$mvnPrefix-sources.jar.asc.sha1",
+      s"$mvnPrefix-sources.jar",
+      s"$mvnPrefix.jar.asc",
+      s"$mvnPrefix.pom.asc.md5",
+      s"$mvnPrefix.jar.sha1",
+      s"$mvnPrefix.jar.md5",
+      s"$mvnPrefix-cuda12.jar",
+      s"$mvnPrefix.pom",
+      s"$mvnPrefix-sources.jar.asc",
+      s"$mvnPrefix-cuda12.jar.asc.sha1",
+      s"$mvnPrefix.pom.md5",
+      s"$mvnPrefix-sources.jar.asc.md5",
+      s"$mvnPrefix.pom.sha1",
+      s"$mvnPrefix-javadoc.jar.asc",
+      s"$mvnPrefix-cuda12.jar.sha1",
+      s"$mvnPrefix-javadoc.jar",
+      s"$mvnPrefix-javadoc.jar.asc.md5",
+      s"$mvnPrefix.jar",
+      s"$mvnPrefix-cuda12.jar.asc.md5",
+      s"$mvnPrefix-javadoc.jar.md5",
+      s"$mvnPrefix-javadoc.jar.sha1",
+      s"$mvnPrefix-sources.jar.sha1",
+      s"$mvnPrefix.jar.asc.sha1",
+      s"$mvnPrefix.jar.asc.md5",
+      s"$mvnPrefix-cuda12.jar.asc"
+    )
+
     // all links should be matching
-    allLinks shouldBe expected
+    allLinks should contain theSameElementsAs expected
   }
 
   // checks that regex is used correctly to filter the href pulled from a given url
@@ -73,14 +93,13 @@ class ToolUtilsSuite extends AnyFunSuite with Logging {
     val jarFileRegEx = ".*\\.jar$"
     val allLinks = WebCrawlerUtil.getPageLinks(webURL, Some(jarFileRegEx))
     val expected = Set[String](
-      s"$mvnPrefix-cuda12-arm64.jar",
       s"$mvnPrefix-cuda12.jar",
       s"$mvnPrefix-javadoc.jar",
       s"$mvnPrefix-sources.jar",
       s"$mvnPrefix.jar"
     )
     // all links should end with jar files
-    allLinks shouldBe expected
+    allLinks should contain theSameElementsAs expected
   }
 
   //
@@ -105,7 +124,7 @@ class ToolUtilsSuite extends AnyFunSuite with Logging {
       case None => fail("Could not find pull the latest release successfully")
     }
     // get all the links on the page
-    val mavenMetaXml = XML.load(s"$baseURL/maven-metadata.xml")
+    val mavenMetaXml = XML.load(s"${baseURL}maven-metadata.xml")
     val allVersions = (mavenMetaXml \\ "metadata" \ "versioning" \ "versions" \ "version").toList
     // get the latest release from the mvn url
     val actualRelease = allVersions.last.text


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1970

- set the jars urls to maven-central after 25.10.0 release.
