### PR TITLE
Honor preserved Spark properties in AutoTuner cluster sizing and memory

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/ClusterConfigurationStrategy.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/ClusterConfigurationStrategy.scala
@@ -48,29 +48,49 @@ case class RecommendedClusterConfig(
  */
 trait ClusterSizingStrategy {
 
-  /** Utility method to compute recommended cores per executor. */
-  final def computeRecommendedCoresPerExec(platform: Platform, totalCoresCount: Int): Int = {
-    platform.getUserEnforcedSparkProperty("spark.executor.cores").map(_.toInt).getOrElse {
-      if (platform.isPlatformCSP) {
-        // For CSPs, we already have the recommended cores per executor based on the instance type
-        platform.recommendedCoresPerExec
-      } else {
-        // For onprem, we do want to limit to the total cores count
-        // Sanity check to avoid returning 0 cores per executor in case
-        // set wrongly by the user
-        if (totalCoresCount > 0) {
-          math.min(platform.recommendedCoresPerExec, totalCoresCount)
-        } else {
+  /**
+   * Utility method to compute recommended cores per executor.
+   *
+   * Precedence: user-enforced spark.executor.cores, then (if preserved) the
+   * source value, then the platform default. Non-numeric / non-positive values
+   * fall through to the default. `sourceLookup` reads the source-application
+   * properties (NOT event-log-derived initial values).
+   *
+   * TODO(#2053): only non-positive values are rejected here; a value exceeding the
+   * worker's core count is validated separately in Platform, so the two can diverge
+   * on invalid input. Centralizing the validation is a deferred follow-up.
+   */
+  final def computeRecommendedCoresPerExec(
+      platform: Platform,
+      totalCoresCount: Int,
+      sourceLookup: String => Option[String]): Int = {
+    platform.getEnforcedOrPreservedSparkProperty("spark.executor.cores", sourceLookup)
+      .flatMap(v => scala.util.Try(v.toInt).toOption)
+      .filter(_ > 0)
+      .getOrElse {
+        if (platform.isPlatformCSP) {
+          // For CSPs, we already have the recommended cores per executor based on the instance type
           platform.recommendedCoresPerExec
+        } else {
+          // For onprem, we do want to limit to the total cores count
+          // Sanity check to avoid returning 0 cores per executor in case
+          // set wrongly by the user
+          if (totalCoresCount > 0) {
+            math.min(platform.recommendedCoresPerExec, totalCoresCount)
+          } else {
+            platform.recommendedCoresPerExec
+          }
         }
       }
-    }
   }
 
   final def computeRecommendedInstances(
       platform: Platform,
+      sourceLookup: String => Option[String],
       computeRecommendedInstancesExpr: () => Int): Int = {
-    platform.getUserEnforcedSparkProperty("spark.executor.instances").map(_.toInt)
+    platform.getEnforcedOrPreservedSparkProperty("spark.executor.instances", sourceLookup)
+      .flatMap(v => scala.util.Try(v.toInt).toOption)
+      .filter(_ > 0)
       .getOrElse(computeRecommendedInstancesExpr())
   }
 
@@ -79,6 +99,7 @@ trait ClusterSizingStrategy {
     platform: Platform,
     initialNumExecutors: Int,
     initialCoresPerExec: Int,
+    sourceSparkProperties: Map[String, String],
     getMemoryPerNodeMb: => Long,
     getRecommendedGpuDevice: => GpuDevice,
     getRecommendedNumGpus: => Int): RecommendedClusterConfig
@@ -94,12 +115,14 @@ object ConstantTotalCoresStrategy extends ClusterSizingStrategy {
       platform: Platform,
       initialNumExecutors: Int,
       initialCoresPerExec: Int,
+      sourceSparkProperties: Map[String, String],
       getMemoryPerNodeMb: => Long,
       getRecommendedGpuDevice: => GpuDevice,
       getRecommendedNumGpus: => Int): RecommendedClusterConfig = {
     val totalCoresCount = initialCoresPerExec * initialNumExecutors
-    val recommendedCoresPerExec = computeRecommendedCoresPerExec(platform, totalCoresCount)
-    val recommendedNumExecutors = computeRecommendedInstances(platform,
+    val recommendedCoresPerExec =
+      computeRecommendedCoresPerExec(platform, totalCoresCount, sourceSparkProperties.get)
+    val recommendedNumExecutors = computeRecommendedInstances(platform, sourceSparkProperties.get,
       () => math.ceil(totalCoresCount.toDouble / recommendedCoresPerExec).toInt)
     RecommendedClusterConfig(recommendedNumExecutors, recommendedCoresPerExec,
       getMemoryPerNodeMb, getRecommendedGpuDevice, getRecommendedNumGpus)
@@ -115,12 +138,14 @@ object ConstantGpuCountStrategy extends ClusterSizingStrategy {
       platform: Platform,
       initialNumExecutors: Int,
       initialCoresPerExec: Int,
+      sourceSparkProperties: Map[String, String],
       getMemoryPerNodeMb: => Long,
       getRecommendedGpuDevice: => GpuDevice,
       getRecommendedNumGpus: => Int): RecommendedClusterConfig = {
     val totalCoresCount = initialCoresPerExec * initialNumExecutors
-    val recommendedCoresPerExec = computeRecommendedCoresPerExec(platform, totalCoresCount)
-    val recommendNumExecutors = computeRecommendedInstances(platform,
+    val recommendedCoresPerExec =
+      computeRecommendedCoresPerExec(platform, totalCoresCount, sourceSparkProperties.get)
+    val recommendNumExecutors = computeRecommendedInstances(platform, sourceSparkProperties.get,
       () => initialNumExecutors)
     RecommendedClusterConfig(recommendNumExecutors, recommendedCoresPerExec,
       getMemoryPerNodeMb, getRecommendedGpuDevice, getRecommendedNumGpus)
@@ -137,12 +162,18 @@ object SourceCoresPreservingStrategy extends ClusterSizingStrategy {
       platform: Platform,
       initialNumExecutors: Int,
       initialCoresPerExec: Int,
+      sourceSparkProperties: Map[String, String],
       getMemoryPerNodeMb: => Long,
       getRecommendedGpuDevice: => GpuDevice,
       getRecommendedNumGpus: => Int): RecommendedClusterConfig = {
-    val coresPerExec = platform.getUserEnforcedSparkProperty("spark.executor.cores")
-      .map(_.toInt).getOrElse(initialCoresPerExec)
-    val numExecutors = computeRecommendedInstances(platform, () => initialNumExecutors)
+    val coresPerExec =
+      platform.getEnforcedOrPreservedSparkProperty(
+          "spark.executor.cores", sourceSparkProperties.get)
+        .flatMap(v => scala.util.Try(v.toInt).toOption)
+        .filter(_ > 0)
+        .getOrElse(initialCoresPerExec)
+    val numExecutors =
+      computeRecommendedInstances(platform, sourceSparkProperties.get, () => initialNumExecutors)
     RecommendedClusterConfig(numExecutors, coresPerExec,
       getMemoryPerNodeMb, getRecommendedGpuDevice, getRecommendedNumGpus)
   }
@@ -223,6 +254,7 @@ abstract class ClusterConfigurationStrategy(
         platform,
         initialNumExecutors,
         getInitialCoresPerExec,
+        sourceSparkProperties,
         getRecommendedMemoryPerNodeMb,
         getRecommendedGpuDevice,
         getRecommendedNumGpus
@@ -257,7 +289,8 @@ class EventLogBasedStrategy(
    */
   // scalastyle:on line.size.limit
   override def getRecommendedMemoryPerNodeMb: Long = {
-    val heapMemMB = platform.getUserEnforcedSparkProperty("spark.executor.memory")
+    val heapMemMB = platform.getEnforcedOrPreservedSparkProperty("spark.executor.memory",
+        sourceSparkProperties.get)
       .map(StringUtils.convertToMB(_, Some(ByteUnit.BYTE)))
       .getOrElse(clusterInfoFromEventLog.executorHeapMemory)
     // Get a combined spark properties function that includes user enforced properties

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -702,18 +702,20 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
                 _recommendedWorkerNode.numGpus).toInt
             }
 
-            // Calculate cores per executor: use user-enforced value if specified and valid,
-            // otherwise divide total cores in the instance by the number of GPUs
+            // Calculate cores per executor: use the user-specified value (enforced, or
+            // preserved from the source application) if valid, otherwise divide total
+            // cores in the instance by the number of GPUs.
             val defaultCoresPerExecutor = math.ceil(
               _recommendedWorkerNode.cores.toDouble / _recommendedWorkerNode.numGpus
             ).toInt
-            val recommendedCoresPerExecutor = getUserEnforcedSparkProperty("spark.executor.cores")
+            val recommendedCoresPerExecutor =
+              getEnforcedOrPreservedSparkProperty("spark.executor.cores", sourceSparkProperties.get)
               .flatMap(v => scala.util.Try(v.toInt).toOption)
-              .filter { enforcedCores =>
+              .filter { specifiedCores =>
                 val maxCores = _recommendedWorkerNode.cores
-                val isValid = enforcedCores > 0 && enforcedCores <= maxCores
+                val isValid = specifiedCores > 0 && specifiedCores <= maxCores
                 if (!isValid) {
-                  logWarning(s"User-enforced spark.executor.cores=$enforcedCores is invalid " +
+                  logWarning(s"User-specified spark.executor.cores=$specifiedCores is invalid " +
                     s"(must be > 0 and <= $maxCores cores on instance " +
                     s"${_recommendedWorkerNode.name}). " +
                     s"Using default value: $defaultCoresPerExecutor")
@@ -764,6 +766,22 @@ abstract class Platform(var gpuDevice: Option[GpuDevice],
    */
   final def getUserEnforcedSparkProperty(propertyKey: String): Option[String] = {
     userEnforcedRecommendations.get(propertyKey)
+  }
+
+  /**
+   * Resolve the baseline value to use for a Spark property during recommendation
+   * calculations. Precedence: user-enforced value first, then (if the property is
+   * in the target cluster's `preserve` list) its source-application value. Returns
+   * None if neither applies (caller falls back to its computed default).
+   *
+   * @param propertyKey  the Spark property name
+   * @param sourceLookup accessor for the source-application property value
+   */
+  final def getEnforcedOrPreservedSparkProperty(
+      propertyKey: String,
+      sourceLookup: String => Option[String]): Option[String] = {
+    getUserEnforcedSparkProperty(propertyKey)
+      .orElse(if (isPropertyPreserved(propertyKey)) sourceLookup(propertyKey) else None)
   }
 
   /**

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -668,17 +668,15 @@ abstract class AutoTuner(
     }
   }
 
-  private lazy val userEnforcedMemorySettings: MemorySettings = {
-    val executorHeap = platform.getUserEnforcedSparkProperty("spark.executor.memory")
-      .map(StringUtils.convertToMB(_, Some(ByteUnit.BYTE)))
-    val executorMemOverhead = platform.getUserEnforcedSparkProperty("spark.executor.memoryOverhead")
-      .map(StringUtils.convertToMB(_, Some(ByteUnit.BYTE)))
-    val pinnedMem = platform.getUserEnforcedSparkProperty("spark.rapids.memory.pinnedPool.size")
-      .map(StringUtils.convertToMB(_, Some(ByteUnit.BYTE)))
-    val spillMem = platform.getUserEnforcedSparkProperty("spark.rapids.memory.spillPool.size")
-      .map(StringUtils.convertToMB(_, Some(ByteUnit.BYTE)))
-    val sparkOffHeapMem = platform.getUserEnforcedSparkProperty("spark.memory.offHeap.size")
-      .map(StringUtils.convertToMB(_, Some(ByteUnit.BYTE)))
+  private lazy val baselineMemorySettings: MemorySettings = {
+    def baseline(key: String): Option[Long] =
+      platform.getEnforcedOrPreservedSparkProperty(key, getPropertyValueFromSource)
+        .map(StringUtils.convertToMB(_, Some(ByteUnit.BYTE)))
+    val executorHeap = baseline("spark.executor.memory")
+    val executorMemOverhead = baseline("spark.executor.memoryOverhead")
+    val pinnedMem = baseline("spark.rapids.memory.pinnedPool.size")
+    val spillMem = baseline("spark.rapids.memory.spillPool.size")
+    val sparkOffHeapMem = baseline("spark.memory.offHeap.size")
     MemorySettings(executorHeap, executorMemOverhead, pinnedMem, spillMem, sparkOffHeapMem)
   }
 
@@ -764,7 +762,7 @@ abstract class AutoTuner(
       totalMemForExecExpr: () => Double): Either[String, (MemorySettings, Boolean)] = {
 
     // Set executor heap using user enforced value or max of calculator result and 2GB/core
-    val executorHeapMB = userEnforcedMemorySettings.executorHeap.getOrElse {
+    val executorHeapMB = baselineMemorySettings.executorHeap.getOrElse {
       Math.max(
         execHeapCalculator(),
         configProvider
@@ -784,7 +782,7 @@ abstract class AutoTuner(
       totalMemForExecutors * executorAvailableMemFraction
     }.toLong
     // Calculate off-heap memory size using new hybrid scan detection logic
-    val sparkOffHeapMemMB: Long = userEnforcedMemorySettings.sparkOffHeapMem.getOrElse(
+    val sparkOffHeapMemMB: Long = baselineMemorySettings.sparkOffHeapMem.getOrElse(
       calculateOffHeapMemorySize(numExecutorCores)
     )
     val pySparkMemMB = platform.getPySparkMemoryMB(getPropertyValue).getOrElse(0L)
@@ -800,7 +798,7 @@ abstract class AutoTuner(
     var setMaxBytesInFlight = false
     val defaultPinnedMem = configProvider.getEntry("PINNED_MEMORY").getDefaultAsMemory(ByteUnit.MiB)
     val defaultSpillMem = configProvider.getEntry("SPILL_MEMORY").getDefaultAsMemory(ByteUnit.MiB)
-    val minOverhead: Long = userEnforcedMemorySettings.executorMemOverhead.getOrElse {
+    val minOverhead: Long = baselineMemorySettings.executorMemOverhead.getOrElse {
       if (isOffHeapLimitUserEnabled) {
         executorMemOverhead
       } else {
@@ -839,7 +837,7 @@ abstract class AutoTuner(
       }
 
       // Pinned memory calculation - use new formula for onPrem, original logic for CSP
-      var pinnedMem = userEnforcedMemorySettings.pinnedMem.getOrElse {
+      var pinnedMem = baselineMemorySettings.pinnedMem.getOrElse {
         if (!platform.isPlatformCSP && hostOffHeapLimitSizeMB > 0) {
           // Use new formula for onPrem platform
           calculatePinnedMemorySize(numExecutorCores, hostOffHeapLimitSizeMB)
@@ -852,8 +850,8 @@ abstract class AutoTuner(
       // Spill storage is set to the pinned size by default. Its not guaranteed to use just pinned
       // memory though so the size worst case would be doesn't use any pinned memory and uses
       // all off heap memory.
-      var spillMem = userEnforcedMemorySettings.spillMem.getOrElse(pinnedMem)
-      var finalExecutorMemOverhead = userEnforcedMemorySettings.executorMemOverhead.getOrElse {
+      var spillMem = baselineMemorySettings.spillMem.getOrElse(pinnedMem)
+      var finalExecutorMemOverhead = baselineMemorySettings.executorMemOverhead.getOrElse {
         if (isOffHeapLimitUserEnabled) {
           executorMemOverhead
         } else {
@@ -871,7 +869,7 @@ abstract class AutoTuner(
         // If there is any user-enforced memory settings, add a warning comment
         // indicating that the current setup is not optimal and no memory-related
         // tunings are recommended.
-        if (userEnforcedMemorySettings.hasAnyMemorySettings) {
+        if (baselineMemorySettings.hasAnyMemorySettings) {
           return Left(generateInsufficientMemoryComment(executorHeapMB, finalExecutorMemOverhead,
             sparkOffHeapMemMB, pySparkMemMB))
         }

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -866,9 +866,9 @@ abstract class AutoTuner(
       // Handle the case when the final executor memory overhead is larger than the
       // available memory left for the executor.
       if (execMemLeft < finalExecutorMemOverhead) {
-        // If there is any user-enforced memory settings, add a warning comment
-        // indicating that the current setup is not optimal and no memory-related
-        // tunings are recommended.
+        // If there are any baseline memory settings (user-enforced or preserved),
+        // add a warning comment indicating that the current setup is not optimal
+        // and no memory-related tunings are recommended.
         if (baselineMemorySettings.hasAnyMemorySettings) {
           return Left(generateInsufficientMemoryComment(executorHeapMB, finalExecutorMemOverhead,
             sparkOffHeapMemMB, pySparkMemMB))

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -771,7 +771,8 @@ abstract class AutoTuner(
       numExecutorCores: Int,
       totalMemForExecExpr: () => Double): Either[String, (MemorySettings, Boolean)] = {
 
-    // Set executor heap using user enforced value or max of calculator result and 2GB/core
+    // Set executor heap using a baseline value, if present, otherwise max of
+    // calculator result and 2GB/core.
     val executorHeapMB = baselineMemorySettings.executorHeap.getOrElse {
       Math.max(
         execHeapCalculator(),

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -287,7 +287,7 @@ abstract class AutoTuner(
 
   // Check if off-heap limit is enabled - centralized to avoid repeated property lookups
   private lazy val isOffHeapLimitUserEnabled: Boolean = {
-    platform.getUserEnforcedSparkProperty("spark.rapids.memory.host.offHeapLimit.enabled")
+    getBaselineSparkProperty("spark.rapids.memory.host.offHeapLimit.enabled")
       .exists(_.trim.equalsIgnoreCase("true"))
   }
 
@@ -508,8 +508,11 @@ abstract class AutoTuner(
    * Criteria:
    * - The property is in the skipped recommendations list
    * - The property is in the limited logic recommendations list
-   * - The property is enforced by the user (since we have already handled it during
-   *   initRecommendations() and initialization of finalTuningTable)
+   * - The property is preserved from source values or otherwise marked for limited logic
+   * - The property is enforced by the user
+   *
+   * Preserved and enforced properties are handled during initRecommendations() and
+   * initialization of finalTuningTable, so later recommendation logic should not overwrite them.
    * @param key the property to check
    * @return true if the recommendation should be ignored, false otherwise
    */
@@ -651,6 +654,14 @@ abstract class AutoTuner(
   }
 
   /**
+   * Spark property value to use as an input baseline for recommendation calculations.
+   * User-enforced values take precedence over preserved source values.
+   */
+  private def getBaselineSparkProperty(key: String): Option[String] = {
+    platform.getEnforcedOrPreservedSparkProperty(key, getPropertyValueFromSource)
+  }
+
+  /**
    * Note: All memory values are in MB.
    */
   private case class MemorySettings(
@@ -670,8 +681,7 @@ abstract class AutoTuner(
 
   private lazy val baselineMemorySettings: MemorySettings = {
     def baseline(key: String): Option[Long] =
-      platform.getEnforcedOrPreservedSparkProperty(key, getPropertyValueFromSource)
-        .map(StringUtils.convertToMB(_, Some(ByteUnit.BYTE)))
+      getBaselineSparkProperty(key).map(StringUtils.convertToMB(_, Some(ByteUnit.BYTE)))
     val executorHeap = baseline("spark.executor.memory")
     val executorMemOverhead = baseline("spark.executor.memoryOverhead")
     val pinnedMem = baseline("spark.rapids.memory.pinnedPool.size")
@@ -823,8 +833,8 @@ abstract class AutoTuner(
       // (only for onPrem when offHeapLimit is enabled)
       val hostOffHeapLimitSizeMB = if (!platform.isPlatformCSP &&
         isOffHeapLimitUserEnabled) {
-        val userOffHeapLimitOpt = platform
-          .getUserEnforcedSparkProperty("spark.rapids.memory.host.offHeapLimit.size")
+        val userOffHeapLimitOpt =
+          getBaselineSparkProperty("spark.rapids.memory.host.offHeapLimit.size")
         if (userOffHeapLimitOpt.isDefined) {
           StringUtils.convertToMB(
             userOffHeapLimitOpt.get,

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -2328,6 +2328,52 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
         s"memoryOverhead with preserve=$overheadWith vs without=$overheadWithout")
   }
 
+  // Issue #2053: host off-heap limit settings affect pinned-memory sizing on on-prem
+  // clusters, so preserved source values must be used as calculation baselines.
+  test("preserved host off-heap limit settings are used as memory sizing baselines") {
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "20",
+        "spark.executor.memory" -> "6144M",
+        "spark.executor.instances" -> "20",
+        "spark.rapids.memory.host.offHeapLimit.enabled" -> "true",
+        "spark.rapids.memory.host.offHeapLimit.size" -> "80g",
+        "spark.executor.resource.gpu.amount" -> "1",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
+        "spark.rapids.sql.enabled" -> "true"
+      )
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      cpuCores = Some(20),
+      memoryGB = Some(120L),
+      gpuCount = Some(1),
+      gpuMemory = Some("48g"),
+      gpuDevice = Some("l20"),
+      preserveSparkProperties = List(
+        "spark.rapids.memory.host.offHeapLimit.enabled",
+        "spark.rapids.memory.host.offHeapLimit.size")
+    )
+    val infoProvider = getMockInfoProvider(0, Seq(0),
+      Seq(0.0), logEventsProps, Some(testSparkVersion))
+    val platform = PlatformFactory.createInstance(PlatformNames.ONPREM, Some(targetClusterInfo))
+    configureEventLogClusterInfoForTest(
+      platform,
+      numCores = 20,
+      numWorkers = 4,
+      gpuCount = 1,
+      sparkProperties = logEventsProps.toMap
+    )
+
+    val autoTuner = buildAutoTunerForTests(infoProvider, platform, Some(Kubernetes))
+    val (properties, _) = autoTuner.getRecommendedProperties(showOnlyUpdatedProps = false)
+    val recommendedProps = properties.map(p => p.name -> p.getTuneValue()).toMap
+
+    assert(recommendedProps.get("spark.rapids.memory.host.offHeapLimit.enabled").contains("true"))
+    assert(recommendedProps.get("spark.rapids.memory.host.offHeapLimit.size").contains("80g"))
+    assert(recommendedProps.get("spark.rapids.memory.pinnedPool.size").contains("40g"),
+      s"Expected pinned memory to use preserved host off-heap limit size, " +
+        s"got ${recommendedProps.get("spark.rapids.memory.pinnedPool.size")}")
+  }
+
   // Test for https://github.com/NVIDIA/spark-rapids-tools/issues/2074
   // When HEAP_PER_CORE caps executor heap (48g -> 16g with 8 cores), the freed memory
   // should be redistributed into overhead to preserve the total memory budget (~66g).

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -22,8 +22,10 @@ import com.nvidia.spark.rapids.tool.{DynamicAllocationInfo, GpuTypes, NodeInstan
 import com.nvidia.spark.rapids.tool.profiling.Profiler
 import com.nvidia.spark.rapids.tool.tuning.config.{ConfTypeEnum, TuningConfigEntry, TuningEntryDefinition}
 
+import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.{SparkSession, TrampolineUtil}
 import org.apache.spark.sql.rapids.tool.annotation.Since
+import org.apache.spark.sql.rapids.tool.util.StringUtils
 
 /**
  * Test suite for the Profiling AutoTuner that uses the new target cluster properties format.
@@ -2202,6 +2204,128 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
       DynamicAllocationInfo(
         enabled = true, max = "9", min = "2",
         initial = "9"))
+  }
+
+  // Issue #2053: when spark.executor.cores is in the target cluster `preserve` list,
+  // the preserved source value (8) must be the sizing baseline, NOT re-sliced to the
+  // platform default (16). Same scenario as "dynamic allocation enforces invariant with
+  // target cluster" above, but with preserve. Core ratio = 8/8 = 1.0, so source DA is not
+  // scaled; initialExecutors is still boosted to match executor.instances=18.
+  // Expected: cores=8, instances=18, DA min=4 / initial=18 / max=18.
+  test("preserved spark.executor.cores is respected by cluster sizing and dynamic allocation") {
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "8",
+        "spark.executor.memory" -> "16g",
+        "spark.executor.resource.gpu.amount" -> "1",
+        "spark.dynamicAllocation.enabled" -> "true",
+        "spark.dynamicAllocation.initialExecutors" -> "8",
+        "spark.dynamicAllocation.minExecutors" -> "4",
+        "spark.dynamicAllocation.maxExecutors" -> "18",
+        "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
+        "spark.rapids.sql.enabled" -> "true"
+      )
+
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      cpuCores = Some(16),
+      memoryGB = Some(64),
+      gpuCount = Some(1),
+      gpuDevice = Some(GpuTypes.L4.toString),
+      preserveSparkProperties = List("spark.executor.cores")
+    )
+
+    val infoProvider = getMockInfoProvider(0, Seq(0),
+      Seq(0.0), logEventsProps, Some(testSparkVersion))
+    val platform =
+      PlatformFactory.createInstance(PlatformNames.ONPREM, Some(targetClusterInfo))
+
+    configureEventLogClusterInfoForTest(
+      platform,
+      numCores = 8,
+      numWorkers = 18,
+      gpuCount = 1,
+      sparkProperties = logEventsProps.toMap
+    )
+
+    val autoTuner = buildAutoTunerForTests(infoProvider, platform, Some(Yarn))
+    // Use showOnlyUpdatedProps = false so that DA values left unchanged from source
+    // (min/max, since the core ratio is now 1.0) are still present to assert on.
+    val (properties, _) = autoTuner.getRecommendedProperties(showOnlyUpdatedProps = false)
+    val recommendedProps = properties.map(p => p.name -> p.getTuneValue()).toMap
+
+    def assertProp(name: String, expected: String): Unit =
+      assert(recommendedProps.get(name).contains(expected),
+        s"$name: expected $expected, got ${recommendedProps.get(name)}")
+
+    assertProp("spark.executor.cores", "8")
+    assertProp("spark.executor.instances", "18")
+    assertProp("spark.dynamicAllocation.minExecutors", "4")
+    assertProp("spark.dynamicAllocation.initialExecutors", "18")
+    assertProp("spark.dynamicAllocation.maxExecutors", "18")
+  }
+
+  // Issue #2053: when spark.executor.memory is preserved, the source heap value (8g)
+  // must be used as the memory sizing BASELINE that drives dependent memory sizing
+  // (e.g. executor.memoryOverhead), not merely echoed to the output. Asserting only the
+  // final executor.memory value is insufficient: the final preserve override already
+  // forces that value regardless of whether the baseline reads preserve. We therefore
+  // assert that a dependent value (memoryOverhead) actually changes when the heap
+  // baseline is the preserved 8g versus the larger computed default.
+  test("preserved spark.executor.memory is used as the memory sizing baseline") {
+    def runWith(preserve: List[String]): Map[String, String] = {
+      val logEventsProps: mutable.Map[String, String] =
+        mutable.LinkedHashMap[String, String](
+          "spark.executor.cores" -> "8",
+          "spark.executor.instances" -> "2",
+          "spark.executor.memory" -> "8g",
+          "spark.executor.resource.gpu.amount" -> "1",
+          "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
+          "spark.rapids.sql.enabled" -> "true"
+        )
+      val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+        cpuCores = Some(16),
+        memoryGB = Some(64),
+        gpuCount = Some(1),
+        gpuDevice = Some(GpuTypes.L4.toString),
+        preserveSparkProperties = preserve
+      )
+      val infoProvider = getMockInfoProvider(0, Seq(0),
+        Seq(0.0), logEventsProps, Some(testSparkVersion))
+      val platform =
+        PlatformFactory.createInstance(PlatformNames.ONPREM, Some(targetClusterInfo))
+      configureEventLogClusterInfoForTest(
+        platform,
+        numCores = 8,
+        numWorkers = 2,
+        gpuCount = 1,
+        sparkProperties = logEventsProps.toMap
+      )
+      val autoTuner = buildAutoTunerForTests(infoProvider, platform, Some(Kubernetes))
+      val (properties, _) = autoTuner.getRecommendedProperties(showOnlyUpdatedProps = false)
+      properties.map(p => p.name -> p.getTuneValue()).toMap
+    }
+
+    val withPreserve = runWith(List("spark.executor.memory"))
+    val withoutPreserve = runWith(List.empty)
+
+    // Sanity: the preserved heap is echoed to the output.
+    val heapMB = withPreserve.get("spark.executor.memory")
+      .map(v => StringUtils.convertToMB(v, Some(ByteUnit.BYTE)))
+      .getOrElse(fail("spark.executor.memory not found in recommendations"))
+    assert(heapMB == StringUtils.convertToMB("8g", Some(ByteUnit.BYTE)),
+      s"Expected preserved heap 8g, got ${heapMB}MB")
+
+    // The real proof: preserving the 8g heap as the baseline changes dependent memory
+    // sizing. Without preserve, the baseline is the larger computed default, so the
+    // recommended executor.memoryOverhead differs.
+    val overheadWith = withPreserve.get("spark.executor.memoryOverhead")
+    val overheadWithout = withoutPreserve.get("spark.executor.memoryOverhead")
+    assert(overheadWith.isDefined && overheadWithout.isDefined,
+      s"Expected executor.memoryOverhead in both runs, " +
+        s"got with=$overheadWith without=$overheadWithout")
+    assert(overheadWith != overheadWithout,
+      s"Preserving spark.executor.memory should change dependent memory sizing; " +
+        s"memoryOverhead with preserve=$overheadWith vs without=$overheadWithout")
   }
 
   // Test for https://github.com/NVIDIA/spark-rapids-tools/issues/2074

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -1423,12 +1423,11 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
             |--conf spark.executor.cores=16
             |--conf spark.executor.instances=8
             |--conf spark.executor.memory=40g
-            |--conf spark.executor.memoryOverhead=19660m
+            |--conf spark.executor.memoryOverhead=11468m
             |--conf spark.executor.resource.gpu.amount=1
             |--conf spark.locality.wait=0
             |--conf spark.plugins=com.nvidia.spark.SQLPlugin
-            |--conf spark.rapids.memory.pinnedPool.size=6g
-            |--conf spark.rapids.shuffle.multiThreaded.maxBytesInFlight=4g
+            |--conf spark.rapids.memory.pinnedPool.size=3686m
             |--conf spark.rapids.shuffle.multiThreaded.reader.threads=28
             |--conf spark.rapids.shuffle.multiThreaded.writer.threads=28
             |--conf spark.rapids.sql.batchSizeBytes=1g
@@ -1453,7 +1452,6 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
             |- 'spark.plugins' should be set to the class name required for the RAPIDS Accelerator for Apache Spark.
             |  Refer to: https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html
             |- 'spark.rapids.memory.pinnedPool.size' was not set.
-            |- 'spark.rapids.shuffle.multiThreaded.maxBytesInFlight' was not set.
             |- 'spark.rapids.shuffle.multiThreaded.reader.threads' was not set.
             |- 'spark.rapids.shuffle.multiThreaded.writer.threads' was not set.
             |- 'spark.rapids.sql.batchSizeBytes' was not set.


### PR DESCRIPTION
Fixes #2053

## Problem

Properties in `sparkProperties.preserve` were applied only as a final output override. Cluster sizing, executor-instance derivation, dynamic allocation, and memory sizing all ignored them and used platform defaults — then the preserved value was stamped on top, yielding inconsistent recommendations.

Example: preserved `spark.executor.cores=8` but `spark.executor.instances=9` (computed as if cores were the default 16).

## Fix

`preserve` now behaves like `enforced` — an authoritative baseline throughout, with precedence `enforced > preserve > computed default`.

- Add `Platform.getEnforcedOrPreservedSparkProperty(key, sourceLookup)`.
- Resolve cores/instances and memory through it: `createRecommendedGpuClusterInfo`, the `ClusterConfigurationStrategy` sizing strategies, and the `AutoTuner` / `EventLogBasedStrategy` memory baselines.
- Dynamic allocation needs no change — it derives from the recommended cores.

Same example now yields `cores=8`, `instances=18`.

## Tests

- Preserved cores → correct instances and dynamic allocation.
- Preserved memory → dependent sizing (`memoryOverhead`) reflects the preserved heap.
- No-preserve behavior is unchanged (regression guard).
- Updated the e2e preserve expectations to the now-consistent values.

## Known follow-up

An invalid preserved/enforced `spark.executor.cores` exceeding the target worker's cores can still diverge between the strategy and `Platform` (final cores fall back, executor count uses the invalid value). This is pre-existing for `enforced` and only affects an already-warned misconfiguration.
