### PR TITLE
Add Spark Connect event parsing support

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -488,6 +488,18 @@
                 <hadoop.version>3.3.6</hadoop.version>
                 <iceberg.spark.artifact>${iceberg.spark35x.artifact}</iceberg.spark.artifact>
             </properties>
+            <dependencies>
+                <!-- Spark Connect event classes for test verification (Spark 3.5+).
+                     At runtime, the Spark distribution provides this jar.
+                     The tools code uses reflection (no compile-time imports) so this
+                     is only needed to test Connect event parsing. -->
+                <dependency>
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-connect_${scala.binary.version}</artifactId>
+                    <version>${spark.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <!-- Profile for Spark 3.5.7 - activates when buildver is set -->
         <profile>
@@ -506,6 +518,14 @@
                 <hadoop.version>3.3.6</hadoop.version>
                 <iceberg.spark.artifact>${iceberg.spark35x.artifact}</iceberg.spark.artifact>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-connect_${scala.binary.version}</artifactId>
+                    <version>${spark.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <!--

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -489,15 +489,10 @@
                 <iceberg.spark.artifact>${iceberg.spark35x.artifact}</iceberg.spark.artifact>
             </properties>
             <dependencies>
-                <!-- Spark Connect event classes for test verification (Spark 3.5+).
-                     At runtime, the Spark distribution provides this jar.
-                     The tools code uses reflection (no compile-time imports) so this
-                     is only needed to test Connect event parsing. -->
+                <!-- Version/scope come from dependencyManagement. -->
                 <dependency>
                     <groupId>org.apache.spark</groupId>
                     <artifactId>spark-connect_${scala.binary.version}</artifactId>
-                    <version>${spark.version}</version>
-                    <scope>test</scope>
                 </dependency>
             </dependencies>
         </profile>
@@ -519,11 +514,10 @@
                 <iceberg.spark.artifact>${iceberg.spark35x.artifact}</iceberg.spark.artifact>
             </properties>
             <dependencies>
+                <!-- Version/scope come from dependencyManagement. -->
                 <dependency>
                     <groupId>org.apache.spark</groupId>
                     <artifactId>spark-connect_${scala.binary.version}</artifactId>
-                    <version>${spark.version}</version>
-                    <scope>test</scope>
                 </dependency>
             </dependencies>
         </profile>
@@ -735,6 +729,17 @@
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-compiler</artifactId>
                 <version>${scala.version}</version>
+            </dependency>
+            <!-- Spark Connect event classes for test verification (Spark 3.5+).
+                 At runtime, the Spark distribution provides this jar. The tools code
+                 uses reflection (no compile-time imports), so this is only needed to
+                 test Connect event parsing. Declared here so 3.5+ profiles can opt
+                 in with just groupId/artifactId. -->
+            <dependency>
+                <groupId>org.apache.spark</groupId>
+                <artifactId>spark-connect_${scala.binary.version}</artifactId>
+                <version>${spark.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/core/src/main/resources/parser/eventlog-parser.yaml
+++ b/core/src/main/resources/parser/eventlog-parser.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/src/main/resources/parser/eventlog-parser.yaml
+++ b/core/src/main/resources/parser/eventlog-parser.yaml
@@ -50,6 +50,18 @@ eventsTable:
   streamingQueryEnd: org.apache.spark.sql.streaming.StreamingQueryListener$QueryTerminatedEvent
   # List of RAPIDS events
   rapidsBuildInfo: com.nvidia.spark.rapids.SparkRapidsBuildInfoEvent
+  # List of Spark Connect events (Spark 3.5+).
+  # These events are deserialized by JsonProtocol when the spark-connect jar is on the
+  # classpath. Otherwise they are silently skipped (ClassNotFoundException -> None).
+  connectSessionStarted: org.apache.spark.sql.connect.service.SparkListenerConnectSessionStarted
+  connectSessionClosed: org.apache.spark.sql.connect.service.SparkListenerConnectSessionClosed
+  connectOpStarted: org.apache.spark.sql.connect.service.SparkListenerConnectOperationStarted
+  connectOpAnalyzed: org.apache.spark.sql.connect.service.SparkListenerConnectOperationAnalyzed
+  connectOpReady: org.apache.spark.sql.connect.service.SparkListenerConnectOperationReadyForExecution
+  connectOpFinished: org.apache.spark.sql.connect.service.SparkListenerConnectOperationFinished
+  connectOpClosed: org.apache.spark.sql.connect.service.SparkListenerConnectOperationClosed
+  connectOpFailed: org.apache.spark.sql.connect.service.SparkListenerConnectOperationFailed
+  connectOpCanceled: org.apache.spark.sql.connect.service.SparkListenerConnectOperationCanceled
 # List of events that can be supported by each tool
 toolsConfig:
   - className: FilterAppInfo
@@ -88,6 +100,16 @@ toolsConfig:
       - logStart
       - streamingQueryStart
       - streamingQueryEnd
+      # Spark Connect events (Spark 3.5+)
+      - connectSessionStarted
+      - connectSessionClosed
+      - connectOpStarted
+      - connectOpAnalyzed
+      - connectOpReady
+      - connectOpFinished
+      - connectOpClosed
+      - connectOpFailed
+      - connectOpCanceled
   - className: ApplicationInfo
     supportedEvents:
       - taskEnd
@@ -120,3 +142,13 @@ toolsConfig:
       - streamingQueryStart
       - streamingQueryEnd
       - rapidsBuildInfo
+      # Spark Connect events (Spark 3.5+)
+      - connectSessionStarted
+      - connectSessionClosed
+      - connectOpStarted
+      - connectOpAnalyzed
+      - connectOpReady
+      - connectOpFinished
+      - connectOpClosed
+      - connectOpFailed
+      - connectOpCanceled

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ConnectClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ConnectClassWarehouse.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.profiling
+
+/**
+ * Tool-owned storage classes for Spark Connect event data.
+ *
+ * These classes hold data extracted reflectively from Spark Connect listener events
+ * (Spark 3.5+). They intentionally do NOT import or reference any Spark Connect
+ * classes, so they compile for all supported Spark profiles (3.2–3.5+).
+ *
+ * This follows the same pattern as [[SQLExecutionInfoClass]], which stores data
+ * extracted from SparkListenerSQLExecutionStart without being a Spark type itself.
+ */
+
+/**
+ * Holds session lifecycle data extracted from SparkListenerConnectSessionStarted
+ * and SparkListenerConnectSessionClosed events.
+ *
+ * @param sessionId UUID assigned by Connect to identify the client session.
+ * @param userId    User who owns the session.
+ * @param startTime Epoch millis when the session was created.
+ * @param endTime   Epoch millis when the session was closed (None if still open or
+ *                  server was killed before the close event).
+ */
+case class ConnectSessionInfo(
+    sessionId: String,
+    userId: String,
+    startTime: Long,
+    var endTime: Option[Long] = None)
+
+/**
+ * Aggregates the full lifecycle of a single Spark Connect operation, populated
+ * incrementally as events arrive. The lifecycle is:
+ *
+ * Started → Analyzed → ReadyForExecution → Finished → Closed
+ *                                        └→ Failed
+ *                                        └→ Canceled
+ *
+ * @param operationId     UUID assigned by Connect for this operation.
+ * @param sessionId       The session this operation belongs to.
+ * @param userId          User who submitted the operation.
+ * @param jobTag          Correlation key linking to
+ *                        SQLExecutionStart.jobTags and
+ *                        JobStart.Properties["spark.job.tags"].
+ * @param statementText   Protobuf text format of the ExecutePlanRequest logical plan.
+ * @param startTime       Epoch millis when the operation was received.
+ * @param analyzeTime     Epoch millis after plan analysis completed.
+ * @param readyForExecTime Epoch millis when planning completed and execution can start.
+ * @param finishTime      Epoch millis when execution completed (before results sent).
+ * @param closeTime       Epoch millis when results were sent and operation cleaned up.
+ * @param producedRowCount Number of result rows (from OperationFinished).
+ * @param errorMessage    Error message if the operation failed.
+ * @param isCanceled      True if the operation was explicitly canceled by the client.
+ */
+class ConnectOperationInfo(
+    val operationId: String,
+    val sessionId: String,
+    val userId: String,
+    val jobTag: String,
+    val statementText: String,
+    val startTime: Long,
+    var analyzeTime: Option[Long] = None,
+    var readyForExecTime: Option[Long] = None,
+    var finishTime: Option[Long] = None,
+    var closeTime: Option[Long] = None,
+    var producedRowCount: Option[Long] = None,
+    var errorMessage: Option[String] = None,
+    var isCanceled: Boolean = false)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ConnectClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ConnectClassWarehouse.scala
@@ -59,8 +59,8 @@ class ConnectSessionInfo(
  * @param producedRowCount Number of result rows (from OperationFinished).
  * @param errorMessage    Error message if the operation failed.
  * @param failTime        Epoch millis when the operation failed.
- * @param isCanceled      True if the operation was explicitly canceled.
- * @param cancelTime      Epoch millis when the operation was canceled.
+ * @param cancelTime      Epoch millis when the operation was canceled
+ *                        (isDefined implies canceled).
  */
 class ConnectOperationInfo(
     val operationId: String,
@@ -76,5 +76,7 @@ class ConnectOperationInfo(
     var producedRowCount: Option[Long] = None,
     var errorMessage: Option[String] = None,
     var failTime: Option[Long] = None,
-    var isCanceled: Boolean = false,
-    var cancelTime: Option[Long] = None)
+    var cancelTime: Option[Long] = None) {
+
+  def isCanceled: Boolean = cancelTime.isDefined
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ConnectClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ConnectClassWarehouse.scala
@@ -17,19 +17,12 @@
 package com.nvidia.spark.rapids.tool.profiling
 
 /**
- * Tool-owned storage classes for Spark Connect event data.
- *
- * These classes hold data extracted reflectively from Spark Connect listener events
- * (Spark 3.5+). They intentionally do NOT import or reference any Spark Connect
- * classes, so they compile for all supported Spark profiles (3.2–3.5+).
- *
- * This follows the same pattern as [[SQLExecutionInfoClass]], which stores data
- * extracted from SparkListenerSQLExecutionStart without being a Spark type itself.
+ * Storage classes for Spark Connect event data (Spark 3.5+).
+ * Populated reflectively by [[org.apache.spark.sql.rapids.tool.util.ConnectEventHandler]].
  */
 
 /**
- * Holds session lifecycle data extracted from SparkListenerConnectSessionStarted
- * and SparkListenerConnectSessionClosed events.
+ * Session lifecycle data from Connect session events.
  *
  * @param sessionId UUID assigned by Connect to identify the client session.
  * @param userId    User who owns the session.
@@ -44,8 +37,8 @@ case class ConnectSessionInfo(
     var endTime: Option[Long] = None)
 
 /**
- * Aggregates the full lifecycle of a single Spark Connect operation, populated
- * incrementally as events arrive. The lifecycle is:
+ * Full lifecycle of a single Connect operation. Populated incrementally
+ * as events arrive. The lifecycle is:
  *
  * Started → Analyzed → ReadyForExecution → Finished → Closed
  *                                        └→ Failed

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ConnectClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ConnectClassWarehouse.scala
@@ -30,10 +30,10 @@ package com.nvidia.spark.rapids.tool.profiling
  * @param endTime   Epoch millis when the session was closed (None if still open or
  *                  server was killed before the close event).
  */
-case class ConnectSessionInfo(
-    sessionId: String,
-    userId: String,
-    startTime: Long,
+class ConnectSessionInfo(
+    val sessionId: String,
+    val userId: String,
+    val startTime: Long,
     var endTime: Option[Long] = None)
 
 /**

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ConnectClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ConnectClassWarehouse.scala
@@ -58,7 +58,9 @@ case class ConnectSessionInfo(
  * @param closeTime       Epoch millis when results were sent and operation cleaned up.
  * @param producedRowCount Number of result rows (from OperationFinished).
  * @param errorMessage    Error message if the operation failed.
- * @param isCanceled      True if the operation was explicitly canceled by the client.
+ * @param failTime        Epoch millis when the operation failed.
+ * @param isCanceled      True if the operation was explicitly canceled.
+ * @param cancelTime      Epoch millis when the operation was canceled.
  */
 class ConnectOperationInfo(
     val operationId: String,
@@ -73,4 +75,6 @@ class ConnectOperationInfo(
     var closeTime: Option[Long] = None,
     var producedRowCount: Option[Long] = None,
     var errorMessage: Option[String] = None,
-    var isCanceled: Boolean = false)
+    var failTime: Option[Long] = None,
+    var isCanceled: Boolean = false,
+    var cancelTime: Option[Long] = None)

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -138,12 +138,10 @@ abstract class AppBase(
   var sparkRapidsBuildInfo: SparkRapidsBuildInfoEvent = SparkRapidsBuildInfoEvent(immutable.Map(),
     immutable.Map(), immutable.Map(), immutable.Map())
 
-  // Spark Connect metadata (Spark 3.5+). Populated by ConnectEventHandler when
-  // processing event logs from Connect servers. Empty for non-Connect event logs.
+  // Spark Connect metadata (Spark 3.5+). Empty for non-Connect event logs.
   val connectSessions: HashMap[String, ConnectSessionInfo] = HashMap.empty
   val connectOperations: HashMap[String, ConnectOperationInfo] = HashMap.empty
-  // Maps jobTag -> operationId for correlation with SQLExecutionStart.jobTags
-  // and JobStart.Properties["spark.job.tags"].
+  // jobTag -> operationId index for correlation with SQL executions and jobs.
   val jobTagToConnectOpId: HashMap[String, String] = HashMap.empty
   def isConnectMode: Boolean = connectOperations.nonEmpty
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -26,7 +26,7 @@ import com.nvidia.spark.rapids.SparkRapidsBuildInfoEvent
 import com.nvidia.spark.rapids.tool.{DatabricksEventLog, DatabricksRollingEventLogFilesFileReader, EventLogInfo, Identifiable, Platform}
 import com.nvidia.spark.rapids.tool.planparser.{BatchScanExecParser, ReadParser}
 import com.nvidia.spark.rapids.tool.planparser.hive.HiveParseHelper
-import com.nvidia.spark.rapids.tool.profiling.{BlockManagerRemovedCase, DriverAccumCase, JobInfoClass, ResourceProfileInfoCase, SQLExecutionInfoClass, SQLPlanMetricsCase}
+import com.nvidia.spark.rapids.tool.profiling.{BlockManagerRemovedCase, ConnectOperationInfo, ConnectSessionInfo, DriverAccumCase, JobInfoClass, ResourceProfileInfoCase, SQLExecutionInfoClass, SQLPlanMetricsCase}
 import com.nvidia.spark.rapids.tool.qualification.AppSubscriber
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -137,6 +137,15 @@ abstract class AppBase(
 
   var sparkRapidsBuildInfo: SparkRapidsBuildInfoEvent = SparkRapidsBuildInfoEvent(immutable.Map(),
     immutable.Map(), immutable.Map(), immutable.Map())
+
+  // Spark Connect metadata (Spark 3.5+). Populated by ConnectEventHandler when
+  // processing event logs from Connect servers. Empty for non-Connect event logs.
+  val connectSessions: HashMap[String, ConnectSessionInfo] = HashMap.empty
+  val connectOperations: HashMap[String, ConnectOperationInfo] = HashMap.empty
+  // Maps jobTag -> operationId for correlation with SQLExecutionStart.jobTags
+  // and JobStart.Properties["spark.job.tags"].
+  val jobTagToConnectOpId: HashMap[String, String] = HashMap.empty
+  def isConnectMode: Boolean = connectOperations.nonEmpty
 
   def sqlPlans: immutable.Map[Long, SparkPlanInfo] = sqlManager.getPlanInfos
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
@@ -25,7 +25,7 @@ import com.nvidia.spark.rapids.tool.profiling.{BlockManagerRemovedCase, DriverAc
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler._
 import org.apache.spark.sql.execution.ui._
-import org.apache.spark.sql.rapids.tool.util.{EventUtils, StringUtils}
+import org.apache.spark.sql.rapids.tool.util.{ConnectEventHandler, EventUtils, StringUtils}
 import org.apache.spark.sql.streaming.StreamingQueryListener
 
 abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener with Logging {
@@ -102,7 +102,14 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
           event.asInstanceOf[SparkRapidsBuildInfoEvent])
       case _ =>
         val wasResourceProfileAddedEvent = doSparkListenerResourceProfileAddedReflect(app, event)
-        if (!wasResourceProfileAddedEvent) doOtherEvent(app, event)
+        if (!wasResourceProfileAddedEvent) {
+          // Try to handle as a Spark Connect event (3.5+). Connect event classes
+          // are not on the classpath for older Spark versions, so they arrive here
+          // via the default case after successful JsonProtocol deserialization.
+          if (!ConnectEventHandler.processConnectEvent(app, event)) {
+            doOtherEvent(app, event)
+          }
+        }
     }
   }
 
@@ -232,7 +239,11 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
       doSparkListenerLogStart(app, e)
     case _ =>
       val wasResourceProfileAddedEvent = doSparkListenerResourceProfileAddedReflect(app, event)
-      if (!wasResourceProfileAddedEvent) doOtherEvent(app, event)
+      if (!wasResourceProfileAddedEvent) {
+        if (!ConnectEventHandler.processConnectEvent(app, event)) {
+          doOtherEvent(app, event)
+        }
+      }
   }
 
   def doSparkListenerResourceProfileAdded(

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/EventProcessorBase.scala
@@ -103,9 +103,6 @@ abstract class EventProcessorBase[T <: AppBase](app: T) extends SparkListener wi
       case _ =>
         val wasResourceProfileAddedEvent = doSparkListenerResourceProfileAddedReflect(app, event)
         if (!wasResourceProfileAddedEvent) {
-          // Try to handle as a Spark Connect event (3.5+). Connect event classes
-          // are not on the classpath for older Spark versions, so they arrive here
-          // via the default case after successful JsonProtocol deserialization.
           if (!ConnectEventHandler.processConnectEvent(app, event)) {
             doOtherEvent(app, event)
           }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/ConnectEventHandler.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/ConnectEventHandler.scala
@@ -80,7 +80,7 @@ object ConnectEventHandler extends Logging {
   // --- Session event handlers ---
 
   private def handleSessionStarted(app: AppBase, event: SparkListenerEvent): Unit = {
-    val info = ConnectSessionInfo(
+    val info = new ConnectSessionInfo(
       sessionId = getString(event, "sessionId"),
       userId = getString(event, "userId"),
       startTime = getLong(event, "eventTime"))
@@ -154,8 +154,8 @@ object ConnectEventHandler extends Logging {
 
   /**
    * Looks up the ConnectOperationInfo for the event's operationId and applies
-   * the update function. Logs a warning if the operation wasn't found (e.g.,
-   * OperationStarted was missing or events arrived out of order).
+   * the update function. Logs at debug level if the operation is missing
+   * (e.g., OperationStarted was not observed or events arrived out of order).
    */
   private def updateOperation(app: AppBase, event: SparkListenerEvent)(
       f: ConnectOperationInfo => Unit): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/ConnectEventHandler.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/ConnectEventHandler.scala
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool.util
+
+import com.nvidia.spark.rapids.tool.profiling.{ConnectOperationInfo, ConnectSessionInfo}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.scheduler.SparkListenerEvent
+import org.apache.spark.sql.rapids.tool.AppBase
+
+/**
+ * Handles Spark Connect listener events using reflection.
+ *
+ * Connect event classes live in the spark-connect jar (org.apache.spark.sql.connect.service)
+ * which is only available for Spark 3.5+. Since the tools compile against a single shared
+ * source tree for Spark 3.2–3.5+, we cannot import Connect classes directly.
+ *
+ * Instead, this handler:
+ * 1. Checks the event class name to identify Connect events (cheap string prefix check)
+ * 2. Uses cached reflective method accessors to extract field values
+ * 3. Stores the extracted data in tool-owned types (ConnectSessionInfo, ConnectOperationInfo)
+ *
+ * This follows the established patterns in EventUtils (modifiedConfigsField,
+ * rootExecutionIdField) and EventProcessorBase (doSparkListenerResourceProfileAddedReflect).
+ * Reflection is preferred over version checks because vendors may backport features.
+ */
+object ConnectEventHandler extends Logging {
+
+  private val CONNECT_EVENT_PREFIX =
+    "org.apache.spark.sql.connect.service.SparkListenerConnect"
+
+  /**
+   * Quick class-name check to avoid reflection overhead for non-Connect events.
+   * Called from the default case in EventProcessorBase.processAnyEvent.
+   */
+  def isConnectEvent(event: SparkListenerEvent): Boolean = {
+    event.getClass.getName.startsWith(CONNECT_EVENT_PREFIX)
+  }
+
+  /**
+   * Process a Connect event by extracting data via reflection and storing it
+   * in the app's Connect storage maps.
+   *
+   * @return true if the event was a recognized Connect event, false otherwise
+   */
+  def processConnectEvent(app: AppBase, event: SparkListenerEvent): Boolean = {
+    if (!isConnectEvent(event)) {
+      return false
+    }
+    val suffix = event.getClass.getName.stripPrefix(CONNECT_EVENT_PREFIX)
+    try {
+      suffix match {
+        case "SessionStarted" => handleSessionStarted(app, event)
+        case "SessionClosed" => handleSessionClosed(app, event)
+        case "OperationStarted" => handleOperationStarted(app, event)
+        case "OperationAnalyzed" => handleOperationAnalyzed(app, event)
+        case "OperationReadyForExecution" => handleOperationReadyForExecution(app, event)
+        case "OperationFinished" => handleOperationFinished(app, event)
+        case "OperationClosed" => handleOperationClosed(app, event)
+        case "OperationFailed" => handleOperationFailed(app, event)
+        case "OperationCanceled" => handleOperationCanceled(app, event)
+        case _ =>
+          logDebug(s"Unrecognized Connect event suffix: $suffix")
+          return false
+      }
+      true
+    } catch {
+      case e @ (_: NoSuchMethodException | _: SecurityException) =>
+        logWarning(s"Connect event reflection failed for $suffix: ${e.getMessage}")
+        false
+    }
+  }
+
+  // --- Session event handlers ---
+
+  private def handleSessionStarted(app: AppBase, event: SparkListenerEvent): Unit = {
+    val info = ConnectSessionInfo(
+      sessionId = getString(event, "sessionId"),
+      userId = getString(event, "userId"),
+      startTime = getLong(event, "eventTime"))
+    app.connectSessions.put(info.sessionId, info)
+    logDebug(s"Connect session started: ${info.sessionId} user=${info.userId}")
+  }
+
+  private def handleSessionClosed(app: AppBase, event: SparkListenerEvent): Unit = {
+    val sessionId = getString(event, "sessionId")
+    val eventTime = getLong(event, "eventTime")
+    app.connectSessions.get(sessionId).foreach { session =>
+      session.endTime = Some(eventTime)
+    }
+    logDebug(s"Connect session closed: $sessionId")
+  }
+
+  // --- Operation event handlers ---
+
+  private def handleOperationStarted(app: AppBase, event: SparkListenerEvent): Unit = {
+    val info = new ConnectOperationInfo(
+      operationId = getString(event, "operationId"),
+      sessionId = getString(event, "sessionId"),
+      userId = getString(event, "userId"),
+      jobTag = getString(event, "jobTag"),
+      statementText = getString(event, "statementText"),
+      startTime = getLong(event, "eventTime"))
+    app.connectOperations.put(info.operationId, info)
+    app.jobTagToConnectOpId.put(info.jobTag, info.operationId)
+    logDebug(s"Connect operation started: ${info.operationId} " +
+      s"session=${info.sessionId} user=${info.userId}")
+  }
+
+  private def handleOperationAnalyzed(app: AppBase, event: SparkListenerEvent): Unit = {
+    updateOperation(app, event) { op =>
+      op.analyzeTime = Some(getLong(event, "eventTime"))
+    }
+  }
+
+  private def handleOperationReadyForExecution(app: AppBase, event: SparkListenerEvent): Unit = {
+    updateOperation(app, event) { op =>
+      op.readyForExecTime = Some(getLong(event, "eventTime"))
+    }
+  }
+
+  private def handleOperationFinished(app: AppBase, event: SparkListenerEvent): Unit = {
+    updateOperation(app, event) { op =>
+      op.finishTime = Some(getLong(event, "eventTime"))
+      op.producedRowCount = getOptLong(event, "producedRowCount")
+    }
+  }
+
+  private def handleOperationClosed(app: AppBase, event: SparkListenerEvent): Unit = {
+    updateOperation(app, event) { op =>
+      op.closeTime = Some(getLong(event, "eventTime"))
+    }
+  }
+
+  private def handleOperationFailed(app: AppBase, event: SparkListenerEvent): Unit = {
+    updateOperation(app, event) { op =>
+      op.errorMessage = Some(getString(event, "errorMessage"))
+    }
+  }
+
+  private def handleOperationCanceled(app: AppBase, event: SparkListenerEvent): Unit = {
+    updateOperation(app, event) { op =>
+      op.isCanceled = true
+    }
+  }
+
+  /**
+   * Looks up the ConnectOperationInfo for the event's operationId and applies
+   * the update function. Logs a warning if the operation wasn't found (e.g.,
+   * OperationStarted was missing or events arrived out of order).
+   */
+  private def updateOperation(app: AppBase, event: SparkListenerEvent)(
+      f: ConnectOperationInfo => Unit): Unit = {
+    val opId = getString(event, "operationId")
+    app.connectOperations.get(opId) match {
+      case Some(op) => f(op)
+      case None =>
+        logDebug(s"Connect operation $opId not found for " +
+          s"${event.getClass.getSimpleName} event (OperationStarted may be missing)")
+    }
+  }
+
+  // Reflective field accessors are delegated to EventUtils which provides
+  // generic cached method invocation (getString, getLong, getOptLong).
+  // This avoids duplicating the reflection/caching logic.
+
+  private def getString(event: SparkListenerEvent, methodName: String): String =
+    EventUtils.getStringFromEvent(event, methodName)
+
+  private def getLong(event: SparkListenerEvent, methodName: String): Long =
+    EventUtils.getLongFromEvent(event, methodName)
+
+  private def getOptLong(event: SparkListenerEvent, methodName: String): Option[Long] =
+    EventUtils.getOptLongFromEvent(event, methodName)
+}

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/ConnectEventHandler.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/ConnectEventHandler.scala
@@ -23,30 +23,20 @@ import org.apache.spark.scheduler.SparkListenerEvent
 import org.apache.spark.sql.rapids.tool.AppBase
 
 /**
- * Handles Spark Connect listener events using reflection.
+ * Reflective handler for Spark Connect listener events (Spark 3.5+).
  *
- * Connect event classes live in the spark-connect jar (org.apache.spark.sql.connect.service)
- * which is only available for Spark 3.5+. Since the tools compile against a single shared
- * source tree for Spark 3.2–3.5+, we cannot import Connect classes directly.
- *
- * Instead, this handler:
- * 1. Checks the event class name to identify Connect events (cheap string prefix check)
- * 2. Uses cached reflective method accessors to extract field values
- * 3. Stores the extracted data in tool-owned types (ConnectSessionInfo, ConnectOperationInfo)
- *
- * This follows the established patterns in EventUtils (modifiedConfigsField,
- * rootExecutionIdField) and EventProcessorBase (doSparkListenerResourceProfileAddedReflect).
- * Reflection is preferred over version checks because vendors may backport features.
+ * Connect event classes reside in the spark-connect jar and are not
+ * directly imported to preserve compatibility with older Spark profiles.
+ * Events are identified by class-name prefix, fields are extracted via
+ * cached reflective accessors in [[EventUtils]], and results are stored
+ * in [[ConnectSessionInfo]] and [[ConnectOperationInfo]].
  */
 object ConnectEventHandler extends Logging {
 
   private val CONNECT_EVENT_PREFIX =
     "org.apache.spark.sql.connect.service.SparkListenerConnect"
 
-  /**
-   * Quick class-name check to avoid reflection overhead for non-Connect events.
-   * Called from the default case in EventProcessorBase.processAnyEvent.
-   */
+  /** Quick class-name check to avoid reflection for non-Connect events. */
   def isConnectEvent(event: SparkListenerEvent): Boolean = {
     event.getClass.getName.startsWith(CONNECT_EVENT_PREFIX)
   }
@@ -173,10 +163,6 @@ object ConnectEventHandler extends Logging {
           s"${event.getClass.getSimpleName} event (OperationStarted may be missing)")
     }
   }
-
-  // Reflective field accessors are delegated to EventUtils which provides
-  // generic cached method invocation (getString, getLong, getOptLong).
-  // This avoids duplicating the reflection/caching logic.
 
   private def getString(event: SparkListenerEvent, methodName: String): String =
     EventUtils.getStringFromEvent(event, methodName)

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/ConnectEventHandler.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/ConnectEventHandler.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.rapids.tool.util
 
+import scala.collection.mutable
 import scala.util.control.NonFatal
 
 import com.nvidia.spark.rapids.tool.profiling.{ConnectOperationInfo, ConnectSessionInfo}
@@ -37,6 +38,10 @@ object ConnectEventHandler extends Logging {
 
   private val CONNECT_EVENT_PREFIX =
     "org.apache.spark.sql.connect.service.SparkListenerConnect"
+
+  // Tracks event suffixes that have already produced a reflection-failure warning,
+  // so a recurring failure (e.g. a renamed field) logs once instead of per event.
+  private val warnedFailures = mutable.HashSet[String]()
 
   /** Quick class-name check to avoid reflection for non-Connect events. */
   def isConnectEvent(event: SparkListenerEvent): Boolean = {
@@ -72,7 +77,11 @@ object ConnectEventHandler extends Logging {
       true
     } catch {
       case NonFatal(e) =>
-        logWarning(s"Connect event reflection failed for $suffix: ${e.getMessage}")
+        if (warnedFailures.add(suffix)) {
+          logWarning(s"Connect event reflection failed for $suffix: ${e.getMessage}")
+        } else {
+          logDebug(s"Connect event reflection failed for $suffix: ${e.getMessage}")
+        }
         false
     }
   }
@@ -148,7 +157,6 @@ object ConnectEventHandler extends Logging {
   private def handleOperationCanceled(app: AppBase, event: SparkListenerEvent): Unit = {
     updateOperation(app, event) { op =>
       op.cancelTime = Some(getLong(event, "eventTime"))
-      op.isCanceled = true
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/ConnectEventHandler.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/ConnectEventHandler.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.rapids.tool.util
 
+import scala.util.control.NonFatal
+
 import com.nvidia.spark.rapids.tool.profiling.{ConnectOperationInfo, ConnectSessionInfo}
 
 import org.apache.spark.internal.Logging
@@ -69,7 +71,7 @@ object ConnectEventHandler extends Logging {
       }
       true
     } catch {
-      case e @ (_: NoSuchMethodException | _: SecurityException) =>
+      case NonFatal(e) =>
         logWarning(s"Connect event reflection failed for $suffix: ${e.getMessage}")
         false
     }
@@ -138,12 +140,14 @@ object ConnectEventHandler extends Logging {
 
   private def handleOperationFailed(app: AppBase, event: SparkListenerEvent): Unit = {
     updateOperation(app, event) { op =>
+      op.failTime = Some(getLong(event, "eventTime"))
       op.errorMessage = Some(getString(event, "errorMessage"))
     }
   }
 
   private def handleOperationCanceled(app: AppBase, event: SparkListenerEvent): Unit = {
     updateOperation(app, event) { op =>
+      op.cancelTime = Some(getLong(event, "eventTime"))
       op.isCanceled = true
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
@@ -193,26 +193,30 @@ object EventUtils extends Logging {
   }
 
 
-  // Reads the root execution ID from a SparkListenerSQLExecutionStart event using reflection.
-  // Reflection is used here to maintain compatibility with different versions of Spark,
-  // as the rootExecutionId field is introduced in Spark 3.4. This allows the
-  // code to access the field dynamically at runtime, and maintaining backward compatibility.
-  def readRootIDFromSQLStartEvent(event: SparkListenerSQLExecutionStart): Option[Long] = {
-    Try(rootExecutionIdField.get(event).asInstanceOf[Option[Long]]).getOrElse(None)
+  // Reads the root execution ID from a SparkListenerSQLExecutionStart event using
+  // reflection. The rootExecutionId field was introduced in Spark 3.4. On older
+  // versions the accessor method doesn't exist, so invokeMethodOnEvent throws
+  // NoSuchMethodException which is caught by Try → returns None.
+  def readRootIDFromSQLStartEvent(
+      event: SparkListenerSQLExecutionStart): Option[Long] = {
+    Try(invokeMethodOnEvent(event, "rootExecutionId")
+      .asInstanceOf[Option[Long]]).getOrElse(None)
   }
 
   // Reads modifiedConfigs via reflection (field added in Spark 3.3, SPARK-34735).
-  // Contains per-execution config overrides from spark.conf.set(). Empty on Spark 3.2.x.
+  // Contains per-execution config overrides from spark.conf.set().
+  // Empty on Spark 3.2.x where the accessor method doesn't exist.
   def readModifiedConfigsFromSQLStartEvent(
       event: SparkListenerSQLExecutionStart): Map[String, String] = {
-    modifiedConfigsField.flatMap { field =>
-      Try(Option(field.get(event)).map(_.asInstanceOf[Map[String, String]]))
-        .toOption.flatten
-    }.getOrElse(Map.empty)
+    Try {
+      Option(invokeMethodOnEvent(event, "modifiedConfigs"))
+        .map(_.asInstanceOf[Map[String, String]])
+    }.toOption.flatten.getOrElse(Map.empty)
   }
 
   @throws[com.fasterxml.jackson.core.JsonParseException]
-  private def handleEventJsonParseEx(ex: com.fasterxml.jackson.core.JsonParseException): Unit = {
+  private def handleEventJsonParseEx(
+      ex: com.fasterxml.jackson.core.JsonParseException): Unit = {
     // Spark 3.4- will throw a JsonParseException if the eventlog is incomplete (lines are broken)
     val exMsg = ex.getMessage
     if (exMsg != null && exMsg.contains("Unexpected end-of-input within/between Object entries")) {
@@ -228,23 +232,6 @@ object EventUtils extends Logging {
       }
       throw ex
     }
-  }
-
-  private lazy val rootExecutionIdField = {
-    val field = classOf[SparkListenerSQLExecutionStart].getDeclaredField("rootExecutionId")
-    field.setAccessible(true)
-    field
-  }
-
-  // Reflection field for modifiedConfigs, introduced in Spark 3.3.0 (SPARK-34735).
-  // Returns None if the field does not exist (Spark 3.2.x).
-  private lazy val modifiedConfigsField: Option[java.lang.reflect.Field] = {
-    Try {
-      val field = classOf[SparkListenerSQLExecutionStart]
-        .getDeclaredField("modifiedConfigs")
-      field.setAccessible(true)
-      field
-    }.toOption
   }
 
   private lazy val runtimeEventFromJsonMethod = {
@@ -333,6 +320,67 @@ object EventUtils extends Logging {
       case None =>
         throw new IllegalArgumentException(s"Unknown tool name $toolName. " +
           s"Accepted tool names: ${acceptedLinesToolMap.keys.mkString(", ")}")
+    }
+  }
+
+  // --- Generic reflective method accessors ---
+  //
+  // Used to extract values from event objects whose classes may not be on the
+  // compile-time classpath (e.g., Spark Connect events in spark-connect jar).
+  // Method references are cached by (className, methodName) to avoid repeated
+  // lookups. Case class accessor methods are no-arg methods named after fields.
+
+  // Cache of reflective method accessors, keyed by (className, methodName).
+  private val methodCache =
+    new mutable.HashMap[(String, String), Option[java.lang.reflect.Method]]()
+
+  /** Get a String value from an object via reflective method invocation. */
+  def getStringFromEvent(event: AnyRef, methodName: String): String = {
+    invokeMethodOnEvent(event, methodName).asInstanceOf[String]
+  }
+
+  /** Get a Long value from an object via reflective method invocation. */
+  def getLongFromEvent(event: AnyRef, methodName: String): Long = {
+    invokeMethodOnEvent(event, methodName).asInstanceOf[Long]
+  }
+
+  /** Get an Option[Long] value from an object via reflective method invocation.
+   *  Handles Option[Long], plain Long, and numeric types (Integer, etc.) from
+   *  Jackson deserialization where JSON numbers may arrive as different types. */
+  def getOptLongFromEvent(event: AnyRef, methodName: String): Option[Long] = {
+    Try {
+      invokeMethodOnEvent(event, methodName) match {
+        case opt: Option[_] => opt.map {
+          case n: Number => n.longValue()
+          case other => other.asInstanceOf[java.lang.Long].toLong
+        }
+        case n: Number => Some(n.longValue())
+        case _ => None
+      }
+    }.getOrElse(None)
+  }
+
+  /**
+   * Invoke a no-arg method on an object, caching the Method reference.
+   * @throws NoSuchMethodException if the method does not exist on the object's class.
+   */
+  @throws[NoSuchMethodException]
+  def invokeMethodOnEvent(event: AnyRef, methodName: String): Any = {
+    val clazz = event.getClass
+    val key = (clazz.getName, methodName)
+    val method = methodCache.synchronized {
+      methodCache.getOrElseUpdate(key, {
+        Try {
+          val m = clazz.getMethod(methodName)
+          m.setAccessible(true)
+          m
+        }.toOption
+      })
+    }
+    method match {
+      case Some(m) => m.invoke(event)
+      case None =>
+        throw new NoSuchMethodException(s"${clazz.getName}.$methodName not found")
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
@@ -193,19 +193,15 @@ object EventUtils extends Logging {
   }
 
 
-  // Reads the root execution ID from a SparkListenerSQLExecutionStart event using
-  // reflection. The rootExecutionId field was introduced in Spark 3.4. On older
-  // versions the accessor method doesn't exist, so invokeMethodOnEvent throws
-  // NoSuchMethodException which is caught by Try → returns None.
+  // Reads rootExecutionId via reflection (Spark 3.4+). Returns None on older versions.
   def readRootIDFromSQLStartEvent(
       event: SparkListenerSQLExecutionStart): Option[Long] = {
     Try(invokeMethodOnEvent(event, "rootExecutionId")
       .asInstanceOf[Option[Long]]).getOrElse(None)
   }
 
-  // Reads modifiedConfigs via reflection (field added in Spark 3.3, SPARK-34735).
-  // Contains per-execution config overrides from spark.conf.set().
-  // Empty on Spark 3.2.x where the accessor method doesn't exist.
+  // Reads modifiedConfigs via reflection (Spark 3.3+, SPARK-34735).
+  // Returns empty map on older versions.
   def readModifiedConfigsFromSQLStartEvent(
       event: SparkListenerSQLExecutionStart): Map[String, String] = {
     Try {
@@ -324,11 +320,7 @@ object EventUtils extends Logging {
   }
 
   // --- Generic reflective method accessors ---
-  //
-  // Used to extract values from event objects whose classes may not be on the
-  // compile-time classpath (e.g., Spark Connect events in spark-connect jar).
-  // Method references are cached by (className, methodName) to avoid repeated
-  // lookups. Case class accessor methods are no-arg methods named after fields.
+  // Cached by (className, methodName) for repeated use.
 
   // Cache of reflective method accessors, keyed by (className, methodName).
   private val methodCache =

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
@@ -324,7 +324,8 @@ object EventUtils extends Logging {
 
   // Cache of reflective method accessors, keyed by (className, methodName).
   private val methodCache =
-    new mutable.HashMap[(String, String), Option[java.lang.reflect.Method]]()
+    new java.util.concurrent.ConcurrentHashMap[
+      (String, String), Option[java.lang.reflect.Method]]()
 
   /** Get a String value from an object via reflective method invocation. */
   def getStringFromEvent(event: AnyRef, methodName: String): String = {
@@ -360,15 +361,8 @@ object EventUtils extends Logging {
   def invokeMethodOnEvent(event: AnyRef, methodName: String): Any = {
     val clazz = event.getClass
     val key = (clazz.getName, methodName)
-    val method = methodCache.synchronized {
-      methodCache.getOrElseUpdate(key, {
-        Try {
-          val m = clazz.getMethod(methodName)
-          m.setAccessible(true)
-          m
-        }.toOption
-      })
-    }
+    val method = methodCache.computeIfAbsent(key,
+      _ => Try(clazz.getMethod(methodName)).toOption)
     method match {
       case Some(m) => m.invoke(event)
       case None =>

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ConnectEventSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ConnectEventSuite.scala
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.profiling
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+
+import com.nvidia.spark.rapids.BaseNoSparkSuite
+import com.nvidia.spark.rapids.tool.EventLogPathProcessor
+
+import org.apache.spark.sql.TrampolineUtil
+import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
+import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
+
+/**
+ * Tests for Spark Connect event parsing via ConnectEventHandler.
+ *
+ * Connect event classes (org.apache.spark.sql.connect.service.*) are only on the
+ * test classpath when spark-connect is a dependency (Spark 3.5.7 default profile).
+ * On other profiles, these tests are skipped via runConditionalTest, following the
+ * same pattern as Delta Lake and Iceberg tests.
+ */
+class ConnectEventSuite extends BaseNoSparkSuite {
+
+  private val hadoopConf = RapidsToolsConfUtil.newHadoopConf()
+
+  /**
+   * Condition checker for Connect event tests. Returns (true, _) when the
+   * spark-connect jar is on the classpath, allowing JsonProtocol to deserialize
+   * Connect events. Follows the same pattern as checkIcebergSupportForSpark()
+   * and checkDeltaLakeSparkRelease() in BaseNoSparkSuite.
+   */
+  private def checkConnectClassesAvailable(): (Boolean, String) = {
+    val available = try {
+      Class.forName(
+        "org.apache.spark.sql.connect.service.SparkListenerConnectSessionStarted")
+      true
+    } catch {
+      case _: ClassNotFoundException => false
+    }
+    (available, "spark-connect jar not on classpath (requires Spark 3.5+ test profile)")
+  }
+
+  // --- Standard boilerplate events for a valid event log ---
+
+  private val logStartEvent =
+    """{"Event":"SparkListenerLogStart","Spark Version":"3.5.0"}"""
+  private val appStartEvent =
+    """{"Event":"SparkListenerApplicationStart","App Name":"ConnectTest",""" +
+      """"App ID":"local-connecttest","Timestamp":100000,"User":"testUser"}"""
+  private val envUpdateEvent =
+    """{"Event":"SparkListenerEnvironmentUpdate","JVM Information":{},""" +
+      """"Spark Properties":{"spark.master":"local[*]"},""" +
+      """"Hadoop Properties":{},"System Properties":{"file.encoding":"UTF-8"},""" +
+      """"Classpath Entries":{}}"""
+  private val appEndEvent =
+    """{"Event":"SparkListenerApplicationEnd","Timestamp":200000}"""
+
+  // --- Connect event JSON lines ---
+
+  private val sessionStartedEvent =
+    """{"Event":"org.apache.spark.sql.connect.service.SparkListenerConnectSessionStarted",""" +
+      """"sessionId":"sess-aaa-111","userId":"userA","eventTime":110000,""" +
+      """"extraTags":{}}"""
+
+  private val sessionClosedEvent =
+    """{"Event":"org.apache.spark.sql.connect.service.SparkListenerConnectSessionClosed",""" +
+      """"sessionId":"sess-aaa-111","userId":"userA","eventTime":190000,""" +
+      """"extraTags":{}}"""
+
+  // scalastyle:off line.size.limit
+  private val opStartedEvent =
+    """{"Event":"org.apache.spark.sql.connect.service.SparkListenerConnectOperationStarted",""" +
+      """"jobTag":"SparkConnect_OperationTag_User_userA_Session_sess-aaa-111_Operation_op-bbb-222",""" +
+      """"operationId":"op-bbb-222","eventTime":120000,""" +
+      """"sessionId":"sess-aaa-111","userId":"userA","userName":"",""" +
+      """"statementText":"common { plan_id: 0 } range { start: 0 end: 100 step: 1 }",""" +
+      """"sparkSessionTags":[],"extraTags":{}}"""
+  // scalastyle:on line.size.limit
+
+  // scalastyle:off line.size.limit
+  private val opAnalyzedEvent =
+    """{"Event":"org.apache.spark.sql.connect.service.SparkListenerConnectOperationAnalyzed",""" +
+      """"jobTag":"SparkConnect_OperationTag_User_userA_Session_sess-aaa-111_Operation_op-bbb-222",""" +
+      """"operationId":"op-bbb-222","eventTime":121000,"extraTags":{}}"""
+
+  private val opReadyEvent =
+    """{"Event":"org.apache.spark.sql.connect.service.SparkListenerConnectOperationReadyForExecution",""" +
+      """"jobTag":"SparkConnect_OperationTag_User_userA_Session_sess-aaa-111_Operation_op-bbb-222",""" +
+      """"operationId":"op-bbb-222","eventTime":121500,"extraTags":{}}"""
+
+  private val opFinishedEvent =
+    """{"Event":"org.apache.spark.sql.connect.service.SparkListenerConnectOperationFinished",""" +
+      """"jobTag":"SparkConnect_OperationTag_User_userA_Session_sess-aaa-111_Operation_op-bbb-222",""" +
+      """"operationId":"op-bbb-222","eventTime":125000,"producedRowCount":10,"extraTags":{}}"""
+
+  private val opClosedEvent =
+    """{"Event":"org.apache.spark.sql.connect.service.SparkListenerConnectOperationClosed",""" +
+      """"jobTag":"SparkConnect_OperationTag_User_userA_Session_sess-aaa-111_Operation_op-bbb-222",""" +
+      """"operationId":"op-bbb-222","eventTime":125500,"extraTags":{}}"""
+
+  private val opFailedEvent =
+    """{"Event":"org.apache.spark.sql.connect.service.SparkListenerConnectOperationFailed",""" +
+      """"jobTag":"SparkConnect_OperationTag_User_userA_Session_sess-aaa-111_Operation_op-bbb-222",""" +
+      """"operationId":"op-bbb-222","eventTime":125000,""" +
+      """"errorMessage":"ModuleNotFoundError: No module named 'helper'","extraTags":{}}"""
+
+  private val opCanceledEvent =
+    """{"Event":"org.apache.spark.sql.connect.service.SparkListenerConnectOperationCanceled",""" +
+      """"jobTag":"SparkConnect_OperationTag_User_userA_Session_sess-aaa-111_Operation_op-bbb-222",""" +
+      """"operationId":"op-bbb-222","eventTime":125000,"extraTags":{}}"""
+  // scalastyle:on line.size.limit
+
+  /**
+   * Helper to write synthetic event log lines to a temp file and process through
+   * ApplicationInfo, then run assertions.
+   */
+  private def withConnectEventLog(events: String*)(verify: ApplicationInfo => Unit): Unit = {
+    val content = events.mkString("\n")
+    TrampolineUtil.withTempDir { tempDir =>
+      val path = Paths.get(tempDir.getAbsolutePath, "test_eventlog")
+      Files.write(path, content.getBytes(StandardCharsets.UTF_8))
+      val app = new ApplicationInfo(hadoopConf,
+        EventLogPathProcessor.getEventLogInfo(path.toString, hadoopConf).head._1)
+      verify(app)
+    }
+  }
+
+  // --- Connect-specific tests (skipped when spark-connect not on classpath) ---
+
+  runConditionalTest(
+    "Connect session and operation lifecycle parsed correctly",
+    checkConnectClassesAvailable) {
+    withConnectEventLog(
+      logStartEvent, appStartEvent, envUpdateEvent,
+      sessionStartedEvent,
+      opStartedEvent, opAnalyzedEvent, opReadyEvent,
+      opFinishedEvent, opClosedEvent,
+      sessionClosedEvent,
+      appEndEvent) { app =>
+      assert(app.isConnectMode, "Should detect Connect mode")
+
+      // Verify session
+      assert(app.connectSessions.size == 1)
+      val session = app.connectSessions("sess-aaa-111")
+      assert(session.userId == "userA")
+      assert(session.startTime == 110000L)
+      assert(session.endTime.contains(190000L))
+
+      // Verify operation lifecycle
+      assert(app.connectOperations.size == 1)
+      val op = app.connectOperations("op-bbb-222")
+      assert(op.sessionId == "sess-aaa-111")
+      assert(op.userId == "userA")
+      assert(op.startTime == 120000L)
+      assert(op.analyzeTime.contains(121000L))
+      assert(op.readyForExecTime.contains(121500L))
+      assert(op.finishTime.contains(125000L))
+      assert(op.closeTime.contains(125500L))
+      assert(op.producedRowCount.contains(10L))
+      assert(op.errorMessage.isEmpty)
+      assert(!op.isCanceled)
+
+      // Verify jobTag correlation index
+      val expectedTag =
+        "SparkConnect_OperationTag_User_userA_Session_sess-aaa-111_Operation_op-bbb-222"
+      assert(app.jobTagToConnectOpId.get(expectedTag).contains("op-bbb-222"))
+    }
+  }
+
+  runConditionalTest(
+    "Connect failed operation captures error message",
+    checkConnectClassesAvailable) {
+    withConnectEventLog(
+      logStartEvent, appStartEvent, envUpdateEvent,
+      sessionStartedEvent,
+      opStartedEvent, opAnalyzedEvent, opFailedEvent,
+      sessionClosedEvent,
+      appEndEvent) { app =>
+      assert(app.isConnectMode)
+      val op = app.connectOperations("op-bbb-222")
+      assert(op.analyzeTime.contains(121000L))
+      assert(op.errorMessage.contains("ModuleNotFoundError: No module named 'helper'"))
+      assert(op.finishTime.isEmpty)
+      assert(op.closeTime.isEmpty)
+    }
+  }
+
+  runConditionalTest(
+    "Connect canceled operation sets isCanceled flag",
+    checkConnectClassesAvailable) {
+    withConnectEventLog(
+      logStartEvent, appStartEvent, envUpdateEvent,
+      sessionStartedEvent,
+      opStartedEvent, opCanceledEvent,
+      sessionClosedEvent,
+      appEndEvent) { app =>
+      assert(app.isConnectMode)
+      val op = app.connectOperations("op-bbb-222")
+      assert(op.isCanceled)
+    }
+  }
+
+  runConditionalTest(
+    "Connect session without close event leaves endTime as None",
+    checkConnectClassesAvailable) {
+    withConnectEventLog(
+      logStartEvent, appStartEvent, envUpdateEvent,
+      sessionStartedEvent,
+      opStartedEvent, opFinishedEvent, opClosedEvent,
+      // No sessionClosedEvent — server was killed
+      appEndEvent) { app =>
+      assert(app.isConnectMode)
+      val session = app.connectSessions("sess-aaa-111")
+      assert(session.endTime.isEmpty, "Session endTime should be None without close event")
+    }
+  }
+
+  runConditionalTest(
+    "Connect statementText captured from OperationStarted",
+    checkConnectClassesAvailable) {
+    withConnectEventLog(
+      logStartEvent, appStartEvent, envUpdateEvent,
+      sessionStartedEvent,
+      opStartedEvent, opFinishedEvent, opClosedEvent,
+      sessionClosedEvent,
+      appEndEvent) { app =>
+      val op = app.connectOperations("op-bbb-222")
+      assert(op.statementText.contains("range"))
+      assert(op.statementText.contains("plan_id: 0"))
+    }
+  }
+
+  // --- Non-conditional tests (always run) ---
+
+  test("Non-Connect event log has isConnectMode == false") {
+    withConnectEventLog(
+      logStartEvent, appStartEvent, envUpdateEvent, appEndEvent) { app =>
+      assert(!app.isConnectMode)
+      assert(app.connectSessions.isEmpty)
+      assert(app.connectOperations.isEmpty)
+      assert(app.jobTagToConnectOpId.isEmpty)
+    }
+  }
+}

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ConnectEventSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ConnectEventSuite.scala
@@ -27,23 +27,14 @@ import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
 import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
 
 /**
- * Tests for Spark Connect event parsing via ConnectEventHandler.
- *
- * Connect event classes (org.apache.spark.sql.connect.service.*) are only on the
- * test classpath when spark-connect is a dependency (Spark 3.5.7 default profile).
- * On other profiles, these tests are skipped via runConditionalTest, following the
- * same pattern as Delta Lake and Iceberg tests.
+ * Tests for Spark Connect event parsing.
+ * Requires spark-connect on the test classpath (Spark 3.5+ profiles).
  */
 class ConnectEventSuite extends BaseNoSparkSuite {
 
   private val hadoopConf = RapidsToolsConfUtil.newHadoopConf()
 
-  /**
-   * Condition checker for Connect event tests. Returns (true, _) when the
-   * spark-connect jar is on the classpath, allowing JsonProtocol to deserialize
-   * Connect events. Follows the same pattern as checkIcebergSupportForSpark()
-   * and checkDeltaLakeSparkRelease() in BaseNoSparkSuite.
-   */
+  /** Checks whether Connect event classes are available on the classpath. */
   private def checkConnectClassesAvailable(): (Boolean, String) = {
     val available = try {
       Class.forName(


### PR DESCRIPTION
## Summary

Adds reflective parsing of 9 Spark Connect listener events (Spark 3.5+) to extract session and operation lifecycle data from Connect server event logs. This is **Part 2** of the Spark Connect support work (Part 1: #2059 added `modifiedConfigs` parsing).

Closes #2064

### What this enables
- **Connect mode detection**: `isConnectMode` flag on `AppBase` when Connect events are present
- **Session lifecycle**: userId, sessionId, start/end times
- **Operation lifecycle**: full timing breakdown (start → analyze → ready → finish → close), error messages, cancellation, producedRowCount
- **jobTag correlation index**: links Connect operations to SQL executions and jobs via `jobTagToConnectOpId`

### Design
- **No Connect class imports in shared source** — compiles for all Spark profiles (3.2–3.5+)
- **Reflective parsing** via `ConnectEventHandler` using cached method accessors (follows `rootExecutionId`/`modifiedConfigs` patterns in `EventUtils`)
- **Tool-owned storage types** (`ConnectSessionInfo`, `ConnectOperationInfo`) — follows `SQLExecutionInfoClass` pattern
- **spark-connect dependency** added as `test` scope for 3.5.7 profiles only; at runtime the Spark distribution provides it
- **Generic reflective accessors** extracted to `EventUtils` (`invokeMethodOnEvent`, `getStringFromEvent`, `getLongFromEvent`, `getOptLongFromEvent`) — also used to refactor existing `rootExecutionId` and `modifiedConfigs` reflection

### Files changed
| File | Description |
|------|-------------|
| `core/pom.xml` | spark-connect test dep for 3.5.7 profiles |
| `eventlog-parser.yaml` | 9 Connect events registered for line filtering |
| `ConnectClassWarehouse.scala` (new) | `ConnectSessionInfo`, `ConnectOperationInfo` |
| `ConnectEventHandler.scala` (new) | Reflective event handler with cached accessors |
| `EventProcessorBase.scala` | Wire Connect handler into default case |
| `AppBase.scala` | Connect storage maps + `isConnectMode` |
| `EventUtils.scala` | Generic reflective accessors; migrated rootExecutionId/modifiedConfigs |
| `ConnectEventSuite.scala` (new) | 6 tests using `runConditionalTest` pattern |

### Analysis docs
- `core/bin/docs/spark-connect-events-analysis.md`
- `core/bin/docs/spark-connect-events-implementation-analysis.md`

## Test plan
- [x] `ConnectEventSuite`: 6 tests covering session lifecycle, operation lifecycle (success/fail/cancel), jobTag correlation, statementText, non-Connect regression
- [x] `ApplicationInfoSuite`: existing modifiedConfigs tests pass with refactored reflection
- [x] `QualificationAutoTunerSuite`: existing autotuner tests pass
- [x] Builds clean on default (3.5.7), Spark 3.5.0, and Scala 2.13 profiles
- [x] Scalestyle passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)