### PR TITLE
Populate data_size for Iceberg V2 scans 

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/IoMetrics.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/IoMetrics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/IoMetrics.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/IoMetrics.scala
@@ -43,11 +43,17 @@ trait IoMetricsTrait {
   protected val DATA_SIZE_LABEL: String
   protected val DECODE_TIME_LABEL: String
 
+  // Data-size metric emitted by Iceberg DataSource V2 BatchScan
+  // (v2Custom_org.apache.iceberg.spark.source.metrics.TotalDataFileSize). It is produced by the
+  // Iceberg source independent of the compute engine, so it is recognized at the base level and
+  // routed to dataSize for all engine helpers (OSS, Photon, Auron).
+  protected val ICEBERG_DATA_SIZE_LABEL = "total data file size (bytes)"
+
   protected val ioLabels: Set[String]
 
   /** Check if a metric name is an I/O metric */
   def isIoMetric(arg: String): Boolean = {
-    ioLabels.contains(arg)
+    ioLabels.contains(arg) || arg == ICEBERG_DATA_SIZE_LABEL
   }
 
   /** Check if a SQL accumulator is an I/O metric */
@@ -85,7 +91,7 @@ trait IoMetricsTrait {
       case BUFFER_TIME_LABEL => destRec.bufferTime = convertMsTime(srcAccum)
       case SCAN_TIME_LABEL => destRec.scanTime = convertMsTime(srcAccum)
       case DECODE_TIME_LABEL => destRec.decodeTime = convertMsTime(srcAccum)
-      case DATA_SIZE_LABEL => destRec.dataSize = srcAccum.total
+      case DATA_SIZE_LABEL | ICEBERG_DATA_SIZE_LABEL => destRec.dataSize = srcAccum.total
       case _ => throw UnsupportedMetricNameException(srcAccum.name)
     }
   }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/views/IoMetricsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/views/IoMetricsSuite.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.views
+
+import com.nvidia.spark.rapids.tool.profiling.SQLAccumProfileResults
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.rapids.tool.UnsupportedMetricNameException
+
+/**
+ * Unit tests for I/O-metric recognition and routing, covering the Iceberg V2
+ * `total data file size (bytes)` scan metric (issue #2115) alongside the existing
+ * file-source `size of files read` metric.
+ */
+class IoMetricsSuite extends AnyFunSuite {
+
+  // Iceberg BatchScan emits its scan bytes under this SQL-plan metric name.
+  private val icebergDataSizeName = "total data file size (bytes)"
+  private val icebergMetricType =
+    "v2Custom_org.apache.iceberg.spark.source.metrics.TotalDataFileSize"
+
+  private def accum(
+      name: String,
+      total: Long,
+      metricType: String = "sum"): SQLAccumProfileResults = {
+    SQLAccumProfileResults(
+      sqlID = 0L,
+      nodeID = 1L,
+      nodeName = "BatchScan",
+      accumulatorId = 486L,
+      name = name,
+      min = 0L,
+      median = total,
+      max = total,
+      total = total,
+      metricType = metricType,
+      stageIds = Set(0))
+  }
+
+  test("Iceberg total data file size is recognized as an I/O metric") {
+    val srcAccum = accum(icebergDataSizeName, 5177503442L, icebergMetricType)
+    assert(IoMetrics.isIoMetric(icebergDataSizeName))
+    assert(IoMetrics.isIoMetric(srcAccum))
+  }
+
+  test("Iceberg total data file size populates dataSize") {
+    val srcAccum = accum(icebergDataSizeName, 5177503442L, icebergMetricType)
+    val rec = IoMetrics(0, 0, 0, 0)
+    IoMetrics.updateIoRecord(rec, srcAccum)
+    assert(rec.dataSize == 5177503442L)
+    // Only the data-size field is touched.
+    assert(rec.bufferTime == 0 && rec.scanTime == 0 && rec.decodeTime == 0)
+  }
+
+  test("file-source 'size of files read' still routes to dataSize (regression)") {
+    val srcAccum = accum("size of files read", 12345L)
+    assert(IoMetrics.isIoMetric(srcAccum))
+    val rec = IoMetrics(0, 0, 0, 0)
+    IoMetrics.updateIoRecord(rec, srcAccum)
+    assert(rec.dataSize == 12345L)
+  }
+
+  test("Photon and Auron helpers also recognize and route the Iceberg metric") {
+    for (helper <- Seq(PhotonIoMetrics, AuronIoMetrics)) {
+      val srcAccum = accum(icebergDataSizeName, 987654321L, icebergMetricType)
+      assert(helper.isIoMetric(srcAccum), s"$helper should recognize the Iceberg metric")
+      val rec = IoMetrics(0, 0, 0, 0)
+      helper.updateIoRecord(rec, srcAccum)
+      assert(rec.dataSize == 987654321L, s"$helper should route the Iceberg metric to dataSize")
+    }
+  }
+
+  test("unrelated metric names remain unsupported") {
+    val srcAccum = accum("some unrelated metric", 1L)
+    assert(!IoMetrics.isIoMetric(srcAccum))
+    val rec = IoMetrics(0, 0, 0, 0)
+    assertThrows[UnsupportedMetricNameException] {
+      IoMetrics.updateIoRecord(rec, srcAccum)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2115 

### Problem
For Iceberg DataSource V2 `BatchScan`, `data_source_information.csv` reports `data_size = 0` even when the scan reads a large volume of data. Any downstream consumer that reads `data_size` (e.g. QualX scan features) is blind to the true scan size for Iceberg tables.

### Root cause
Iceberg `BatchScan` reports its input volume through the SQL-plan metric `total data file size (bytes)` (`v2Custom_...TotalDataFileSize`). The `data_size` column is filled by an I/O-metric helper (`IoMetrics`) that recognizes data-size metrics by exact name, and the only OSS label it knows is `"size of files read"`. Iceberg's metric name isn't in that allowlist, so `DataSourceView` filters it out and `data_size` stays 0. The metric is still present in `sql_plan_metrics_for_application.csv` — only the data-source view drops it.

### Fix
Recognize `"total data file size (bytes)"` in `IoMetrics` and route it to `dataSize`. Because the Iceberg source emits this metric independent of the compute engine, the label is added at the base `IoMetricsTrait` level, so the OSS, Photon, and Auron helpers all inherit it. File-source scans are unaffected — they emit `"size of files read"` on distinct nodes, so the two never collide.

### Verification
- Unit tests (`IoMetricsSuite`, 5 cases): Iceberg metric recognized and routed to `dataSize`; file-source `"size of files read"` still routes correctly (regression); Photon/Auron helpers inherit the behavior; unrelated metric names still rejected.
- End-to-end on an Iceberg V2 event log: after the fix, final-plan Iceberg scans report their true multi-GB `data_size` (matching the raw `total data file size (bytes)` values) instead of 0, with no final-plan Iceberg row left at 0; a non-Iceberg log still populates `data_size` and `scan_time` for Parquet file-source scans.

### Out of scope (separate follow-ups)
- `scan_time` / `scan_bw` for Iceberg: Iceberg `BatchScan` emits no scan-time metric on either engine (`"scan time"` is CPU-`FileSourceScan`-only; GPU splits it into `buffer time` + `GPU decode time`). It is genuinely absent rather than an allowlist miss, so it stays 0 and `scan_bw` degrades safely to 0 in the featurizer — consistent with every GPU scan today.
- Task-level `input_bytesRead`: Spark does not populate V2 scan bytes in task input metrics, so `input_bytesRead_sum` is 0 for Iceberg. That is a distinct path, tracked separately.
