### PR TITLE
Fix DeprecationWarning by migrating cluster-inference props to AbstractPropContainer

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 from typing import Any, List, Union, Optional
 
 from spark_rapids_tools import CspEnv
+from spark_rapids_tools.utils import AbstractPropContainer
 from spark_rapids_pytools.cloud_api.dataproc_job import DataprocLocalRapidsJob
 from spark_rapids_pytools.cloud_api.gstorage import GStorageDriver
 from spark_rapids_pytools.cloud_api.sp_types import PlatformBase, CMDDriverBase, \
@@ -505,7 +506,7 @@ class DataprocCluster(ClusterBase):
             for worker_node in worker_nodes_from_conf:
                 worker_props = {
                     'name': worker_node,
-                    'props': JSONPropertiesContainer(prop_arg=raw_worker_prop, file_load=False),
+                    'props': AbstractPropContainer(props=raw_worker_prop),
                     # set the node zone based on the wrapper defined zone
                     'zone': self.zone
                 }
@@ -516,7 +517,7 @@ class DataprocCluster(ClusterBase):
         raw_master_props = self.props.get_value('config', 'masterConfig')
         master_props = {
             'name': master_nodes_from_conf[0],
-            'props': JSONPropertiesContainer(prop_arg=raw_master_props, file_load=False),
+            'props': AbstractPropContainer(props=raw_master_props),
             # set the node zone based on the wrapper defined zone
             'zone': self.zone
         }

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -14,6 +14,7 @@
 
 """This module provides functionality for cluster inference"""
 
+import json
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional
@@ -22,9 +23,9 @@ from logging import Logger
 import pandas as pd
 
 from spark_rapids_pytools.cloud_api.sp_types import PlatformBase, ClusterBase
-from spark_rapids_pytools.common.prop_manager import JSONPropertiesContainer
 from spark_rapids_pytools.common.utilities import ToolLogging
 from spark_rapids_tools import CspEnv
+from spark_rapids_tools.utils import AbstractPropContainer
 
 
 class ClusterType(Enum):
@@ -145,7 +146,7 @@ class ClusterInference:
             cluster_conf = self.platform.generate_cluster_configuration(cluster_template_args)
             if cluster_conf is None:
                 return None
-            cluster_props_new = JSONPropertiesContainer(cluster_conf, file_load=False)
+            cluster_props_new = AbstractPropContainer(props=json.loads(cluster_conf))
             return self.platform.load_cluster_by_prop(cluster_props_new, is_inferred=True)
         except Exception as e:  # pylint: disable=broad-except
             self.logger.error('Error while inferring cluster: %s', str(e))


### PR DESCRIPTION
## Summary
Fixes #1898

The cluster-inference code path instantiated the deprecated `JSONPropertiesContainer`, whose `@deprecated` decorator emits `DeprecationWarning: use AbstractPropContainer instead. This class does not support CspPaths.` This produced the warnings reported in the issue from `dataproc.py` and `cluster_inference.py`.

## Changes
- `cluster_inference.py`: build the inferred cluster props via `AbstractPropContainer`. The cluster configuration returned by the mustache template (`render_template_file`) is a JSON **string**, so it is parsed with `json.loads` before being passed as `props`.
- `dataproc.py`: build the worker/master node props via `AbstractPropContainer`. These values come from `get_value`/`get_value_silent` and are already `dict` objects, so they are passed directly as `props`.

Both replaced containers are only consumed through `get_value` / `get_value_silent`, which `AbstractPropContainer` supports, so behavior is preserved.

## Notes
- This targets the call sites documented in the issue traceback. Other modules still use `JSONPropertiesContainer` and can be migrated as a follow-up.

## Testing
- `python -m py_compile` on both modified files passes.
- Full test suite / CI to validate behavior (local environment lacks the package runtime dependencies).

Made with [Cursor](https://cursor.com)