### PR TITLE
Fix AutoTuner to redistribute freed memory into overhead when executor heap is reduced

### DIFF
--- a/core/src/main/resources/bootstrap/tuningConfigs.yaml
+++ b/core/src/main/resources/bootstrap/tuningConfigs.yaml
@@ -129,7 +129,7 @@ default:
     description: >-
       Amount of pinned memory for GPU operations
     default: 2g
-    max: 4g
+    max: 8g
     usedBy: spark.rapids.memory.pinnedPool.size
 
   - name: PINNED_MEM_OFFHEAP_RATIO

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -857,7 +857,12 @@ abstract class AutoTuner(
         if (isOffHeapLimitUserEnabled) {
           executorMemOverhead
         } else {
-          executorMemOverhead + pinnedMem + spillMem
+          // Budget-aware: claim the full available memory (execMemLeft) as overhead
+          // so the container request (heap + overhead) covers the total node memory.
+          // This ensures freed memory from HEAP_PER_CORE capping is not wasted, and
+          // any residual budget is available as non-pinned spill fallback, JVM off-heap
+          // headroom, and prevents K8s/YARN from over-scheduling the node.
+          Math.max(executorMemOverhead + pinnedMem + spillMem, execMemLeft)
         }
       }
       // Handle the case when the final executor memory overhead is larger than the

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ClusterRecommendationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ClusterRecommendationSuite.scala
@@ -337,7 +337,7 @@ class ClusterRecommendationSuite extends ProfilingAutoTunerSuiteBase
             |--conf spark.executor.memory=12g
             |--conf spark.memory.offHeap.enabled=true
             |--conf spark.memory.offHeap.size=2g
-            |--conf spark.rapids.memory.pinnedPool.size=4g
+            |--conf spark.rapids.memory.pinnedPool.size=5325m
             |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
             |--conf spark.rapids.shuffle.multiThreaded.writer.threads=20
             |--conf spark.rapids.sql.batchSizeBytes=2147483647b
@@ -460,7 +460,7 @@ class ClusterRecommendationSuite extends ProfilingAutoTunerSuiteBase
             |--conf spark.executor.cores=8
             |--conf spark.executor.instances=4
             |--conf spark.executor.memory=12g
-            |--conf spark.rapids.memory.pinnedPool.size=4g
+            |--conf spark.rapids.memory.pinnedPool.size=6349m
             |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
             |--conf spark.rapids.shuffle.multiThreaded.writer.threads=20
             |--conf spark.rapids.sql.batchSizeBytes=2147483647b

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -172,9 +172,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=2
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -469,9 +469,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=4
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -606,9 +606,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=4
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -675,9 +675,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=8
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -783,9 +783,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -879,9 +879,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -962,10 +962,10 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.nvidia.spark.SQLPlugin
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -1056,10 +1056,10 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.nvidia.spark.WrongPlugin0,com.nvidia.spark.WrongPlugin1,com.nvidia.spark.SQLPlugin
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -1149,9 +1149,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -1243,9 +1243,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -1333,9 +1333,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -1421,9 +1421,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -1504,9 +1504,10 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.nvidia.spark.SQLPlugin
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -1558,9 +1559,10 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.nvidia.spark.SQLPlugin
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -1614,9 +1616,10 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.nvidia.spark.SQLPlugin
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -1704,10 +1707,10 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.filecache.enabled=false
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -1793,9 +1796,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -2005,7 +2008,7 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.executor.resource.gpu.amount=1
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.nvidia.spark.SQLPlugin
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=8g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=20
           |--conf spark.rapids.sql.batchSizeBytes=2147483647b
