### PR TITLE
Improve user-tools path normalization and Hadoop boundary handling

### DIFF
--- a/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/rapids_tool.py
@@ -20,6 +20,7 @@ import logging
 import os
 import re
 import sys
+import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
@@ -46,6 +47,7 @@ from spark_rapids_tools.enums import DependencyType
 from spark_rapids_tools.storagelib import LocalPath, CspFs
 from spark_rapids_tools.storagelib.tools.fs_utils import untar_file
 from spark_rapids_tools.utils import Utilities, AbstractPropContainer
+from spark_rapids_tools.utils.util import get_path_as_uri_for_hadoop
 from spark_rapids_tools.utils.net_utils import DownloadTask
 
 
@@ -452,6 +454,93 @@ class RapidsJarTool(RapidsTool, Generic[ToolResultHandlerT]):
     """
     A wrapper class to represent wrapper commands that require RAPIDS jar file.
     """
+    _HADOOP_PATH_ARG_KEYS = frozenset({
+        'driverlog',
+        'target_cluster_info',
+        'tuning_configs',
+    })
+    # Keep this aligned with EventLogPathProcessor.expandTextFile in Scala. The rewritten
+    # local .txt file is passed back into the JAR, so both sides must agree on how entries
+    # inside an eventlog list file are tokenized.
+    _EVENTLOG_LIST_TOKEN_SPLIT_PATTERN = re.compile(r'[\s,;]+')
+
+    @staticmethod
+    def _prepare_hadoop_arg_path(path_value: str) -> str:
+        """Normalize a single Hadoop/JVM-bound path string."""
+        return get_path_as_uri_for_hadoop(path_value)
+
+    @classmethod
+    def _prepare_hadoop_arg_value(cls, option_key: str, option_value: Any) -> Any:
+        """
+        Normalize supported JAR-bound wrapper options before they are serialized as CLI args.
+
+        `driverlog`, `target_cluster_info`, and `tuning_configs` are the `rapidOptions`
+        entries that cross the Hadoop/JVM boundary, and all three are scalar string paths
+        produced by the argprocessor.
+        """
+        if option_key not in cls._HADOOP_PATH_ARG_KEYS:
+            return option_value
+        return cls._prepare_hadoop_arg_path(option_value)
+
+    @classmethod
+    def _rewrite_local_eventlog_list_file(cls, list_file: str, work_dir: str) -> str:
+        """
+        Rewrite a local eventlog list file so every contained path is explicit for Hadoop.
+
+        Eventlog list files are treated as token lists rather than free-form text. The
+        current contract accepts paths separated by newlines, whitespace, commas, or
+        semicolons, then rewrites the file as one normalized path per line.
+        The rewritten file is created under the wrapper work directory so it remains available
+        for the JAR invocation.
+        """
+        list_path = LocalPath(list_file)
+        if not list_path.is_file():
+            return list_file
+
+        with open(list_path.no_scheme, mode='r', encoding='utf-8') as src_file:
+            list_contents = src_file.read()
+
+        prepared_tokens = [
+            cls._prepare_hadoop_arg_path(token)
+            for token in cls._EVENTLOG_LIST_TOKEN_SPLIT_PATTERN.split(list_contents)
+            if token
+        ]
+        if not prepared_tokens:
+            return list_file
+        with tempfile.NamedTemporaryFile(mode='w',
+                                         encoding='utf-8',
+                                         delete=False,
+                                         dir=work_dir,
+                                         prefix='eventlogs-',
+                                         suffix='.txt') as tmp_file:
+            tmp_file.write('\n'.join(prepared_tokens))
+            tmp_file.write('\n')
+            return f'file://{tmp_file.name}'
+
+    @classmethod
+    def _prepare_eventlog_arg_for_hadoop(cls, eventlog: str, work_dir: str) -> str:
+        """
+        Normalize one eventlog entry before it is handed to the JAR.
+
+        An eventlog entry may itself be a local `.txt` file that expands to multiple eventlog
+        paths. Those files require a second pass over their contents before the JAR consumes them.
+        """
+        prepared_eventlog = cls._prepare_hadoop_arg_path(eventlog)
+        if not prepared_eventlog.lower().endswith('.txt'):
+            return prepared_eventlog
+        if not prepared_eventlog.lower().startswith('file:'):
+            return prepared_eventlog
+        return cls._rewrite_local_eventlog_list_file(prepared_eventlog, work_dir)
+
+    @classmethod
+    def _prepare_eventlog_args_for_hadoop(cls, eventlogs: List[str], work_dir: str) -> List[str]:
+        """
+        Normalize the final eventlog list stored in wrapper context before JAR handoff.
+
+        `_process_eventlogs_args` resolves the top-level wrapper input into `List[str]`; this
+        method applies per-entry normalization and local `.txt` list-file rewriting.
+        """
+        return [cls._prepare_eventlog_arg_for_hadoop(entry, work_dir) for entry in eventlogs]
 
     @cached_property
     def core_handler(self) -> APIResHandler[ToolResultHandlerT]:
