### PR TITLE
Fix parsing of BatchScan in Prof and Qual results

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/BaseSourceScanExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/BaseSourceScanExecParser.scala
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.planparser
+
+import scala.util.matching.Regex
+
+import com.nvidia.spark.rapids.tool.planparser.ops.UnsupportedExprOpRef
+import com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
+import org.apache.spark.sql.rapids.tool.AppBase
+
+/**
+ * Base parser for data source scan execution nodes (e.g., FileSourceScanExec, BatchScan).
+ *
+ * This class provides common functionality for parsing and analyzing scan operations that read
+ * data from external sources such as Parquet, ORC, JSON, CSV, Delta Lake, Iceberg, etc.
+ * It handles both Hive table scans and regular file-based scans.
+ *
+ * The parser performs several key functions:
+ * 1. Extracts metadata about the data source (format, location, schema, filters)
+ * 2. Calculates GPU speedup potential based on the file format and schema data types
+ * 3. Determines if the scan operation is supported on GPU
+ * 4. Reports scan operations in a normalized format for analysis
+ *
+ * Subclasses should override specific methods to handle different scan node types
+ * (e.g., FileSourceScanExec, BatchScan, DataSourceV2ScanExec).
+ *
+ * @param node the SparkPlanGraphNode representing the scan operation
+ * @param checker plugin type checker for determining GPU support and speedup factors
+ * @param sqlID the SQL query ID this scan belongs to
+ * @param app optional AppBase containing application context
+ * @param execName optional override for the execution node name
+ */
+class BaseSourceScanExecParser(
+  override val node: SparkPlanGraphNode,
+  override val checker: PluginTypeChecker,
+  override val sqlID: Long,
+  override val app: Option[AppBase],
+  override val execName: Option[String] = None
+) extends GenericExecParser(
+  node = node,
+  checker = checker,
+  sqlID = sqlID,
+  execName = execName,
+  app = app
+) with Logging {
+  /**
+   * Cached speedup factor calculated for this scan operation.
+   * This value is computed based on the file format and schema compatibility with GPU execution.
+   * It starts at 1.0 (no speedup) and is updated when pullSupportedFlag() is called.
+   * A value greater than 1.0 indicates potential GPU acceleration.
+   */
+  protected var calculatedSpeedup: Double = 1.0
+
+  /**
+   * Flag indicating whether this is a Hive table scan.
+   * Hive table scans are also FileSourceScanExec nodes, but we want to
+   * report them differently.
+   * We detect them using the HiveParseHelper.
+   */
+  protected val isHiveScan: Boolean = HiveParseHelper.isHiveTableScanNode(node)
+
+  /**
+   * Regular expression to extract the first word from a node name.
+   * Matches the first alphanumeric characters of a string after trimming leading/trailing
+   * white spaces. Used to extract the scan type (e.g., "Scan", "BatchScan", "FileSourceScan").
+   * Pattern: `^\s*(\w+).*`
+   */
+  protected val nodeNameRegeX: Regex = """^\s*(\w+).*""".r
+
+  /**
+   * The token representing the scan node type extracted from the trimmed node name.
+   * This is used as part of the reported exec name to identify the type of scan operation.
+   * Examples: "Scan", "BatchScan", "FileSourceScan"
+   */
+  protected lazy val scanNodeToken: String = trimmedNodeName
+
+  /**
+   * Record containing the parsed metadata information from the read node.
+   * This includes:
+   * - schema: the read schema
+   * - location: the data source location (file path, table name, etc.)
+   * - format: the data format (parquet, orc, json, csv, etc.)
+   * - tags: additional metadata tags (filters, pushed filters, partition filters)
+   *
+   * The metadata is extracted differently for Hive scans vs. regular scans.
+   */
+  protected lazy val readInfo: ReadMetaData = if (isHiveScan) {
+    HiveParseHelper.parseReadNode(node)
+  } else {
+    ReadParser.parseReadNode(node)
+  }
+
+  /**
+   * The normalized format string extracted from readInfo in lowercase.
+   * This ensures consistent format comparison regardless of case variations in the event log.
+   * Examples: "parquet", "orc", "json", "csv", "delta", "iceberg"
+   */
+  protected lazy val readFormat: String = readInfo.getReadFormatLC
+
+  /**
+   * Check if the scan operation is supported.
+   * Delta Lake metadata table scans are not supported.
+   * @return true if supported, false otherwise
+   */
+  protected def isScanOpSupported: Boolean = true
+
+  /**
+   * Determine the operation type for the scan.
+   * If it is a delta lake metadata table scan, then return ReadDeltaLog.
+   * Otherwise, return ReadExec.
+   * @return the operation type
+   */
+  protected def pullOpType: OpTypes.Value = OpTypes.ReadExec
+
+  /**
+   * Parse a non-RDD scan operation and generate ExecInfo.
+   * This method performs the complete analysis of a scan operation:
+   * 1. Computes the execution duration from metrics
+   * 2. Parses expressions used in the scan (filters, projections)
+   * 3. Identifies unsupported expressions that cannot run on GPU
+   * 4. Determines if the entire scan is GPU-supported
+   * 5. Creates and returns an ExecInfo object with all the collected information
+   *
+   * The scan is considered supported if both:
+   * - The pullSupportedFlag() returns true (format and schema are GPU-compatible)
+   * - There are no unsupported expressions
+   *
+   * @return ExecInfo containing analysis results and GPU compatibility information
+   */
+  protected def parseNonRDDScan: ExecInfo = {
+    val duration = computeDuration
+    val expressions = parseExpressions()
+    val notSupportedExprs = getNotSupportedExprs(expressions)
+    val isExecSupported = pullSupportedFlag() && notSupportedExprs.isEmpty
+    createExecInfo(
+      calculatedSpeedup,
+      isExecSupported,
+      duration,
+      notSupportedExprs = notSupportedExprs,
+      expressions = expressions)
+  }
+
+  /**
+   * Override the reported execution name to include the data format.
+   * The reported exec name follows the pattern: "<ScanType> <format>"
+   * This makes it easier to identify scan operations by their data format in execution reports.
+   *
+   * Examples:
+   * - "Scan parquet"
+   * - "BatchScan orc"
+   * - "FileSourceScan json"
+   *
+   * @return the formatted execution name for reporting
+   */
+  override def reportedExecName: String = s"$scanNodeToken $readFormat"
+
+  /**
+   * Calculate the speedup factor for the scan operation.
+   *
+   * The speedup factor is calculated as:
+   * speedupFactor = checker.getSpeedupFactor(fullExecName) * readScoreRatio
+   *
+   * Where:
+   * - checker.getSpeedupFactor(fullExecName): base speedup for the scan operation type
+   * - readScoreRatio: calculated from the file format and schema data type compatibility
+   *
+   * The read score ratio is computed by ReadParser.calculateReadScoreRatio which:
+   * 1. Checks if the file format is GPU-supported
+   * 2. Analyzes the schema to determine the ratio of GPU-supported data types
+   * 3. Returns a score between 0.0 and 1.0
+   *
+   * The final speedup factor is clamped to a minimum of 1.0 (no slowdown).
+   *
+   * @param registeredName optional registered name to check
+   * @return the calculated speedup factor (minimum 1.0)
+   */
+  override def pullSpeedupFactor(registeredName: Option[String] = None): Double = {
+    val speedupFactor = checker.getSpeedupFactor(fullExecName)
+    // don't use the isExecSupported because we have finer grain.
+    val score = ReadParser.calculateReadScoreRatio(readInfo, checker)
+    Math.max(speedupFactor * score, 1.0)
+  }
+
+  /**
+   * Determine if the scan operation is supported on GPU.
+   *
+   * This method performs a comprehensive check of GPU support by:
+   * 1. Verifying the scan operation type is supported (e.g., not a Delta Lake metadata scan)
+   * 2. Checking if the operation is registered as GPU-supported in the checker
+   * 3. Calculating the speedup factor based on format and schema compatibility
+   * 4. Determining support based on whether speedup > 1.0
+   *
+   * The scan is considered GPU-supported if ALL of the following are true:
+   * - isScanOpSupported returns true (operation-specific checks pass)
+   * - checker.isExecSupported() returns true (operation type is GPU-supported)
+   * - calculatedSpeedup > 1.0 (file format and schema are GPU-compatible)
+   *
+   * If any check fails, the method returns false and calculatedSpeedup remains 1.0.
+   * As a side effect, this method updates the calculatedSpeedup field for later use.
+   *
+   * @param registeredName optional registered name to check for GPU support
+   * @return true if the scan operation can benefit from GPU acceleration, false otherwise
+   */
+  override def pullSupportedFlag(registeredName: Option[String] = None): Boolean = {
+    if (checker.isExecSupported(registeredName.getOrElse(fullExecName)) && isScanOpSupported) {
+      calculatedSpeedup = pullSpeedupFactor()
+      // If calculated speedup factor is GT 1.0, then the format and the schema run on GPU.
+      // Otherwise, it returns false.
+      return calculatedSpeedup > 1.0
+    }
+    false
+  }
+
+  /**
+   * Create an ExecInfo object with scan-specific information.
+   *
+   * This method constructs the execution information object that will be reported in the
+   * qualification/profiling output. It customizes the expression field based on the scan type:
+   * - If the format is unknown, uses the full node description
+   * - Otherwise, uses a formatted string "Format: <format>" for clarity
+   *
+   * The created ExecInfo includes:
+   * - sqlID: the SQL query ID this scan belongs to
+   * - exec: the reported execution name (e.g., "Scan parquet")
+   * - expr: the expression/format description
+   * - speedupFactor: calculated GPU speedup potential
+   * - duration: execution time from metrics
+   * - nodeId: graph node identifier
+   * - opType: operation type (usually ReadExec or ReadDeltaLog)
+   * - isSupported: whether GPU acceleration is supported
+   * - children: child execution nodes
+   * - unsupportedExecReason: reason for lack of GPU support (if any)
+   * - expressions: array of parsed expression strings
+   *
+   * @param speedupFactor the calculated GPU speedup factor
+   * @param isSupported whether the scan is GPU-supported
+   * @param duration optional execution duration in milliseconds
+   * @param notSupportedExprs sequence of unsupported expressions found
+   * @param expressions array of all parsed expression strings
+   * @return ExecInfo object containing all scan analysis results
+   */
+  override protected def createExecInfo(
+    speedupFactor: Double,
+    isSupported: Boolean,
+    duration: Option[Long],
+    notSupportedExprs: Seq[UnsupportedExprOpRef],
+    expressions: Array[String]
+  ): ExecInfo = {
+    val expr = if (readInfo.hasUnknownFormat) {
+      node.desc
+    } else {
+      s"Format: $readFormat"
+    }
+    ExecInfo.createExecNoNode(
+      sqlID = sqlID,
+      exec = reportedExecName,
+      expr = expr,
+      speedupFactor = speedupFactor,
+      duration = duration,
+      nodeId = node.id,
+      opType = pullOpType,
+      isSupported = isSupported,
+      children = getChildren,
+      unsupportedExecReason = unsupportedReason,
+      expressions = expressions)
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/BatchScanExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/BatchScanExecParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,49 +16,598 @@
 
 package com.nvidia.spark.rapids.tool.planparser
 
+import scala.util.matching.Regex
+
 import com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
 import org.apache.spark.sql.rapids.tool.AppBase
+import org.apache.spark.sql.rapids.tool.util.{CacheablePropsHandler, StringUtils}
 
-case class BatchScanExecParser(
-    node: SparkPlanGraphNode,
-    checker: PluginTypeChecker,
-    sqlID: Long,
-    app: AppBase) extends ExecParser with Logging {
-  val nodeName = "BatchScan"
-  val fullExecName = nodeName + "Exec"
 
-  override def parse: ExecInfo = {
-    val accumId = node.metrics.find(_.name == "scan time").map(_.accumulatorId)
-    val maxDuration = SQLPlanParser.getTotalDuration(accumId, app)
-    val readInfo = ReadParser.parseReadNode(node)
-    // don't use the isExecSupported because we have finer grain.
-    val score = ReadParser.calculateReadScoreRatio(readInfo, checker)
-    val speedupFactor = checker.getSpeedupFactor(fullExecName)
-    val overallSpeedup = Math.max((speedupFactor * score), 1.0)
+/**
+ * Helper object to extract stable table/scan names and metadata from BatchScan node descriptions.
+ *
+ * This object provides utility methods to parse BatchScan execution nodes (both CPU and GPU
+ * variants) and extract important metadata such as table names, filters, and file locations.
+ * The implementation uses node.desc instead of node.name to ensure consistency across
+ * different Spark versions.
+ *
+ * BatchScan nodes appear in Spark plans when reading from:
+ * - DataSource V2 tables (Iceberg, Delta Lake, etc.)
+ * - File-based data sources using the new DataSource V2 API
+ *
+ * The helper handles both regular BatchScan and GpuBatchScan nodes.
+ */
+object BatchScanExtractorHelper {
+  // The following substring indicates a BatchScan operation. i.e., "GpuBatchScan", and "BatchScan"
+  val OPERATOR_KEYWORD: String = "BatchScan"
+  // Pattern to match BatchScan description format:
+  // "BatchScan <tableName>[schema] <tableName> (branch=...)" or
+  // "GpuBatchScan <tableName>[schema] <tableName> (branch=...)"
+  // We extract the table name that appears after "BatchScan" or "GpuBatchScan" and before the
+  // schema brackets
+  private val batchScanPattern: Regex =
+    """^(?:Gpu)?BatchScan\s+([^\[\]]+?)\s*\[.*""".r
 
-    // 1- Set the exec name to be the batchScan + format
-    // 2- If the format cannot be found, then put the entire node description to make it easy to
-    // troubleshoot by reading the output files.
-    val readFormat = readInfo.getReadFormatLC
-    val execExpression = if (readInfo.hasUnknownFormat) {
-      node.desc
+  // Pattern to extract filters from the description.
+  // The following pattern mainly appears in BatchScan applied on table.
+  // Matches: [filters=<filterContent>, groupedBy=...] RuntimeFilters: [<runtimeFilterContent>]
+  // Use non-greedy match (.*?) and look for ", groupedBy=" to properly handle commas in filters
+  private val filtersPatternForTables: Regex =
+    """.*\[filters=(.*?),\s*groupedBy=[^]]*]\s*RuntimeFilters:\s*\[([^]]*)].*""".r
+
+  /**
+   * Case class to hold extracted filter information from a BatchScan node.
+   *
+   * This class encapsulates both static filters (applied at plan time) and runtime filters
+   * (applied during execution based on dynamic conditions like dynamic partition pruning).
+   *
+   * @param filters The static filters applied to the scan (empty string if no filters).
+   *                Example: "ss_sold_date_sk IS NOT NULL, ss_store_sk IS NOT NULL"
+   * @param runtimeFilters The runtime dynamic filters applied (empty string if no runtime filters).
+   *                       Example: "dynamicpruningexpression(ss_sold_date_sk#1834L IN ...)"
+   */
+  case class BatchScanFiltersForTables(
+    filters: String,
+    runtimeFilters: String) {
+
+    /**
+     * Converts the filter information to a tags map compatible with ReadMetaData.
+     *
+     * This method creates a map that conforms to the ReadParser metadata tag format:
+     * - DataFilters: Set to INAPPLICABLE (not available for table-based BatchScan)
+     * - PartitionFilters: Set to INAPPLICABLE (not available for table-based BatchScan)
+     * - PushedFilters: Combined filters and runtime filters in format
+     *                  "filters=[...],runtimeFilters=[...]"
+     *
+     * @return Map of metadata tag names to their values
+     */
+    def toTagsMap: Map[String, String] = {
+      val tags = scala.collection.immutable.Map[String, String](
+        ReadParser.METAFIELD_TAG_DATA_FILTERS -> StringUtils.INAPPLICABLE_EXTRACT,
+        ReadParser.METAFIELD_TAG_PARTITION_FILTERS -> StringUtils.INAPPLICABLE_EXTRACT,
+        ReadParser.METAFIELD_TAG_PUSHED_FILTERS ->
+          s"filters=[$filters],runtimeFilters=[$runtimeFilters]"
+      )
+      tags
+    }
+  }
+
+  /**
+   * Extracts the stable name from a BatchScan node description.
+   *
+   * @param nodeDesc The node description string (typically from SparkPlanGraphNode.desc)
+   * @return Some(tableName) if pattern matches, None otherwise
+   *
+   * Examples:
+   * - "BatchScan catalog.database.tableName[id#159...] catalog.database.tableName (branch=null)..."
+   *   returns Some("catalog.database.tableName")
+   * - "BatchScan catalog.database.tableName[id#16L...] ..."
+   *   returns Some("catalog.database.tableName")
+   */
+  def extractTableName(nodeDesc: String): Option[String] = {
+    batchScanPattern.findFirstMatchIn(nodeDesc).map(m => m.group(1).trim)
+  }
+
+  /**
+   * Extracts filter information from a BatchScan node description.
+   *
+   * @param nodeDesc The node description string (typically from SparkPlanGraphNode.desc)
+   * @return Some(BatchScanFilters) if pattern matches, None otherwise
+   *
+   * Examples:
+   * - "... [filters=, groupedBy=] RuntimeFilters: []"
+   *   returns Some(BatchScanFilters("", ""))
+   * - "... [filters=f_00 IS NOT NULL, f_00 > 50.00, groupedBy=]
+   *   RuntimeFilters: []"
+   *   returns Some(BatchScanFilters("f_00 IS NOT NULL, f_00 > 50.00", ""))
+   * - "... [filters=f_01 IS NOT NULL, groupedBy=]
+   *   RuntimeFilters: [dynamicpruningexpression(f_01#1834L IN dynamicpruning#2440)]"
+   *   returns Some(BatchScanFilters("f_01 IS NOT NULL",
+   *   "dynamicpruningexpression(f_01#1834L IN dynamicpruning#2440)"))
+   */
+  def extractFilters(nodeDesc: String): Option[BatchScanFiltersForTables] = {
+    filtersPatternForTables.findFirstMatchIn(nodeDesc).map { m =>
+      BatchScanFiltersForTables(
+        filters = m.group(1).trim,
+        runtimeFilters = m.group(2).trim
+      )
+    }
+  }
+
+  /**
+   * Extracts the full location path from a BatchScan node name.
+   * In recent Spark versions, the BatchScan node name contains the full location:
+   * "BatchScan <format> <location>" or "GpuBatchScan <format> <location>"
+   *
+   * @param nodeName the node name to extract location from
+   * @return Some(location) if successfully extracted, None otherwise
+   *
+   * Examples:
+   * - "BatchScan json file:/path/to/file"
+   *   returns Some("file:/path/to/file")
+   * - "GpuBatchScan parquet hdfs://namenode:8020/user/data/table"
+   *   returns Some("hdfs://namenode:8020/user/data/table")
+   */
+  def extractLocationFromNodeName(nodeName: String): Option[String] = {
+    // Pattern to match BatchScan or GpuBatchScan followed by format and location
+    // The pattern captures everything after the format (which is typically a single word)
+    val locationPattern = """^(?:Gpu)?BatchScan\s+\S+\s+(.+)""".r
+    nodeName match {
+      case locationPattern(location) => Some(location.trim)
+      case _ => None
+    }
+  }
+}
+
+/**
+ * Trait for extracting metadata from scan execution nodes.
+ *
+ * This trait provides the base interface for scan metadata extraction, allowing different
+ * implementations to handle various types of scan operations (file-based, table-based, etc.).
+ * It also provides utility methods for checking application-level configuration like
+ * Iceberg support.
+ */
+trait ScanMetadataExtractorTrait {
+  /**
+   * Checks if Iceberg support is enabled in the application.
+   *
+   * Iceberg is a table format that can be used with BatchScan operations. This method
+   * checks the application properties to determine if Iceberg tables are being used.
+   * If no app context is provided, it conservatively returns false.
+   *
+   * @param ap optional CacheablePropsHandler containing application properties
+   * @return true if Iceberg is enabled in the application, false otherwise
+   */
+  def isIcebergEnabled(ap: Option[CacheablePropsHandler]): Boolean = {
+    val appEnabled = ap match {
+      case None => false  // no app provided then we assume it is false to be safe.
+      case Some(a) =>
+        // If the app is provided, then check if iceberg is enabled
+        a.icebergEnabled
+    }
+    appEnabled
+  }
+
+  /**
+   * Extracts metadata from a scan node.
+   *
+   * This method should be implemented by subtraits/subclasses to extract relevant metadata
+   * from different types of scan nodes (BatchScan, FileSourceScan, etc.). The extracted
+   * metadata includes information about the data format, location, schema, and filters.
+   *
+   * @param sNode the SparkPlanGraphNode representing the scan operation
+   * @param a optional CacheablePropsHandler containing application-level properties
+   * @return ReadMetaData containing extracted scan metadata
+   */
+  def extractReadMeta(sNode: SparkPlanGraphNode,
+      a: Option[CacheablePropsHandler]): ReadMetaData
+}
+
+/**
+ * Trait for extracting metadata from file-based BatchScan nodes.
+ *
+ * This trait handles BatchScan operations that read from files (as opposed to tables).
+ * It extracts metadata using ReadParser and handles special cases like truncated location
+ * paths in the node description.
+ *
+ * For file-based BatchScan nodes, the description typically contains:
+ * - Format information (e.g., "Format: parquet")
+ * - Location information (e.g., "Location: InMemoryFileIndex[hdfs://...")
+ * - ReadSchema information
+ *
+ * In recent Spark versions, when the location in the description is truncated (ends with "..."),
+ * this trait attempts to extract the full location from the node name which may contain the
+ * complete path.
+ */
+trait BatchScanMetaExtractorTrait extends ScanMetadataExtractorTrait {
+  /**
+   * Extracts metadata from a file-based BatchScan node.
+   *
+   * This method performs the following steps:
+   * 1. Uses ReadParser to extract basic metadata from the node description
+   * 2. Checks if the location is truncated (ends with "...")
+   * 3. If truncated, attempts to extract the full location from the node name
+   * 4. Returns ReadMetaData with the corrected location
+   *
+   * The node name format in recent Spark versions: "BatchScan &lt;format&gt; &lt;location&gt;"
+   * Example: "BatchScan parquet hdfs://namenode:8020/path/to/data"
+   *
+   * @param sNode the SparkPlanGraphNode representing the BatchScan operation
+   * @param a optional CacheablePropsHandler (not used for file-based scans)
+   * @return ReadMetaData with extracted and potentially corrected metadata
+   */
+  override def extractReadMeta(sNode: SparkPlanGraphNode,
+      a: Option[CacheablePropsHandler]): ReadMetaData = {
+    // Fallback to default extraction using ReadParser
+    // In some recent spark versions the BatchScan will contain the full location of file
+    // the format of the nodeName would be like
+    // BatchScan <format> <location>
+    // if this is the case, then we can get the full name from the node name in case the location
+    // is truncated.
+    val readMeta = ReadParser.parseReadNode(sNode)
+
+    // Check if the location is truncated (ends with "...") in the description
+    // If so, try to extract the full location from the node name
+    val finalLocation = if (readMeta.location.endsWith("...")) {
+      BatchScanExtractorHelper.extractLocationFromNodeName(sNode.name).getOrElse(readMeta.location)
     } else {
-      s"Format: $readFormat"
+      readMeta.location
     }
 
-    ExecInfo.createExecNoNode(
-      sqlID = sqlID,
-      exec = s"$nodeName $readFormat",
-      expr = execExpression,
-      speedupFactor = overallSpeedup,
-      duration = maxDuration,
-      nodeId = node.id,
-      opType = OpTypes.ReadExec,
-      isSupported = score > 0.0,
-      children = None,
-      expressions = Seq.empty)
+    // Return the ReadMetaData with the potentially corrected location
+    readMeta.copy(location = finalLocation)
+  }
+}
+
+/**
+ * Trait for extracting metadata from table-based BatchScan nodes.
+ *
+ * This trait handles BatchScan operations that read from catalog tables (e.g., Iceberg, Delta Lake)
+ * as opposed to direct file reads. Table-based BatchScan nodes have different metadata structure
+ * and don't contain explicit format/location/schema tags in their descriptions.
+ *
+ * For table-based BatchScan nodes, the description typically contains:
+ * - Table name (e.g., "catalog.database.table")
+ * - Filter information in the format: [filters=..., groupedBy=...] RuntimeFilters: [...]
+ * - No explicit Format, Location, or ReadSchema tags
+ *
+ * The format is inferred based on application context
+ * (e.g., if Iceberg is enabled, assume Iceberg).
+ */
+trait BatchScanMetaExtractorFromTableTrait extends BatchScanMetaExtractorTrait {
+  /**
+   * Extracts metadata from a table-based BatchScan node.
+   *
+   * This method performs the following steps:
+   * 1. Extracts the table name from the node description
+   * 2. Determines the table format based on application configuration:
+   *    - If Iceberg is enabled, assumes "Iceberg" format
+   *    - Otherwise, format is UNKNOWN
+   * 3. Extracts filter information (static filters and runtime filters)
+   * 4. Returns ReadMetaData with:
+   *    - location = table name
+   *    - format = determined format
+   *    - schema = empty (not available for table scans)
+   *    - tags = extracted filter information
+   *
+   * Note: We cannot rely on node name alone because different Spark versions use different
+   * representations. The description parsing is more reliable.
+   *
+   * @param sNode the SparkPlanGraphNode representing the BatchScan operation
+   * @param a optional CacheablePropsHandler containing application properties
+   *          (used for Iceberg check)
+   * @return ReadMetaData with extracted table metadata
+   */
+  override def extractReadMeta(sNode: SparkPlanGraphNode,
+      a: Option[CacheablePropsHandler]): ReadMetaData = {
+    // we cannot rely on nodename alone because different spark versions changed the representation
+    // of nodename. So we need to parse the description.
+    val (tableName, tblFormat) =
+      BatchScanExtractorHelper.extractTableName(sNode.desc) match {
+        case Some(tbl) =>
+          // Now, decide on the format of the table
+          if (isIcebergEnabled(a)) {
+            // we cannot extract the format from the batchScan node alone.
+            // Optimistically assume that this is supported (parquet)
+            (tbl, ReadParser.finalizeFormat("Iceberg", sNode))
+          } else {
+            (tbl, StringUtils.UNKNOWN_EXTRACT)
+          }
+        case None => (StringUtils.UNKNOWN_EXTRACT, StringUtils.UNKNOWN_EXTRACT)
+      }
+    // We cannot know the format from the tableName
+    val filterTags = BatchScanExtractorHelper.extractFilters(sNode.desc) match {
+      case Some(filters) => filters.toTagsMap
+      case None => ReadParser.DEFAULT_METAFIELD_MAP
+    }
+    ReadMetaData(schema = "", location = tableName, format = tblFormat, tags = filterTags)
+  }
+}
+
+/**
+ * Singleton object implementing table-based BatchScan metadata extraction.
+ *
+ * This object provides a concrete implementation of BatchScanMetaExtractorFromTableTrait
+ * for extracting metadata from BatchScan nodes that read from catalog tables.
+ * It can be used as a reusable extractor instance throughout the codebase.
+ */
+object BatchScanMetaExtractorFromTable extends BatchScanMetaExtractorFromTableTrait {
+
+}
+
+/**
+ * Singleton object implementing file-based BatchScan metadata extraction.
+ *
+ * This object provides a concrete implementation of BatchScanMetaExtractorTrait
+ * for extracting metadata from BatchScan nodes that read from files.
+ * It can be used as a reusable extractor instance throughout the codebase.
+ */
+object BatchScanMetaExtractor extends BatchScanMetaExtractorTrait {
+
+}
+
+/**
+ * Parser for file-based BatchScan execution nodes.
+ *
+ * This class handles parsing of BatchScan nodes that read data from files using DataSource V2 API.
+ * BatchScan is the execution node used by Spark's DataSource V2 framework for reading data from
+ * various file formats (Parquet, ORC, JSON, CSV, etc.) and modern table formats
+ * (Delta Lake, Iceberg).
+ *
+ * Key features:
+ * - Extracts metadata about the data source (format, location, schema, filters)
+ * - Calculates GPU speedup potential based on format and data type compatibility
+ * - Handles both CPU BatchScan and GpuBatchScan nodes
+ * - Supports extraction of full file paths when descriptions are truncated
+ *
+ * Note: BatchScan nodes typically don't have timing metrics, so duration will be None.
+ *
+ * @param node the SparkPlanGraphNode representing the BatchScan operation
+ * @param checker plugin type checker for determining GPU support and speedup factors
+ * @param sqlID the SQL query ID this scan belongs to
+ * @param app optional AppBase containing application context
+ */
+class BatchScanExecParser(
+    override val node: SparkPlanGraphNode,
+    override val checker: PluginTypeChecker,
+    override val sqlID: Long,
+    override val app: Option[AppBase]
+) extends BaseSourceScanExecParser(
+    node = node,
+    checker = checker,
+    sqlID = sqlID,
+    execName = Some("BatchScanExec"),
+    app = app
+) with Logging with BatchScanMetaExtractorTrait {
+  /**
+   * The actual execution name used for pattern matching.
+   * This is used to extract the scan token from the node name.
+   */
+  protected val actualExecName = BatchScanExtractorHelper.OPERATOR_KEYWORD
+
+  /**
+   * Regular expression to extract "BatchScan" from the node name.
+   * Overrides the base class regex to specifically match "BatchScan" prefix.
+   * Pattern: `^\s*(BatchScan).*`
+   */
+  override val nodeNameRegeX: Regex = s"""^\\s*($actualExecName).*""".r
+
+  /**
+   * Metadata extracted from the BatchScan node using file-based extraction logic.
+   * This overrides the base class to use the BatchScanMetaExtractorTrait implementation
+   * which handles truncated locations and file-based scans.
+   */
+  override lazy val readInfo: ReadMetaData = extractReadMeta(node, app)
+
+  /**
+   * The scan node token extracted from the node name.
+   * If pattern matching succeeds, returns "BatchScan", otherwise falls back to actualExecName.
+   * This token is used as part of the reported execution name.
+   */
+  override lazy val scanNodeToken: String = nodeNameRegeX.findFirstMatchIn(trimmedNodeName) match {
+    case Some(m) => m.group(1)
+    // in case not found, use the full exec name
+    case None => actualExecName
+  }
+
+  /**
+   * Parse the BatchScan execution node and generate ExecInfo.
+   *
+   * This method delegates to parseNonRDDScan from the base class which:
+   * 1. Computes execution duration (typically None for BatchScan)
+   * 2. Parses expressions and identifies unsupported ones
+   * 3. Determines GPU support and calculates speedup
+   * 4. Creates ExecInfo with all collected information
+   *
+   * @return ExecInfo containing analysis results for this BatchScan operation
+   */
+  override def parse: ExecInfo = {
+    parseNonRDDScan
+  }
+}
+
+/**
+ * Parser for table-based BatchScan execution nodes.
+ *
+ * This case class extends BatchScanExecParser to handle BatchScan operations that read from
+ * catalog tables (e.g., Iceberg, Delta Lake) rather than direct file paths. It uses
+ * BatchScanMetaExtractorFromTableTrait to extract metadata specific to table scans.
+ *
+ * Differences from file-based BatchScan:
+ * - No explicit Format, Location, or ReadSchema tags in node description
+ * - Table name is used as the location
+ * - Format is inferred from application configuration (e.g., Iceberg if enabled)
+ * - Filter information is extracted from [filters=..., groupedBy=...] RuntimeFilters: [...] pattern
+ *
+ * The parser automatically detects whether a BatchScan is table-based or file-based by checking
+ * for the presence of metadata field tags in the node description.
+ *
+ * @param node the SparkPlanGraphNode representing the table-based BatchScan operation
+ * @param checker plugin type checker for determining GPU support and speedup factors
+ * @param sqlID the SQL query ID this scan belongs to
+ * @param app optional AppBase containing application context (used for Iceberg detection)
+ */
+case class BatchScanFromTableExecParser(
+    override val node: SparkPlanGraphNode,
+    override val checker: PluginTypeChecker,
+    override val sqlID: Long,
+    override val app: Option[AppBase]
+) extends BatchScanExecParser (
+    node = node,
+    checker = checker,
+    sqlID = sqlID,
+    app = app
+) with Logging with BatchScanMetaExtractorFromTableTrait {
+
+}
+
+/**
+ * Companion object for BatchScanExecParser providing factory methods and utility functions.
+ *
+ * This object implements the GroupParserTrait to integrate with the parser framework.
+ * It provides methods to:
+ * - Determine if a node is a BatchScan operation
+ * - Distinguish between table-based and file-based BatchScan nodes
+ * - Create appropriate parser instances based on the node type
+ * - Extract metadata from BatchScan nodes
+ *
+ * The object uses a set of metadata field tags to differentiate between table-based and
+ * file-based scans. File-based scans contain tags like "Format:", "Location:", and "ReadSchema:"
+ * in their descriptions, while table-based scans do not.
+ */
+object BatchScanExecParser extends GroupParserTrait {
+  /**
+   * Set of metadata field tags that indicate a file-based BatchScan.
+   * If a node description contains any of these tags, it's considered a file-based scan.
+   */
+  val lookupMetaFields = Set(
+    ReadParser.METAFIELD_TAG_LOCATION,
+    ReadParser.METAFIELD_TAG_FORMAT,
+    ReadParser.METAFIELD_TAG_READ_SCHEMA)
+
+  /**
+   * Checks if the given node name represents a BatchScan operation.
+   *
+   * @param nodeName the name of the execution node
+   * @return true if the node name contains "BatchScan", false otherwise
+   */
+  override def accepts(nodeName: String): Boolean = {
+    nodeName.contains(BatchScanExtractorHelper.OPERATOR_KEYWORD)
+  }
+
+  /**
+   * Checks if the given node name represents a BatchScan operation (with configuration).
+   * This variant accepts a configuration provider but delegates to the simpler accepts method.
+   *
+   * @param nodeName the name of the execution node
+   * @param confProvider optional configuration provider (unused)
+   * @return true if the node name contains "BatchScan", false otherwise
+   */
+  override def accepts(
+      nodeName: String,
+      confProvider: Option[CacheablePropsHandler]): Boolean = {
+    accepts(nodeName)
+  }
+
+  /**
+   * Checks if the given node represents a BatchScan operation.
+   * This variant accepts the full node and configuration but delegates to name-based checking.
+   *
+   * @param node the SparkPlanGraphNode to check
+   * @param confProvider optional configuration provider (unused)
+   * @return true if the node represents a BatchScan operation, false otherwise
+   */
+  override def accepts(
+      node: SparkPlanGraphNode,
+      confProvider: Option[CacheablePropsHandler]): Boolean = {
+    accepts(node.name, confProvider)
+  }
+
+  /**
+   * Creates an appropriate ExecParser for a BatchScan node.
+   *
+   * This factory method determines whether the BatchScan is table-based or file-based
+   * and creates the corresponding parser instance:
+   * - BatchScanFromTableExecParser for table-based scans
+   * - BatchScanExecParser for file-based scans
+   *
+   * The determination is made by checking if the node description contains any of the
+   * metadata field tags in lookupMetaFields. If none are found, it's a table-based scan.
+   *
+   * @param node the SparkPlanGraphNode representing the BatchScan operation
+   * @param checker plugin type checker for GPU support analysis
+   * @param sqlID the SQL query ID this scan belongs to
+   * @param execName optional execution name override (unused)
+   * @param opType optional operation type override (unused)
+   * @param app optional AppBase containing application context
+   * @return ExecParser instance appropriate for the BatchScan type
+   */
+  override def createExecParser(
+      node: SparkPlanGraphNode,
+      checker: PluginTypeChecker,
+      sqlID: Long,
+      execName: Option[String] = None,
+      opType: Option[OpTypes.Value] = None,
+      app: Option[AppBase] = None): ExecParser = {
+    // Decide whether this is batch scan from table or from file
+    if (isBatScanFromTable(node)) {
+      // Fallback to batch scan from table
+      BatchScanFromTableExecParser(
+        node = node,
+        checker = checker,
+        sqlID = sqlID,
+        app = app)
+
+    } else {
+      new BatchScanExecParser(
+        node = node,
+        checker = checker,
+        sqlID = sqlID,
+        app = app)
+    }
+  }
+
+  /**
+   * Determines if a BatchScan node is table-based (as opposed to file-based).
+   *
+   * This method checks if any of the metadata field tags (Format, Location, ReadSchema)
+   * are present in the node description. If none are found, the node is considered a
+   * table-based scan.
+   *
+   * Logic:
+   * - File-based scans contain tags like "Format: parquet", "Location: hdfs://...", etc.
+   * - Table-based scans don't have these tags, only table name and filter information
+   *
+   * @param node the SparkPlanGraphNode to check
+   * @return true if this is a table-based BatchScan, false if file-based
+   */
+  def isBatScanFromTable(node: SparkPlanGraphNode): Boolean = {
+    // Decide whether this is batch scan from table or from file
+    !lookupMetaFields.exists(node.desc.contains(_))
+  }
+
+  /**
+   * Extracts metadata from a BatchScan node using the appropriate extractor.
+   *
+   * This method determines if the BatchScan is table-based or file-based and delegates
+   * to the appropriate metadata extractor:
+   * - BatchScanMetaExtractorFromTable for table-based scans
+   * - BatchScanMetaExtractor for file-based scans
+   *
+   * @param node the SparkPlanGraphNode representing the BatchScan operation
+   * @param confProvider optional CacheablePropsHandler for application properties
+   * @return ReadMetaData containing extracted metadata (format, location, schema, filters)
+   */
+  def extractReadMetaData(
+      node: SparkPlanGraphNode,
+      confProvider: Option[CacheablePropsHandler] = None): ReadMetaData = {
+    if (isBatScanFromTable(node)) {
+      BatchScanMetaExtractorFromTable.extractReadMeta(node, confProvider)
+    } else {
+      BatchScanMetaExtractor.extractReadMeta(node, confProvider)
+    }
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/FileSourceScanExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/FileSourceScanExecParser.scala
@@ -17,7 +17,6 @@
 package com.nvidia.spark.rapids.tool.planparser
 
 import com.nvidia.spark.rapids.tool.planparser.delta.DeltaLakeHelper.{DELTALAKE_LOG_FILE_KEYWORD, DELTALAKE_META_KEYWORD, DELTALAKE_META_SCAN_RDD_KEYWORD}
-import com.nvidia.spark.rapids.tool.planparser.ops.UnsupportedExprOpRef
 import com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker
 
 import org.apache.spark.internal.Logging
@@ -25,42 +24,90 @@ import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
 import org.apache.spark.sql.rapids.tool.{AppBase, RDDCheckHelper}
 import org.apache.spark.sql.rapids.tool.util.CacheablePropsHandler
 
+
 case class FileSourceScanExecParser(
     override val node: SparkPlanGraphNode,
     override val checker: PluginTypeChecker,
     override val sqlID: Long,
     override val app: Option[AppBase]
-) extends GenericExecParser(
+) extends BaseSourceScanExecParser(
     node = node,
     checker = checker,
     sqlID = sqlID,
     app = app
 ) with Logging {
-  private var calculatedSpeedup: Double = 1.0
-  // Hive table scans are also FileSourceScanExec nodes, but we want to
-  // report them differently.
-  // We detect them using the HiveParseHelper.
-  private val isHiveScan: Boolean = HiveParseHelper.isHiveTableScanNode(node)
-  // Matches the first alphaneumeric characters of a string after trimming leading/trailing
-  // white spaces.
-  private val nodeNameRegeX = """^\s*(\w+).*""".r
+  // The node name for Scans is Scan <format> so here we hardcode
+  override lazy val fullExecName: String = if (isHiveScan) {
+    HiveParseHelper.SCAN_HIVE_EXEC_NAME
+  } else {
+    "FileSourceScanExec"
+  }
+
   // Record containing the parsed information from the read node.
-  private lazy val readInfo: ReadMetaData = if (isHiveScan) {
+  override lazy val readInfo: ReadMetaData = if (isHiveScan) {
     HiveParseHelper.parseReadNode(node)
   } else {
     ReadParser.parseReadNode(node)
   }
-  // Caches the normalized format extracted from readInfo
-  private lazy val readFormat: String = readInfo.getReadFormatLC
 
   // 1- Set the exec name to nodeLabel + format
   // 2- If the format is not found, then put the entire node description to make it easy to
   // troubleshoot by reading the output files.
-  private lazy val scanNodeToken: String = nodeNameRegeX.findFirstMatchIn(trimmedNodeName) match {
+  override lazy val scanNodeToken: String = nodeNameRegeX.findFirstMatchIn(trimmedNodeName) match {
     case Some(m) => m.group(1)
     // in case not found, use the full exec name
     case None => fullExecName
   }
+
+  /**
+   * Check if the scan operation is supported.
+   * Delta Lake metadata table scans are not supported.
+   * @return true if supported, false otherwise
+   */
+  override def isScanOpSupported: Boolean = {
+    if (isDeltaLakeMetaScan) {
+      // Delta Lake metadata table scans are not supported
+      // No need to set the reason because it is set automatically inside the object ExecInfo
+      false
+    } else {
+      true
+    }
+  }
+
+  /**
+   * Determine the operation type for the scan.
+   * If it is a delta lake metadata table scan, then return ReadDeltaLog.
+   * Otherwise, return ReadExec.
+   * @return the operation type
+   */
+  override def pullOpType: OpTypes.Value = if (isDeltaLakeMetaScan) {
+    OpTypes.ReadDeltaLog
+  } else {
+    super.pullOpType
+  }
+
+  override protected def getDurationSqlMetrics: Set[String] = Set(
+    "scan time",
+    // delta lake metadata tables have a metric called metadata time.
+    "metadata time")
+
+  /**
+   * Determine the operation type for RDD scans.
+   * If it is a delta lake metadata table scan, then return ReadRDDDeltaLog.
+   * Otherwise, return ReadRDD.
+   * A deltaLake scann RDD has known pattern in the node name or description.
+   * nodeName: Scan ExistingRDD Delta Table State #0 - /path/to/_delta_log
+   * nodeDesc: Scan ExistingRDD Delta Table State #0 - /path/to/_delta_log[...]
+   * @return
+   */
+  private def pullOpTypeForRDD: OpTypes.Value = {
+    if (isDeltaLakeMetaScanRDD) {
+      OpTypes.ReadRDDDeltaLog
+    } else {
+      OpTypes.ReadRDD
+    }
+  }
+
   /**
    * Check if the scan operation is a Delta Lake metadata table scan.
    * Delta Lake metadata table scans are not supported.
@@ -89,98 +136,6 @@ case class FileSourceScanExecParser(
     appEnabled &&
       (node.name.contains(DELTALAKE_META_SCAN_RDD_KEYWORD) ||
         node.desc.contains(DELTALAKE_META_KEYWORD))
-  }
-
-  /**
-   * Check if the scan operation is supported.
-   * Delta Lake metadata table scans are not supported.
-   * @return true if supported, false otherwise
-   */
-  private def isScanOpSupported: Boolean = {
-    if (isDeltaLakeMetaScan) {
-      // Delta Lake metadata table scans are not supported
-      // No need to set the reason because it is set automatically inside the object ExecInfo
-      false
-    } else {
-      true
-    }
-  }
-
-  /**
-   * Determine the operation type for the scan.
-   * If it is a delta lake metadata table scan, then return ReadDeltaLog.
-   * Otherwise, return ReadExec.
-   * @return the operation type
-   */
-  def pullOpType: OpTypes.Value = if (isDeltaLakeMetaScan) {
-    OpTypes.ReadDeltaLog
-  } else {
-    OpTypes.ReadExec
-  }
-
-  /**
-   * Determine the operation type for RDD scans.
-   * If it is a delta lake metadata table scan, then return ReadRDDDeltaLog.
-   * Otherwise, return ReadRDD.
-   * A deltaLake scann RDD has known pattern in the node name or description.
-   * nodeName: Scan ExistingRDD Delta Table State #0 - /path/to/_delta_log
-   * nodeDesc: Scan ExistingRDD Delta Table State #0 - /path/to/_delta_log[...]
-   * @return
-   */
-  def pullOpTypeForRDD: OpTypes.Value = {
-    if (isDeltaLakeMetaScanRDD) {
-      OpTypes.ReadRDDDeltaLog
-    } else {
-      OpTypes.ReadRDD
-    }
-  }
-
-  // The node name for Scans is Scan <format> so here we hardcode
-  override lazy val fullExecName: String = if (isHiveScan) {
-    HiveParseHelper.SCAN_HIVE_EXEC_NAME
-  } else {
-    "FileSourceScanExec"
-  }
-  override protected def getDurationSqlMetrics: Set[String] = Set(
-    "scan time",
-    // delta lake metadata tables have a metric called metadata time.
-    "metadata time")
-
-  override def reportedExecName: String = s"$scanNodeToken $readFormat"
-
-  /**
-   * Calculate the speedup factor for the scan operation.
-   * The speedup factor is calculated as:
-   * speedupFactor = checker.getSpeedupFactor(fullExecName) * score
-   * where score is the read score ratio calculated from the readInfo and the checker.
-   * @param registeredName optional registered name to check
-   * @return the speedup factor
-   */
-  override def pullSpeedupFactor(registeredName: Option[String] = None): Double = {
-    val speedupFactor = checker.getSpeedupFactor(fullExecName)
-    // don't use the isExecSupported because we have finer grain.
-    val score = ReadParser.calculateReadScoreRatio(readInfo, checker)
-    Math.max(speedupFactor * score, 1.0)
-  }
-
-  /**
-   * Check if the scan operation is supported.
-   * Delta Lake metadata table scans are not supported.
-   * If the operation is supported, then check if the format and schema are supported.
-   * If both are supported, then calculate the speedup factor.
-   * If the calculated speedup factor is GT 1.0, then return true.
-   * Otherwise, return false.
-   * @param registeredName optional registered name to check
-   * @return true if supported, false otherwise
-   */
-  override def pullSupportedFlag(registeredName: Option[String] = None): Boolean = {
-    if (checker.isExecSupported(registeredName.getOrElse(fullExecName)) && isScanOpSupported) {
-      calculatedSpeedup = pullSpeedupFactor()
-      // If calculated speedup factor is GT 1.0, then the format and the schema run on GPU.
-      // Otherwise, it returns false.
-      return calculatedSpeedup > 1.0
-    }
-    false
   }
 
   override def parse: ExecInfo = {
@@ -213,48 +168,12 @@ case class FileSourceScanExecParser(
         expressions = Seq.empty
       )
     } else {
-      val duration = computeDuration
-      val expressions = parseExpressions()
-      val notSupportedExprs = getNotSupportedExprs(expressions)
-      val isExecSupported = pullSupportedFlag() && notSupportedExprs.isEmpty
-      createExecInfo(
-        calculatedSpeedup,
-        isExecSupported,
-        duration,
-        notSupportedExprs = notSupportedExprs,
-        expressions = expressions)
+      parseNonRDDScan
     }
-  }
-
-  override protected def createExecInfo(
-    speedupFactor: Double,
-    isSupported: Boolean,
-    duration: Option[Long],
-    notSupportedExprs: Seq[UnsupportedExprOpRef],
-    expressions: Array[String]
-  ): ExecInfo = {
-    val expr = if (readInfo.hasUnknownFormat) {
-      node.desc
-    } else {
-      s"Format: $readFormat"
-    }
-    ExecInfo.createExecNoNode(
-      sqlID = sqlID,
-      exec = reportedExecName,
-      expr = expr,
-      speedupFactor = speedupFactor,
-      duration = duration,
-      nodeId = node.id,
-      opType = pullOpType,
-      isSupported = isSupported,
-      children = getChildren,
-      unsupportedExecReason = unsupportedReason,
-      expressions = expressions)
   }
 }
 
 object FileSourceScanExecParser extends GroupParserTrait {
-  val execName = "FileSourceScan"
 
   override def accepts(nodeName: String): Boolean = {
     ReadParser.isScanNode(nodeName)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -572,8 +572,9 @@ object SQLPlanParser extends Logging {
            | "PythonMapInArrow" | "MapInArrow" | "Range" | "RunningWindowFunction"
            | "Sample" | "Union" | "WindowInPandas" =>
         GenericExecParser(node, checker, sqlID, app = Some(app)).parse
-      case "BatchScan" =>
-        BatchScanExecParser(node, checker, sqlID, app).parse
+      case batchScan if BatchScanExecParser.accepts(batchScan, Some(app)) =>
+        // BatchScan operation
+        BatchScanExecParser.createExecParser(node, checker, sqlID, app = Option(app)).parse
       case "BroadcastExchange" =>
         BroadcastExchangeExecParser(node, checker, sqlID, app).parse
       case "BroadcastHashJoin" =>

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
@@ -345,7 +345,7 @@ class RunningQualificationApp(
   def buildPlanGraphsInternal(): Unit = {
     this.synchronized {
       if (!_graphBuilt) {
-        sqlManager.buildPlanGraph(this, this)
+        sqlManager.buildPlanGraph(this)
         _graphBuilt = true
       }
     }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModel.scala
@@ -19,7 +19,9 @@ package org.apache.spark.sql.rapids.tool.store
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.execution.SparkPlanInfo
+import org.apache.spark.sql.rapids.tool.AppBase
 import org.apache.spark.sql.rapids.tool.util.ToolsPlanGraph
+
 
 /**
  * SQLPlanModel is a class to store the information of a SQL Plan including all its versions.
@@ -31,8 +33,11 @@ import org.apache.spark.sql.rapids.tool.util.ToolsPlanGraph
  * 1- Use this class iff you need to keep track of all information inside all versions of a SQLPlan.
  * 2- Do some memory optimizations to reduce the overhead of storing all versions.
  * @param id SqlId
+ * @param appInst the instance of AppBase where the SQLPlanModel belongs to. This is used to
+ *                extract some information and properties to help with parsing and operator
+ *                extraction. For example, if application is Iceberg, deltaLake, etc.
  */
-class SQLPlanModel(val id: Long) {
+class SQLPlanModel(val id: Long, appInst: AppBase) {
   // TODO: common information related to the SQLPlan should be added as fields in this class.
   //       For example, the information tracked in
   //       AppBase.sqlIdToInfo Map[sqlId, SQLExecutionInfoClass] should belong here.
@@ -66,7 +71,8 @@ class SQLPlanModel(val id: Long) {
    */
   def addPlan(planInfo: SparkPlanInfo, physicalPlanDescription: String): Unit = {
     // By default, a new planVersion is defined as final.
-    val planVersion = new SQLPlanVersion(id, versionsCount, planInfo, physicalPlanDescription)
+    val planVersion = new SQLPlanVersion(
+        id, versionsCount, planInfo, physicalPlanDescription, appInst)
     // Update references and shortcuts to the latest plan and cache previous one if any
     updateVersions(planVersion)
   }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelPrimaryWithDSCaching.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelPrimaryWithDSCaching.scala
@@ -17,13 +17,19 @@
 package org.apache.spark.sql.rapids.tool.store
 
 import org.apache.spark.sql.execution.SparkPlanInfo
+import org.apache.spark.sql.rapids.tool.AppBase
 
 /**
  * An extension of SQLPlanModelWithDSCaching to also cache the
  * primary plan version along with the DataSourceRecords from previous plan.
+ *
  * @param sqlId the executionID of the sqlPlan.
+ * @param appInst the application instance the sqlPlan belongs to. This is used to
+ *                extract some information and properties to help with parsing and operator
+ *                extraction. For example, if application is Iceberg, deltaLake, etc.
  */
-class SQLPlanModelPrimaryWithDSCaching(sqlId: Long) extends SQLPlanModelWithDSCaching(sqlId) {
+class SQLPlanModelPrimaryWithDSCaching(
+    sqlId: Long, appInst: AppBase) extends SQLPlanModelWithDSCaching(sqlId, appInst) {
 
   private var cachedPrimaryPlanVersion: SQLPlanVersion = _
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelWithDSCaching.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelWithDSCaching.scala
@@ -18,11 +18,17 @@ package org.apache.spark.sql.rapids.tool.store
 
 import scala.collection.mutable.ArrayBuffer
 
+import org.apache.spark.sql.rapids.tool.AppBase
+
 /**
  * An extension of SQLPlanModel to only cache the DataSourceRecords from previous plan.
  * @param sqlId the executionID of the sqlPlan.
+ * @param appInst the application instance the sqlPlan belongs to. This is used to
+ *                extract some information and properties to help with parsing and operator
+ *                extraction. For example, if application is Iceberg, deltaLake, etc.
  */
-class SQLPlanModelWithDSCaching(sqlId: Long) extends SQLPlanModel(sqlId) {
+class SQLPlanModelWithDSCaching(
+    sqlId: Long, appInst: AppBase) extends SQLPlanModel(sqlId, appInst) {
   // List that captures the DSV1Reads of previous PlanInfo versions excluding the most recent one.
   // This contains only the DataSourceRecords of previous plan excluding the
   private val cachedDataSources: ArrayBuffer[DataSourceRecord] = new ArrayBuffer[DataSourceRecord]()

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -355,7 +355,8 @@ class ApplicationInfoSuite extends AnyFunSuite with Logging {
       val allFormats = dsRes.map { r =>
         r.format
       }.toSet
-      val expectedFormats = Set("Text", "CSV(GPU)", "Parquet(GPU)", "ORC(GPU)", "JSON(GPU)")
+      // The RAPIDS plugin reports supported GPU scans as "gpu*"
+      val expectedFormats = Set("Text", "gpuCSV", "gpuParquet", "gpuORC", "gpuJSON")
       assert(allFormats.equals(expectedFormats))
       val allSchema = dsRes.map { r =>
         r.schema
@@ -392,8 +393,9 @@ class ApplicationInfoSuite extends AnyFunSuite with Logging {
       val allFormats = dsRes.map { r =>
         r.format
       }.toSet
+      // The RAPIDS plugin reports supported GPU scans as "gpu*"
       val expectedFormats =
-        Set("Text", "gpucsv(GPU)", "gpujson(GPU)", "gpuparquet(GPU)", "gpuorc(GPU)")
+        Set("Text", "gpucsv", "gpujson", "gpuparquet", "gpuorc")
       assert(allFormats.equals(expectedFormats))
       val allSchema = dsRes.map { r =>
         r.schema


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1980

This change addresses critical issues in the `BatchScan` node parsing logic.

- Adds support for Apache Iceberg tables in the qualification tool.
- The changes improve data source extraction accuracy across different Spark versions.
- Fix several edge cases that caused incorrect format detection and duplicate entries.

### Problem Statement

The BatchScan parser was designed for older Spark releases where the `nodeName` field was an exact match to the scan type (e.g., "BatchScan"). However, in newer Spark versions, the `nodeName` includes additional format and/or source information (e.g., "BatchScan parquet file:/path/to/data"), which broke the existing parsing logic. This resulted in:

1. **Incorrect format extraction** - The parser couldn't properly identify data formats
2. **Duplicate data source entries** - ReusedSubquery nodes caused plan information to be counted twice
3. **GPU format misidentification** - Appending "(GPU)" suffix to formats that already started with "gpu"
4. **Missing Iceberg support** - Iceberg table scans were not properly recognized or qualified

### Iceberg Support

This PR introduces **initial support for Apache Iceberg** tables in qualification:

- **Detection**: Automatically detects Iceberg-enabled applications via `spark.sql.catalog.*` properties
- **Table Scans**: Properly identifies and parses Iceberg table BatchScan operations
- **Format Recognition**: Reports Iceberg scans as "Iceberg" format
- **GPU Support**: Marks Iceberg operations as supported (when format is detected as Iceberg)

**Known Limitation**: The exact underlying file format (Parquet, ORC, Avro) of Iceberg tables cannot be determined from the event log alone. All Iceberg scans are reported with format "Iceberg" and marked as supported.

### Changes

#### 1. **New Base Parser Class** (`BaseSourceScanExecParser.scala`)
- Introduced a new base class that provides common functionality for all data source scan parsers
- Consolidates logic for:
  - Metadata extraction (format, location, schema, filters)
  - GPU speedup calculation based on file format and schema compatibility
  - GPU support determination
  - Expression parsing and unsupported expression detection
- Comprehensive JavaDoc documentation explaining each method and field

#### 2. **Enhanced BatchScan Parser** (`BatchScanExecParser.scala`)

- **Major refactoring**: Now extends `BaseSourceScanExecParser`
- Added `BatchScanExtractorHelper` object with utility methods:
  - `extractTableName()` - Extracts stable table names from Iceberg/Delta Lake scans
  - `extractFilters()` - Properly extracts both static filters and runtime filters
  - `extractLocationFromNodeName()` - Handles truncated location paths by extracting full paths from node names
- Introduced trait-based metadata extraction:
  - `ScanMetadataExtractorTrait` - Base interface for metadata extraction
  - `BatchScanMetaExtractorTrait` - For file-based BatchScan nodes
  - `BatchScanMetaExtractorFromTableTrait` - For table-based BatchScan nodes (Iceberg, Delta)
- **Fixed**: Now uses `node.desc` instead of `node.name` for consistent parsing across Spark versions
- **Fixed**: Properly handles both `GpuBatchScan` and `BatchScan` prefixes
- **Fixed**: Correctly extracts filters even when they contain commas
- **Fixed**: Handles empty schema/tags cases (e.g., `struct<>`, `[]`)

#### 3. **Improved ReadParser** (`ReadParser.scala`)

- **Fixed**: `isDataSourceV2Node()` now uses substring matching instead of exact matching
  - Removed `DATASOURCE_V2_NODE_EXACT_PREF` set
  - Consolidated to `DATASOURCE_V2_NODE_PREF` with "BatchScan" covering both variants
- **Enhanced**: `extractReadTags()` method improvements:
  - Fixed regex to properly handle empty tags (e.g., `TagName: []`)
  - Improved handling of truncated tags ending with `...`
  - Added support for RuntimeFilters tag
  - Fixed schema extraction when followed by "RuntimeFilters:" instead of comma
- **New**: `finalizeFormat()` method:
  - Prevents duplicate "gpu" prefix (e.g., "gpugpuparquet" → "gpuparquet")
  - Only adds "gpu" prefix if node is GPU and format doesn't already have it
- **New**: `combinePushedFilters()` method to merge static and runtime filters
- **Enhanced**: `ReadMetaData.pushedFilters` property with comprehensive JavaDoc

#### 4. **Fixed Duplicate Data Sources** (`AppBase.scala`)

- **Critical fix**: Filter out `ReusedSubquery` nodes in `getPlanMetaWithSchema()` and `getPlanInfoWithHiveScan()`
  - ReusedSubquery nodes are references to other nodes, not actual operations
  - Caused data sources to be counted twice in reports
- **Improved**: Data source matching logic using `LinkedHashSet` to preserve order and avoid duplicates
- **Enhanced**: Each scan node is now matched only once to its corresponding plan info
- **Enhanced**: Better handling of empty schema cases
- **Fixed**: Integration with `BatchScanExecParser` for proper metadata extraction

#### 5. **SQL Plan Model Updates** (`SQLPlanModel*.scala`, `SQLPlanVersion.scala`)

- Updated `SQLPlanModelManager` to accept `CacheablePropsHandler` for Iceberg detection
- Modified constructors across SQL plan model classes to support app context passing
- Enhanced Photon node handling to check `photonName` field for proper node matching

### Bug Fixes Summary

1. ✅ **BatchScan node name compatibility** - Works with both old (exact match) and new (format-prefixed) Spark versions
2. ✅ **GPU format prefix duplication** - Prevents "`gpu*(GPU)`..." prefixes
3. ✅ **Duplicate data source entries** - Filters out `ReusedSubquery` nodes
4. ✅ **Filter extraction** - Handles commas within filter expressions
5. ✅ **Empty schema/tags** - Properly handles `struct<>` and `[]` cases
6. ✅ **Truncated locations** - Extracts full paths from node names when description is truncated
7. ✅ **Runtime filters** - Captures and reports dynamic runtime filters

### Testing

- ✅ All existing tests pass
- ✅ New unit tests for BatchScan parsing
- ✅ Updated tests to validate RuntimeFilters extraction
- ✅ Manual testing with Iceberg event logs

### Compatibility

- **Backward Compatible**: Works with older Spark versions (exact match node names)
- **Forward Compatible**: Works with newer Spark versions (prefixed node names)
- **Changes in Output**:
  - datasource Information changes the format from "`*(GPU)`" to `gpu*` 
  - In case of empty filters, the value will be empty string. The legacy behavior used to show "unknown". The empty string is better because it indicates that the filter is extracted but it is empty.
  - In presence of runtimeFilters, PushedFilters will be reported as `filters:[],RuntimeFilters:[]`is is to avoid adding a new column. RuntimeFilters shows up mainly with batchscan.