@@ -2160,9 +2163,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -2328,7 +2331,7 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.databricks.adaptive.autoOptimizeShuffle.enabled=false
           |--conf spark.executor.memory=64g
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=4505m
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=48
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=48
@@ -2530,9 +2533,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -2620,9 +2623,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -2687,11 +2690,11 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.kryo.registrator=com.nvidia.spark.rapids.GpuKryoRegistrator
           |--conf spark.kryoserializer.buffer.max=512m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -2765,11 +2768,11 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.kryo.registrator=org.apache.SomeRegistrator,org.apache.SomeOtherRegistrator,com.nvidia.spark.rapids.GpuKryoRegistrator
           |--conf spark.kryoserializer.buffer.max=512m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -2842,11 +2845,11 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.kryo.registrator=com.nvidia.spark.rapids.GpuKryoRegistrator
           |--conf spark.kryoserializer.buffer.max=512m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -2932,7 +2935,7 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.executor.cores=16
           |--conf spark.executor.extraJavaOptions=-XX:-UseTransparentHugePages
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=13106m
+          |--conf spark.executor.memoryOverhead=13107m
           |--conf spark.locality.wait=0
           |--conf spark.rapids.memory.pinnedPool.size=2867m
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
@@ -3002,9 +3005,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -3073,9 +3076,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |Spark Properties:
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -3159,9 +3162,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
             |--conf spark.dataproc.enhanced.execution.enabled=false
             |--conf spark.dataproc.enhanced.optimizer.enabled=false
             |--conf spark.executor.memory=32g
-            |--conf spark.executor.memoryOverhead=15564m
+            |--conf spark.executor.memoryOverhead=19660m
             |--conf spark.locality.wait=0
-            |--conf spark.rapids.memory.pinnedPool.size=4g
+            |--conf spark.rapids.memory.pinnedPool.size=6g
             |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
             |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
             |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -3312,9 +3315,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -3401,9 +3404,9 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.instances=8
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -3549,20 +3552,20 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
   // Test cases for memory overhead configuration
   testMemoryOverhead(
     testName = "Test memory overhead with unit should be skipped when appropriate",
-    initialValue = "15564m",
+    initialValue = "19660m",
     expectedValue = None
   )
 
   testMemoryOverhead(
     testName = "Test memory overhead without unit should be skipped when appropriate",
-    initialValue = "15564",
+    initialValue = "19660",
     expectedValue = None
   )
 
   testMemoryOverhead(
     testName = "Test memory overhead without unit should be updated and set",
     initialValue = "8712",
-    expectedValue = Some("15564m")
+    expectedValue = Some("19660m")
   )
 
   // Test cases for Kryo buffer configuration

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -2204,7 +2204,7 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
         initial = "9"))
   }
 
-  // Regression test for https://github.com/NVIDIA/spark-rapids-tools/issues/2074
+  // Test for https://github.com/NVIDIA/spark-rapids-tools/issues/2074
   // When HEAP_PER_CORE caps executor heap (48g -> 16g with 8 cores), the freed memory
   // should be redistributed into overhead to preserve the total memory budget (~66g).
   test("On-prem K8s with large heap reduced by HEAP_PER_CORE redistributes freed memory") {

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -101,9 +101,9 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -370,10 +370,10 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.kryoserializer.buffer.max=512m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -448,11 +448,11 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.kryo.registrator=org.apache.SomeRegistrator,org.apache.OtherRegistrator,com.nvidia.spark.rapids.GpuKryoRegistrator
           |--conf spark.kryoserializer.buffer.max=512m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -550,10 +550,10 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
       s"""|
           |Spark Properties:
           |--conf spark.executor.memory=16g
-          |--conf spark.executor.memoryOverhead=9830m
+          |--conf spark.executor.memoryOverhead=34918m
           |--conf spark.executor.resource.gpu.vendor=nvidia.com
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=8g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=20
           |--conf spark.rapids.sql.batchSizeBytes=2147483647b
@@ -656,10 +656,10 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |Spark Properties:
           |--conf spark.executor.cores=16
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=11468m
+          |--conf spark.executor.memoryOverhead=32g
           |--conf spark.executor.resource.gpu.vendor=nvidia.com
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=8g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=24
           |--conf spark.rapids.sql.batchSizeBytes=2147483647b
@@ -909,10 +909,10 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |Spark Properties:
           |--conf spark.executor.cores=16
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=11468m
+          |--conf spark.executor.memoryOverhead=32g
           |--conf spark.executor.resource.gpu.vendor=nvidia.com
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=8g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=24
           |--conf spark.rapids.sql.batchSizeBytes=2147483647b
@@ -1019,9 +1019,9 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=16g
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=4506m
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -1140,9 +1140,9 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.memory=14736m
-          |--conf spark.executor.memoryOverhead=13761m
+          |--conf spark.executor.memoryOverhead=37692m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=8g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -1275,9 +1275,9 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -1381,9 +1381,9 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -1489,9 +1489,9 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -1594,9 +1594,9 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.execution.enabled=false
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=19660m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6g
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -1719,9 +1719,9 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |--conf spark.dataproc.enhanced.optimizer.enabled=false
           |--conf spark.executor.cores=16
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=15564m
+          |--conf spark.executor.memoryOverhead=16g
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=4506m
           |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -2040,9 +2040,9 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
       s"""|
           |Spark Properties:
           |--conf spark.executor.memory=16g
-          |--conf spark.executor.memoryOverhead=9830m
+          |--conf spark.executor.memoryOverhead=35560m
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=8g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=20
           |--conf spark.rapids.sql.batchSizeBytes=2147483647b
@@ -2119,9 +2119,9 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
           |Spark Properties:
           |--conf spark.executor.cores=16
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=11468m
+          |--conf spark.executor.memoryOverhead=32g
           |--conf spark.locality.wait=0
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=8g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=24
           |--conf spark.rapids.sql.batchSizeBytes=2147483647b
@@ -2202,5 +2202,91 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
       DynamicAllocationInfo(
         enabled = true, max = "9", min = "2",
         initial = "9"))