@@ -522,6 +611,7 @@ class RapidsJarTool(RapidsTool, Generic[ToolResultHandlerT]):
         self.logger.debug('Processing Rapids plugin Arguments %s', self.rapids_options)
         raw_tool_opts: Dict[str, Any] = {}
         for key, value in self.rapids_options.items():
+            value = self._prepare_hadoop_arg_value(key, value)
             if not isinstance(value, bool):
                 # a boolean flag, does not need to have its value added to the list
                 if isinstance(value, str):
@@ -767,7 +857,10 @@ class RapidsJarTool(RapidsTool, Generic[ToolResultHandlerT]):
                               'The cluster Spark properties may be missing "spark.eventLog.dir". '
                               'Re-run the command passing "--eventlogs" flag to the wrapper.')
             raise RuntimeError('Invalid arguments. The list of Apache Spark event logs is empty.')
-        self.ctxt.set_ctxt('eventLogs', spark_event_logs)
+        self.ctxt.set_ctxt(
+            'eventLogs',
+            self._prepare_eventlog_args_for_hadoop(spark_event_logs, self.ctxt.get_local_work_dir())
+        )
 
     def _create_migration_cluster(self, cluster_type: str, cluster_arg: str) -> ClusterBase:
         if cluster_arg is None:

--- a/user_tools/src/spark_rapids_tools/storagelib/cspfs.py
+++ b/user_tools/src/spark_rapids_tools/storagelib/cspfs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/user_tools/src/spark_rapids_tools/storagelib/cspfs.py
+++ b/user_tools/src/spark_rapids_tools/storagelib/cspfs.py
@@ -98,8 +98,10 @@ class CspFs(abc.ABC, Generic[BoundedCspPath]):
     def __init__(self, *args: Any, **kwargs: Any):
         self.fs = self.create_fs_handler(*args, **kwargs)
 
-    def create_as_path(self, entry_path: Union[str, BoundedCspPath]) -> BoundedCspPath:
-        return self._path_meta.path_class(entry_path=entry_path, fs_obj=self)
+    def create_as_path(self,
+                       entry_path: Union[str, BoundedCspPath],
+                       file_info: Optional[arrow_fs.FileInfo] = None) -> BoundedCspPath:
+        return self._path_meta.path_class(entry_path=entry_path, fs_obj=self, file_info=file_info)
 
     @classmethod
     def copy_file(cls, src: BoundedCspPath, dest: BoundedCspPath):
@@ -179,7 +181,7 @@ class CspFs(abc.ABC, Generic[BoundedCspPath]):
         dir_info_list = path.fs_obj.get_file_info(
             arrow_fs.FileSelector(base_dir=path.no_scheme))
         return [
-            path.create_sub_path(dir_info.base_name)
+            path.create_sub_path(dir_info.base_name, file_info=dir_info)
             for dir_info in dir_info_list
             if item_type is None or dir_info.type == item_type
         ]
@@ -213,11 +215,11 @@ class CspFs(abc.ABC, Generic[BoundedCspPath]):
         res = []
         for i_entry in dir_list:
             item_name = i_entry.base_name
-            item = csp_path.create_sub_path(item_name)
+            item = csp_path.create_sub_path(item_name, file_info=i_entry)
             if i_entry.type == FileType.Directory and recursive:
                 res.extend(
                     self.glob_inner(
-                        csp_path.create_sub_path(item_name),
+                        item,
                         pattern,
                         item_type,
                         recursive=recursive))

