### PR TITLE
Preserve glob metacharacters in local file URIs for Hadoop boundary

### DIFF
--- a/user_tools/src/spark_rapids_tools/utils/util.py
+++ b/user_tools/src/spark_rapids_tools/utils/util.py
@@ -16,13 +16,14 @@
 
 import os
 from contextlib import contextmanager
-from pathlib import Path, PurePath
+from pathlib import Path
 import re
 import shutil
 import ssl
 import sys
 import textwrap
 import urllib
+import urllib.parse
 import tempfile
 import xml.etree.ElementTree as elem_tree
 from functools import reduce
@@ -106,6 +107,17 @@ def _strip_path_quotes_and_whitespace(fpath: str) -> str:
     return fpath.strip().strip("'\"")
 
 
+# Glob metacharacters must survive URI construction so that Hadoop's Path/GlobPattern
+# can expand wildcards on the JAR side. PurePath.as_uri() percent-encodes these, which
+# silently defeats glob expansion for local paths like `/data/cpu/*`.
+_LOCAL_URI_SAFE_CHARS = '/*?[]'
+
+
+def _local_path_to_file_uri(local_path: str) -> str:
+    """Build a `file://` URI from an absolute local path, preserving glob metacharacters."""
+    return 'file://' + urllib.parse.quote(local_path, safe=_LOCAL_URI_SAFE_CHARS)
+
+
 def _normalize_file_uri(fpath: str) -> str:
     """Canonicalize `file:` URIs into absolute `file://` form when the scheme is present."""
     if not fpath.lower().startswith('file:'):
@@ -114,7 +126,7 @@ def _normalize_file_uri(fpath: str) -> str:
     _, _, path_part = fpath.partition(':')
     normalized_path = '/' + path_part.lstrip('/') if path_part else '/'
     absolute_path = os.path.abspath(normalized_path)
-    return PurePath(absolute_path).as_uri()
+    return _local_path_to_file_uri(absolute_path)
 
 
 def _normalize_s3_uri(fpath: str, target_scheme: str = 's3') -> str:
@@ -150,7 +162,7 @@ def get_path_as_uri(fpath: str) -> str:
         return normalized_path
     # stringify the path to apply the common methods which is expanding the file.
     local_path = stringify_path(normalized_path)
-    return PurePath(local_path).as_uri()
+    return _local_path_to_file_uri(local_path)
 
 
 def get_path_as_uri_for_hadoop(fpath: str) -> str:
@@ -168,7 +180,7 @@ def get_path_as_uri_for_hadoop(fpath: str) -> str:
     if re.match(r'\w+://', normalized_path):
         return normalized_path
     local_path = stringify_path(normalized_path)
-    return PurePath(local_path).as_uri()
+    return _local_path_to_file_uri(local_path)
 
 
 def to_camel_case(word: str) -> str:

--- a/user_tools/tests/spark_rapids_tools_ut/test_path_boundary.py
+++ b/user_tools/tests/spark_rapids_tools_ut/test_path_boundary.py
@@ -124,3 +124,41 @@ class TestPathBoundaryQualification:
         remote_txt = 's3a://bucket/eventlogs.txt'
 
         assert RapidsJarToolTestShim.prepare_eventlog_arg_for_hadoop(remote_txt, '/tmp') == remote_txt
+
+    def test_prepare_hadoop_arg_path_preserves_glob_metacharacters(self):
+        # Hadoop expands globs on the JAR side, so `*`, `?`, and `[...]` ranges must survive
+        # URI construction verbatim. Percent-encoding them silently disables glob expansion.
+        assert RapidsJarToolTestShim.prepare_hadoop_arg_path(
+            '/data/eventlogs/cpu/*'
+        ) == 'file:///data/eventlogs/cpu/*'
+        assert RapidsJarToolTestShim.prepare_hadoop_arg_path(
+            'file:///data/eventlogs/gpu/*'
+        ) == 'file:///data/eventlogs/gpu/*'
+        assert RapidsJarToolTestShim.prepare_hadoop_arg_path(
+            '/data/eventlogs/app-?'
+        ) == 'file:///data/eventlogs/app-?'
+        assert RapidsJarToolTestShim.prepare_hadoop_arg_path(
+            '/data/eventlogs/app-[0-9]'
+        ) == 'file:///data/eventlogs/app-[0-9]'
+        # Remote globs must not be touched either.
+        assert RapidsJarToolTestShim.prepare_hadoop_arg_path(
+            's3://bucket/eventlogs/*'
+        ) == 's3a://bucket/eventlogs/*'
+
+    def test_rewrite_local_eventlog_list_preserves_glob_metacharacters(self, tmp_path):
+        eventlogs_txt = tmp_path / 'eventlogs.txt'
+        eventlogs_txt.write_text(
+            '/data/eventlogs/cpu/*\n'
+            '/data/eventlogs/gpu/*\n',
+            encoding='utf-8'
+        )
+
+        rewritten_arg = RapidsJarToolTestShim.prepare_eventlog_arg_for_hadoop(
+            str(eventlogs_txt), str(tmp_path)
+        )
+
+        rewritten_path = Path(rewritten_arg.removeprefix('file://'))
+        assert rewritten_path.read_text(encoding='utf-8') == (
+            'file:///data/eventlogs/cpu/*\n'
+            'file:///data/eventlogs/gpu/*\n'
+        )


### PR DESCRIPTION
Fixes #2079 

## Summary
- Fix regression from #2073 where `PurePath.as_uri()` percent-encodes glob metacharacters (`*`, `?`, `[`, `]`) when building `file://` URIs, silently defeating Hadoop-side glob expansion for local eventlog paths.
- Replace the three `PurePath(...).as_uri()` call sites in `util.py` (`_normalize_file_uri`, `get_path_as_uri`, `get_path_as_uri_for_hadoop`) with a shared `_local_path_to_file_uri` helper that uses `urllib.parse.quote(..., safe='/*?[]')`.
- Spaces, `#`, and non-ASCII characters still get properly URI-encoded; only glob metacharacters are preserved.

## Motivation
A weekly Jenkins job broke on the dataproc training leg after #2073. Dataproc is the only training dataset still using explicit wildcard entries:

```
"${QUALX_DATA_DIR}/.../eventlogs/cpu/*"
"${QUALX_DATA_DIR}/.../eventlogs/gpu/*"
```

After normalization those became `file:///.../eventlogs/cpu/%2A`, which the JAR looked up as literal filenames:

```
WARN EventLogPathProcessor: file:///.../eventlogs/cpu/%2A not found, skipping!
process.success.count = 0 / process.failure.count = 2
```

The bug is not `*`-specific — `?` and `[...]` glob ranges have the same failure mode.