### PR TITLE
Align GPU device naming between Qualification and Profiling outputs

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ClusterRecommendationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ClusterRecommendationSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #1971

## Summary

This PR fixes an inconsistency where Qualification outputs used platform-specific GPU device names (e.g., `"nvidia-l4"`) while Profiling outputs used generic names (e.g., `"L4"`). 

**Root Cause:** GPU device enums normalize platform-specific names to generic strings (`"nvidia-l4"` → `GpuDevice.L4` → `"L4"`). The old Python code had a `lookup_gpu_device_name()` method that converted back to platform-specific names, but it was only called in the Qualification path (`cluster_inference.py`), not in the Profiling path (`_get_gpu_configuration()`).

**The Fix:** Added conversion methods at both layers:
- **Scala**: New `getPlatformGpuDeviceName()` method converts at output (all paths)
- **Python**: New `get_platform_gpu_device_name()` called in `_get_gpu_configuration()` (all config generation)

## Solution

### Scala Changes
- **Platform.scala**: Added base `getPlatformGpuDeviceName()` method (default returns generic name)
- **DataprocPlatform**: Override with mappings: `L4Gpu → "nvidia-l4"`, `T4Gpu → "nvidia-tesla-t4"`, etc.
- **Cluster recommendations**: Now call `getPlatformGpuDeviceName()` when generating `RecommendedClusterInfo`

### Python Changes
- **sp_types.py (PlatformBase)**: Added base `get_platform_gpu_device_name()` method (default returns as-is)
- **dataproc.py (DataprocPlatform)**: Override with mappings: `'L4' → 'nvidia-l4'`, `'T4' → 'nvidia-tesla-t4'`, etc.
- **sp_types.py (ClusterBase)**: Updated `_get_gpu_configuration()` to call platform conversion method
- **cluster_inference.py**: Simplified to use platform-specific names directly from Scala output

## Why Both Scala AND Python Need the Conversion

While Scala now outputs platform-specific names, Python also needs the conversion for these scenarios:

### **Cluster Creation Scripts from Existing Clusters (Legacy Code)**
When users provide an existing Dataproc cluster (via `--cpu_cluster` or reading actual cluster properties), Python:
- Reads cluster properties: `acceleratorType: "nvidia-l4"`
- Converts to enum: `GpuDevice.L4` (for internal processing)
- Later needs to generate cluster creation scripts via `generate_create_script()`
- Must convert `"L4"` → `"nvidia-l4"` for the gcloud template

**Example flow:**
```python
# User provides existing cluster
cluster = platform.connect_cluster_by_name("my-cluster")

# Cluster internally stores GpuDevice.L4
gpu_device = cluster.get_gpu_per_worker()  # Returns ("L4", 1)

# Generate cluster creation script
script = cluster.generate_create_script()
# Uses template: dataproc-create_gpu_cluster_script.ms
# Template line 16: --worker-accelerator type={{ GPU_DEVICE }},count={{ GPU_PER_WORKER }}
# Without conversion: --worker-accelerator type=L4,count=1  ❌ (Invalid!)
# With conversion:    --worker-accelerator type=nvidia-l4,count=1  ✅ (Valid!)
```
## Testing
- Updated unit tests with the new value.
- Verified with actual Dataproc event logs (for L4, T4 etc):

**Qualification output:**
```json
{
  "recommendedClusterInfo": {
    "gpuDevice": "nvidia-l4"
  }
}
```

**app_metadata.json:**
```json
{
  "recommendedCluster": {
    "gpuInfo": {
      "device": "nvidia-l4"
    }
  }
}
```

**Profiling output:**
```json
{
  "recommendedClusterInfo": {
    "gpuDevice": "nvidia-l4"
  }
}
```


## GPU Device Mappings (Dataproc)

Reference: https://cloud.google.com/dataproc/docs/concepts/compute/gpus#types_of_gpus

| Generic Name | Dataproc Accelerator Name |
|--------------|---------------------------|
| L4           | nvidia-l4                 |
| T4           | nvidia-tesla-t4           |
| A100         | nvidia-a100-80gb          |
| P100         | nvidia-tesla-p100         |
| V100         | nvidia-tesla-v100         |
| P4           | nvidia-tesla-p4           |

## Other Platforms

Other platforms (EMR, Databricks on AWS, Azure) do not require this, as GPU type is implicitly defined by the instance type and does not need to be specified in CLI commands or API calls.