--- a/user_tools/src/spark_rapids_tools/storagelib/csppath.py
+++ b/user_tools/src/spark_rapids_tools/storagelib/csppath.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -229,7 +229,15 @@ class CspPath(metaclass=CspPathMeta):
             # both must refer to an existing file, not just have a valid URI shape.
             normalized_value = str(file_path).strip().strip("'\"")
             if normalized_value.lower().startswith('file:'):
-                return CspPath(normalized_value).is_file()
+                try:
+                    return CspPath(normalized_value).is_file()
+                except Exception as err:  # pylint: disable=broad-except
+                    if raise_on_error:
+                        raise PydanticCustomError(
+                            'file_path',
+                            f'File path {file_path} could not be validated as a local file.\n  Error:{err}'
+                        ) from err
+                    return False
             return True
         except ValidationError as err:
             if raise_on_error:

--- a/user_tools/src/spark_rapids_tools/storagelib/csppath.py
+++ b/user_tools/src/spark_rapids_tools/storagelib/csppath.py
@@ -222,7 +222,14 @@ class CspPath(metaclass=CspPathMeta):
                      extensions: List[str] = None,
                      raise_on_error: bool = True):
         try:
-            TypeAdapter(AcceptedFilePath).validate_python({'file_path': file_path, 'extensions': extensions})
+            TypeAdapter(AcceptedFilePath).validate_python(
+                {'file_path': file_path, 'extensions': extensions}
+            )
+            # Keep local file URIs semantically aligned with plain local paths:
+            # both must refer to an existing file, not just have a valid URI shape.
+            normalized_value = str(file_path).strip().strip("'\"")
+            if normalized_value.lower().startswith('file:'):
+                return CspPath(normalized_value).is_file()
             return True
         except ValidationError as err:
             if raise_on_error:
@@ -253,7 +260,8 @@ class CspPath(metaclass=CspPathMeta):
     def __init__(
             self,
             entry_path: Union[str, Self],
-            fs_obj: Optional['CspFs'] = None
+            fs_obj: Optional['CspFs'] = None,
+            file_info: Optional[FileInfo] = None
     ) -> None:
         self.is_valid_csppath(entry_path, raise_on_error=True)
         self._fpath = str(entry_path)
@@ -270,6 +278,8 @@ class CspPath(metaclass=CspPathMeta):
             )
         self.fs_obj = fs_obj
         self._file_info = None
+        if file_info is not None:
+            self._cache_file_info(file_info)
 
     def __str__(self) -> str:
         return self._fpath
@@ -288,6 +298,14 @@ class CspPath(metaclass=CspPathMeta):
 
     def _pull_file_info(self) -> FileInfo:
         return self.fs_obj.get_file_info(self.no_scheme)
+
+    def _cache_file_info(self, file_info: FileInfo) -> None:
+        self._file_info = file_info
+        self.__dict__['file_info'] = file_info
+
+    def invalidate_file_info(self) -> None:
+        self._file_info = None
+        self.__dict__.pop('file_info', None)
 
     @cached_property
     def file_info(self) -> FileInfo:
@@ -313,20 +331,20 @@ class CspPath(metaclass=CspPathMeta):
             if self.exists():
                 raise CspFileExistsError(f'Path already Exists: {self}')
         self.fs_obj.create_dir(self.no_scheme)
-        # force the file information object to be retrieved again by invalidating the cached property
-        if 'file_info' in self.__dict__:
-            del self.__dict__['file_info']
+        self.invalidate_file_info()
 
     def open_input_stream(self):
         return self.fs_obj.open_input_stream(self.no_scheme)
 
     def open_output_stream(self):
+        self.invalidate_file_info()
         return self.fs_obj.open_output_stream(self.no_scheme)
 
     def open_append_stream(self):
+        self.invalidate_file_info()
         return self.fs_obj.open_append_stream(self.no_scheme)
 
