### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Checkout code
         uses: NVIDIA/spark-rapids-common/checkout@main
       - name: Label PR
-        uses: actions/labeler@v5
+        uses: actions/labeler@v6
         with:
           configuration-path: ".github/labeler.yml"

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -52,7 +52,7 @@ jobs:
       uses: NVIDIA/spark-rapids-common/checkout@main
 
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: adopt
         java-version: ${{ matrix.java-version }}

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -35,7 +35,7 @@ jobs:
           scripts/prefetch_deps.sh "$RAPIDS_USER_TOOLS_CACHE_FOLDER" "onprem,dataproc,emr,databricks_aws,databricks_azure" "user_tools/src/spark_rapids_pytools/resources"
 
       - name: Upload RAPIDS cache artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: rapids-cache
           path: ${{ env.RAPIDS_USER_TOOLS_CACHE_FOLDER }}
@@ -56,7 +56,7 @@ jobs:
           ./build.sh non-fat
 
       - name: Upload generated tools resources
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: tools-generated
           path: user_tools/src/spark_rapids_pytools/resources/generated_files
@@ -77,18 +77,18 @@ jobs:
         uses: NVIDIA/spark-rapids-common/checkout@main
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Restore RAPIDS cache artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: rapids-cache
           path: ${{ env.RAPIDS_USER_TOOLS_CACHE_FOLDER }}
 
       - name: Restore generated tools resources
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: tools-generated
           path: user_tools/src/spark_rapids_pytools/resources/generated_files


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | python-unit-test.yml |
| `actions/labeler` | [`v5`](https://github.com/actions/labeler/releases/tag/v5) | [`v6`](https://github.com/actions/labeler/releases/tag/v6) | [Release](https://github.com/actions/labeler/releases/tag/v6) | labeler.yml |
| `actions/setup-java` | [`v4`](https://github.com/actions/setup-java/releases/tag/v4) | [`v5`](https://github.com/actions/setup-java/releases/tag/v5) | [Release](https://github.com/actions/setup-java/releases/tag/v5) | mvn-verify-check.yml |
| `actions/setup-python` | [`v5`](https://github.com/actions/setup-python/releases/tag/v5) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | python-unit-test.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | python-unit-test.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
