### PR TITLE
Disable text output format by default

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -356,7 +356,7 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
   val defaultRuntime: SparkRuntime.SparkRuntime = SparkRuntime.SPARK
   // Set of supported runtimes for the platform
   protected val supportedRuntimes: Set[SparkRuntime.SparkRuntime] = Set(
-    SparkRuntime.SPARK, SparkRuntime.SPARK_RAPIDS
+    SparkRuntime.SPARK, SparkRuntime.SPARK_RAPIDS, SparkRuntime.AURON
   )
 
   // scalastyle:off line.size.limit

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/FileSourceScanExecParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/FileSourceScanExecParser.scala
@@ -119,7 +119,7 @@ case class FileSourceScanExecParser(
       case Some(a) =>
         // If the app is provided, then check if delta lake is enabled or it is databricks
         // Databricks has delta lake built-in.
-        a.deltaLakeEnabled || a.isDatabricks
+        a.isDeltaLakeOSSEnabled || a.isDatabricks
     }
     appEnabled &&
       (node.desc.contains(DELTALAKE_META_KEYWORD) || node.desc.contains(DELTALAKE_LOG_FILE_KEYWORD))
@@ -131,7 +131,7 @@ case class FileSourceScanExecParser(
       case Some(a) =>
         // If the app is provided, then check if delta lake is enabled or it is databricks
         // Databricks has delta lake built-in.
-        a.deltaLakeEnabled || a.isDatabricks
+        a.isDeltaLakeOSSEnabled || a.isDatabricks
     }
     appEnabled &&
       (node.name.contains(DELTALAKE_META_SCAN_RDD_KEYWORD) ||

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -487,7 +487,7 @@ object SQLPlanParser extends Logging {
       app: AppBase,
       planExecs: Seq[ExecInfo]
   ): Seq[ExecInfo] = {
-    if (app.deltaLakeEnabled || app.isDatabricks) {
+    if (app.isDeltaLakeOSSEnabled || app.isDatabricks) {
       if (planExecs.exists { e =>
           // check if the exec is a cluster node and if so check its children.
           if (e.isClusterNode) {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/auron/AuronParseHelper.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/auron/AuronParseHelper.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids.tool.planparser.auron
+
+import scala.util.matching.Regex
+
+import com.nvidia.spark.rapids.tool.plugins.{AppPropVersionExtractorFromCPTrait, PropConditionOnSparkExtTrait}
+
+object AuronParseHelper extends PropConditionOnSparkExtTrait
+    with AppPropVersionExtractorFromCPTrait {
+  private val AURON_ENABLED_KEY = "spark.auron.enabled"
+  private val AURON_ENABLED_KEY_DEFAULT = "true"
+  // An Auron app is identified using the following properties from spark properties.
+  override val extensionRegxMap = Map(
+    "spark.sql.extensions" -> ".*AuronSparkSessionExtension.*"
+  )
+
+  override val cpKeyRegex: Regex = """auron-spark-[\w.-]+-(\d+\.\d+\.\d+)-incubating\.jar""".r
+
+  override def eval(properties: collection.Map[String, String]): Boolean = {
+    val auronExtensionExists = super.eval(properties)
+    auronExtensionExists && isAuronTurnedOn(properties)
+  }
+
+  private def isAuronTurnedOn(properties: collection.Map[String, String]): Boolean = {
+    properties.getOrElse(AURON_ENABLED_KEY, AURON_ENABLED_KEY_DEFAULT)
+      .trim.equalsIgnoreCase(AURON_ENABLED_KEY_DEFAULT)
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/auron/AuronPlugin.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/auron/AuronPlugin.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.planparser.auron
+
+import com.nvidia.spark.rapids.tool.plugins.{AppPropRuntimeTrait, AppPropVersionExtractorTrait, BaseAppPropPlug, PropConditionTrait}
+
+import org.apache.spark.sql.rapids.tool.util.SparkRuntime
+import org.apache.spark.sql.rapids.tool.util.SparkRuntime.SparkRuntime
+
+/**
+ * Trait to indicate that the plugin is related to Auron runtime.
+ */
+trait AuronPropRuntimeTrait extends AppPropRuntimeTrait {
+  override val runtime: Option[SparkRuntime] = Some(SparkRuntime.AURON)
+}
+
+/**
+ * Plugin implementation for Auron usage in Spark applications.
+ * Note that Auron can be used with feature support such as GPU and Iceberg.
+ * @param id The unique identifier for the plugin.
+ */
+class AuronPlugin(override val id: String) extends BaseAppPropPlug(id = id)
+    with AuronPropRuntimeTrait {
+  /**
+   * Callback function to evaluate the property based on application properties.
+   */
+  override val propCondition: PropConditionTrait = AuronParseHelper
+
+  /**
+   * Callback function to extract the version of Auron from application properties.
+   */
+  override val versionExtractor: Option[AppPropVersionExtractorTrait] = Some(AuronParseHelper)
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/delta/DeltaLakeOSSPlugin.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/delta/DeltaLakeOSSPlugin.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.planparser.delta
+
+import com.nvidia.spark.rapids.tool.plugins.{AppPropVersionExtractorTrait, BaseAppPropPlug, PropConditionTrait}
+
+/**
+ * Plugin implementation for Delta OSS usage in Spark applications.
+ */
+class DeltaLakeOSSPlugin(override val id: String) extends BaseAppPropPlug(id = id) {
+
+  /**
+   * Callback function to evaluate the property based on application properties.
+   */
+  override val propCondition: PropConditionTrait = DeltaLakeHelper
+  /**
+   * Callback function to extract the version of Delta OSS from application properties.
+   */
+  override val versionExtractor: Option[AppPropVersionExtractorTrait] = Some(DeltaLakeHelper)
+
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/plugins/AppPropPlugContainerTrait.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/plugins/AppPropPlugContainerTrait.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.plugins
+
+import org.apache.spark.sql.rapids.tool.util.SparkRuntime.SparkRuntime
+
+/**
+ * Trait that provides functionality to manage and interact with application property plugins.
+ * It initializes a map of available plugins, allows re-evaluation of plugins based on
+ * application properties, and provides methods to check if specific plugins are enabled.
+ */
+trait AppPropPlugContainerTrait {
+  // Initialize the plugin map once
+  def initPluginMap(): Map[String, BaseAppPropPlug] = BaseAppPropPlug.loadAppPropPlugs()
+
+  // Map of plugin ID to AppPropPlugTrait instances
+  val pluginMap: Map[String, AppPropPlugTrait] = initPluginMap()
+
+  /**
+   * Re-evaluates all plugins with the provided application properties. This is typically invoked
+   * when the application properties change, allowing each plugin to update its state accordingly.
+   * For example, during an environment update event, or job start.
+   * @param properties Application properties to re-evaluate the plugins against.
+   */
+  def reEvaluate(properties: collection.Map[String, String]): Unit = {
+    pluginMap.values.foreach(_.reEvaluate(properties))
+  }
+
+  /**
+   * Checks if a plugin with the given ID is enabled.
+   * @param pluginId The ID of the plugin to check.
+   * @return true if the plugin is enabled, false otherwise.
+   */
+  def isEnabled(pluginId: String): Boolean = {
+    pluginMap.get(pluginId).exists(_.isEnabled)
+  }
+
+  /**
+   * Retrieves the Spark runtime associated with the enabled plugins.
+   * @return An Option containing the SparkRuntime if any enabled plugin has a defined runtime,
+   *         otherwise None.
+   */
+  def getSparkRuntimePlugins: Option[SparkRuntime] = {
+    pluginMap.values.filter(_.isEnabled).find(_.runtime.isDefined).flatMap(_.runtime)
+  }
+
+  // Begin definition of shortcuts for plugin enabled checks.
+
+  // A flag to indicate whether the spark App is configured to use Auron.
+  def isAuronEnabled: Boolean = {
+    isEnabled(BaseAppPropPlug.AURON_PLUG_ID)
+  }
+  // A flag to indicate whether the spark App is configured to use DeltaLake.
+  // Note that this is only a best-effort flag based on the spark properties.
+  def isDeltaLakeOSSEnabled: Boolean = {
+    isEnabled(BaseAppPropPlug.DELTA_OSS_PLUG_ID)
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/plugins/AppPropPlugTrait.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/plugins/AppPropPlugTrait.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.plugins
+
+import org.apache.spark.sql.rapids.tool.util.SparkRuntime
+
+/**
+ * Trait representing the reported Runtime based on each type of plugin.
+ * By default, runtime plugins do not specify the runtime; except some specific ones
+ * that override this trait to indicate the runtime they represent. Example of that is
+ * the Auron plugin which indicates the Auron runtime.
+ */
+trait AppPropRuntimeTrait {
+  val runtime: Option[SparkRuntime.SparkRuntime] = None
+}
+
+/**
+ * Trait representing a plugin that evaluates application properties to determine
+ * if certain features or configurations are enabled.
+ */
+trait AppPropPlugTrait extends AppPropRuntimeTrait {
+  /**
+   * Indicates that once the property is set to True, it should remain True and not be re-evaluated.
+   */
+  val stickyTrue: Boolean = true
+  /**
+   * Indicates whether the property is currently enabled. This flag is mutable and can be updated
+   * based on the evaluation of application properties.
+   */
+  var isEnabled: Boolean = false
+  /**
+   * Callback function to evaluate the property based on application properties.
+   */
+  val propCondition: PropConditionTrait
+
+  /**
+   * Optional callback function to extract the version of the feature from application properties.
+   */
+  val versionExtractor: Option[AppPropVersionExtractorTrait] = None
+
+  /**
+   * Re-evaluates the property based on the provided application properties.
+   * This is only done if the property is not already enabled and stickyTrue is false.
+   * @param properties Application properties to evaluate against.
+   */
+  def reEvaluate(properties: collection.Map[String, String]): Unit = {
+    if (!(isEnabled && stickyTrue)) {
+      isEnabled ||= propCondition.eval(properties)
+    }
+  }
+
+  /**
+   * Extracts the version information from the application properties.
+   * By default, this method returns None. Subclasses can override this method
+   * to provide specific logic for extracting version information.
+   *
+   * @param properties Application properties to extract version from.
+   * @return An Option containing the version string if found, otherwise None.
+   */
+  def evalPluginVersion(properties: collection.Map[String, String]): Option[String] = {
+    if (!isEnabled) {
+      return None
+    }
+    versionExtractor.flatMap(_.extractVersion(properties))
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/plugins/AppPropVersionExtractorFromCPTrait.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/plugins/AppPropVersionExtractorFromCPTrait.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.plugins
+
+import scala.util.matching.Regex
+
+/**
+ * An implementation of AppPropVersionExtractorTrait that extracts version information
+ * from classpath keys in the application properties using a regular expression.
+ */
+trait AppPropVersionExtractorFromCPTrait extends AppPropVersionExtractorTrait {
+  /**
+   * Regular expression to match the classpath key for version extraction.
+   * The regex should contain a capturing group for the version.
+   */
+  val cpKeyRegex: Regex
+
+  /**
+   * Extracts the version information from the application properties by searching
+   * for classpath keys that match the defined regular expression.
+   *
+   * @param properties Application properties to extract version from.
+   * @return An Option containing the version string if found, otherwise None.
+   */
+  override def extractVersion(properties: collection.Map[String, String]): Option[String] = {
+    properties.keys.collectFirst {
+      case cpKeyRegex(version) => version
+    }
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/plugins/AppPropVersionExtractorTrait.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/plugins/AppPropVersionExtractorTrait.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.plugins
+
+/**
+ * Trait for extracting version information from application properties.
+ * By default, this trait does not implement any extraction logic. Each specific implementation
+ * should extend this to specify how to extract version information.
+ * For example, some plugins extract the version from the classPath jar file names.
+ */
+trait AppPropVersionExtractorTrait {
+  /**
+   * Extracts the version information from the application properties.
+   * By default, this method returns None. Subclasses can override this method
+   * to provide specific logic for extracting version information.
+   *
+   * @param properties Application properties to extract version from.
+   * @return An Option containing the version string if found, otherwise None.
+   */
+  def extractVersion(properties: collection.Map[String, String]): Option[String] = None
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/plugins/BaseAppPropPlug.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/plugins/BaseAppPropPlug.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.plugins
+
+import scala.util.Try
+
+import org.apache.spark.internal.Logging
+
+/**
+ * Abstract base class for application property plugins.
+ * This class provides a common structure for plugins that handle application properties.
+ *
+ * @param id The unique identifier for the plugin.
+ */
+abstract class BaseAppPropPlug(val id: String) extends AppPropPlugTrait {
+
+}
+
+/**
+ * Configuration case class for application property plugins.
+ *
+ * @param plugId The unique identifier for the plugin.
+ * @param enabled Flag indicating whether the plugin is enabled.
+ * @param additionalConfigs Map of additional configuration key-value pairs.
+ */
+case class AppPropPlugConfig(
+    plugId: String,
+    enabled: Boolean,
+    additionalConfigs: Map[String, String]) {
+  def getClassName: String = additionalConfigs.getOrElse("className", "")
+}
+
+/**
+ * Companion object for BaseAppPropPlug.
+ * Contains constants for known plugin IDs.
+ */
+object BaseAppPropPlug extends Logging {
+  // Define known plugin IDs as constants
+  val AURON_PLUG_ID: String = "auron"
+  val DELTA_OSS_PLUG_ID: String = "delta-oss"
+  val HIVE_PLUG_ID: String = "hive"
+  val ICEBERG_PLUG_ID: String = "iceberg"
+  val PHOTON_PLUG_ID: String = "photon"
+
+  /**
+   * Default configuration map for application property plugins.
+   * This map defines the default settings for each known plugin.
+   * Later we can move this into a configuration file to allow easier customization.
+   */
+  val APP_PROP_PLUG_CONFIG_MAP: Map[String, AppPropPlugConfig] = Map(
+    AURON_PLUG_ID -> AppPropPlugConfig(
+      plugId = AURON_PLUG_ID,
+      enabled = true,
+      additionalConfigs = Map(
+        "className" -> "com.nvidia.spark.rapids.tool.planparser.auron.AuronPlugin"
+      )
+    ),
+    DELTA_OSS_PLUG_ID -> AppPropPlugConfig(
+      plugId = DELTA_OSS_PLUG_ID,
+      enabled = true,
+      additionalConfigs = Map(
+        "className" -> "com.nvidia.spark.rapids.tool.planparser.delta.DeltaLakeOSSPlugin"
+      )
+    )
+  )
+
+  /**
+   * Load the default application property plugin configurations.
+   * @return Map of plugin IDs to their configurations for enabled plugins.
+   */
+  def loadDefaultAppPropPlugConfigs(): Map[String, AppPropPlugConfig] = {
+    APP_PROP_PLUG_CONFIG_MAP.filter { case (_, v) => v.enabled }
+  }
+
+  /**
+   * Instantiate an application property plugin based on its configuration using reflection.
+   * @param plugConf The configuration for the plugin to instantiate.
+   * @return Try[BaseAppPropPlug] instance if successful, or a Failure if instantiation fails.
+   */
+  private def instantiateAppPropPlug(plugConf: AppPropPlugConfig): Try[BaseAppPropPlug] = Try {
+    val className = plugConf.getClassName
+    val clazz = Class.forName(className)
+    val plugin = try {
+      // Try to instantiate with a String constructor (plugId)
+      clazz.getConstructor(classOf[String])
+        .newInstance(plugConf.plugId)
+        .asInstanceOf[BaseAppPropPlug]
+    } catch {
+      case _: NoSuchMethodException =>
+        // Fall back to no-arg constructor
+        clazz.getConstructor().newInstance().asInstanceOf[BaseAppPropPlug]
+    }
+    plugin
+  }
+
+  /**
+   * Load and instantiate all enabled application property plugins.
+   * @return Map of plugin IDs to their instantiated BaseAppPropPlug instances.
+   */
+  def loadAppPropPlugs(): Map[String, BaseAppPropPlug] = {
+    val enabledPlugs = loadDefaultAppPropPlugConfigs()
+    enabledPlugs.flatMap { case (plugId, plugConf) =>
+      instantiateAppPropPlug(plugConf) match {
+        case scala.util.Success(plugin) =>
+          Some(plugId -> plugin)
+        case scala.util.Failure(exception) =>
+          // Log the error and skip this plugin
+          logWarning(s"Failed to instantiate plugin $plugId: ${exception.getMessage}")
+          None
+      }
+    }
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/plugins/PropConditionOnSparkExtTrait.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/plugins/PropConditionOnSparkExtTrait.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids.tool.plugins
+
+/**
+ * A condition that checks for the presence of specific Spark extensions
+ * by matching property keys and regex patterns in the application properties.
+ * The condition evaluates to true if any of the specified properties match their
+ * corresponding regex patterns.
+ */
+trait PropConditionOnSparkExtTrait extends PropConditionTrait {
+  /**
+   * A map where keys are Spark extension property names and values are
+   * regex patterns to match against the property values.
+   */
+  val extensionRegxMap: Map[String, String]
+
+  /**
+   * Evaluates the condition against the provided application properties.
+   * @param props A map of application properties.
+   * @return true if any property matches its corresponding regex pattern, false otherwise.
+   */
+  override def eval(props: collection.Map[String, String]): Boolean = {
+    extensionRegxMap.exists { case (key, value) =>
+      props.get(key).exists(_.matches(value))
+    }
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/plugins/PropConditionTrait.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/plugins/PropConditionTrait.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.plugins
+
+/**
+ * A trait for evaluating conditions based on application properties.
+ */
+trait PropConditionTrait {
+  def eval(props: collection.Map[String, String]): Boolean
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
@@ -356,10 +356,10 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
     profileOutputWriter.writeText("### A. Information Collected ###")
     profileOutputWriter.writeTable(ProfInformationView.getLabel, app.appInfo)
     profileOutputWriter.writeTable(ProfLogPathView.getLabel, app.appLogPath)
-    profileOutputWriter.writeTable(ProfDataSourceView.getLabel, app.dsInfo)
+    profileOutputWriter.writeCSVTable(ProfDataSourceView.getLabel, app.dsInfo)
     profileOutputWriter.writeTable(ProfExecutorView.getLabel, app.execInfo)
-    profileOutputWriter.writeTable(ProfJobsView.getLabel, app.jobInfo)
-    profileOutputWriter.writeTable(ProfSQLToStageView.getLabel, app.sqlStageInfo)
+    profileOutputWriter.writeCSVTable(ProfJobsView.getLabel, app.jobInfo)
+    profileOutputWriter.writeCSVTable(ProfSQLToStageView.getLabel, app.sqlStageInfo)
     profileOutputWriter.writeTable(RapidsQualPropertiesView.getLabel, app.rapidsProps,
       Some(RapidsQualPropertiesView.getDescription))
     profileOutputWriter.writeTable(SparkQualPropertiesView.getLabel, app.sparkProps,
@@ -368,35 +368,26 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs, enablePB: Boolea
       Some(SystemQualPropertiesView.getDescription))
     profileOutputWriter.writeTable(ProfRapidsJarView.getLabel, app.rapidsJar,
       Some(ProfRapidsJarView.getDescription))
-    profileOutputWriter.writeTable(ProfSQLPlanMetricsView.getLabel, app.sqlMetrics,
-      Some(ProfSQLPlanMetricsView.getDescription))
-    profileOutputWriter.writeTable(ProfStageMetricView.getLabel, app.stageMetrics,
-      Some(ProfStageMetricView.getDescription))
-    profileOutputWriter.writeTable(ProfSQLCodeGenView.getLabel, app.wholeStage,
-      Some(ProfSQLCodeGenView.getDescription))
+    profileOutputWriter.writeCSVTable(ProfSQLPlanMetricsView.getLabel, app.sqlMetrics)
+    profileOutputWriter.writeCSVTable(ProfStageMetricView.getLabel, app.stageMetrics)
+    profileOutputWriter.writeCSVTable(ProfSQLCodeGenView.getLabel, app.wholeStage)
     profileOutputWriter.writeJsonL(ProfAppSQLPlanInfoView.getLabel, app.sqlPlanInfo)
 
     profileOutputWriter.writeText("\n### B. Analysis ###\n")
-    profileOutputWriter.writeTable(JOB_AGG_LABEL, app.jobAggMetrics,
-      Some(AGG_DESCRIPTION(JOB_AGG_LABEL)))
-    profileOutputWriter.writeTable(STAGE_AGG_LABEL, app.stageAggMetrics,
-      Some(AGG_DESCRIPTION(STAGE_AGG_LABEL)))
-    profileOutputWriter.writeTable(SQL_AGG_LABEL, app.sqlTaskAggMetrics,
-      Some(AGG_DESCRIPTION(SQL_AGG_LABEL)))
-    profileOutputWriter.writeTable(IO_LABEL, app.ioMetrics)
-    profileOutputWriter.writeTable(SQL_DUR_LABEL, app.durAndCpuMet)
+    profileOutputWriter.writeCSVTable(JOB_AGG_LABEL, app.jobAggMetrics)
+    profileOutputWriter.writeCSVTable(STAGE_AGG_LABEL, app.stageAggMetrics)
+    profileOutputWriter.writeCSVTable(SQL_AGG_LABEL, app.sqlTaskAggMetrics)
+    profileOutputWriter.writeCSVTable(IO_LABEL, app.ioMetrics)
+    profileOutputWriter.writeCSVTable(SQL_DUR_LABEL, app.durAndCpuMet)
     // writeOps are generated in only CSV format
     profileOutputWriter.writeCSVTable(ProfWriteOpsView.getLabel, app.writeOpsInfo)
-    val skewHeader = TASK_SHUFFLE_SKEW
-    val skewTableDesc = AGG_DESCRIPTION(TASK_SHUFFLE_SKEW)
-    profileOutputWriter.writeTable(skewHeader, app.skewInfo, tableDesc = Some(skewTableDesc))
-
+    profileOutputWriter.writeCSVTable(TASK_SHUFFLE_SKEW, app.skewInfo)
     profileOutputWriter.writeText("\n### C. Health Check###\n")
-    profileOutputWriter.writeTable(ProfFailedTaskView.getLabel, app.failedTasks)
+    profileOutputWriter.writeCSVTable(ProfFailedTaskView.getLabel, app.failedTasks)
     profileOutputWriter.writeTable(ProfFailedStageView.getLabel, app.failedStages)
     profileOutputWriter.writeTable(ProfFailedJobsView.getLabel, app.failedJobs)
     profileOutputWriter.writeTable(ProfRemovedBLKMgrView.getLabel, app.removedBMs)
-    profileOutputWriter.writeTable(ProfRemovedExecutorView.getLabel, app.removedExecutors)
+    profileOutputWriter.writeCSVTable(ProfRemovedExecutorView.getLabel, app.removedExecutors)
     profileOutputWriter.writeTable("Unsupported SQL Plan", app.unsupportedOps,
       Some("Unsupported SQL Ops"))
     if (outputAlignedSQLIds) {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/QualRawReportGenerator.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/QualRawReportGenerator.scala
@@ -52,15 +52,13 @@ object QualRawReportGenerator extends Logging {
   private def generateSQLProcessingView(
       pWriter: ProfileOutputWriter,
       sqlPlanAnalyzer: AppSQLPlanAnalyzer): Seq[SQLAccumProfileResults] = {
-    pWriter.writeTable(QualSQLToStageView.getLabel,
+    pWriter.writeCSVTable(QualSQLToStageView.getLabel,
       QualSQLToStageView.getRawViewFromSqlProcessor(sqlPlanAnalyzer))
     val sqlPlanMetrics = QualSQLPlanMetricsView.getRawViewFromSqlProcessor(sqlPlanAnalyzer)
-    pWriter.writeTable(QualSQLPlanMetricsView.getLabel,
-      sqlPlanMetrics,
-      Some(QualSQLPlanMetricsView.getDescription))
-    pWriter.writeTable(QualSQLCodeGenView.getLabel,
-      QualSQLCodeGenView.getRawViewFromSqlProcessor(sqlPlanAnalyzer),
-      Some(QualSQLCodeGenView.getDescription))
+    pWriter.writeCSVTable(QualSQLPlanMetricsView.getLabel,
+      sqlPlanMetrics)
+    pWriter.writeCSVTable(QualSQLCodeGenView.getLabel,
+      QualSQLCodeGenView.getRawViewFromSqlProcessor(sqlPlanAnalyzer))
     sqlPlanMetrics
   }
 
@@ -83,12 +81,11 @@ object QualRawReportGenerator extends Logging {
         QualAppSQLPlanInfoView.getRawView(Seq(app)))
       // Skipping writing to profile file as it would be too large
       dataSourceInfo = QualDataSourceView.getRawView(Seq(app), sqlPlanMetricsResults)
-      pWriter.writeTable(QualDataSourceView.getLabel, dataSourceInfo)
+      pWriter.writeCSVTable(QualDataSourceView.getLabel, dataSourceInfo)
       pWriter.writeTable(QualExecutorView.getLabel, QualExecutorView.getRawView(Seq(app)))
-      pWriter.writeTable(QualAppJobView.getLabel, QualAppJobView.getRawView(Seq(app)))
-      pWriter.writeTable(QualStageMetricView.getLabel,
-        QualStageMetricView.getRawViewFromSqlProcessor(sqlPlanAnalyzer),
-        Some(QualStageMetricView.getDescription))
+      pWriter.writeCSVTable(QualAppJobView.getLabel, QualAppJobView.getRawView(Seq(app)))
+      pWriter.writeCSVTable(QualStageMetricView.getLabel,
+        QualStageMetricView.getRawViewFromSqlProcessor(sqlPlanAnalyzer))
       pWriter.writeTable(RapidsQualPropertiesView.getLabel,
         RapidsQualPropertiesView.getRawView(Seq(app)),
         Some(RapidsQualPropertiesView.getDescription))
@@ -102,17 +99,17 @@ object QualRawReportGenerator extends Logging {
       constructLabelsMaps(QualSparkMetricsAggregator
         .getAggRawMetrics(
           app, sqlAnalyzer = Some(sqlPlanAnalyzer))).foreach { case (label, metrics) =>
-          pWriter.writeTable(label, metrics, AGG_DESCRIPTION.get(label))
+          pWriter.writeCSVTable(label, metrics)
       }
       pWriter.writeText("\n### C. Health Check###\n")
-      pWriter.writeTable(QualFailedTaskView.getLabel, QualFailedTaskView.getRawView(Seq(app)))
+      pWriter.writeCSVTable(QualFailedTaskView.getLabel, QualFailedTaskView.getRawView(Seq(app)))
       pWriter.writeTable(
         QualFailedStageView.getLabel, QualFailedStageView.getRawView(Seq(app)))
       pWriter.writeTable(
         QualAppFailedJobView.getLabel, QualAppFailedJobView.getRawView(Seq(app)))
       pWriter.writeTable(
         QualRemovedBLKMgrView.getLabel, QualRemovedBLKMgrView.getRawView(Seq(app)))
-      pWriter.writeTable(
+      pWriter.writeCSVTable(
         QualRemovedExecutorView.getLabel, QualRemovedExecutorView.getRawView(Seq(app)))
       // we only need to write the CSV report of the WriteOps
       pWriter.writeCSVTable(QualWriteOpsView.getLabel, QualWriteOpsView.getRawView(Seq(app)))


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #1793

- disable the text format reports of large tables. In legacy output, the `profile.log` could grow up to tens of MB. The generation of text format of large files puts more stress on the heap.
- the change saves 12% of execution time and reduces the memory usage significantly for each app.
- Addds a "plugin" pattern to allow extending the appProperties analysis in a more standard way. This helps in future work to support more features in a plugin fashion.

This pull request introduces a new plugin-based framework for detecting and managing Spark application features (such as Auron and Delta Lake OSS) via application properties, and refactors the detection logic to use this extensible system. It also adds support for the new Auron runtime and improves version extraction for plugins. The changes are grouped below by theme.

**Plugin Framework and Extensibility**

* Added a new plugin trait system for feature detection, including `AppPropPlugTrait`, `AppPropPlugContainerTrait`, and version extraction traits, enabling modular and extensible management of Spark app features. (`core/src/main/scala/com/nvidia/spark/rapids/tool/plugins/AppPropPlugTrait.scala`, `AppPropPlugContainerTrait.scala`, `AppPropVersionExtractorTrait.scala`, `AppPropVersionExtractorFromCPTrait.scala`) [[1]](diffhunk://#diff-7a79307feb4c471d67d7fc97bf8abab8054bb5846a983d1f9c58620a9abad879R1-R80) [[2]](diffhunk://#diff-6b37699ecdb72fc1053d26ca94eb1241b702fb399c3229aeaa564c73ae341650R1-R72) [[3]](diffhunk://#diff-e3b54995cffd3b3c835f1f6f17c21e85b41a9f905adcfc6b8ae0f7a12347d797R1-R35) [[4]](diffhunk://#diff-27c9a8aae81228af437c5534b4920a26ae60f3a2537cbebc71a7f12f21a19c46R1-R44)

* Implemented plugins for Auron (`AuronPlugin`, `AuronParseHelper`) and Delta Lake OSS (`DeltaLakeOSSPlugin`, refactored `DeltaLakeHelper`) to detect feature enablement and extract version info from Spark properties using regex. (`planparser/auron/AuronPlugin.scala`, `AuronParseHelper.scala`, `planparser/delta/DeltaLakeOSSPlugin.scala`, `DeltaLakeHelper.scala`) [[1]](diffhunk://#diff-2c2ae1ea77ad16ec6fcae6ac7ce262eed55ed07d6d5a28b20da66be130f572fcR1-R47) [[2]](diffhunk://#diff-35d9909451fe8f72f5640cd9fbe0ba3b280b8fd0ad64fce7dc7049fad5ce624bR1-R42) [[3]](diffhunk://#diff-68061ea0fe9eb3eb29ef9d78af254c15cbc4a7dd3efe03d604be2781991f0c78R1-R35) [[4]](diffhunk://#diff-ee0ec72fb40304b89a6f4519231fcf850ca34a37c683d3b238a1b47adbbd003fR19-R22) [[5]](diffhunk://#diff-ee0ec72fb40304b89a6f4519231fcf850ca34a37c683d3b238a1b47adbbd003fL57-R80)

**Runtime and Feature Detection Logic**

* Updated the `Platform` class to support the new `AURON` runtime in its set of supported Spark runtimes. (`Platform.scala`)

* Replaced direct checks for Delta Lake enablement with `isDeltaLakeOSSEnabled` and for Auron with `isAuronEnabled`, using the new plugin system throughout plan parser logic. (`FileSourceScanExecParser.scala`, `SQLPlanParser.scala`) [[1]](diffhunk://#diff-e036cf39b742bf9bccff421d1f0189d5c0de4e4f9382010ba9b158b712dc0f10L122-R122) [[2]](diffhunk://#diff-e036cf39b742bf9bccff421d1f0189d5c0de4e4f9382010ba9b158b712dc0f10L134-R134) [[3]](diffhunk://#diff-bd184b969d31154f381accb5760ded13e259f7c47ddd7f6d9f64d07d3977efbeL490-R490)

**Delta Lake Detection and Version Extraction Improvements**

* Refactored `DeltaLakeHelper` to use regex-based detection for Delta Lake extensions and catalog, and to extract the version from classpath entries, removing the old static property matching logic. (`DeltaLakeHelper.scala`) [[1]](diffhunk://#diff-ee0ec72fb40304b89a6f4519231fcf850ca34a37c683d3b238a1b47adbbd003fL57-R80) [[2]](diffhunk://#diff-ee0ec72fb40304b89a6f4519231fcf850ca34a37c683d3b238a1b47adbbd003fL101-L114)

**Auron Runtime Support**

* Added Auron-specific detection logic and plugin, including property key and extension regex checks, and runtime reporting. (`AuronParseHelper.scala`, `AuronPlugin.scala`) [[1]](diffhunk://#diff-35d9909451fe8f72f5640cd9fbe0ba3b280b8fd0ad64fce7dc7049fad5ce624bR1-R42) [[2]](diffhunk://#diff-2c2ae1ea77ad16ec6fcae6ac7ce262eed55ed07d6d5a28b20da66be130f572fcR1-R47)

**Delta Lake OSS Plugin**

* Added a dedicated plugin for Delta Lake OSS feature detection and version extraction using the new plugin framework. (`DeltaLakeOSSPlugin.scala`)