-    def create_sub_path(self, relative: str) -> 'CspPath':
+    def create_sub_path(self, relative: str, file_info: Optional[FileInfo] = None) -> 'CspPath':
         """
         Given a relative path, it will return a new CspPath object with the relative path appended to
         the current path. This is just for building a path, and it does not call mkdirs.
@@ -347,7 +365,7 @@ class CspPath(metaclass=CspPathMeta):
         if self._fpath.endswith('/'):
             postfix = ''
         new_path = f'{self._fpath}{postfix}{sub_path}'
-        return CspPath(new_path)
+        return CspPath(new_path, fs_obj=self.fs_obj, file_info=file_info)
 
     def to_str_format(self) -> str:
         """

--- a/user_tools/src/spark_rapids_tools/utils/util.py
+++ b/user_tools/src/spark_rapids_tools/utils/util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -101,26 +101,27 @@ def stringify_path(fpath) -> str:
     return os.path.abspath(expanded_path)
 
 
-def _strip_path_wrappers(fpath: str) -> str:
+def _strip_path_quotes_and_whitespace(fpath: str) -> str:
+    """Remove surrounding whitespace and quote characters from a path-like string."""
     return fpath.strip().strip("'\"")
 
 
 def _normalize_file_uri(fpath: str) -> str:
+    """Canonicalize `file:` URIs into absolute `file://` form when the scheme is present."""
     if not fpath.lower().startswith('file:'):
         return fpath
 
-    path_part = fpath[5:]
-    normalized_path = f'/{path_part.lstrip("/")}' if path_part else '/'
+    _, _, path_part = fpath.partition(':')
+    normalized_path = '/' + path_part.lstrip('/') if path_part else '/'
     absolute_path = os.path.abspath(normalized_path)
     return PurePath(absolute_path).as_uri()
 
 
-def _normalize_s3_uri(fpath: str) -> str:
-    lower_path = fpath.lower()
-    if lower_path.startswith('s3a://'):
-        return f's3://{fpath[6:]}'
-    if lower_path.startswith('s3n://'):
-        return f's3://{fpath[6:]}'
+def _normalize_s3_uri(fpath: str, target_scheme: str = 's3') -> str:
+    """Rewrite S3-family URI schemes to the requested target scheme without changing the path."""
+    scheme, separator, path_part = fpath.partition('://')
+    if separator and scheme.lower() in {'s3', 's3a', 's3n'}:
+        return f'{target_scheme}://{path_part}'
     return fpath
 
 
@@ -143,11 +144,29 @@ def is_http_file(value: Any) -> bool:
 
 
 def get_path_as_uri(fpath: str) -> str:
-    normalized_path = _normalize_s3_uri(_normalize_file_uri(_strip_path_wrappers(fpath)))
+    normalized_path = _normalize_s3_uri(_normalize_file_uri(_strip_path_quotes_and_whitespace(fpath)))
     if re.match(r'\w+://', normalized_path):
         # that's already a valid url
         return normalized_path
     # stringify the path to apply the common methods which is expanding the file.
+    local_path = stringify_path(normalized_path)
+    return PurePath(local_path).as_uri()
+
+
+def get_path_as_uri_for_hadoop(fpath: str) -> str:
+    """
+    Normalize a path for Hadoop/JVM consumers.
+
+    This differs from ``get_path_as_uri`` in one important way:
+    S3-family URIs are normalized to ``s3a://`` because that is the
+    Hadoop-facing scheme expected by the tools JAR.
+    """
+    normalized_path = _normalize_s3_uri(
+        _normalize_file_uri(_strip_path_quotes_and_whitespace(fpath)),
+        target_scheme='s3a'
+    )
+    if re.match(r'\w+://', normalized_path):
+        return normalized_path
     local_path = stringify_path(normalized_path)
     return PurePath(local_path).as_uri()
 

--- a/user_tools/src/spark_rapids_tools/utils/util.py
+++ b/user_tools/src/spark_rapids_tools/utils/util.py
@@ -101,6 +101,29 @@ def stringify_path(fpath) -> str:
     return os.path.abspath(expanded_path)
 
 
