### PR TITLE
Fix AutoTuner to skip cluster sizing configs for on-prem in Profiling

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/ClusterConfigurationStrategy.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/ClusterConfigurationStrategy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,6 +123,27 @@ object ConstantGpuCountStrategy extends ClusterSizingStrategy {
     val recommendNumExecutors = computeRecommendedInstances(platform,
       () => initialNumExecutors)
     RecommendedClusterConfig(recommendNumExecutors, recommendedCoresPerExec,
+      getMemoryPerNodeMb, getRecommendedGpuDevice, getRecommendedNumGpus)
+  }
+}
+
+/**
+ * Strategy that preserves the source cluster's cores-per-executor and executor count.
+ * Used in profiling mode on fixed (on-prem) hardware where node slicing is not
+ * changeable. User-enforced overrides are still honored.
+ */
+object SourceCoresPreservingStrategy extends ClusterSizingStrategy {
+  def computeRecommendedConfig(
+      platform: Platform,
+      initialNumExecutors: Int,
+      initialCoresPerExec: Int,
+      getMemoryPerNodeMb: => Long,
+      getRecommendedGpuDevice: => GpuDevice,
+      getRecommendedNumGpus: => Int): RecommendedClusterConfig = {
+    val coresPerExec = platform.getUserEnforcedSparkProperty("spark.executor.cores")
+      .map(_.toInt).getOrElse(initialCoresPerExec)
+    val numExecutors = computeRecommendedInstances(platform, () => initialNumExecutors)
+    RecommendedClusterConfig(numExecutors, coresPerExec,
       getMemoryPerNodeMb, getRecommendedGpuDevice, getRecommendedNumGpus)
   }
 }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -586,7 +586,7 @@ abstract class AutoTuner(
    */
   private def configureGPURecommendedInstanceType(): Unit = {
     platform.createRecommendedGpuClusterInfo(recommendations, getAllSourceProperties,
-      autoTunerHelper.recommendedClusterSizingStrategy)
+      autoTunerHelper.recommendedClusterSizingStrategy(platform))
     platform.recommendedClusterInfo.foreach { gpuClusterRec =>
       // TODO: Should we skip recommendation if cores per executor is lower than a min value?
       appendRecommendation("spark.executor.cores", gpuClusterRec.coresPerExecutor)
@@ -2225,10 +2225,10 @@ class ProfilingAutoTuner(
  */
 trait AutoTunerHelper extends Logging {
   /**
-   * Default strategy for cluster shape recommendation.
+   * Strategy for cluster shape recommendation.
    * See [[com.nvidia.spark.rapids.tool.ClusterSizingStrategy]] for different strategies.
    */
-  lazy val recommendedClusterSizingStrategy: ClusterSizingStrategy = ConstantGpuCountStrategy
+  def recommendedClusterSizingStrategy(platform: Platform): ClusterSizingStrategy
   // the plugin jar is in the form of rapids-4-spark_scala_binary-(version)-*.jar
   lazy val pluginJarRegEx: Regex = "rapids-4-spark_\\d\\.\\d+-(\\d{2}\\.\\d{2}\\.\\d+).*\\.jar".r
   lazy val gpuKryoRegistratorClassName = "com.nvidia.spark.rapids.GpuKryoRegistrator"
@@ -2326,6 +2326,21 @@ trait AutoTunerHelper extends Logging {
  * implementation of the `AutoTunerHelper` interface.
  */
 object ProfilingAutoTunerHelper extends AutoTunerHelper {
+  /**
+   * On-prem profiling without a target cluster: use SourceCoresPreservingStrategy
+   * to preserve the source cluster's cores and executor count (the hardware is fixed).
+   * For CSP platforms or when a target cluster is provided, use ConstantGpuCountStrategy.
+   */
+  def recommendedClusterSizingStrategy(platform: Platform): ClusterSizingStrategy = {
+    // true when user provided target hardware (workerInfo with cores/memory/GPU)
+    val hasTargetWorkerInfo = platform.targetCluster.exists(!_.getWorkerInfo.isEmpty)
+    if (!platform.isPlatformCSP && !hasTargetWorkerInfo) {
+      SourceCoresPreservingStrategy
+    } else {
+      ConstantGpuCountStrategy
+    }
+  }
+
   def createAutoTunerInstance(
       appInfoProvider: AppSummaryInfoBaseProvider,
       platform: Platform,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTuner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ object QualificationAutoTunerHelper extends AutoTunerHelper {
    * For the Qualification Tool's recommendation for cluster sizing, we want to keep
    * the total number of CPU cores between the source and target clusters constant.
    */
-  override lazy val recommendedClusterSizingStrategy: ClusterSizingStrategy =
+  def recommendedClusterSizingStrategy(platform: Platform): ClusterSizingStrategy =
     ConstantTotalCoresStrategy
 
   override def createAutoTunerInstance(

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -1995,23 +1995,24 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
+    // SourceCoresPreservingStrategy preserves source executor.cores=8 (from spark props),
+    // so memory and thread calculations are based on 8 cores instead of platform-recommended 16.
     val expectedResults =
       s"""|
           |Spark Properties:
-          |--conf spark.executor.cores=16
           |--conf spark.executor.instances=8
-          |--conf spark.executor.memory=32g
+          |--conf spark.executor.memory=16g
           |--conf spark.executor.resource.gpu.amount=1
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.nvidia.spark.SQLPlugin
           |--conf spark.rapids.memory.pinnedPool.size=4g
-          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
-          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=24
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=20
           |--conf spark.rapids.sql.batchSizeBytes=2147483647b
           |--conf spark.rapids.sql.concurrentGpuTasks=3
           |--conf spark.rapids.sql.enabled=true
           |--conf spark.rapids.sql.incompatibleDateFormats.enabled=true
-          |--conf spark.rapids.sql.multiThreadedRead.numThreads=32
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=20
           |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
           |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
           |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -2008,7 +2008,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
       mutable.LinkedHashMap[String, String](
         "spark.executor.cores" -> "8",
         "spark.executor.instances" -> "4",
-        "spark.executor.memory" -> "80g",
+        "spark.executor.memory" -> "16g",
         "spark.executor.resource.gpu.amount" -> "1",
         "spark.dynamicAllocation.enabled" -> "true",
         "spark.dynamicAllocation.minExecutors" -> "1",
@@ -2021,14 +2021,12 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
       logEventsProps, Some(testSparkVersion))
     val platform = PlatformFactory.createInstance(PlatformNames.ONPREM)
 
-    val sparkPropsWithMemory = logEventsProps +
-      ("spark.executor.memory" -> "81920MiB")
     configureEventLogClusterInfoForTest(
       platform,
       numCores = 8,
       numWorkers = 4,
       gpuCount = 1,
-      sparkProperties = sparkPropsWithMemory.toMap
+      sparkProperties = logEventsProps.toMap
     )
 
     val autoTuner = buildAutoTunerForTests(infoProvider, platform, Some(Yarn))

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -2001,17 +2001,105 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
     // Note: spark.executor.cores may not appear in output if source already has same value
   }
 
-  // Source: 8 cores, 18 executors (from event log),
-  // target: 16 cores (ONPREM default).
-  // ConstantGpuCountStrategy preserves GPU count:
-  //   executor.instances stays at 18.
-  // initialExecutors is boosted to match executor.instances
-  //   max(floor(8*0.5),18)=18.
-  // maxExecutors is independently scaled by core ratio
-  //   floor(18*0.5)=9.
-  // Violation: initial(18) > max(9). Enforcement caps to 9.
-  test("dynamic allocation enforces invariant " +
-      "with ConstantGpuCountStrategy") {
+  // On-prem profiling without target cluster uses SourceCoresPreservingStrategy,
+  // which keeps source cores. Dynamic allocation runs with 1:1 ratio so values are unchanged.
+  test("On-prem profiling without target cluster uses source cores for all recommendations") {
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "8",
+        "spark.executor.instances" -> "4",
+        "spark.executor.memory" -> "80g",
+        "spark.executor.resource.gpu.amount" -> "1",
+        "spark.dynamicAllocation.enabled" -> "true",
+        "spark.dynamicAllocation.minExecutors" -> "1",
+        "spark.dynamicAllocation.maxExecutors" -> "20",
+        "spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin"
+      )
+
+    val infoProvider = getMockInfoProvider(8126464.0, Seq(0), Seq(0.004),
+      logEventsProps, Some(testSparkVersion))
+    val platform = PlatformFactory.createInstance(PlatformNames.ONPREM)
+
+    val sparkPropsWithMemory = logEventsProps +
+      ("spark.executor.memory" -> "81920MiB")
+    configureEventLogClusterInfoForTest(
+      platform,
+      numCores = 8,
+      numWorkers = 4,
+      gpuCount = 1,
+      sparkProperties = sparkPropsWithMemory.toMap
+    )
+
+    val autoTuner = buildAutoTunerForTests(infoProvider, platform, Some(Yarn))
+    val (properties, _) = autoTuner.getRecommendedProperties()
+    val propNames = properties.map(_.name).toSet
+
+    // Memory and GPU tuning properties are present
+    Seq(
+      "spark.executor.memory",
+      "spark.executor.memoryOverhead",
+      "spark.rapids.memory.pinnedPool.size",
+      "spark.rapids.sql.concurrentGpuTasks",
+      "spark.rapids.sql.batchSizeBytes"
+    ).foreach { p =>
+      assert(propNames.contains(p), s"Expected '$p' to be present")
+    }
+  }
+
+  // With a target cluster that has workerInfo, full sizing recommendations apply.
+  test("On-prem profiling with target cluster produces full recommendations") {
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "8",
+        "spark.executor.instances" -> "2",
+        "spark.executor.memory" -> "80g",
+        "spark.executor.resource.gpu.amount" -> "1",
+        "spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin"
+      )
+
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      cpuCores = Some(16),
+      memoryGB = Some(64),
+      gpuCount = Some(1),
+      gpuDevice = Some(GpuTypes.L4.toString)
+    )
+
+    val infoProvider = getMockInfoProvider(8126464.0, Seq(0), Seq(0.004),
+      logEventsProps, Some(testSparkVersion))
+    val platform = PlatformFactory.createInstance(PlatformNames.ONPREM, Some(targetClusterInfo))
+
+    val sparkPropsWithMemory = logEventsProps +
+      ("spark.executor.memory" -> "81920MiB")
+    configureEventLogClusterInfoForTest(
+      platform,
+      numCores = 8,
+      numWorkers = 2,
+      gpuCount = 1,
+      sparkProperties = sparkPropsWithMemory.toMap
+    )
+
+    val autoTuner = buildAutoTunerForTests(infoProvider, platform, Some(Yarn))
+    val (properties, _) = autoTuner.getRecommendedProperties()
+    val propNames = properties.map(_.name).toSet
+
+    Seq(
+      "spark.executor.cores",
+      "spark.executor.memory",
+      "spark.rapids.memory.pinnedPool.size",
+      "spark.rapids.sql.concurrentGpuTasks",
+      "spark.rapids.sql.batchSizeBytes"
+    ).foreach { p =>
+      assert(propNames.contains(p), s"Expected '$p' to be present with target cluster")
+    }
+  }
+
+  // With a target cluster, ConstantGpuCountStrategy re-slices cores (8 -> 16).
+  // Core ratio = 8/16 = 0.5, so DA values are halved.
+  // initialExecutors is boosted to max(floor(8*0.5), executor.instances=18) = 18.
+  // maxExecutors = floor(18*0.5) = 9. Violation: initial(18) > max(9), capped to 9.
+  test("dynamic allocation enforces invariant with target cluster") {
     val logEventsProps: mutable.Map[String, String] =
       mutable.LinkedHashMap[String, String](
         "spark.executor.cores" -> "8",
@@ -2021,15 +2109,21 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
         "spark.dynamicAllocation.initialExecutors" -> "8",
         "spark.dynamicAllocation.minExecutors" -> "4",
         "spark.dynamicAllocation.maxExecutors" -> "18",
-        "spark.plugins" ->
-          "com.nvidia.spark.SQLPlugin",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
         "spark.rapids.sql.enabled" -> "true"
       )
+
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      cpuCores = Some(16),
+      memoryGB = Some(64),
+      gpuCount = Some(1),
+      gpuDevice = Some(GpuTypes.L4.toString)
+    )
 
     val infoProvider = getMockInfoProvider(0, Seq(0),
       Seq(0.0), logEventsProps, Some(testSparkVersion))
     val platform =
-      PlatformFactory.createInstance(PlatformNames.ONPREM)
+      PlatformFactory.createInstance(PlatformNames.ONPREM, Some(targetClusterInfo))
 
     configureEventLogClusterInfoForTest(
       platform,
@@ -2043,8 +2137,6 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
       infoProvider, platform, Some(Yarn))
     val (properties, comments) =
       autoTuner.getRecommendedProperties()
-    // After enforcement: initial capped from 18 to 9,
-    // max=floor(18*0.5)=9, min=max(1,floor(4*0.5))=2
     assertDynamicAllocationRecommendations(properties, comments,
       DynamicAllocationInfo(
         enabled = true, max = "9", min = "2",

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -2008,11 +2008,14 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
       mutable.LinkedHashMap[String, String](
         "spark.executor.cores" -> "8",
         "spark.executor.instances" -> "4",
-        "spark.executor.memory" -> "16g",
+        "spark.executor.memory" -> "47222m",
         "spark.executor.resource.gpu.amount" -> "1",
+        "spark.executor.resource.gpu.discoveryScript" ->
+          "${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh",
         "spark.dynamicAllocation.enabled" -> "true",
+        "spark.dynamicAllocation.initialExecutors" -> "4",
         "spark.dynamicAllocation.minExecutors" -> "1",
-        "spark.dynamicAllocation.maxExecutors" -> "20",
+        "spark.dynamicAllocation.maxExecutors" -> "10",
         "spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.SQLPlugin"
       )
@@ -2030,29 +2033,60 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
     )
 
     val autoTuner = buildAutoTunerForTests(infoProvider, platform, Some(Yarn))
-    val (properties, _) = autoTuner.getRecommendedProperties()
-    val propNames = properties.map(_.name).toSet
-
-    // Memory and GPU tuning properties are present
-    Seq(
-      "spark.executor.memory",
-      "spark.executor.memoryOverhead",
-      "spark.rapids.memory.pinnedPool.size",
-      "spark.rapids.sql.concurrentGpuTasks",
-      "spark.rapids.sql.batchSizeBytes"
-    ).foreach { p =>
-      assert(propNames.contains(p), s"Expected '$p' to be present")
-    }
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.executor.memory=16g
+          |--conf spark.executor.memoryOverhead=9830m
+          |--conf spark.locality.wait=0
+          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=20
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
+          |--conf spark.rapids.sql.concurrentGpuTasks=3
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=20
+          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
+          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
+          |--conf spark.sql.adaptive.coalescePartitions.initialPartitionNum=200
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
+          |--conf spark.sql.files.maxPartitionBytes=4g
+          |--conf spark.task.resource.gpu.amount=0.001
+          |
+          |Comments:
+          |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.rapids.memory.pinnedPool.size' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- 'spark.rapids.sql.concurrentGpuTasks' was not set.
+          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
+          |- 'spark.shuffle.manager' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.coalescePartitions.initialPartitionNum' was not set.
+          |- 'spark.sql.files.maxPartitionBytes' was not set.
+          |- 'spark.task.resource.gpu.amount' was not set.
+          |- ${classPathComments("rapids.jars.missing")}
+          |- ${classPathComments("rapids.shuffle.jars")}
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    compareOutput(expectedResults, autoTunerOutput)
   }
 
-  // With a target cluster that has workerInfo, full sizing recommendations apply.
+  // With a target cluster that has workerInfo, ConstantGpuCountStrategy re-slices cores.
   test("On-prem profiling with target cluster produces full recommendations") {
     val logEventsProps: mutable.Map[String, String] =
       mutable.LinkedHashMap[String, String](
         "spark.executor.cores" -> "8",
         "spark.executor.instances" -> "2",
-        "spark.executor.memory" -> "80g",
+        "spark.executor.memory" -> "47222m",
         "spark.executor.resource.gpu.amount" -> "1",
+        "spark.executor.resource.gpu.discoveryScript" ->
+          "${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh",
         "spark.rapids.sql.enabled" -> "true",
         "spark.plugins" -> "com.nvidia.spark.SQLPlugin"
       )
@@ -2068,29 +2102,58 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
       logEventsProps, Some(testSparkVersion))
     val platform = PlatformFactory.createInstance(PlatformNames.ONPREM, Some(targetClusterInfo))
 
-    val sparkPropsWithMemory = logEventsProps +
-      ("spark.executor.memory" -> "81920MiB")
     configureEventLogClusterInfoForTest(
       platform,
       numCores = 8,
       numWorkers = 2,
       gpuCount = 1,
-      sparkProperties = sparkPropsWithMemory.toMap
+      sparkProperties = logEventsProps.toMap
     )
 
     val autoTuner = buildAutoTunerForTests(infoProvider, platform, Some(Yarn))
-    val (properties, _) = autoTuner.getRecommendedProperties()
-    val propNames = properties.map(_.name).toSet
-
-    Seq(
-      "spark.executor.cores",
-      "spark.executor.memory",
-      "spark.rapids.memory.pinnedPool.size",
-      "spark.rapids.sql.concurrentGpuTasks",
-      "spark.rapids.sql.batchSizeBytes"
-    ).foreach { p =>
-      assert(propNames.contains(p), s"Expected '$p' to be present with target cluster")
-    }
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.executor.cores=16
+          |--conf spark.executor.memory=32g
+          |--conf spark.executor.memoryOverhead=11468m
+          |--conf spark.locality.wait=0
+          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=24
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
+          |--conf spark.rapids.sql.concurrentGpuTasks=3
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=32
+          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
+          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
+          |--conf spark.sql.adaptive.coalescePartitions.initialPartitionNum=200
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
+          |--conf spark.sql.files.maxPartitionBytes=4g
+          |--conf spark.task.resource.gpu.amount=0.001
+          |
+          |Comments:
+          |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.rapids.memory.pinnedPool.size' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- 'spark.rapids.sql.concurrentGpuTasks' was not set.
+          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
+          |- 'spark.shuffle.manager' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.coalescePartitions.initialPartitionNum' was not set.
+          |- 'spark.sql.files.maxPartitionBytes' was not set.
+          |- 'spark.task.resource.gpu.amount' was not set.
+          |- ${classPathComments("rapids.jars.missing")}
+          |- ${classPathComments("rapids.shuffle.jars")}
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    compareOutput(expectedResults, autoTunerOutput)
   }
 
   // With a target cluster, ConstantGpuCountStrategy re-slices cores (8 -> 16).


### PR DESCRIPTION
Fixes #2054

When running profiling tool for onprem platforms without target `workerInfo`, the autotuner was recommending a new `spark.executor.cores` value from the platform default even though the hardware for the profiled run is already allocated. That wrong core value then changed downstream recommendations such as executor memory, RAPIDS thread counts, and dynamic allocation.

This PR adds `SourceCoresPreservingStrategy` for that path, so profiling keeps the source executor cores and executor count instead of recomputing them. If the user provides target `workerInfo`, the existing full-sizing behavior still applies.

Reviewer focus:
- On-prem profiling without target `workerInfo` should preserve source cores.
- On-prem profiling with target `workerInfo` should still use full sizing.
- Downstream recommendations should now follow the source core count in the fixed-hardware path.

Testing:
- Updated profiling expectations for on-prem without a target cluster.
- Added coverage for on-prem with target `workerInfo`.
- Added dynamic allocation coverage for the target-cluster path.