+  }
+
+  // Regression test for https://github.com/NVIDIA/spark-rapids-tools/issues/2074
+  // When HEAP_PER_CORE caps executor heap (48g -> 16g with 8 cores), the freed memory
+  // should be redistributed into overhead to preserve the total memory budget (~66g).
+  test("On-prem K8s with large heap reduced by HEAP_PER_CORE redistributes freed memory") {
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "8",
+        "spark.executor.instances" -> "18",
+        "spark.executor.memory" -> "48g",
+        "spark.executor.memoryOverhead" -> "18g",
+        "spark.executor.resource.gpu.amount" -> "1",
+        "spark.dynamicAllocation.enabled" -> "true",
+        "spark.dynamicAllocation.initialExecutors" -> "8",
+        "spark.dynamicAllocation.minExecutors" -> "4",
+        "spark.dynamicAllocation.maxExecutors" -> "18",
+        "spark.executor.resource.gpu.discoveryScript" ->
+          "${SPARK_HOME}/examples/src/main/scripts/getGpusResources.sh",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin"
+      )
+
+    val infoProvider = getMockInfoProvider(8126464.0, Seq(0), Seq(0.004),
+      logEventsProps, Some(testSparkVersion))
+    val platform = PlatformFactory.createInstance(PlatformNames.ONPREM)
+
+    configureEventLogClusterInfoForTest(
+      platform,
+      numCores = 8,
+      numWorkers = 18,
+      gpuCount = 1,
+      sparkProperties = logEventsProps.toMap
+    )
+
+    val autoTuner = buildAutoTunerForTests(infoProvider, platform, Some(Kubernetes))
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    // Total memory budget = 48g + 18g = 67584 MB
+    // HEAP_PER_CORE (2g) * 8 cores = 16g -> heap capped from 48g to 16g
+    // execMemLeft = 67584 - 16384 = 51200 MB
+    // pinnedMem = min(8g, (51200 - 1638) / 2) = 8g
+    // finalExecutorMemOverhead = max(1638 + 8192 + 8192, 51200) = 51200 = 50g
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.dynamicAllocation.initialExecutors=18
+          |--conf spark.executor.memory=16g
+          |--conf spark.executor.memoryOverhead=50g
+          |--conf spark.executor.resource.gpu.vendor=nvidia.com
+          |--conf spark.locality.wait=0
+          |--conf spark.rapids.memory.pinnedPool.size=8g
+          |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
+          |--conf spark.rapids.shuffle.multiThreaded.writer.threads=20
+          |--conf spark.rapids.sql.batchSizeBytes=2147483647b
+          |--conf spark.rapids.sql.concurrentGpuTasks=3
+          |--conf spark.rapids.sql.enabled=true
+          |--conf spark.rapids.sql.multiThreadedRead.numThreads=20
+          |--conf spark.shuffle.manager=com.nvidia.spark.rapids.spark$testSmVersion.RapidsShuffleManager
+          |--conf spark.sql.adaptive.advisoryPartitionSizeInBytes=128m
+          |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
+          |--conf spark.sql.adaptive.coalescePartitions.initialPartitionNum=200
+          |--conf spark.sql.adaptive.coalescePartitions.minPartitionSize=4m
+          |--conf spark.sql.files.maxPartitionBytes=4g
+          |--conf spark.task.resource.gpu.amount=0.001
+          |
+          |Comments:
+          |- 'spark.executor.resource.gpu.vendor' was not set.
+          |- 'spark.rapids.memory.pinnedPool.size' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
+          |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
+          |- 'spark.rapids.sql.batchSizeBytes' was not set.
+          |- 'spark.rapids.sql.concurrentGpuTasks' was not set.
+          |- 'spark.rapids.sql.enabled' was not set.
+          |- 'spark.rapids.sql.multiThreadedRead.numThreads' was not set.
+          |- 'spark.shuffle.manager' was not set.
+          |- 'spark.sql.adaptive.advisoryPartitionSizeInBytes' was not set.
+          |- 'spark.sql.adaptive.autoBroadcastJoinThreshold' was not set.
+          |- 'spark.sql.adaptive.coalescePartitions.initialPartitionNum' was not set.
+          |- 'spark.sql.files.maxPartitionBytes' was not set.
+          |- 'spark.task.resource.gpu.amount' was not set.
+          |- ${classPathComments("rapids.jars.missing")}
+          |- ${classPathComments("rapids.shuffle.jars")}
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    compareOutput(expectedResults, autoTunerOutput)
   }
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -141,8 +141,8 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
       "44g",
       Seq(
         "--conf spark.executor.memory=32g",
-        "--conf spark.executor.memoryOverhead=11468m",
-        "--conf spark.rapids.memory.pinnedPool.size=4g"
+        "--conf spark.executor.memoryOverhead=14g",
+        "--conf spark.rapids.memory.pinnedPool.size=5530m"
       ))
   )
   // scalastyle:on line.size.limit