+def _strip_path_wrappers(fpath: str) -> str:
+    return fpath.strip().strip("'\"")
+
+
+def _normalize_file_uri(fpath: str) -> str:
+    if not fpath.lower().startswith('file:'):
+        return fpath
+
+    path_part = fpath[5:]
+    normalized_path = f'/{path_part.lstrip("/")}' if path_part else '/'
+    absolute_path = os.path.abspath(normalized_path)
+    return PurePath(absolute_path).as_uri()
+
+
+def _normalize_s3_uri(fpath: str) -> str:
+    lower_path = fpath.lower()
+    if lower_path.startswith('s3a://'):
+        return f's3://{fpath[6:]}'
+    if lower_path.startswith('s3n://'):
+        return f's3://{fpath[6:]}'
+    return fpath
+
+
 def resolve_and_prepare_log_file(tools_home_dir: str):
     run_id = Utils.get_or_set_rapids_tools_env('RUN_ID')
     log_dir = f'{tools_home_dir}/logs'
@@ -120,11 +143,12 @@ def is_http_file(value: Any) -> bool:
 
 
 def get_path_as_uri(fpath: str) -> str:
-    if re.match(r'\w+://', fpath):
+    normalized_path = _normalize_s3_uri(_normalize_file_uri(_strip_path_wrappers(fpath)))
+    if re.match(r'\w+://', normalized_path):
         # that's already a valid url
-        return fpath
+        return normalized_path
     # stringify the path to apply the common methods which is expanding the file.
-    local_path = stringify_path(fpath)
+    local_path = stringify_path(normalized_path)
     return PurePath(local_path).as_uri()
 
 

--- a/user_tools/tests/spark_rapids_tools_ut/test_csppath.py
+++ b/user_tools/tests/spark_rapids_tools_ut/test_csppath.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import pyarrow.fs as arrow_fs
 import pytest
+from pydantic_core import PydanticCustomError
 
 from spark_rapids_tools.storagelib import CspFs, CspPath
 from spark_rapids_tools.storagelib.local.localpath import LocalPath
@@ -54,6 +55,20 @@ class TestCspPathNormalization:
 class TestCspPathFileInfoCaching:
     """Verify metadata reuse and invalidation behaviour."""
 
+    def test_is_file_path_returns_false_when_local_file_lookup_raises(self, monkeypatch, tmp_path):
+        local_file = tmp_path / "guarded.txt"
+        local_file.write_text("data", encoding="utf-8")
+
+        def raising_is_file(path_obj):
+            del path_obj
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(CspPath, "is_file", raising_is_file)
+
+        assert CspPath.is_file_path(local_file.as_uri(), raise_on_error=False) is False
+        with pytest.raises(PydanticCustomError, match="could not be validated as a local file"):
+            CspPath.is_file_path(local_file.as_uri())
+
     def test_list_all_reuses_file_info_from_directory_listing(self, monkeypatch, tmp_path):
         child = tmp_path / "child.txt"
         child.write_text("data", encoding="utf-8")
@@ -75,7 +90,7 @@ class TestCspPathFileInfoCaching:
         direct_lookup_calls.clear()
         assert child_path.exists() is True
         assert child_path.base_name() == "child.txt"
-        assert direct_lookup_calls == []
+        assert not direct_lookup_calls
 
     def test_open_output_stream_invalidates_stale_file_info(self, tmp_path):
         created_path = CspPath(str(tmp_path / "created.txt"))

