### PR TITLE
Refactor ToolsPlanGraph for Improved Code Quality

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/plangraph/ToolsPlanGraph.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/plangraph/ToolsPlanGraph.scala
@@ -58,7 +58,7 @@ case class SQLPlanMetric(
  */
 @ToolsReflection(
   ToolsPlanGraph.SPARK_VERSION,
-  ToolsPlanGraph.INJECT_PLATFORM_MSG + ToolsPlanGraph.CONSTRUCTOR_STUB_MSG + ".")
+  ToolsPlanGraph.INJECT_PLATFORM_MSG + ToolsPlanGraph.CONSTRUCTOR_STUB_MSG)
 class SparkPlanGraphNode(
     val id: Long,
     val name: String,
@@ -90,7 +90,7 @@ class SparkPlanGraphNode(
  */
 @ToolsReflection(
   ToolsPlanGraph.SPARK_VERSION,
-  ToolsPlanGraph.INJECT_PLATFORM_MSG + ToolsPlanGraph.CONSTRUCTOR_STUB_MSG + ".")
+  ToolsPlanGraph.INJECT_PLATFORM_MSG + ToolsPlanGraph.CONSTRUCTOR_STUB_MSG)
 class SparkPlanGraphCluster(
     id: Long,
     name: String,
@@ -643,7 +643,7 @@ object ToolsPlanGraph {
   val INJECT_PLATFORM_MSG = "Inject information related to the platform. "
   val CONSTRUCTOR_STUB_MSG =
     "Constructors in different spark versions may have different parameters. " +
-      "So we use that stub for tools"
+      "So we use that stub for tools."
 
   // The actual code used to build the graph. If the API is not available, then fallback to the
   // Spark default API.


### PR DESCRIPTION
Fixes #1998

## Overview
This PR addresses code quality issues in `ToolsPlanGraph.scala` by eliminating string literal duplication and reducing method cognitive complexity.

## Changes Made

### 1. Eliminated String Literal Duplication
**Problem:** String literals were duplicated multiple times throughout the file.

**Solution:** 
- Defined constants in the `ToolsPlanGraph` object:
  - `SPARK_VERSION`: Platform version identifier
  - `CONSTRUCTOR_STUB_MSG`: Constructor parameter message
  - `INJECT_PLATFORM_MSG`: Platform injection message
- Replaced all duplicate string literals with references to these constants


### 2. Reduced Method Cognitive Complexity
**Problem:** The `assignNodesToStageClusters()` method had a cognitive complexity of 48, well above the threshold of 15.

**Solution:**
Extracted complex nested logic into two helper methods:

#### `tryAssignOrphanNode()`
- Handles assignment of orphan nodes based on adjacent nodes
- Processes both WholeStageCodeGen clusters and regular nodes
- Manages edge-based cluster assignment (incoming and outgoing edges)
- Preserves all original logic including special case handling

#### `tryAssignShuffleReadCornerCase()`
- Handles the specific corner case for shuffleRead nodes
- Breaks cycles in the graph when needed
- Assigns highest stage order to shuffleRead nodes reading from driver