@@ -372,11 +372,11 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.executor.cores=16
           |--conf spark.executor.instances=2
           |--conf spark.executor.memory=19648m
-          |--conf spark.executor.memoryOverhead=10156m
+          |--conf spark.executor.memoryOverhead=15168m
           |--conf spark.executor.resource.gpu.amount=1
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.nvidia.spark.SQLPlugin
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=6602m
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=24
           |--conf spark.rapids.sql.batchSizeBytes=1g
@@ -516,12 +516,12 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
       s"""|
           |Spark Properties:
           |--conf spark.executor.memory=16g
-          |--conf spark.executor.memoryOverhead=9830m
+          |--conf spark.executor.memoryOverhead=109772m
           |--conf spark.executor.resource.gpu.amount=1
           |--conf spark.executor.resource.gpu.discoveryScript=/opt/sparkPlugin/gpuDiscoveryScript.sh
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.nvidia.spark.SQLPlugin
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=8g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=20
           |--conf spark.rapids.sql.batchSizeBytes=1g
@@ -806,7 +806,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.executor.resource.gpu.amount=1
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.nvidia.spark.SQLPlugin
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=8g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=20
           |--conf spark.rapids.sql.batchSizeBytes=1g
@@ -877,7 +877,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.executor.resource.gpu.amount=1
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.nvidia.spark.SQLPlugin
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=7373m
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=20
           |--conf spark.rapids.sql.batchSizeBytes=1g
@@ -956,7 +956,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.executor.resource.gpu.amount=1
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.existing.plugin1,com.existing.plugin2
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=7373m
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=20
           |--conf spark.rapids.sql.batchSizeBytes=1g
@@ -1302,7 +1302,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.executor.resource.gpu.amount=1
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.nvidia.spark.SQLPlugin
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=8g
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=24
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=24
           |--conf spark.rapids.sql.batchSizeBytes=1g
@@ -1423,11 +1423,11 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
             |--conf spark.executor.cores=16
             |--conf spark.executor.instances=8
             |--conf spark.executor.memory=40g
-            |--conf spark.executor.memoryOverhead=15564m
+            |--conf spark.executor.memoryOverhead=19660m
             |--conf spark.executor.resource.gpu.amount=1
             |--conf spark.locality.wait=0
             |--conf spark.plugins=com.nvidia.spark.SQLPlugin
-            |--conf spark.rapids.memory.pinnedPool.size=4g
+            |--conf spark.rapids.memory.pinnedPool.size=6g
             |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
             |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
             |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
@@ -1524,7 +1524,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.executor.resource.gpu.amount=1
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.existing.plugin1,com.existing.plugin2
-          |--conf spark.rapids.memory.pinnedPool.size=4g
+          |--conf spark.rapids.memory.pinnedPool.size=7373m
           |--conf spark.rapids.shuffle.multiThreaded.reader.threads=20
           |--conf spark.rapids.shuffle.multiThreaded.writer.threads=20
           |--conf spark.rapids.sql.batchSizeBytes=1g
@@ -1612,7 +1612,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.executor.extraJavaOptions=-XX:-UseTransparentHugePages
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=13106m
+          |--conf spark.executor.memoryOverhead=13107m
           |--conf spark.executor.resource.gpu.amount=1
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.nvidia.spark.SQLPlugin
@@ -1794,7 +1794,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.executor.extraJavaOptions=-XX:-UseTransparentHugePages
           |--conf spark.executor.instances=10
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=13106m
+          |--conf spark.executor.memoryOverhead=13107m
           |--conf spark.executor.resource.gpu.amount=1
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.nvidia.spark.SQLPlugin
@@ -1893,7 +1893,7 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
           |--conf spark.executor.extraJavaOptions=-XX:-UseTransparentHugePages
           |--conf spark.executor.instances=14
           |--conf spark.executor.memory=32g
-          |--conf spark.executor.memoryOverhead=13106m
+          |--conf spark.executor.memoryOverhead=13107m
           |--conf spark.executor.resource.gpu.amount=1
           |--conf spark.locality.wait=0
           |--conf spark.plugins=com.nvidia.spark.SQLPlugin


### PR DESCRIPTION
Fixes #2074

## Summary

When `HEAP_PER_CORE` cap reduces executor heap (e.g., 48g → 16g with 8 cores), the freed memory was not redistributed into overhead, leaving ~41g of a ~66g budget unclaimed by the container.

**Changes:**
- Make `finalExecutorMemOverhead` budget-aware: `Math.max(overhead + pinnedMem + spillMem, execMemLeft)` so the container request (heap + overhead) covers the full node memory
- Increase `PINNED_MEMORY.max` from 4g to 8g.

## Before / After (66g budget, 8 cores, 1 GPU)

| Component | Before | After |
|-----------|--------|-------|
| Heap | 16g | 16g |
| Pinned | 4g | 8g |
| finalExecutorMemOverhead | 9.8g | 50g |
| **Total (heap + overhead)** | **~26g** | **~66g** |

Note: Excess overhead beyond pinned+spill is not wasted - it serves as non-pinned spill fallback (avoids disk spill), JVM off-heap headroom etc.

## Test plan

- [x] Updated expected values in ProfilingAutoTunerSuite, ProfilingAutoTunerSuiteV2, QualificationAutoTunerSuite, ClusterRecommendationSuite
- [x] Added test for this issue scenario (on-prem K8s, 8 cores, 1 GPU, 48g heap + 18g overhead)