--- a/user_tools/tests/spark_rapids_tools_ut/test_csppath.py
+++ b/user_tools/tests/spark_rapids_tools_ut/test_csppath.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for CspPath normalization and file-info caching."""
+
+from pathlib import Path
+
+import pyarrow.fs as arrow_fs
+import pytest
+
+from spark_rapids_tools.storagelib import CspFs, CspPath
+from spark_rapids_tools.storagelib.local.localpath import LocalPath
+from spark_rapids_tools.storagelib.s3.s3path import S3Path
+
+
+class TestCspPathNormalization:
+    """Verify normalization logic at the CspPath entry point."""
+
+    @pytest.mark.parametrize(
+        "input_path",
+        [
+            "s3a://bucket/path/to/file",
+            "s3n://bucket/path/to/file",
+            " 's3a://bucket/path/to/file' ",
+        ],
+    )
+    def test_normalizes_s3_family_schemes(self, input_path):
+        csp_path = CspPath(input_path)
+
+        assert isinstance(csp_path, S3Path)
+        assert str(csp_path) == "s3://bucket/path/to/file"
+        assert csp_path.no_scheme == "bucket/path/to/file"
+
+    @pytest.mark.parametrize("input_path", ["file:/tmp/demo.txt", "file://tmp/demo.txt", "file:////tmp/demo.txt"])
+    def test_normalizes_file_scheme_variants(self, input_path):
+        csp_path = CspPath(input_path)
+
+        assert isinstance(csp_path, LocalPath)
+        assert str(csp_path) == Path("/tmp/demo.txt").as_uri()
+        assert csp_path.no_scheme == "/tmp/demo.txt"
+
+
+class TestCspPathFileInfoCaching:
+    """Verify metadata reuse and invalidation behaviour."""
+
+    def test_list_all_reuses_file_info_from_directory_listing(self, monkeypatch, tmp_path):
+        child = tmp_path / "child.txt"
+        child.write_text("data", encoding="utf-8")
+
+        root = CspPath(str(tmp_path))
+        original_get_file_info = root.fs_obj.get_file_info
+        direct_lookup_calls = []
+
+        def tracking_get_file_info(path_or_selector):
+            if not isinstance(path_or_selector, arrow_fs.FileSelector):
+                direct_lookup_calls.append(path_or_selector)
+            return original_get_file_info(path_or_selector)
+
+        monkeypatch.setattr(root.fs_obj, "get_file_info", tracking_get_file_info)
+
+        items = CspFs.list_all(root)
+        child_path = next(item for item in items if str(item).endswith("child.txt"))
+
+        direct_lookup_calls.clear()
+        assert child_path.exists() is True
+        assert child_path.base_name() == "child.txt"
+        assert direct_lookup_calls == []
+
+    def test_open_output_stream_invalidates_stale_file_info(self, tmp_path):
+        created_path = CspPath(str(tmp_path / "created.txt"))
+
+        assert created_path.exists() is False
+
+        with created_path.open_output_stream() as output_stream:
+            output_stream.write(b"payload")
+
+        assert created_path.exists() is True
+        assert created_path.is_file() is True

--- a/user_tools/tests/spark_rapids_tools_ut/test_path_boundary.py
+++ b/user_tools/tests/spark_rapids_tools_ut/test_path_boundary.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for path qualification at the tools-to-Hadoop boundary."""
+
+from pathlib import Path
+
+from spark_rapids_pytools.rapids.rapids_tool import RapidsJarTool
+
+
+class RapidsJarToolTestShim(RapidsJarTool):
+    """Expose wrapper boundary helpers through a public test shim."""
+
+    @classmethod
+    def prepare_hadoop_arg_path(cls, path_value: str) -> str:
+        return getattr(RapidsJarTool, '_prepare_hadoop_arg_path')(path_value)
+
+    @classmethod
+    def prepare_hadoop_arg_value(cls, option_key: str, option_value):
+        return getattr(RapidsJarTool, '_prepare_hadoop_arg_value')(option_key, option_value)
+
+    @classmethod
+    def prepare_eventlog_args_for_hadoop(cls, eventlogs, work_dir: str):
+        return getattr(RapidsJarTool, '_prepare_eventlog_args_for_hadoop')(eventlogs, work_dir)
+
+    @classmethod
+    def prepare_eventlog_arg_for_hadoop(cls, eventlog: str, work_dir: str) -> str:
+        return getattr(RapidsJarTool, '_prepare_eventlog_arg_for_hadoop')(eventlog, work_dir)
+
+
+class TestPathBoundaryQualification:
+    """Verify Hadoop-bound path qualification remains explicit and idempotent."""
+
+    def test_prepare_hadoop_arg_path_qualifies_local_paths(self, tmp_path):
+        local_file = tmp_path / 'worker_info.yaml'
+
+        assert RapidsJarToolTestShim.prepare_hadoop_arg_path(str(local_file)) == f'file://{local_file}'
+        assert RapidsJarToolTestShim.prepare_hadoop_arg_path(f" '{local_file}' ") == f'file://{local_file}'
+        assert RapidsJarToolTestShim.prepare_hadoop_arg_path('file:/tmp/demo.yaml') == 'file:///tmp/demo.yaml'
+        assert RapidsJarToolTestShim.prepare_hadoop_arg_path('file://tmp/demo.yaml') == 'file:///tmp/demo.yaml'
+
+    def test_prepare_hadoop_arg_path_normalizes_s3_family_for_hadoop(self):
+        assert RapidsJarToolTestShim.prepare_hadoop_arg_path('s3://bucket/path') == 's3a://bucket/path'
+        assert RapidsJarToolTestShim.prepare_hadoop_arg_path('s3n://bucket/path') == 's3a://bucket/path'
+        assert RapidsJarToolTestShim.prepare_hadoop_arg_path('s3a://bucket/path') == 's3a://bucket/path'
+
+    def test_prepare_hadoop_arg_path_preserves_non_s3_remote_schemes(self):
+        assert RapidsJarToolTestShim.prepare_hadoop_arg_path('gs://bucket/path') == 'gs://bucket/path'
+        assert RapidsJarToolTestShim.prepare_hadoop_arg_path('hdfs://namenode:8020/path') == 'hdfs://namenode:8020/path'
+
+    def test_prepare_hadoop_arg_value_targets_only_jvm_bound_keys(self, tmp_path):
+        local_file = tmp_path / 'driver.log'
+
+        assert RapidsJarToolTestShim.prepare_hadoop_arg_value('driverlog', str(local_file)) == f'file://{local_file}'
+        assert RapidsJarToolTestShim.prepare_hadoop_arg_value('target_cluster_info', str(local_file)) == \
+            f'file://{local_file}'
+        assert RapidsJarToolTestShim.prepare_hadoop_arg_value('toolsJar', str(local_file)) == str(local_file)
+
+    def test_prepare_eventlog_args_for_hadoop_qualifies_each_token(self, tmp_path):
+        local_dir = tmp_path / 'eventlogs'
+        local_txt = tmp_path / 'eventlogs.txt'
+        tokens = [
+            str(local_dir),
+            'file:/tmp/eventlog.zstd',
+            's3://bucket/eventlog-legacy.zstd',
+            's3a://bucket/eventlog.zstd',
+            str(local_txt),
+        ]
+
+        prepared_tokens = RapidsJarToolTestShim.prepare_eventlog_args_for_hadoop(tokens, str(tmp_path))
+
+        assert prepared_tokens == [
+            f'file://{local_dir}',
+            'file:///tmp/eventlog.zstd',
+            's3a://bucket/eventlog-legacy.zstd',
+            's3a://bucket/eventlog.zstd',
+            f'file://{local_txt}',
+        ]
+
+    def test_prepare_eventlog_arg_for_hadoop_rewrites_local_txt_lists(self, tmp_path):
+        eventlogs_txt = tmp_path / 'eventlogs.txt'
+        eventlogs_txt.write_text(
+            '/tmp/logs/app-1,\n'
+            'file:/tmp/logs/app-2;\n'
+            's3://bucket/app-legacy\t'
+            's3a://bucket/app-3\n',
+            encoding='utf-8'
+        )
+
+        rewritten_arg = RapidsJarToolTestShim.prepare_eventlog_arg_for_hadoop(str(eventlogs_txt), str(tmp_path))
+
+        assert rewritten_arg.startswith('file://')
+        assert rewritten_arg != f'file://{eventlogs_txt}'
+
+        rewritten_path = Path(rewritten_arg.removeprefix('file://'))
+        assert rewritten_path.exists()
+        assert rewritten_path.read_text(encoding='utf-8') == (
+            'file:///tmp/logs/app-1\n'
+            'file:///tmp/logs/app-2\n'
+            's3a://bucket/app-legacy\n'
+            's3a://bucket/app-3\n'
+        )
+
+    def test_prepare_eventlog_arg_for_hadoop_preserves_empty_local_txt_lists(self, tmp_path):
+        eventlogs_txt = tmp_path / 'empty-eventlogs.txt'
+        eventlogs_txt.write_text('  \n,\n;\n', encoding='utf-8')
+
+        rewritten_arg = RapidsJarToolTestShim.prepare_eventlog_arg_for_hadoop(str(eventlogs_txt), str(tmp_path))
+
+        assert rewritten_arg == eventlogs_txt.as_uri()
+
+    def test_prepare_eventlog_arg_for_hadoop_preserves_remote_txt_lists(self):
+        remote_txt = 's3a://bucket/eventlogs.txt'
+
+        assert RapidsJarToolTestShim.prepare_eventlog_arg_for_hadoop(remote_txt, '/tmp') == remote_txt

