### PR TITLE
Add EMR_STEP_ID to retained system properties

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -970,7 +970,7 @@ class EmrPlatform(gpuDevice: Option[GpuDevice],
   override def isPlatformCSP: Boolean = true
   override def requirePathRecommendations: Boolean = false
 
-  override def getRetainedSystemProps: Set[String] = Set("EMR_CLUSTER_ID")
+  override def getRetainedSystemProps: Set[String] = Set("EMR_CLUSTER_ID", "EMR_STEP_ID")
 
   override def createClusterInfo(coresPerExecutor: Int,
       numExecsPerNode: Int,


### PR DESCRIPTION
Currently the EMR platform retains `EMR_CLUSTER_ID` via `getRetainedSystemProps`. We also should add `EMR_STEP_ID`, which will be useful for Aether to obtain details about the step from the API.