### PR TITLE
Parse modifiedConfigs from SQLExecutionStart for accurate AutoTuner input

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -306,7 +306,12 @@ class SQLExecutionInfoClass(
     var endTime: Option[Long],
     var duration: Option[Long],
     var hasDatasetOrRDD: Boolean,
-    var sqlCpuTimePercent: Double = -1) {
+    var sqlCpuTimePercent: Double = -1,
+    // Per-SQL-execution config overrides from spark.conf.set() calls.
+    // Captured from SparkListenerSQLExecutionStart.modifiedConfigs (Spark 3.3+).
+    // Empty for Spark 3.2.x event logs or when no runtime config changes were made.
+    // This stores only the overrides, not the full config set.
+    val modifiedConfigs: Map[String, String] = Map.empty) {
   def setDsOrRdd(value: Boolean): Unit = {
     hasDatasetOrRDD = value
   }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
@@ -160,11 +160,10 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
     app.sqlManager.addNewExecution(event.executionId, event.sparkPlanInfo,
       event.physicalPlanDescription)
 
-    // Merge runtime config overrides into app-level sparkProperties.
+    // Merge runtime config overrides into app-level sparkProperties with
+    // redaction and predicate updates (gpuMode, etc.).
     // Last-write-wins if multiple SQL executions have different modifiedConfigs.
-    if (modifiedConfigs.nonEmpty) {
-      app.sparkProperties ++= modifiedConfigs
-    }
+    app.mergeModifiedConfigs(modifiedConfigs)
   }
 
   def doSparkListenerSQLExecutionEnd(

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
@@ -141,6 +141,10 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
       event: SparkListenerSQLExecutionStart): Unit = {
     logDebug("Processing event: " + event.getClass)
     val rootExecutionIdOpt = EventUtils.readRootIDFromSQLStartEvent(event)
+    // Extract modifiedConfigs: per-SQL-execution config overrides set via
+    // spark.conf.set(). Available in Spark 3.3+ (SPARK-34735).
+    // Returns empty map for older Spark versions.
+    val modifiedConfigs = EventUtils.readModifiedConfigsFromSQLStartEvent(event)
     val sqlExecution = new SQLExecutionInfoClass(
       event.executionId,
       rootExecutionIdOpt,
@@ -149,11 +153,28 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
       event.time,
       None,
       None,
-      hasDatasetOrRDD = false
+      hasDatasetOrRDD = false,
+      modifiedConfigs = modifiedConfigs
     )
     app.sqlIdToInfo.put(event.executionId, sqlExecution)
     app.sqlManager.addNewExecution(event.executionId, event.sparkPlanInfo,
       event.physicalPlanDescription)
+
+    // Merge modifiedConfigs into the app-level sparkProperties so the auto-tuner
+    // and all downstream consumers see the effective config state, not just the
+    // baseline from SparkListenerEnvironmentUpdate.
+    //
+    // Design decisions:
+    // - Last-write-wins: if multiple SQL executions have different modifiedConfigs
+    //   (e.g., multi-session Connect server), later values overwrite earlier ones.
+    //   Per-session tracking is deferred to Spark Connect support (Part 2).
+    // - Only non-empty maps trigger the merge to avoid unnecessary map operations
+    //   for the common case (spark-submit with no runtime config changes).
+    // - The ++= operator ensures override semantics: modifiedConfigs values replace
+    //   existing baseline values for the same keys while preserving all others.
+    if (modifiedConfigs.nonEmpty) {
+      app.sparkProperties ++= modifiedConfigs
+    }
   }
 
   def doSparkListenerSQLExecutionEnd(

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -160,18 +160,8 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
     app.sqlManager.addNewExecution(event.executionId, event.sparkPlanInfo,
       event.physicalPlanDescription)
 
-    // Merge modifiedConfigs into the app-level sparkProperties so the auto-tuner
-    // and all downstream consumers see the effective config state, not just the
-    // baseline from SparkListenerEnvironmentUpdate.
-    //
-    // Design decisions:
-    // - Last-write-wins: if multiple SQL executions have different modifiedConfigs
-    //   (e.g., multi-session Connect server), later values overwrite earlier ones.
-    //   Per-session tracking is deferred to Spark Connect support (Part 2).
-    // - Only non-empty maps trigger the merge to avoid unnecessary map operations
-    //   for the common case (spark-submit with no runtime config changes).
-    // - The ++= operator ensures override semantics: modifiedConfigs values replace
-    //   existing baseline values for the same keys while preserving all others.
+    // Merge runtime config overrides into app-level sparkProperties.
+    // Last-write-wins if multiple SQL executions have different modifiedConfigs.
     if (modifiedConfigs.nonEmpty) {
       app.sparkProperties ++= modifiedConfigs
     }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/CacheablePropsHandler.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/CacheablePropsHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -176,6 +176,17 @@ trait CacheablePropsHandler extends AppPropPlugContainerTrait {
 
     // After setting the properties, validate the properties.
     validateAppEventlogProperties()
+  }
+
+  /**
+   * Merges modifiedConfigs from SparkListenerSQLExecutionStart into sparkProperties.
+   * Applies redaction (processPropKeys) and updates derived predicates (gpuMode, etc.).
+   */
+  def mergeModifiedConfigs(modifiedConfigs: Map[String, String]): Unit = {
+    if (modifiedConfigs.nonEmpty) {
+      sparkProperties ++= processPropKeys(modifiedConfigs)
+      updatePredicatesFromSparkProperties()
+    }
   }
 
   def handleJobStartForCachedProps(event: SparkListenerJobStart): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
@@ -201,6 +201,18 @@ object EventUtils extends Logging {
     Try(rootExecutionIdField.get(event).asInstanceOf[Option[Long]]).getOrElse(None)
   }
 
+  // Reads the modifiedConfigs from a SparkListenerSQLExecutionStart event using
+  // reflection. Reflection is used here to maintain compatibility with Spark 3.2.x,
+  // as the modifiedConfigs field was introduced in Spark 3.3.0 (SPARK-34735).
+  // This field contains per-SQL-execution config overrides set via spark.conf.set().
+  // Returns an empty map for Spark versions that don't have this field.
+  def readModifiedConfigsFromSQLStartEvent(
+      event: SparkListenerSQLExecutionStart): Map[String, String] = {
+    modifiedConfigsField.flatMap { field =>
+      Try(field.get(event).asInstanceOf[Map[String, String]]).toOption
+    }.getOrElse(Map.empty)
+  }
+
   @throws[com.fasterxml.jackson.core.JsonParseException]
   private def handleEventJsonParseEx(ex: com.fasterxml.jackson.core.JsonParseException): Unit = {
     // Spark 3.4- will throw a JsonParseException if the eventlog is incomplete (lines are broken)
@@ -224,6 +236,17 @@ object EventUtils extends Logging {
     val field = classOf[SparkListenerSQLExecutionStart].getDeclaredField("rootExecutionId")
     field.setAccessible(true)
     field
+  }
+
+  // Reflection field for modifiedConfigs, introduced in Spark 3.3.0 (SPARK-34735).
+  // Returns None if the field does not exist (Spark 3.2.x).
+  private lazy val modifiedConfigsField: Option[java.lang.reflect.Field] = {
+    Try {
+      val field = classOf[SparkListenerSQLExecutionStart]
+        .getDeclaredField("modifiedConfigs")
+      field.setAccessible(true)
+      field
+    }.toOption
   }
 
   private lazy val runtimeEventFromJsonMethod = {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
@@ -206,7 +206,8 @@ object EventUtils extends Logging {
   def readModifiedConfigsFromSQLStartEvent(
       event: SparkListenerSQLExecutionStart): Map[String, String] = {
     modifiedConfigsField.flatMap { field =>
-      Try(field.get(event).asInstanceOf[Map[String, String]]).toOption
+      Try(Option(field.get(event)).map(_.asInstanceOf[Map[String, String]]))
+        .toOption.flatten
     }.getOrElse(Map.empty)
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -201,11 +201,8 @@ object EventUtils extends Logging {
     Try(rootExecutionIdField.get(event).asInstanceOf[Option[Long]]).getOrElse(None)
   }
 
-  // Reads the modifiedConfigs from a SparkListenerSQLExecutionStart event using
-  // reflection. Reflection is used here to maintain compatibility with Spark 3.2.x,
-  // as the modifiedConfigs field was introduced in Spark 3.3.0 (SPARK-34735).
-  // This field contains per-SQL-execution config overrides set via spark.conf.set().
-  // Returns an empty map for Spark versions that don't have this field.
+  // Reads modifiedConfigs via reflection (field added in Spark 3.3, SPARK-34735).
+  // Contains per-execution config overrides from spark.conf.set(). Empty on Spark 3.2.x.
   def readModifiedConfigsFromSQLStartEvent(
       event: SparkListenerSQLExecutionStart): Map[String, String] = {
     modifiedConfigsField.flatMap { field =>

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -1279,20 +1279,27 @@ class ApplicationInfoSuite extends AnyFunSuite with Logging {
         EventLogPathProcessor.getEventLogInfo(
           eventLogFilePath.toString, hadoopConf).head._1)
 
-      // Verify modifiedConfigs is stored on the SQL execution
       val sqlInfo = app.sqlIdToInfo.get(0L)
       assert(sqlInfo.isDefined)
-      assert(sqlInfo.get.modifiedConfigs.nonEmpty)
-      assert(sqlInfo.get.modifiedConfigs("spark.sql.autoBroadcastJoinThreshold") == "-1")
-      assert(sqlInfo.get.modifiedConfigs("spark.app.name") == "saralihalli-test")
-
-      // Verify modifiedConfigs was merged into app-level sparkProperties,
-      // overriding the baseline from SparkListenerEnvironmentUpdate.
-      assert(app.sparkProperties.getOrElse(
-        "spark.sql.autoBroadcastJoinThreshold", "") == "-1")
-      assert(app.sparkProperties.getOrElse(
-        "spark.app.name", "") == "saralihalli-test")
-      // Verify baseline properties that were NOT overridden are still present
+      // modifiedConfigs field was added in Spark 3.3 (SPARK-34735).
+      // On Spark 3.2.x the field doesn't exist, so reflection returns empty and
+      // the baseline sparkProperties remain unchanged.
+      if (sqlInfo.get.modifiedConfigs.nonEmpty) {
+        // Spark 3.3+: modifiedConfigs is parsed and merged
+        assert(sqlInfo.get.modifiedConfigs("spark.sql.autoBroadcastJoinThreshold") == "-1")
+        assert(sqlInfo.get.modifiedConfigs("spark.app.name") == "saralihalli-test")
+        assert(app.sparkProperties.getOrElse(
+          "spark.sql.autoBroadcastJoinThreshold", "") == "-1")
+        assert(app.sparkProperties.getOrElse(
+          "spark.app.name", "") == "saralihalli-test")
+      } else {
+        // Spark 3.2.x: modifiedConfigs not available, baseline unchanged
+        assert(app.sparkProperties.getOrElse(
+          "spark.sql.autoBroadcastJoinThreshold", "") == "10485760")
+        assert(app.sparkProperties.getOrElse(
+          "spark.app.name", "") == "OriginalAppName")
+      }
+      // Baseline properties that were NOT overridden are always present
       assert(app.sparkProperties.getOrElse(
         "spark.master", "") == "local[*]")
     }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -1261,4 +1261,67 @@ class ApplicationInfoSuite extends AnyFunSuite with Logging {
       assert(result.isEmpty)
     }
   }
+
+  test("test modifiedConfigs parsed from SQLExecutionStart and merged into sparkProperties") {
+    TrampolineUtil.withTempDir { tempDir =>
+      val eventLogFilePath = Paths.get(tempDir.getAbsolutePath, "test_eventlog")
+      // scalastyle:off line.size.limit
+      val eventLogContent =
+        """{"Event":"SparkListenerLogStart","Spark Version":"3.5.0"}
+          |{"Event":"SparkListenerApplicationStart","App Name":"ModifiedConfigs_Test","App ID":"local-modconftest","Timestamp":123456,"User":"testUser"}
+          |{"Event":"SparkListenerEnvironmentUpdate","JVM Information":{},"Spark Properties":{"spark.sql.autoBroadcastJoinThreshold":"10485760","spark.app.name":"OriginalAppName","spark.master":"local[*]"},"Hadoop Properties":{},"System Properties":{"file.encoding":"UTF-8"},"Classpath Entries":{}}
+          |{"Event":"org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart","executionId":0,"rootExecutionId":0,"description":"test query","details":"SELECT * FROM t1","physicalPlanDescription":"== Physical Plan ==\nRange (1)\n\n(1) Range\nOutput [1]: [id#0L]\nArguments: Range (0, 10, step=1, splits=Some(4))\n","sparkPlanInfo":{"nodeName":"Range","simpleString":"Range (0, 10, step=1, splits=Some(4))","children":[],"metadata":{},"metrics":[]},"time":123457,"modifiedConfigs":{"spark.sql.autoBroadcastJoinThreshold":"-1","spark.app.name":"saralihalli-test"}}
+          |{"Event":"SparkListenerApplicationEnd","Timestamp":123460}""".stripMargin
+      // scalastyle:on line.size.limit
+      Files.write(eventLogFilePath, eventLogContent.getBytes(StandardCharsets.UTF_8))
+
+      val app = new ApplicationInfo(hadoopConf,
+        EventLogPathProcessor.getEventLogInfo(
+          eventLogFilePath.toString, hadoopConf).head._1)
+
+      // Verify modifiedConfigs is stored on the SQL execution
+      val sqlInfo = app.sqlIdToInfo.get(0L)
+      assert(sqlInfo.isDefined)
+      assert(sqlInfo.get.modifiedConfigs.nonEmpty)
+      assert(sqlInfo.get.modifiedConfigs("spark.sql.autoBroadcastJoinThreshold") == "-1")
+      assert(sqlInfo.get.modifiedConfigs("spark.app.name") == "saralihalli-test")
+
+      // Verify modifiedConfigs was merged into app-level sparkProperties,
+      // overriding the baseline from SparkListenerEnvironmentUpdate.
+      assert(app.sparkProperties.getOrElse(
+        "spark.sql.autoBroadcastJoinThreshold", "") == "-1")
+      assert(app.sparkProperties.getOrElse(
+        "spark.app.name", "") == "saralihalli-test")
+      // Verify baseline properties that were NOT overridden are still present
+      assert(app.sparkProperties.getOrElse(
+        "spark.master", "") == "local[*]")
+    }
+  }
+
+  test("test empty modifiedConfigs does not affect sparkProperties") {
+    TrampolineUtil.withTempDir { tempDir =>
+      val eventLogFilePath = Paths.get(tempDir.getAbsolutePath, "test_eventlog")
+      // scalastyle:off line.size.limit
+      val eventLogContent =
+        """{"Event":"SparkListenerLogStart","Spark Version":"3.5.0"}
+          |{"Event":"SparkListenerApplicationStart","App Name":"EmptyModConf_Test","App ID":"local-emptymodconf","Timestamp":123456,"User":"testUser"}
+          |{"Event":"SparkListenerEnvironmentUpdate","JVM Information":{},"Spark Properties":{"spark.sql.autoBroadcastJoinThreshold":"10485760","spark.master":"local[*]"},"Hadoop Properties":{},"System Properties":{"file.encoding":"UTF-8"},"Classpath Entries":{}}
+          |{"Event":"org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart","executionId":0,"rootExecutionId":0,"description":"test query","details":"SELECT 1","physicalPlanDescription":"== Physical Plan ==\nRange (1)\n","sparkPlanInfo":{"nodeName":"Range","simpleString":"Range","children":[],"metadata":{},"metrics":[]},"time":123457,"modifiedConfigs":{}}
+          |{"Event":"SparkListenerApplicationEnd","Timestamp":123460}""".stripMargin
+      // scalastyle:on line.size.limit
+      Files.write(eventLogFilePath, eventLogContent.getBytes(StandardCharsets.UTF_8))
+
+      val app = new ApplicationInfo(hadoopConf,
+        EventLogPathProcessor.getEventLogInfo(
+          eventLogFilePath.toString, hadoopConf).head._1)
+
+      val sqlInfo = app.sqlIdToInfo.get(0L)
+      assert(sqlInfo.isDefined)
+      assert(sqlInfo.get.modifiedConfigs.isEmpty)
+
+      // Verify baseline sparkProperties are unchanged
+      assert(app.sparkProperties.getOrElse(
+        "spark.sql.autoBroadcastJoinThreshold", "") == "10485760")
+    }
+  }
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -1305,6 +1305,37 @@ class ApplicationInfoSuite extends AnyFunSuite with Logging {
     }
   }
 
+  test("test modifiedConfigs redacts sensitive properties") {
+    TrampolineUtil.withTempDir { tempDir =>
+      val eventLogFilePath = Paths.get(tempDir.getAbsolutePath, "test_eventlog")
+      // scalastyle:off line.size.limit
+      // modifiedConfigs includes a sensitive S3 secret key that should be redacted
+      val eventLogContent =
+        """{"Event":"SparkListenerLogStart","Spark Version":"3.5.0"}
+          |{"Event":"SparkListenerApplicationStart","App Name":"Redaction_Test","App ID":"local-redacttest","Timestamp":123456,"User":"testUser"}
+          |{"Event":"SparkListenerEnvironmentUpdate","JVM Information":{},"Spark Properties":{"spark.master":"local[*]"},"Hadoop Properties":{},"System Properties":{"file.encoding":"UTF-8"},"Classpath Entries":{}}
+          |{"Event":"org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart","executionId":0,"rootExecutionId":0,"description":"test","details":"SELECT 1","physicalPlanDescription":"== Physical Plan ==\nRange (1)\n","sparkPlanInfo":{"nodeName":"Range","simpleString":"Range","children":[],"metadata":{},"metrics":[]},"time":123457,"modifiedConfigs":{"spark.hadoop.fs.s3a.secret.key":"my-secret-key","spark.app.name":"safe-value"}}
+          |{"Event":"SparkListenerApplicationEnd","Timestamp":123460}""".stripMargin
+      // scalastyle:on line.size.limit
+      Files.write(eventLogFilePath, eventLogContent.getBytes(StandardCharsets.UTF_8))
+
+      val app = new ApplicationInfo(hadoopConf,
+        EventLogPathProcessor.getEventLogInfo(
+          eventLogFilePath.toString, hadoopConf).head._1)
+
+      val sqlInfo = app.sqlIdToInfo.get(0L)
+      assert(sqlInfo.isDefined)
+      // On Spark 3.3+, verify sensitive key is redacted in sparkProperties
+      if (sqlInfo.get.modifiedConfigs.nonEmpty) {
+        // The secret key should be redacted after merge
+        assert(app.sparkProperties.get("spark.hadoop.fs.s3a.secret.key")
+          .forall(_.contains("redacted")))
+        // Non-sensitive key should pass through unchanged
+        assert(app.sparkProperties.getOrElse("spark.app.name", "") == "safe-value")
+      }
+    }
+  }
+
   test("test empty modifiedConfigs does not affect sparkProperties") {
     TrampolineUtil.withTempDir { tempDir =>
       val eventLogFilePath = Paths.get(tempDir.getAbsolutePath, "test_eventlog")

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
@@ -300,4 +300,38 @@ abstract class BaseAutoTunerSuite extends AnyFunSuite with BeforeAndAfterEach
         " <= maxExecutors")),
       "Expected enforcement comment in output")
   }
+
+  test("auto-tuner sees modifiedConfigs values merged into sparkProperties") {
+    // Simulate the state after EventProcessorBase merges modifiedConfigs:
+    // baseline had autoBroadcastJoinThreshold=10485760, but spark.conf.set()
+    // changed it to -1. After merge, sparkProperties contains -1.
+    val propsWithOverride = mutable.Map[String, String](
+      "spark.sql.autoBroadcastJoinThreshold" -> "-1",
+      "spark.master" -> "yarn",
+      "spark.executor.cores" -> "8",
+      "spark.executor.memory" -> "16g",
+      "spark.rapids.sql.enabled" -> "true"
+    )
+    val mockAppInfoProvider = new AppInfoProviderMockTest(
+      maxInput = 1000.0,
+      spilledMetrics = Seq.empty,
+      jvmGCFractions = Seq.empty,
+      propsFromLog = propsWithOverride,
+      sparkVersion = Some("3.5.0"),
+      rapidsJars = Seq.empty,
+      distinctLocationPct = 0.0,
+      redundantReadSize = 0L,
+      meanInput = 500.0,
+      meanShuffleRead = 200.0,
+      shuffleStagesWithPosSpilling = Set.empty,
+      shuffleSkewStages = Set.empty,
+      scanStagesWithGpuOom = false,
+      shuffleStagesWithOom = false
+    )
+    // The auto-tuner should see the overridden value, not the baseline
+    assert(mockAppInfoProvider.getSparkProperty(
+      "spark.sql.autoBroadcastJoinThreshold") == Some("-1"))
+    assert(mockAppInfoProvider.getAllProperties(
+      "spark.sql.autoBroadcastJoinThreshold") == "-1")
+  }
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
@@ -29,6 +29,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.rapids.tool.{RecommendedClusterInfo, ToolUtils}
+import org.apache.spark.sql.rapids.tool.util.CacheablePropsHandler
 
 
 case class DriverInfoProviderMockTest(unsupportedOps: Seq[DriverLogUnsupportedOperators])
@@ -302,41 +303,26 @@ abstract class BaseAutoTunerSuite extends AnyFunSuite with BeforeAndAfterEach
   }
 
   test("auto-tuner sees modifiedConfigs values merged into sparkProperties") {
-    // Verify the merge path: baseline properties from EnvironmentUpdate, then
-    // modifiedConfigs overrides applied via mergeModifiedConfigs.
-    val propsFromEnv = mutable.Map[String, String](
+    // Test mergeModifiedConfigs directly on a CacheablePropsHandler instance.
+    // This is the same path EventProcessorBase calls during event processing.
+    val handler = new CacheablePropsHandler {}
+    handler.sparkProperties = Map(
       "spark.sql.autoBroadcastJoinThreshold" -> "10485760",
-      "spark.master" -> "yarn",
-      "spark.executor.cores" -> "8",
-      "spark.executor.memory" -> "16g",
-      "spark.rapids.sql.enabled" -> "true"
+      "spark.master" -> "yarn"
     )
-    val mockAppInfoProvider = new AppInfoProviderMockTest(
-      maxInput = 1000.0,
-      spilledMetrics = Seq.empty,
-      jvmGCFractions = Seq.empty,
-      propsFromLog = propsFromEnv,
-      sparkVersion = Some("3.5.0"),
-      rapidsJars = Seq.empty,
-      distinctLocationPct = 0.0,
-      redundantReadSize = 0L,
-      meanInput = 500.0,
-      meanShuffleRead = 200.0,
-      shuffleStagesWithPosSpilling = Set.empty,
-      shuffleSkewStages = Set.empty,
-      scanStagesWithGpuOom = false,
-      shuffleStagesWithOom = false
-    )
+
     // Before merge: baseline value
-    assert(mockAppInfoProvider.getSparkProperty(
-      "spark.sql.autoBroadcastJoinThreshold") == Some("10485760"))
+    assert(handler.sparkProperties("spark.sql.autoBroadcastJoinThreshold") == "10485760")
 
-    // Simulate what EventProcessorBase does: merge modifiedConfigs into the
-    // provider's property map (same map instance the auto-tuner reads from).
-    propsFromEnv ++= Map("spark.sql.autoBroadcastJoinThreshold" -> "-1")
+    // Merge overrides (same call EventProcessorBase makes)
+    handler.mergeModifiedConfigs(Map(
+      "spark.sql.autoBroadcastJoinThreshold" -> "-1",
+      "spark.app.name" -> "test-app"
+    ))
 
-    // After merge: auto-tuner should see the overridden value
-    assert(mockAppInfoProvider.getSparkProperty(
-      "spark.sql.autoBroadcastJoinThreshold") == Some("-1"))
+    // After merge: overridden value wins, baseline preserved, new key added
+    assert(handler.sparkProperties("spark.sql.autoBroadcastJoinThreshold") == "-1")
+    assert(handler.sparkProperties("spark.master") == "yarn")
+    assert(handler.sparkProperties("spark.app.name") == "test-app")
   }
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
@@ -302,11 +302,10 @@ abstract class BaseAutoTunerSuite extends AnyFunSuite with BeforeAndAfterEach
   }
 
   test("auto-tuner sees modifiedConfigs values merged into sparkProperties") {
-    // Simulate the state after EventProcessorBase merges modifiedConfigs:
-    // baseline had autoBroadcastJoinThreshold=10485760, but spark.conf.set()
-    // changed it to -1. After merge, sparkProperties contains -1.
-    val propsWithOverride = mutable.Map[String, String](
-      "spark.sql.autoBroadcastJoinThreshold" -> "-1",
+    // Verify the merge path: baseline properties from EnvironmentUpdate, then
+    // modifiedConfigs overrides applied via mergeModifiedConfigs.
+    val propsFromEnv = mutable.Map[String, String](
+      "spark.sql.autoBroadcastJoinThreshold" -> "10485760",
       "spark.master" -> "yarn",
       "spark.executor.cores" -> "8",
       "spark.executor.memory" -> "16g",
@@ -316,7 +315,7 @@ abstract class BaseAutoTunerSuite extends AnyFunSuite with BeforeAndAfterEach
       maxInput = 1000.0,
       spilledMetrics = Seq.empty,
       jvmGCFractions = Seq.empty,
-      propsFromLog = propsWithOverride,
+      propsFromLog = propsFromEnv,
       sparkVersion = Some("3.5.0"),
       rapidsJars = Seq.empty,
       distinctLocationPct = 0.0,
@@ -328,10 +327,16 @@ abstract class BaseAutoTunerSuite extends AnyFunSuite with BeforeAndAfterEach
       scanStagesWithGpuOom = false,
       shuffleStagesWithOom = false
     )
-    // The auto-tuner should see the overridden value, not the baseline
+    // Before merge: baseline value
+    assert(mockAppInfoProvider.getSparkProperty(
+      "spark.sql.autoBroadcastJoinThreshold") == Some("10485760"))
+
+    // Simulate what EventProcessorBase does: merge modifiedConfigs into the
+    // provider's property map (same map instance the auto-tuner reads from).
+    propsFromEnv ++= Map("spark.sql.autoBroadcastJoinThreshold" -> "-1")
+
+    // After merge: auto-tuner should see the overridden value
     assert(mockAppInfoProvider.getSparkProperty(
       "spark.sql.autoBroadcastJoinThreshold") == Some("-1"))
-    assert(mockAppInfoProvider.getAllProperties(
-      "spark.sql.autoBroadcastJoinThreshold") == "-1")
   }
 }


### PR DESCRIPTION
## Summary

- Parse the `modifiedConfigs` field from `SparkListenerSQLExecutionStart` events (Spark 3.3+, SPARK-34735) to capture runtime config overrides set via `spark.conf.set()`
- Merge overrides into app-level `sparkProperties` so the AutoTuner and profiling output reflect the effective config state, not just the baseline from `SparkListenerEnvironmentUpdate`
- This is critical for Spark Connect workloads where `spark.conf.set()` is the only way users can customize configs (they don't control the server startup)
- Uses reflection for backward compatibility with Spark 3.2.x

Closes #2059

## Changes

| File | Change |
|------|--------|
| `EventUtils.scala` | Add `readModifiedConfigsFromSQLStartEvent()` via reflection |
| `ProfileClassWarehouse.scala` | Add `modifiedConfigs` field to `SQLExecutionInfoClass` |
| `EventProcessorBase.scala` | Extract modifiedConfigs, store per-execution, merge into sparkProperties |
| `ApplicationInfoSuite.scala` | Tests for parsing, merge, and empty modifiedConfigs |
| `BaseAutoTunerSuite.scala` | Test verifying AutoTuner sees merged values |

## Validation

Ran profiling on a real Spark Connect event log with `spark.conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")`:

**Before (baseline):** `spark_properties.csv` shows `spark.app.name=Spark Connect server`, no `autoBroadcastJoinThreshold` entry

**After (with changes):** `spark_properties.csv` shows `spark.app.name=saralihalli-test`, `spark.sql.autoBroadcastJoinThreshold=-1` — correctly reflecting the runtime overrides

AutoTuner input table also reflects the overridden values.

## Test plan

- [x] `mvn clean verify -DskipTests` passes (style checks clean)
- [x] Profiling output diff validated on real Spark Connect event log
- [x] AutoTuner input table shows merged config values
- [ ] CI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)