--- a/user_tools/tests/spark_rapids_tools_ut/test_tool_argprocessor.py
+++ b/user_tools/tests/spark_rapids_tools_ut/test_tool_argprocessor.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/user_tools/tests/spark_rapids_tools_ut/test_tool_argprocessor.py
+++ b/user_tools/tests/spark_rapids_tools_ut/test_tool_argprocessor.py
@@ -17,6 +17,7 @@
 import dataclasses
 import warnings
 from collections import defaultdict
+from pathlib import Path
 from typing import Dict, Callable, List
 
 import pytest
@@ -96,6 +97,26 @@ class TestToolArgProcessor(SparkRapidsToolsUT):  # pylint: disable=too-few-publi
                                                  tools_jar=kwargs.get('tools_jar'),
                                                  tools_config_path=kwargs.get('tools_config_path'),
                                                  submission_mode=kwargs.get('submission_mode'))
+        assert pytest_wrapped_e.type == SystemExit
+
+    @staticmethod
+    def create_estimation_model_args_should_pass(custom_model_file: str = None):
+        return AbsToolUserArgModel.create_tool_args(
+            {'toolName': 'qualification', 'validatorName': 'estimation_model_args'},
+            estimation_model=None,
+            custom_model_file=custom_model_file,
+            qualx_config=None,
+        )
+
+    @staticmethod
+    def create_estimation_model_args_should_fail(custom_model_file: str):
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            AbsToolUserArgModel.create_tool_args(
+                {'toolName': 'qualification', 'validatorName': 'estimation_model_args'},
+                estimation_model=None,
+                custom_model_file=custom_model_file,
+                qualx_config=None,
+            )
         assert pytest_wrapped_e.type == SystemExit
 
     @staticmethod
