### PR TITLE
Fix S3 credential resolution by delegating to AWS SDK DefaultAWSCrede…

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -99,18 +99,6 @@ class DBAWSPlatform(EMRPlatform):
 @dataclass
 class DBAWSCMDDriver(CMDDriverBase):
     """Represents the command interface that will be used by DATABRICKS_AWS"""
-
-    def _list_inconsistent_configurations(self) -> list:
-        incorrect_envs = super()._list_inconsistent_configurations()
-        required_props = self.get_required_props()
-        if required_props is not None:
-            for prop_entry in required_props:
-                prop_value = self.env_vars.get(prop_entry)
-                if prop_value is None and prop_entry.startswith('aws_'):
-                    incorrect_envs.append('AWS credentials are not set correctly ' +
-                                          '(this is required to access resources on S3)')
-                    return incorrect_envs
-        return incorrect_envs
 
     def _build_platform_list_cluster(self, cluster, query_args: dict = None) -> list:
         pass

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -16,6 +16,7 @@
 
 import configparser
 import json
+import os
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
@@ -560,12 +561,20 @@ class CMDDriverBase:
         """
         res = {
             'jvmArgs': {
-                # TODO: setting the AWS access keys from jvm arguments did not work
-                # 'Dspark.hadoop.fs.s3a.secret.key': aws_access_key,
-                # 'Dspark.hadoop.fs.s3a.access.key': aws_access_id
+                # Use the full AWS SDK default credential chain for S3A, which covers:
+                # env vars, ~/.aws/credentials (with AWS_PROFILE), EC2 instance profiles,
+                # and ECS container credentials — matching AWS CLI / boto3 behavior.
+                'Drapids.tools.hadoop.fs.s3a.aws.credentials.provider':
+                    'com.amazonaws.auth.DefaultAWSCredentialsProviderChain'
             },
             'envArgs': {}
         }
+        # Pass custom S3 endpoint to hadoop-aws if set, matching the Python-side
+        # S3Fs handler logic (AWS_ENDPOINT_URL_S3 takes precedence over AWS_ENDPOINT_URL).
+        s3_endpoint = os.environ.get('AWS_ENDPOINT_URL_S3') or os.environ.get('AWS_ENDPOINT_URL')
+        if s3_endpoint:
+            res['jvmArgs']['Drapids.tools.hadoop.fs.s3a.endpoint'] = s3_endpoint
+            res['jvmArgs']['Drapids.tools.hadoop.fs.s3a.path.style.access'] = 'true'
         jvm_gc_type = submit_args.get('jvmGC')
         if jvm_gc_type is not None:
             xgc_key = f'XX:{jvm_gc_type}'
@@ -582,9 +591,15 @@ class CMDDriverBase:
             return res
         env_args_table = {}
         for sys_var in global_sys_vars:
-            prop_value = self.get_env_var(sys_var['confProperty'])
-            if prop_value:
-                env_args_table.setdefault(sys_var['varKey'], prop_value)
+            var_key = sys_var['varKey']
+            # OS env vars take precedence over credentials file (matches AWS SDK behavior)
+            os_value = os.environ.get(var_key)
+            if os_value:
+                env_args_table.setdefault(var_key, os_value)
+            else:
+                prop_value = self.get_env_var(sys_var['confProperty'])
+                if prop_value:
+                    env_args_table.setdefault(var_key, prop_value)
         res.update({'envArgs': env_args_table})
         return res
 

--- a/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/databricks_aws-configs.json
@@ -166,7 +166,7 @@
     "//description": "Define the metadata related to the system, prerequisites, and configurations",
     "envParams": ["profile", "awsProfile", "deployMode", "sshPort", "sshKeyFile"],
     "//initialConfigList": "represents the list of the configurations that need to be loaded first",
-    "initialConfigList": ["profile", "awsProfile", "cliConfigFile", "awsCliConfigFile", "awsCredentialFile"],
+    "initialConfigList": ["profile", "awsProfile", "cliConfigFile", "awsCliConfigFile"],
     "//loadedConfigProps": "list of properties read by the configParser",
     "loadedConfigProps": ["region", "output"],
     "cliConfig": {
@@ -185,11 +185,6 @@
           "//comment": "the token is not being used for now",
           "envVariableKey": "DATABRICKS_TOKEN",
           "confProperty": "databricksToken"
-        },
-        {
-          "envVariableKey": "AWS_SHARED_CREDENTIALS_FILE",
-          "confProperty": "awsCredentialFile",
-          "defaultValue": "~/.aws/credentials"
         },
         {
           "envVariableKey": "AWS_CONFIG_FILE",
@@ -238,26 +233,13 @@
             "configFileProp": "_awsCliConfigFile_"
           }
         ],
-        "credentialsMap": [
-          {
-            "confProperty": "aws_access_key_id",
-            "section": "_awsProfile_",
-            "propKey": "aws_access_key_id",
-            "configFileProp": "_awsCredentialFile_"
-          },
-          {
-            "confProperty": "aws_secret_access_key",
-            "section": "_awsProfile_",
-            "propKey": "aws_secret_access_key",
-            "configFileProp": "_awsCredentialFile_"
-          }
-        ]
+        "credentialsMap": []
       }
     },
     "cmdRunnerProperties": {
       "systemPrerequisites": ["databricks", "aws"],
       "//description": "define the properties passed to the CMD runner to be set as env-vars",
-      "inheritedProps": ["profile", "awsProfile", "region", "aws_access_key_id", "aws_secret_access_key"],
+      "inheritedProps": ["profile", "awsProfile", "region"],
       "cliPiggyBackEnvVars": {
         "//description": "Holds information about the variables that will be attached to the command runner",
         "definedVars": [
@@ -293,18 +275,7 @@
       },
       "rapidsJobs": {
         "LOCAL": {
-          "definedVars": [
-            {
-              "varLabel": "awsAccessKeyID",
-              "confProperty": "aws_access_key_id",
-              "varKey": "AWS_ACCESS_KEY_ID"
-            },
-            {
-              "varLabel": "awsSecretAccessKey",
-              "confProperty": "aws_secret_access_key",
-              "varKey": "AWS_SECRET_ACCESS_KEY"
-            }
-          ]
+          "definedVars": []
         }
       }
     }

--- a/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
+++ b/user_tools/src/spark_rapids_pytools/resources/emr-configs.json
@@ -166,16 +166,11 @@
     "//description": "Define the metadata related to the system, prerequisites, and configurations",
     "envParams": ["profile", "keyPairPath", "deployMode"],
     "//initialConfigList": "represents the list of the configurations that need to be loaded first",
-    "initialConfigList": ["profile", "credentialFile", "cliConfigFile", "keyPairPath"],
+    "initialConfigList": ["profile", "cliConfigFile", "keyPairPath"],
     "//loadedConfigProps": "list of properties read by the configParser",
     "loadedConfigProps": ["region", "output"],
     "cliConfig": {
       "envVariables": [
-        {
-          "envVariableKey": "AWS_SHARED_CREDENTIALS_FILE",
-          "confProperty": "credentialFile",
-          "defaultValue": "~/.aws/credentials"
-        },
         {
           "envVariableKey": "AWS_CONFIG_FILE",
           "confProperty": "cliConfigFile",
@@ -221,24 +216,13 @@
             "section": "_profile_"
           }
         ],
-        "credentialsMap": [
-          {
-            "confProperty": "aws_access_key_id",
-            "section": "_profile_",
-            "propKey": "aws_access_key_id"
-          },
-          {
-            "confProperty": "aws_secret_access_key",
-            "section": "_profile_",
-            "propKey": "aws_secret_access_key"
-          }
-        ]
+        "credentialsMap": []
       }
     },
     "cmdRunnerProperties": {
       "systemPrerequisites": ["aws"],
       "//description": "define the properties passed to the CMD runner to be set as env-vars",
-      "inheritedProps": ["profile", "credentialFile", "keyPairPath", "region", "aws_access_key_id", "aws_secret_access_key"],
+      "inheritedProps": ["profile", "keyPairPath", "region"],
       "cliPiggyBackEnvVars": {
         "//description": "Holds information about the variables that will be attached to the command runner",
         "definedVars": [
@@ -258,18 +242,7 @@
       },
       "rapidsJobs": {
         "LOCAL": {
-          "definedVars": [
-            {
-              "varLabel": "awsAccessKeyID",
-              "confProperty": "aws_access_key_id",
-              "varKey": "AWS_ACCESS_KEY_ID"
-            },
-            {
-              "varLabel": "awsSecretAccessKey",
-              "confProperty": "aws_secret_access_key",
-              "varKey": "AWS_SECRET_ACCESS_KEY"
-            }
-          ]
+          "definedVars": []
         }
       }
     }


### PR DESCRIPTION
Closes #2034 

### Summary

- Replace manual credential injection from `~/.aws/credentials` with AWS SDK v1 `DefaultAWSCredentialsProviderChain` via `rapids.tools.hadoop.fs.s3a.aws.credentials.provider` JVM property
- Add `AWS_ENDPOINT_URL` / `AWS_ENDPOINT_URL_S3` passthrough to hadoop-aws `fs.s3a.endpoint` for S3-compatible storage backends
- Fix env var precedence so OS environment variables override config file values (matching AWS SDK behavior)
- Remove now-dead credential config entries from EMR and Databricks AWS platform configs

### Problem

When users run qualification/profiling tools with AWS temporary credentials (session tokens) stored in `~/.aws/credentials`, the tools fail with `403 Forbidden` from S3. Two issues cause this:

1. **Missing `aws_session_token`**: The credential injection flow reads `aws_access_key_id` and `aws_secret_access_key` from `~/.aws/credentials` but omits `aws_session_token`. The JVM receives an incomplete credential set resulting in 403.
2. **Wrong precedence**: Credentials read from the file are injected as inline env vars (`KEY=VALUE command`), which override the user's OS-level env vars. This breaks the standard AWS resolution order (env vars > credential file).

### Solution

Instead of patching the injection logic, this PR removes it entirely and delegates credential resolution to the AWS SDK's `DefaultAWSCredentialsProviderChain`. This is done by setting the hadoop-aws S3A credential provider via:

```
-Drapids.tools.hadoop.fs.s3a.aws.credentials.provider=com.amazonaws.auth.DefaultAWSCredentialsProviderChain
```

The `rapids.tools.hadoop.*` prefix mechanism (used by `RapidsToolsConfUtil.scala`) strips the prefix and applies the value as Hadoop Configuration, which is the correct way to pass Hadoop config since the tools use `new Configuration()` directly.

The `DefaultAWSCredentialsProviderChain` covers the full credential resolution order:
- Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`)
- Java system properties
- `~/.aws/credentials` file (with `AWS_PROFILE` support)
- EC2/ECS instance profiles

This matches AWS CLI / boto3 behavior and eliminates the need for Python-side credential parsing and injection.

### Additional Changes

**S3-compatible endpoint support**: Added passthrough of `AWS_ENDPOINT_URL_S3` / `AWS_ENDPOINT_URL` environment variables to `fs.s3a.endpoint` and `fs.s3a.path.style.access` JVM args, matching the existing Python-side `S3Fs` handler logic. This enables tools to work with S3-compatible storage backends (e.g., SwiftStack, MinIO).

**Config cleanup**: Removed dead credential-related config entries from both `emr-configs.json` and `databricks_aws-configs.json`:
- `AWS_SHARED_CREDENTIALS_FILE` env variable entries
- `credentialFile` / `awsCredentialFile` from `initialConfigList`
- `credentialsMap` entries (access key, secret key, session token)
- `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token` from `inheritedProps`
- `rapidsJobs.LOCAL.definedVars` credential injection entries

**Stale validation removal**: Removed `_list_inconsistent_configurations()` override from `DBAWSCMDDriver` that warned about missing `aws_*` props — no longer relevant since credentials can come from env vars or instance profiles without being present in the Python context.

### Files Changed

| File | Change |
|------|--------|
| `sp_types.py` | Set `DefaultAWSCredentialsProviderChain` via JVM arg, add S3 endpoint passthrough, fix env var precedence |
| `emr-configs.json` | Remove dead credential config entries |
| `databricks_aws-configs.json` | Remove dead credential config entries |
| `databricks_aws.py` | Remove stale AWS credential validation |