### PR TITLE
Mark Pandas execs as unsupported

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -313,7 +313,6 @@ object ExecInfo {
     // Example: Scan parquet . ->  Scan parquet.
     // scan nodes needs trimming
     val nodeName = node.name.trim
-    // we don't want to mark the *InPandas and ArrowEvalPythonExec as unsupported with UDF
     val containsUDF = udf || ExecHelper.isUDF(node)
     // check is the node has a dataset operations and if so change to not supported
     val rddCheckRes = RDDCheckHelper.isDatasetOrRDDPlan(nodeName, node.desc)

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -326,10 +326,6 @@ object ExecHelper {
     ".*UDF.*".r
   )
 
-  // we don't want to mark the *InPandas and ArrowEvalPythonExec as unsupported with UDF
-  private val skipUDFCheckExecs = Seq("ArrowEvalPython", "AggregateInPandas",
-    "FlatMapGroupsInPandas", "MapInPandas", "WindowInPandas", "PythonMapInArrow", "MapInArrow")
-
   // Set containing execs that should be labeled as "shouldRemove"
   private val execsToBeRemoved = Set(
     "GenerateBloomFilter",      // Exclusive on AWS. Ignore it as metrics cannot be evaluated.
@@ -350,11 +346,7 @@ object ExecHelper {
   )
 
   def isUDF(node: SparkPlanGraphNode): Boolean = {
-    if (skipUDFCheckExecs.exists(node.name.contains(_))) {
-      false
-    } else {
-      UDFRegExLookup.exists(regEx => node.desc.matches(regEx.regex))
-    }
+    UDFRegExLookup.exists(regEx => node.desc.matches(regEx.regex))
   }
 
   def shouldBeRemoved(nodeName: String): Boolean = {

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -808,6 +808,8 @@ class SQLPlanParserSuite extends BasePlanParserSuite with Matchers {
     assertSizeAndSupported(1, aggregateInPandas)
     // this event log had UDF for ArrowEvalPath so shows up as not supported
     val arrowEvalPython = allExecInfo.filter(_.exec == "ArrowEvalPython")
+    // Note that we do not assert speedupFactor == 1, since some speedup is
+    // observed for Pandas execs due to accelerated data transfer
     assert(arrowEvalPython.size == 1)
     assert(arrowEvalPython.forall(!_.isSupported))
     val mapInPandas = allExecInfo.filter(_.exec == "MapInPandas")

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -808,7 +808,8 @@ class SQLPlanParserSuite extends BasePlanParserSuite with Matchers {
     assertSizeAndSupported(1, aggregateInPandas)
     // this event log had UDF for ArrowEvalPath so shows up as not supported
     val arrowEvalPython = allExecInfo.filter(_.exec == "ArrowEvalPython")
-    assertSizeAndSupported(1, arrowEvalPython)
+    assert(arrowEvalPython.size == 1)
+    assert(arrowEvalPython.forall(!_.isSupported))
     val mapInPandas = allExecInfo.filter(_.exec == "MapInPandas")
     assertSizeAndSupported(1, mapInPandas)
     // WindowInPandas configured off by default


### PR DESCRIPTION
This closes #2067 by removing the previous special-handling that marked Pandas/Arrow UDF execs as supported. These execs are now marked unsupported and will appear in `unsupported_operators.csv`, as well as contribute to unsupported task duration. This does *not* change the speedup factor.

A follow-up issue, #2068, is filed to investigate the unsupported duration. There is a duration duplication issue — both pre-existing (for standard Python UDFs, i.e., BatchEvalPython) and implicitly introduced via this PR (for Pandas/Arrow execs) — where the parent Project exec and the child Python exec are both marked as unsupported, and both contribute to unsupported task durations, even though they overlap. This is not *that* critical since unsupported duration is a very coarse estimate, but worth investigation. 