@@ -305,6 +326,22 @@ class TestToolArgProcessor(SparkRapidsToolsUT):  # pylint: disable=too-few-publi
                                                       tools_config_path=tools_conf_path,
                                                       submission_mode=submission_mode)
         assert tool_args['toolsConfig'] is not None
+
+    def test_custom_model_file_requires_existing_json_for_plain_path_and_file_uri(self, tmp_path):
+        missing_plain = '/invalid/path/to/model.json'
+        missing_uri = Path(missing_plain).as_uri()
+
+        self.create_estimation_model_args_should_fail(custom_model_file=missing_plain)
+        self.create_estimation_model_args_should_fail(custom_model_file=missing_uri)
+
+        existing_model = tmp_path / 'custom_model.json'
+        existing_model.write_text('{"model": "ok"}', encoding='utf-8')
+
+        plain_args = self.create_estimation_model_args_should_pass(custom_model_file=str(existing_model))
+        assert plain_args['customModelFile'] == str(existing_model)
+
+        uri_args = self.create_estimation_model_args_should_pass(custom_model_file=existing_model.as_uri())
+        assert uri_args['customModelFile'] == existing_model.as_uri()
 
     def test_arg_cases_coverage(self):
         """


### PR DESCRIPTION
Fixes #1799

## Summary
- normalize storage paths in user tools so `CspPath` and `CspFs` accept local paths, malformed `file:` URIs, and `s3`/`s3a`/`s3n` inputs consistently
- reuse cached listing metadata in `CspPath`/`CspFs` and invalidate stale metadata after local mutations to avoid redundant lookups and stale state
- make local `file://` validation consistent with plain local path validation for existing-file checks
- normalize Hadoop-bound wrapper paths for `eventlogs`, `driverlog`, `target_cluster_info`, and `tuning_configs` so local paths are explicit `file://` URIs and S3-family paths are passed as `s3a://`
- rewrite local `eventlogs.txt` inputs in the wrapper work directory so contained paths are normalized before JAR handoff, while preserving existing empty-list behavior
- keep the eventlog list-file tokenization aligned with the Scala `EventLogPathProcessor` contract

## Testing
- `pytest user_tools/tests/spark_rapids_tools_ut/test_csppath.py -q`
- `pytest user_tools/tests/spark_rapids_tools_ut/test_tool_argprocessor.py -q`
- `pytest user_tools/tests/spark_rapids_tools_ut/test_path_boundary.py -q`
